### PR TITLE
test: close ignored doctest gaps

### DIFF
--- a/src/prolly/batch.rs
+++ b/src/prolly/batch.rs
@@ -309,7 +309,7 @@ pub(crate) struct LeafSpan {
 /// Store's bulk upsert API.
 ///
 /// # Example
-/// ```ignore
+/// ```text
 /// let mut collector = BatchWriteCollector::new();
 /// let cid = collector.add(&node);
 /// collector.flush(&store)?;
@@ -5338,7 +5338,7 @@ impl BatchWriter {
     /// - Requirement 7.4: Ensure atomicity - either all mutations applied or none
     ///
     /// # Example
-    /// ```rust,ignore
+    /// ```rust
     /// use prolly::{BatchWriter, BatchWriterConfig, Prolly, MemStore, Config, Mutation};
     ///
     /// let store = MemStore::new();


### PR DESCRIPTION
## Summary

- classify the private BatchWriteCollector fragment as illustrative text instead of an ignored executable doctest
- promote the valid deferred batch example into the normal doctest suite
- ensure routine test runs cover every runnable documentation example

## Why

The exhaustive proximity and prolly-map creation audit executed the normally ignored tests. It found that the BatchWriteCollector example could not compile because the collector is crate-private and the fragment intentionally omits its node and store setup. The deferred batch example was valid and passed, but was unnecessarily excluded from routine runs.

This is a follow-up to PR #4 and keeps the review diff limited to the newly discovered coverage gap.

## Impact

Normal all-feature test runs now report 98 of 98 doctests passing with zero ignored doctests. The expensive randomized splice oracle remains explicitly ignored by default but was executed successfully during the audit.

## Validation

- cargo fmt --check
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --all-features --quiet: 471 library tests, every integration suite, and 98 of 98 doctests passed
- extended_hundred_seed_splice_oracle: passed all 100 seeds and 50,000 randomized mutation batches in 645.67 seconds
- complete proximity benchmark matrix: passed
- 1M full proximity benchmark: passed
- 10M scale proximity benchmark: passed
- 10K general prolly benchmark: all 27 workloads passed