### PR TITLE
Complete zero-copy prolly reads and retained proximity reranking

### DIFF
--- a/benches/prolly_bench.rs
+++ b/benches/prolly_bench.rs
@@ -47,6 +47,12 @@ fn main() {
             bench_point_deletes(scale);
             return;
         }
+        Ok("zero-copy-reads") => {
+            bench_point_get(scale);
+            bench_range_scan(scale);
+            bench_range_scan_window(scale);
+            return;
+        }
         Ok(_) | Err(_) => {}
     }
 
@@ -128,6 +134,18 @@ fn bench_point_get(items: usize) {
             black_box(prolly.get(&tree, black_box(key)).unwrap());
         }
     });
+
+    let mut session = prolly.read(&tree).unwrap();
+    measure("point_get_borrowed_mem", 10, gets, || {
+        for i in 0..gets {
+            let key = &data[i % data.len()].0;
+            black_box(
+                session
+                    .get_with(black_box(key), |value| black_box(value.len()))
+                    .unwrap(),
+            );
+        }
+    });
 }
 
 fn bench_point_updates(items: usize) {
@@ -177,6 +195,17 @@ fn bench_range_scan(items: usize) {
             .count();
         black_box(count);
     });
+
+    let mut session = prolly.read(&tree).unwrap();
+    measure("range_scan_borrowed_mem", 25, items, || {
+        let count = session
+            .scan_range(&[], None, |entry| {
+                black_box(entry.key());
+                black_box(entry.value());
+            })
+            .unwrap();
+        black_box(count);
+    });
 }
 
 fn bench_range_scan_window(items: usize) {
@@ -200,6 +229,21 @@ fn bench_range_scan_window(items: usize) {
                 black_box(entry);
             })
             .count();
+        black_box(count);
+    });
+
+    let mut session = prolly.read(&tree).unwrap();
+    measure("range_scan_window_borrowed_mem", 50, window_items, || {
+        let count = session
+            .scan_range(
+                black_box(start.as_slice()),
+                Some(black_box(end.as_slice())),
+                |entry| {
+                    black_box(entry.key());
+                    black_box(entry.value());
+                },
+            )
+            .unwrap();
         black_box(count);
     });
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,9 @@ tests described here.
 - [Performance](performance.md): optimization principles, tuning guidance,
   benchmark harnesses, current evidence, workload playbooks, and future
   performance work.
+- [Zero-Copy Read Architecture](superpowers/specs/2026-07-15-prolly-zero-copy-read-architecture-design.md):
+  comprehensive ownership, packed-node, cache, API, diff/merge,
+  secondary-index, proximity, async, binding, correctness, and benchmark design.
 - [Roadmap](roadmap.md): the canonical roadmap for public `0.1`,
   compatibility, production hardening, async/remote storage, AI-native
   primitives, language bindings, and collaboration.

--- a/docs/prolly-go-rust-benchmark.md
+++ b/docs/prolly-go-rust-benchmark.md
@@ -1,0 +1,82 @@
+# Dolt Go vs Rust Prolly Benchmark
+
+This benchmark compares build, write, point-read, and full-range-scan performance
+for the Dolt Go prolly tree and this Rust implementation. It uses native runners
+in separate processes so neither runtime affects the other's measurements.
+
+## Run
+
+Run the complete requested matrix:
+
+```sh
+scripts/run_prolly_comparison.sh
+```
+
+Run a quick parity and smoke comparison:
+
+```sh
+BENCH_SIZES="10000" BENCH_RUNS=1 BENCH_LARGE_RUNS=1 \
+  scripts/run_prolly_comparison.sh
+```
+
+Results are written under `performance-results/dolt-rust/`. Set `BENCH_OUT` to
+retain multiple named runs. The runner stops on any failed process. The
+summarizer also rejects mismatched workload digests, operation counts, or result
+cardinalities between implementations.
+
+## Method
+
+- One worker: `RAYON_NUM_THREADS=1` and `GOMAXPROCS=1`.
+- Fresh datasets: 10K, 50K, 1M, 5M, and 10M records.
+- UTF-8 keys are fixed-width and lexicographically sortable.
+- Values are deterministic pseudo-random payloads from 1 through 100 bytes.
+- Each fresh build or mutation workload is submitted as one bulk write. This
+  avoids retaining thousands of obsolete content-addressed snapshots in the
+  in-memory stores at the 1M–10M tiers.
+- Fresh append, random, and clustered workloads contain the same final records
+  but differ in arrival order.
+- Mutation workloads write 30% of the base size. Random and clustered mutations
+  contain equal numbers of new inserts and updates; append mutations are all new
+  keys above the current maximum.
+- Point reads are validated and capped at 100,000 operations per scenario.
+- Range scans traverse the complete resulting tree and validate strict key order
+  and cardinality in an untimed pass. The timed pass includes logical tuple
+  traversal/decoding and a cheap byte count in both implementations.
+- Reports record the Rust source hash, Go runner hash, and SHA-256 digest of
+  each copied executable. A dirty implementation is never represented by the
+  last commit SHA alone.
+- Logical fixture construction and Dolt tuple encoding happen outside timed write
+  regions. Sorting, mutation buffering, chunking, hashing, encoding tree nodes,
+  and in-memory node-store writes remain timed.
+
+The comparison intentionally uses each implementation's default encoding and
+chunking configuration. It measures the products presented to callers, not a
+forced common wire format.
+
+## Verified zero-copy run (2026-07-16)
+
+The final runs used identical binary hashes across every requested size:
+
+- 10K, 50K, and 1M (three repetitions):
+  `performance-results/zero-copy-10k-50k-1m-final-provenance/`
+- 5M and 10M (one complete repetition; exact ratios are provisional):
+  `performance-results/zero-copy-5m-10m-final-provenance/`
+
+Across all 90 scenarios Rust won 82 and Dolt Go won 8. Rust won every range
+scan (30/30), with measured scan speedups from 2.97x through 6.50x. Point reads
+split 23/30 for Rust and 7/30 for Dolt:
+
+- 10K: Rust won all point workloads, 1.42x–2.18x;
+- 50K: Rust won all point workloads, 1.07x–1.89x;
+- 1M: locality-heavy mutation append/clustered reached 1.59x–1.95x, while
+  fresh/random cases were near parity or slower;
+- 5M and 10M: Rust reached 1.58x–2.15x for mutation append/clustered and
+  1.11x–1.16x for mutation random, while Dolt won every fresh point workload
+  by 1.16x–1.28x.
+
+These results do not establish the requested 1.5x–2x point-read target for a
+large random working set. They show that callback-scoped result borrowing and
+session-local routing solve allocation/locality overhead, while decoded
+`Vec<Vec<u8>>` nodes and their cache footprint dominate at 1M–10M. The next
+point-read optimization must therefore evaluate the packed `ReadNode` phase in
+the zero-copy architecture design rather than further enlarging session caches.

--- a/docs/superpowers/specs/2026-07-15-prolly-zero-copy-read-architecture-design.md
+++ b/docs/superpowers/specs/2026-07-15-prolly-zero-copy-read-architecture-design.md
@@ -1,20 +1,22 @@
 # Prolly Zero-Copy Read Architecture
 
-**Status:** Proposed for review
+**Status:** Accepted architecture; implementation and performance validation in progress
 
-**Date:** 2026-07-15
+**Date:** 2026-07-15; revised 2026-07-16
 
 **Scope:** Program-level design for a safe zero-copy read substrate across the
 core prolly tree, diff and merge, versioned maps, secondary indexes, proximity
-maps, async execution, and language bindings. The core point-read and range-scan
-work is implementation-ready. Secondary-index and proximity-map sections define
-the extension contracts that immediate work must preserve; they do not require
-those consumers to migrate in the first delivery.
+maps and accelerators, async execution, proofs and maintenance, stores, and
+language bindings. Packed immutable read nodes and callback-scoped borrowed
+views are the canonical internal read path. Owned APIs remain explicit boundary
+adapters. Secondary-index and proximity-map consumers may migrate in stages,
+but their codecs, caches, candidate ownership, and query contracts must use the
+same foundation now so that no second lifetime or cache redesign is required.
 
 ## Summary
 
-The Rust implementation currently pays ownership and cache-management costs on
-read paths that Dolt's Go implementation avoids. A warm point read takes an
+Before this work, the Rust implementation paid ownership and cache-management
+costs on read paths that Dolt's Go implementation avoids. A warm point read took an
 exclusive node-cache lock, updates eviction metadata even when the cache is
 unbounded, hashes the root CID on every request, and clones the returned value.
 A range scan clones every key and value and clones the key a second time to
@@ -25,7 +27,7 @@ buffers.
 This design makes callback-scoped borrowed views the canonical Rust read
 mechanism. Existing owned APIs remain source-compatible wrappers and allocate
 only at their explicit ownership boundary. A reusable `ReadSession` retains the
-decoded root directly, keeps a session-local recent leaf, and traverses immutable
+packed root directly, keeps session-local routing state, and traverses immutable
 `Arc`-backed node handles. Cache hits use a read-only path when eviction is
 disabled, and no cache lock remains held during traversal callbacks.
 
@@ -42,18 +44,71 @@ The same foundation supplies:
   `.await`;
 - owned language-binding and persistence boundaries with no API break.
 
-"Zero-copy" in this design has a precise scope. Phase one avoids copying values
-that are already present in a decoded cached node. A cold store read still owns
-the bytes returned by `Store::get`, and the current `Node::from_bytes` still
-decodes keys and values. A later read-node representation may retain packed
-encoded bytes, but it is not required for the first performance gate and does
-not change the wire format.
+"Zero-copy" in this design has a precise scope. The preferred store contract
+returns a retained `Arc<[u8]>`; the cache and packed `ReadNode` keep that same
+allocation alive; values and plain/offset-table keys are slices of it; and a
+callback borrows those slices while the handle is strongly retained. A store
+that only supports owned `Vec<u8>` reads is adapted once into `Arc<[u8]>` at the
+store boundary. Prefix-compressed keys are reconstructed once per node into one
+contiguous retained arena, not allocated once per key or result. Existing node
+bytes and CIDs are unchanged.
 
 Correctness is non-negotiable. Borrowed references cannot escape their callback,
 cached content is immutable and fully validated before admission, snapshots stay
 root-bound, visitor reentrancy never occurs under a cache lock, and every owned
 legacy result must be byte-for-byte equivalent to the borrowed traversal it
-wraps.
+wraps. Unsafe indexing is optional, isolated to a validated packed-node accessor,
+and accepted only with a documented safety proof plus safe-path differential,
+Miri, fuzz, and malformed-input coverage.
+
+## Normative Decision Snapshot
+
+This section is the short authoritative decision record. If older staging text
+elsewhere in this document describes packed nodes, secondary-index views, or
+proximity candidate handles as merely hypothetical, this section takes
+precedence.
+
+1. **One canonical read representation.** Normal tree reads load
+   `Arc<ReadNode>`, not decoded `Arc<Node>`. The write representation may be
+   materialized lazily only when a mutation algorithm genuinely needs owned
+   vectors. A read must never decode through `Node::from_bytes` merely because
+   an owned public result is requested.
+2. **One retained byte allocation.** A native shared store read, cache entry,
+   packed node, traversal handle, secondary-index decoder, and proximity record
+   decoder share immutable bytes through `Arc<[u8]>`. Backends without retained
+   buffers use a correct default adapter with one unavoidable boundary move.
+3. **Borrow inside, own at escape boundaries.** Callback/HRTB views are the
+   internal source of truth. Ownership is introduced only for persisted output,
+   public owned return types, cursors/pages/proofs, FFI/WASM, synthesized merge
+   values, and final proximity neighbors.
+4. **No borrowed reference crosses suspension.** Async methods await a retained
+   handle, invoke a synchronous callback, drop all borrows, and only then await
+   again. Async application callbacks receive owned data or use bounded pages.
+5. **Caches retain handles, never references.** Eviction removes discoverability
+   but cannot invalidate an active `Arc`. Cache byte accounting includes packed
+   bytes, metadata, prefix arenas, decoded typed objects, and externally retained
+   candidate bytes.
+6. **Read-session locality is bounded.** A session retains its root and a small
+   bounded set of internal route nodes. Leaf retention is adaptive so random
+   workloads do not pay continual locality checks or pin a large working set.
+   Session state is worker-local and never changes snapshot identity.
+7. **Secondary indexes compose views.** Physical-key and index-value decoders
+   lend views from the tree callback or bounded scratch. Source joins retain
+   bounded locations/keys and use ordered multi-get; they never eagerly own the
+   full posting list and source result set.
+8. **Proximity search retains candidate sources.** Native hierarchy, eligible
+   exact, HNSW, PQ, and composite search retain `(Arc<typed node>, entry_index,
+   score)` or an equivalent typed handle. Authoritative reranking borrows exact
+   directory records and reuses vector scratch. Only the final `k` results own
+   keys and application values.
+9. **Persisted objects remain self-contained.** Tree nodes, manifests,
+   secondary-index descriptors/checkpoints/bundles, proximity descriptors and
+   accelerator objects, cursors, and proofs never serialize process-local
+   handles or borrowed offsets.
+10. **Performance never weakens validation.** CID, format, ordering, bounds,
+    cardinality, vector, projection, snapshot, and accelerator-source checks run
+    before cache admission or callback exposure. Fast paths may change how data
+    is retained, not what data is accepted.
 
 ## Relationship to Existing Designs
 
@@ -77,7 +132,7 @@ Where those designs require an owned serialized page, cursor, proof, manifest,
 or binding value, this design does not weaken that requirement. It removes
 intermediate ownership inside the Rust process.
 
-## Current Evidence
+## Pre-implementation Evidence and Measured Motivation
 
 ### Cross-language benchmark
 
@@ -85,7 +140,8 @@ The existing one-worker, in-memory comparison uses identical deterministic
 string keys, values from 1 through 100 bytes, append/random/clustered workloads,
 a 30% mixed mutation phase, and post-write point reads and full range scans.
 
-For the repeated one-million-key fresh/random workload, the current median is:
+For the repeated one-million-key fresh/random workload before the packed-read
+implementation, the measured median was:
 
 | Operation | Rust | Dolt Go | Current leader |
 |---|---:|---:|---:|
@@ -97,9 +153,9 @@ To beat the observed Dolt median by 1.5x, Rust must reach no more than
 no more than 718 ns/point read and 55.9 ns/scanned row. These are targets, not
 predicted or fabricated results.
 
-### Point-read path
+### Original point-read path
 
-The current synchronous path in `src/prolly/mod.rs`:
+The original synchronous path in `src/prolly/mod.rs`:
 
 1. probes process-global recent-leaf state using atomics and a lock;
 2. starts from a root CID rather than a retained root node;
@@ -116,7 +172,7 @@ roughly 14% to leaf-value allocation/copy. That benchmark used a more local
 access pattern than the cross-language random workload, so the sample is
 bottleneck evidence, not a replacement comparison result.
 
-### Range path
+### Original range path
 
 `RangeIter` owns its start and end bounds, holds an `Arc<Node>` traversal stack,
 and yields `Result<(Vec<u8>, Vec<u8>), Error>`. Each row currently:
@@ -128,7 +184,7 @@ and yields `Result<(Vec<u8>, Vec<u8>), Error>`. Each row currently:
 Node-cache work is amortized across a leaf, so per-row ownership dominates more
 strongly than it does for point reads.
 
-### Diff and merge
+### Original diff and merge paths
 
 Structural diff prunes identical subtrees correctly, but changed leaf entries
 become owned `Diff` values and are often queued in `VecDeque<Diff>`. Misaligned
@@ -147,14 +203,14 @@ owned right Diff list
   -> rewritten Node values
 ```
 
-### Secondary indexes
+### Original secondary-index paths
 
 Secondary-index exact, prefix, and range convenience methods collect complete
 owned result sets. Physical `(term, primary_key)` keys are decoded into two new
 vectors, and index projection envelopes copy their payload. `records()` first
 owns all index matches and then owns every source lookup value.
 
-### Proximity maps
+### Original proximity-map paths
 
 An exact proximity lookup owns the directory value, decodes the vector into a
 new `Vec<f32>`, and owns the application value. Search paths frequently copy
@@ -183,7 +239,7 @@ must be owned, but most intermediate candidates do not need to be.
 
 ## Non-Goals
 
-The first implementation does not:
+The architecture does not:
 
 - promise zero-copy across an FFI, WASM, serialization, or process boundary;
 - return a free-standing `&[u8]` whose lifetime is detached from a callback or
@@ -196,8 +252,9 @@ The first implementation does not:
 - allow an async visitor to retain borrowed content across `.await`;
 - guarantee the 1.5x-to-2x performance target before measurements demonstrate
   it;
-- implement secondary-index or proximity-map migration in the first core
-  delivery;
+- require every secondary-index build/maintenance or proximity accelerator to
+  migrate in the same core release, although their shared view/handle foundation
+  is mandatory;
 - use unsafe lifetime extension, self-referential structures, or transmute;
 - weaken full validation, snapshot isolation, resource budgets, or deterministic
   result ordering for speed.
@@ -217,18 +274,20 @@ Traversal setup may allocate a path stack, bounds, or reusable scratch space.
 visited entry once traversal is established. Scratch buffers may grow to a
 bounded high-water mark and then be reused.
 
-### Decoded zero-copy
+### Decoded borrowing
 
-The initial `Arc<Node>` cache already owns decoded `Vec<Vec<u8>>` keys and
-values. Borrowing those vectors avoids an additional result copy. This is the
-phase-one meaning of zero-copy.
+An owned `Arc<Node>` can lend its `Vec<Vec<u8>>` keys and values and is still a
+valid compatibility or mutation representation. It avoids a result copy, but it
+is not the canonical read representation because decoding allocates per key and
+value and produces poor cache locality.
 
 ### Packed zero-copy
 
-A later `ReadNode` may retain `Arc<[u8]>` encoded bytes and offsets so values,
-and keys under suitable layouts, can be borrowed without constructing a
-`Vec<Vec<u8>>`. Prefix-compressed keys may still require reconstruction into a
-contiguous arena or reusable scratch buffer.
+`ReadNode` retains `Arc<[u8]>` encoded bytes plus compact validated offsets, so
+values and keys under plain and offset-table layouts are borrowed without
+constructing `Vec<Vec<u8>>`. Prefix-compressed keys are reconstructed once into
+a contiguous `Arc<[u8]>` arena and addressed by the same metadata. This is the
+canonical tree read representation.
 
 ### Required ownership
 
@@ -267,7 +326,10 @@ The following are release-blocking:
 13. Proximity search continues to rerank returned candidates using authoritative
     vectors and preserves deterministic key tie-breaking.
 14. Logical work and budget accounting do not change with cache warmth.
-15. Unsafe code is not required for the initial architecture.
+15. The safe packed accessor is the semantic reference. Any unsafe hot accessor
+    is isolated, cannot construct references before complete validation, proves
+    index and byte-range validity from immutable metadata, and is continuously
+    differential-tested against the safe accessor.
 
 ## Alternatives Considered
 
@@ -298,12 +360,13 @@ Arena or slab allocation could lower allocator overhead, but it would continue
 copying every byte, retain unnecessary memory, and leave the cache/root gap
 untouched. It may complement owned wrappers but is not the core solution.
 
-### Immediately replace the node wire format
+### Replace the node wire format to obtain packed reads
 
-Packed offsets are attractive, but a format cutover would combine lifetime,
-cache, API, persistence, migration, and performance risks. The selected design
-first removes result ownership and cache overhead without a wire change, then
-uses measurements to justify a read representation or format change.
+Rejected. The current compact encodings already contain enough structure to
+build validated offsets over retained bytes. A packed in-memory `ReadNode` does
+not require a format cutover, so lifetime, cache, and API improvements remain
+independent of persisted-format migration. Any future wire-format change must
+still be justified separately by measured read/write and storage gains.
 
 ## Architecture Overview
 
@@ -311,7 +374,7 @@ uses measurements to justify a read representation or format change.
 Tree + Prolly manager
         |
         v
-  ReadSession ------------------- direct root NodeHandle
+  ReadSession ------------------- direct root Arc<ReadNode>
         |                         session-local recent leaf
         |                         request-local metrics
         v
@@ -331,15 +394,17 @@ Tree + Prolly manager
         |
         +---- binding/page/proof: serialize owned result
 
-NodeHandle obtains immutable content through:
+Arc<ReadNode> obtains immutable content through:
 
   Disabled cache | Unbounded read-mostly cache | Bounded cache
         |                    |                         |
         +--------------------+-------------------------+
                              |
-                       validated node load
+                  shared retained-byte load
                              |
-                  Decoded Node now, ReadNode later
+                 CID + format + layout validation
+                             |
+                    packed Arc<ReadNode>
 ```
 
 ## API Coverage and Adoption Policy
@@ -364,11 +429,49 @@ that changes public return types. The complete API surface adopts it as follows:
 | patch/CRDT comparison | borrowed point/diff inputs | persisted patch/result remains owned |
 | stats/debug/verification | borrowed traversal and scalar aggregation | owned report structures/text |
 | proof generation/verification | borrowed node/entry inspection | proofs remain self-contained and owned |
-| sync/GC/content walking | borrow decoded nodes while collecting CIDs | transfer manifests and CID sets own data |
+| sync/GC/content walking | borrow packed nodes while collecting CIDs | transfer manifests and CID sets own data |
 | secondary-index query/build | borrowed match/projection/source views | pages, cursors, bundles remain owned |
 | proximity exact/search/build | record/vector views and candidate handles | `Neighbor`, result, proof remain owned |
 | async equivalents | sync callback after each await | owned streams/pages unchanged |
 | language bindings/WASM | serialize directly from borrowed internals | foreign values remain owned |
+
+### Complete migration ledger
+
+The following ledger prevents an optimized point-read implementation from
+leaving hidden allocation islands in higher-level APIs. “Borrowed core” means
+the operation must consume `ReadNode`, a typed retained content handle, or a
+callback-scoped view; it must not call an owned convenience API internally.
+
+| Subsystem/API family | Canonical internal input | Required owned boundary | Foundation decision |
+|---|---|---|---|
+| point reads, contains, large-value envelope | retained leaf/value slice | legacy `Vec`, resolved external blob | `get_with` and `ValueRefView` |
+| multi-get | bounded `ValueLocation { Arc<ReadNode>, index }` | ordered legacy result vector | preserve duplicates, misses, and input order |
+| forward/reverse range and prefix | traversal stack plus live leaf handle | iterator item, page, serialized cursor | clone cursor key only at cursor/page boundary |
+| rank/select/bounds/first/last | packed internal routing and one leaf view | one optional `KeyValue` | scalar paths never copy values |
+| write-session/transaction reads | stable overlay view merged with base session | existing owned read result | no callback while overlay lock is held |
+| diff/range-diff | two retained subtree cursors and `DiffRef` | `Diff`, page, proof, sync artifact | no eager changed-subtree vectors |
+| conflicts/three-way merge | retained base/left/right views and symbolic decision | synthesized resolution and encoded output nodes | no intermediate owned Diff→Conflict→Mutation chain |
+| CRDT/patch | borrowed comparisons and conflict views | persisted patch/result | policy semantics unchanged |
+| snapshots/versioned/typed maps | root-bound session for exact historical tree | typed decoded object or legacy bytes | typed decode happens inside callback |
+| stats/debug/verify | packed traversal and scalar accumulators | report structures/text | no entry ownership unless report contains bytes |
+| membership/range/diff/search proofs | borrowed node/record inspection | self-contained proof object | proof validity never depends on cache lifetime |
+| sync/export/import/GC/content graph | borrowed child-CID inspection | CID set, transfer manifest, encoded bundle | transfer/persistence remains owned |
+| secondary exact/prefix/range/reverse | `SecondaryIndexMatchRef` over tree entry plus scratch | match/page/cursor | physical ordering and snapshot identity unchanged |
+| secondary source joins | bounded posting chunk plus ordered borrowed source reads | requested final records/page | never collect the full match set first |
+| secondary build/verify/repair/replace | source scan plus streaming extractor views | sorted run/output nodes, descriptors/checkpoints | copy each derived entry at most once into build state |
+| secondary bundle/retention/GC | borrowed tree walk | self-contained bundle/catalog/GC plan | persisted metadata remains canonical |
+| proximity exact/contains/record scan | `StoredRecordRef`/`ProximityRecordRef` | exact owned record | validate encoded vector before exposure |
+| proximity native hierarchy | retained proximity node and entry index | final neighbors | candidate count and pinned bytes are bounded |
+| proximity eligible exact | borrowed directory records | final neighbors | filter eligibility precedes authoritative score |
+| HNSW/PQ/SQ8/composite search | typed accelerator handles plus bounded scratch | final reranked neighbors | approximate scores never replace authoritative rerank |
+| proximity build/rebuild/mutate/verify | record scan and vector view/scratch | encoded nodes, accelerators, descriptors | representation chosen by reuse and measured kernel cost |
+| proximity proof | retained visited typed objects | self-contained proof | proof ordering/completeness independent of cache warmth |
+| async variants | retained handles followed by synchronous callbacks | stream/page or caller-owned copy across await | deterministic delivery after concurrent fetch |
+| FFI/WASM/language bindings | borrowed internal traversal | target-runtime allocation/serialization | existing foreign signatures need not change |
+
+This ledger is an implementation acceptance checklist. A subsystem is migrated
+only when its owned APIs are adapters over the borrowed core and equivalence,
+allocation, and malformed-input tests cover that adapter.
 
 Write APIs necessarily create persisted bytes. `put`, `delete`, `batch`, append,
 builders, range delete, and merge should accept crate-private borrowed mutation
@@ -378,7 +481,7 @@ copies. Public owned `Mutation` remains unchanged. A future public
 the read architecture.
 
 The existing public `Cursor::at_item(&Store, ...)` has no manager and therefore
-cannot use the decoded manager cache or direct-root session. It remains a
+cannot use the packed manager cache or direct-root session. It remains a
 low-level compatibility API, while `Prolly::cursor`, `range_cursor`, and all new
 performance APIs route through manager-backed traversal. Documentation must not
 present the store-only cursor as the preferred high-throughput path.
@@ -400,8 +503,9 @@ The status labels used below are:
   implementation must use the borrowed primitive and allocate only at its owned
   boundary;
 - **crate-private**: foundation required now without a public stability promise;
-- **deferred public**: named and reserved for the secondary-index or proximity
-  phase, not required for the first core release;
+- **foundation now**: public/typed view contract and cache/lifetime behavior are
+  fixed now; individual secondary-index or proximity consumers may migrate in
+  later performance phases;
 - **unchanged**: no signature, ownership, serialization, or binding change.
 
 ### Public types added in core phases 1–4
@@ -1026,8 +1130,8 @@ These names are implementation-oriented and may evolve without semver impact:
 
 | Area | Crate-private additions | Purpose |
 |---|---|---|
-| retained content | `NodeHandle`, `CachedNode`, `ReadNode` | keep validated bytes/decoded node alive for callback scope |
-| routing | `LeafWindow`, `KeyScratch`, `ValueLocation`, `ReadPath` | session-local recent leaf, reconstructed-key scratch, and point lookup location |
+| retained content | `NodeHandle = Arc<ReadNode>`, typed content handles | keep validated bytes and metadata alive for callback scope |
+| routing | `LeafWindow`, `SessionNodeTable`, `ValueLocation`, `ReadPath` | adaptive recent leaf, retained internal routes, and point lookup location |
 | scans | `RangeTraversal`, `ReverseRangeTraversal`, `BorrowedLeafCursor` | bounded forward/reverse leaf traversal shared by visitors and owned adapters |
 | comparison | `BorrowedDiffWalker`, `BorrowedConflictWalker` | aligned and misaligned subtree streaming without eager vectors |
 | writes | `BorrowedMutation<'a>`, `BorrowedMutationSource` | remove temporary owned mutation/diff copies before final node encoding |
@@ -1039,10 +1143,11 @@ The existing public `Store`, `AsyncStore`, `BlobStore`, `Tree`, `Config`, `Node`
 In particular, zero-copy does not require storage backends to return borrowed
 buffers, and it does not change canonical node CIDs.
 
-### Deferred secondary-index public API (phase 5)
+### Secondary-index public API and migration contract
 
-The core release reserves these names and semantics, but they are implemented
-only when secondary-index migration begins:
+These names and semantics are part of the shared foundation. Borrowed codecs,
+query visitors, source joins, and streaming extraction are implemented first;
+build/maintenance consumers migrate behind the unchanged owned API surface:
 
 ```rust,ignore
 pub enum IndexValueRef<'a> {
@@ -1205,7 +1310,7 @@ corresponding owned page API. Early stop returns the last delivered count but
 does not manufacture a serialized cursor; callers that need resumability use
 the existing owned page/cursor boundary.
 
-### Deferred proximity-map public API (phase 6)
+### Proximity-map public API and migration contract
 
 Public views expose safe logical records. Byte-layout helpers remain
 crate-private so an alignment or encoding change does not leak into the API.
@@ -1281,10 +1386,10 @@ then consume these views internally. Existing `ExactProximityRecord`,
 `Neighbor`, `SearchResult`, descriptors, proofs, and persisted accelerator
 artifacts remain owned and unchanged.
 
-`AsyncProximityMap` eventually gains `read`, `get_with`, and `scan_records`
-counterparts with synchronous post-await callbacks. Approximate-search callback
-results are deliberately not exposed: candidate heaps can use retained internal
-handles, but a public result must remain self-contained.
+`AsyncProximityMap` gains `read`, `get_with`, and `scan_records` counterparts
+with synchronous post-await callbacks when its exact-read surface is migrated.
+Approximate-search callback results are deliberately not exposed: candidate
+heaps use retained internal handles, but a public result remains self-contained.
 
 ### Source-file ownership and delivery
 
@@ -1296,7 +1401,7 @@ handles, but a public result must remain self-contained.
 | `src/prolly/diff.rs`, `error.rs`, merge/write modules | borrowed diff/conflict views, symbolic resolver, streaming apply | 3–4 |
 | `src/prolly/versioned_map.rs`, typed map layer, async modules | snapshot/session forwarding and decode-in-callback | 2–4 |
 | `src/prolly/secondary_index/{storage,snapshot,definition,coordinator}.rs` | deferred index views/query/build adoption | 5 |
-| `src/prolly/proximity/storage/record.rs`, `map.rs`, `search/`, `accelerator/`, `proof/` | deferred record/vector views and candidate handles | 6 |
+| `src/prolly/proximity/storage/record.rs`, `map.rs`, `search/`, `accelerator/`, `proof/` | record/vector views, retained candidate handles, authoritative borrowed rerank | 6 |
 | language bindings and WASM adapters | no signature change; serialize/copy at FFI boundary | after each native phase |
 
 Every public borrowed-view addition requires rustdoc examples for both
@@ -1328,9 +1433,9 @@ impl<'a> EntryRef<'a> {
 }
 ```
 
-Fields remain private so later read-node representations can preserve invariants
-without changing construction sites. `EntryRef` is copyable, but the compiler
-still prevents it from escaping its callback lifetime.
+Fields remain private so packed-node metadata and typed views can preserve
+invariants without changing construction sites. `EntryRef` is copyable, but the
+compiler still prevents it from escaping its callback lifetime.
 
 ### Read session
 
@@ -1338,8 +1443,9 @@ still prevents it from escaping its callback lifetime.
 pub struct ReadSession<'manager, 'tree, S: Store> {
     manager: &'manager Prolly<S>,
     tree: &'tree Tree,
-    root: Option<NodeHandle>,
+    root: Option<Arc<ReadNode>>,
     recent_leaf: Option<LeafWindow>,
+    route_nodes: SessionNodeTable,
     local_metrics: LocalReadMetrics,
 }
 
@@ -1359,25 +1465,43 @@ mutated; callers create one session per worker. The manager cache remains shared
 The session owns no persisted state and does not alter tree identity. Dropping it
 releases its root and recent-leaf handles and flushes any local metric aggregate.
 
-### Node handle and representation boundary
+### Packed node handle and representation boundary
 
 ```rust,ignore
-#[derive(Clone)]
-pub(crate) struct NodeHandle(Arc<CachedNode>);
+type NodeHandle = Arc<ReadNode>;
 
-pub(crate) struct CachedNode {
-    cid: Cid,
-    encoded_bytes: usize,
-    retained_bytes: usize,
-    repr: ReadNode,
+struct ReadEntryMeta {
+    key_start: u32,
+    key_len: u32,
+    value_start: u32,
+    value_len: u32,
+    child_count: u64,
 }
 
-pub(crate) enum ReadNode {
-    Decoded(Node),
-    // Later, without changing traversal callers:
-    // Packed(PackedNode),
+pub(crate) struct ReadNode {
+    bytes: Arc<[u8]>,
+    prefix_keys: Option<Arc<[u8]>>,
+    entries: Box<[ReadEntryMeta]>,
+    leaf: bool,
+    level: u8,
+    format: TreeFormat,
+}
+
+struct NodeCacheEntry {
+    read: OnceLock<Arc<ReadNode>>,
+    owned: OnceLock<Arc<Node>>,
+    retained_bytes: usize,
+    /* eviction metadata */
 }
 ```
+
+`bytes` is the immutable encoded allocation returned by `Store::get_shared` or
+created once by the owned-store adapter. Plain and offset-table keys and all
+values point into `bytes`. `prefix_keys` exists only for prefix-compressed
+layouts and contains all reconstructed keys in one immutable arena. Offsets are
+32-bit only after the parser rejects any object that cannot be addressed by
+them. This makes metadata compact and gives validation an explicit maximum
+object size.
 
 Traversal code accesses `ReadNode` through concrete inlineable methods:
 
@@ -1385,17 +1509,31 @@ Traversal code accesses `ReadNode` through concrete inlineable methods:
 fn len(&self) -> usize;
 fn level(&self) -> u8;
 fn is_leaf(&self) -> bool;
-fn key(&self, index: usize, scratch: &mut KeyScratch) -> Result<&[u8], Error>;
-fn value(&self, index: usize) -> Result<&[u8], Error>;
+fn key(&self, index: usize) -> Option<&[u8]>;
+fn value(&self, index: usize) -> Option<&[u8]>;
 fn child_cid(&self, index: usize) -> Result<Cid, Error>;
-fn child_count(&self, index: usize) -> Result<u64, Error>;
-fn search(&self, key: &[u8], scratch: &mut KeyScratch) -> Result<SearchResult, Error>;
+fn child_count(&self, index: usize) -> Option<u64>;
+fn search(&self, key: &[u8]) -> Result<usize, usize>;
 ```
 
-This is not a trait object and introduces no virtual call per key comparison.
-Phase one wraps the existing `Node`. Later packed and prefix-key representations
-can be selected by an enum branch outside tight per-entry loops or specialized
-by layout.
+This is not a trait object and introduces no virtual call or representation
+branch per key comparison. Parsing validates the compact header, canonical tree
+format, layout-specific offsets, sorted unique keys, internal-node shape, value
+ranges, and trailing bytes before publication. CID equality is checked by the
+loader before cache admission.
+
+The cache's `read` representation is authoritative for reads. `owned` is
+materialized lazily only for a write/legacy structural algorithm that cannot yet
+consume `ReadNode`. Cache insertion must not retain independent packed and
+decoded source allocations accidentally: conversion reuses the entry and byte
+accounting reflects every simultaneously live representation. New read code is
+not allowed to request `owned`.
+
+The binary-search hot path may use one isolated unchecked accessor after full
+validation. Its safety proof is: the entry index is bounded by `entries.len()`;
+all `(start, len)` pairs were range-checked against an immutable `Arc` backing;
+metadata and backing bytes cannot mutate; and the returned slice cannot outlive
+`&self`. A safe accessor remains available for validation and differential tests.
 
 Write paths may continue using owned `Node` during early phases. Read and write
 representations must share validation fixtures and canonical encoding tests.
@@ -1564,20 +1702,30 @@ bytes because the blob-store contract is owned.
 For a reusable session:
 
 1. If the tree is empty, return `None`.
-2. Check the session-local recent leaf using its first and last key. This uses no
-   atomics or global lock.
+2. If leaf locality remains enabled, check the session-local recent leaf using
+   its first and last key. This uses no atomics or global lock. After a small
+   bounded run of misses, disable the check for the session so random workloads
+   do not pay it forever.
 3. Start with the session's retained root handle.
 4. Search the current node for the greatest key less than or equal to the query.
 5. For an internal node, load its child handle after releasing all cache locks.
 6. For a leaf, verify exact key equality.
-7. Store the leaf in the session-local recent-leaf window.
+7. Store the leaf in the session-local recent-leaf window only while the
+   locality predictor remains useful.
 8. Invoke the callback with the leaf value slice while the leaf handle is alive.
 
-Random reads pay one predictable recent-leaf bounds check. Clustered and
-sequential reads can avoid the complete root-to-leaf traversal. The existing
-process-global atomics and `RwLock<Option<RecentLeafRead>>` are removed from the
-new session path. The convenience `Prolly::get_with` uses an ephemeral session;
-high-throughput users and benchmarks use a reusable session.
+Random reads pay only a bounded number of recent-leaf checks per session.
+Clustered and sequential reads can avoid the complete root-to-leaf traversal.
+The existing process-global atomics and `RwLock<Option<RecentLeafRead>>` are
+removed from the new session path. The convenience `Prolly::get_with` uses an
+ephemeral session; high-throughput users and benchmarks use a reusable session.
+
+The session also has a fixed-size set-associative route-node table keyed by CID.
+It retains internal nodes strongly for the session lifetime, avoids repeated
+global-cache locking and `Weak::upgrade` atomics, and deliberately excludes
+leaves so a random point workload cannot pin its entire leaf working set. Table
+size and associativity are performance constants validated across 1M, 5M, and
+10M working sets; they are not persisted or part of tree semantics.
 
 The root is never looked up in the cache after session construction. This is the
 direct counterpart of Dolt retaining `StaticMap.Root`.
@@ -1604,6 +1752,43 @@ Owned iterator/page wrappers copy bounds because they outlive the initiating
 call.
 
 ## Node Cache and Loading
+
+### Shared store buffers
+
+The storage contract has additive retained-buffer methods:
+
+```rust,ignore
+pub type SharedReadBatch = Vec<Option<Arc<[u8]>>>;
+
+pub trait Store {
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    fn get_shared(&self, key: &[u8])
+        -> Result<Option<Arc<[u8]>>, Self::Error>;
+
+    fn batch_get_shared_ordered_unique(&self, keys: &[&[u8]])
+        -> Result<SharedReadBatch, Self::Error>;
+
+    fn has_native_shared_reads(&self) -> bool;
+}
+```
+
+The default `get_shared` converts the owned vector into an `Arc` without a
+second byte copy. The default shared batch delegates to the backend's ordered
+batch operation before converting each result, so adding zero-copy support does
+not silently disable remote multi-get. A native retained-buffer store returns
+the same allocation it already owns and reports `has_native_shared_reads =
+true`; `MemStore` is the reference implementation.
+
+`AsyncStore` has the same contract. `Arc<S>`, references, sync-as-async adapters,
+and search-runtime store wrappers must delegate the shared methods instead of
+falling back to the owned default. This is a conformance requirement because one
+missing delegation can reintroduce a full object copy in every read.
+
+Shared bytes are immutable by contract. A store must never mutate or recycle an
+allocation after returning it. A backend whose buffer pool cannot guarantee
+that property must use the owned adapter. `has_native_shared_reads` is only a
+performance capability signal; correctness cannot depend on its value.
 
 ### Explicit cache modes
 
@@ -1668,14 +1853,16 @@ contention profiling makes it necessary for the point-read gate.
 
 On a miss:
 
-1. fetch owned bytes from the store;
+1. fetch retained immutable bytes through `get_shared` (or its owned adapter);
 2. compute `Cid::from_bytes(bytes)` and require equality with the requested CID;
-3. decode the node under explicit size and entry limits;
+3. parse compact metadata and any prefix-key arena under explicit size and entry
+   limits;
 4. validate sorted keys, key/value cardinality, child counts, level, leaf flag,
    and persisted format;
 5. require the node format to equal the session tree format;
-6. calculate encoded and retained decoded byte weights;
-7. publish an immutable `CachedNode`.
+6. calculate encoded bytes, metadata bytes, prefix-arena bytes, and any lazy
+   owned representation already present;
+7. publish an immutable `Arc<ReadNode>` in the cache entry.
 
 If existing store conformance intentionally delegates CID validation elsewhere,
 the final implementation spec may avoid duplicate SHA-256 only when that
@@ -1861,8 +2048,9 @@ snapshot before application code runs.
 
 ## Secondary-Index Foundation
 
-Secondary-index migration is not required in the first core delivery, but core
-interfaces must support it without redesign.
+Secondary-index borrowed codecs and query composition are part of the shared
+foundation. Build and maintenance consumers may migrate after the core read
+path, but they must do so without changing the lifetime/cache model.
 
 ### Borrowed stored-value view
 
@@ -1945,6 +2133,15 @@ Batch size and retained bytes obey `QueryBudget`. Exact posting lists preserve
 primary-key order; broader term ranges preserve physical `(term, primary_key)`
 order.
 
+The chunk must not store `SecondaryIndexMatchRef` or a slice into reusable
+unescape scratch. It stores either (a) a retained physical leaf handle plus
+entry index when later decoding can be repeated cheaply, or (b) one bounded
+owned primary key/projection needed to cross the callback boundary. This is an
+intentional required copy, bounded by chunk policy, and is still materially
+different from owning the complete posting list. After ordered source reads,
+the callback receives a view valid only while both the posting chunk item and
+source leaf handle are alive.
+
 ### Extraction and builds
 
 The current extractor already receives borrowed primary-key and source-value
@@ -1975,7 +2172,7 @@ record before extraction.
 
 ### Secondary-index adoption gates
 
-Later migration must demonstrate:
+Each migrated secondary-index consumer must demonstrate:
 
 - exact owned/borrowed result equivalence for arbitrary escaped terms and keys;
 - zero steady-state allocations per `KeysOnly` match without escaped bytes;
@@ -2082,6 +2279,46 @@ An optional future `visit_neighbors` can invoke a callback over final borrowed
 neighbors for native callers that do not need an owned result. It must still
 retain all required candidate handles until final sorting is complete.
 
+Candidate ownership is backend-specific but follows one protocol:
+
+| Backend | Candidate state retained before rerank | Forbidden intermediate ownership |
+|---|---|---|
+| native hierarchy | `Arc<ProximityNode>`, entry index, approximate/exact score | cloned entry key and vector per frontier visit |
+| eligible exact | bounded directory leaf/record location and score | owned full directory record for every eligible row |
+| HNSW | graph-node/route handle, logical key location, navigation score | cloned application value during navigation |
+| PQ | code-page handle, code index, approximate distance | decoded full vector per candidate |
+| SQ8 | quantized-page handle, entry index, approximate distance | owned dequantized vector per candidate |
+| composite | tagged handle to base or delta source plus shadow decision | flattening both sources into owned candidates |
+
+The candidate set is kept sorted or heap-bounded to the planner's oversampling
+limit. Insertion and truncation must be deterministic on `(score.total_cmp,
+key-bytes)` and must not leave a handle with an invalid entry index. Duplicate
+keys from composite/base/delta sources are resolved before authoritative rerank
+according to shadow semantics.
+
+Authoritative reranking opens one reusable directory `ReadSession`, retrieves
+each exact `StoredRecordRef` through `get_with`/ordered locations, verifies that
+the stored key/vector matches the candidate source contract, copies components
+into aligned scratch only when the selected distance kernel benefits, and
+computes the exact metric. Approximate scores may order the rerank input but
+never the returned result. The final stable sort uses exact score then raw key
+bytes; only those final `k` rows clone key and application value.
+
+For repeated distance evaluation, the representation choice is explicit:
+
+- one-pass exact scan: iterate encoded components or decode into one reusable
+  aligned query-sized scratch buffer;
+- repeated HNSW routing-vector use: cache validated aligned `Arc<[f32]>` when
+  profiling shows that decoding dominates;
+- PQ/SQ8: retain compact codes and tables; decode only final authoritative
+  directory vectors;
+- public exact records: expose the safe encoded view and let callers opt into
+  `copy_to_slice`/`to_vec`.
+
+This hybrid is intentional: eliminating allocations is mandatory on the hot
+path, while eliminating every byte copy is not. A bounded copy into reusable
+SIMD-aligned scratch is correct when it lowers end-to-end latency.
+
 ### Search runtime integration
 
 The existing qualified `SearchRuntime` cache remains authoritative for typed
@@ -2103,7 +2340,7 @@ content kind and measured reuse.
 
 ### Proximity adoption gates
 
-Later migration must prove:
+Each migrated proximity consumer must prove:
 
 - owned exact lookup equals `ProximityRecordRef::to_owned` for every valid
   vector;
@@ -2114,6 +2351,35 @@ Later migration must prove:
   completion, or proofs;
 - candidate handle memory is bounded and accounted;
 - only final results or explicitly retained build/search state are owned.
+
+## Proofs, Maintenance, Sync, and Content Walking
+
+Zero-copy applies to inspection while these APIs run, not to the artifact they
+return. A membership, multi-key, range, diff, or proximity search proof must be
+self-contained and verifiable after every cache/session handle is dropped.
+Therefore proof generation borrows node keys, values, child CIDs, and typed
+records while deciding what to include, then copies/encodes each required proof
+component exactly once into the owned proof. Verification parses proof-owned
+bytes through the same strict view decoders where possible.
+
+Stats, debug, verification, reachability, GC, sync planning, missing-node copy,
+export, and content-graph walkers use `ReadNode`/typed handles for traversal.
+They own only aggregates, CIDs that must enter sets/queues, diagnostic samples,
+transfer manifests, or persisted bundles. Child CID extraction is a fixed
+32-byte value operation and is not treated as a large-value copy. Walkers must
+retain logical visit/budget semantics independently of cache warmth.
+
+Import and write-side verification remain fail-closed:
+
+1. validate serialized object length and kind;
+2. verify CID before cache admission;
+3. parse all layout/codec metadata and canonical constraints;
+4. publish an immutable retained handle only after validation;
+5. materialize owned output only if the import/write algorithm requires it.
+
+No proof, cursor, sync bundle, GC plan, manifest, descriptor, checkpoint, or
+catalog may contain an in-process offset, pointer, `Arc`, cache namespace, or
+session identifier. Snapshot/root CIDs remain the only durable identity.
 
 ## Async Architecture
 
@@ -2245,7 +2511,8 @@ allocator so production allocation paths are not instrumented per operation.
 - async compile-fail tests prove borrowed entries cannot cross `.await`;
 - `ReadSession` is `Send` when its manager/store permit moving between threads,
   but mutation requires exclusive access;
-- no initial API requires unsafe code.
+- no public API requires callers to use unsafe code; implementation unsafe is
+  confined to audited packed/SIMD internals.
 
 ### Core equivalence properties
 
@@ -2325,9 +2592,10 @@ where practical, plus stress tests under ThreadSanitizer-compatible builds.
 - compare owned and borrowed decoder acceptance/rejection sets;
 - run address/thread sanitizers or platform equivalents for concurrent cache and
   async-load stress tests;
-- require no new unsafe block in phase one. Any later SIMD/packed unsafe code
-  receives isolated invariants, Miri-compatible fallbacks, and differential
-  tests.
+- require every unsafe packed/SIMD block to state isolated invariants, retain a
+  safe or Miri-compatible reference path, and pass differential tests. No unsafe
+  lifetime extension, aliasing, unchecked parsing, or callback escape is
+  permitted.
 
 ## Performance Evaluation
 
@@ -2394,8 +2662,8 @@ If the target is missed, profile in this order:
 3. key comparison and binary-search cost;
 4. callback/inlining and traversal state cost;
 5. decoded `Vec<Vec<u8>>` locality;
-6. packed/arena read-node representation;
-7. node-size/chunking effects.
+6. packed metadata size, key-arena locality, and child-CID extraction;
+7. node-size/chunking and persisted-layout effects.
 
 Only one variable changes per diagnostic benchmark. Persisted format changes
 require their own design and compatibility decision.
@@ -2408,6 +2676,36 @@ benchmarks measure exact lookup, authoritative scan/build, eligible-exact,
 native hierarchy, PQ/HNSW reranking, vector dimensions, and candidate memory.
 These are adoption gates, not phase-one blockers.
 
+The minimum secondary-index matrix is:
+
+- posting cardinalities 1, 10, 100, 10K, and broad-range/full-index;
+- `KeysOnly`, included projection, and full-source projection;
+- no-escape and worst-case escaped term/primary keys;
+- owned collection, borrowed visitor, page/cursor, reverse, and early-stop;
+- warm/cold cache, source join hit/missing-source failure, and bounded batch
+  sizes;
+- build, verify, repair, and replace throughput plus peak retained memory.
+
+The minimum proximity matrix is:
+
+- dimensions 32, 128, 384, 768, and 1536 where supported;
+- `k` 1, 10, and 100 with planner oversampling limits recorded;
+- exact/native hierarchy, eligible exact at several selectivities, HNSW, PQ,
+  SQ8, and composite delta/shadow workloads;
+- encoded-component, reusable aligned scratch, and cached decoded-vector kernels;
+- candidate generation separately from authoritative rerank and final result
+  materialization;
+- latency, vectors/second, recall/completion, exact ordering digest, allocations,
+  physical reads, cache hits, candidate count, pinned bytes, and peak RSS.
+
+Every optimization row must pass the same correctness digest or exact neighbor
+comparison required by that backend. Approximate backends report recall and
+completion explicitly; they are never compared as though they performed exact
+work. Performance ratios use medians of interleaved runs on the same machine.
+Raw rows, revisions, compiler versions, CPU, configuration, and failed
+validation rows are retained. A 1.5x–2x target is an engineering objective, not
+permission to omit a regression or manufacture a result.
+
 ## Delivery Sequence
 
 ### Phase 0: Benchmark and semantic lock
@@ -2419,8 +2717,12 @@ These are adoption gates, not phase-one blockers.
 
 ### Phase 1: Core point-read substrate
 
-- introduce `EntryRef`, `ValueRefView`, `NodeHandle`, decoded `ReadNode`, and
+- introduce `EntryRef`, `ValueRefView`, retained shared store reads, packed
+  `ReadNode`, and
   `ReadSession`;
+- parse plain/offset keys and values as slices of `Arc<[u8]>`, reconstruct
+  prefix-compressed keys into one retained arena, and make the packed loader the
+  sole normal read path;
 - validate/load and retain the root;
 - implement session-local recent leaf;
 - implement `get_with`, `get_value_ref_with`, allocation-free `contains_key`,
@@ -2461,8 +2763,8 @@ These are adoption gates, not phase-one blockers.
 - add `scan_exact`, `scan_prefix`, `scan_range`, bounded `scan_records`, and
   `IndexedMap::get_with`;
 - adapt owned pages and bindings;
-- introduce streaming extractor/build sink when the bounded-build milestone is
-  implemented.
+- migrate build, verify, repair, replace, bundle, retention, and GC consumers to
+  source scan/streaming extraction with bounded owned output state.
 
 ### Phase 6: Proximity adoption
 
@@ -2473,50 +2775,98 @@ These are adoption gates, not phase-one blockers.
 - integrate handle accounting with `SearchRuntime`;
 - preserve owned search/proof boundaries.
 
-### Phase 7: Packed read-node evaluation
+### Phase 7: Read-path hardening and representation tuning
 
-- profile the optimized decoded path;
-- prototype packed `OffsetTable`/`Plain` values and prefix-key arenas behind
-  `ReadNode`;
-- compare cold decode time, warm point/range performance, RSS, and write impact;
-- change defaults or persisted formats only through a separate approved design.
+- profile packed point/range, diff/merge, secondary-index, and proximity paths;
+- tune metadata layout, session routing, leaf-locality prediction, batch width,
+  cache sharding, and decoded-vector representation one variable at a time;
+- compare cold parse time, warm performance, allocations, RSS, retained bytes,
+  and write materialization impact;
+- consider a new persisted layout only if the current packed parser remains a
+  measured bottleneck, through a separate format-identity and migration design.
 
 ## Implementation Record (2026-07-16)
 
-The first implementation follows this design without changing persisted bytes
-or existing owned/binding signatures. The implementation anchor is
-`src/prolly/read.rs`; its module documentation references this design directly.
+The implementation follows this design without changing persisted bytes or
+existing owned/binding signatures. The primary anchors are
+`src/prolly/read.rs`, `src/prolly/node.rs`, and the shared-read methods in
+`src/prolly/store/mod.rs`.
 
-Delivered now:
+Implemented foundation:
 
 - callback-scoped `EntryRef`, `ValueRefView`, `DiffRef`, and `ConflictRef`;
-- reusable synchronous and async read sessions, retained roots, session-local
-  recent leaves, and a fixed-size weak route-node table;
+- reusable synchronous and async read sessions with retained packed roots,
+  adaptive recent-leaf state, and a bounded strong internal-route table;
 - borrowed point, multi-get, forward/reverse range, prefix, bound, rank, select,
   diff, conflict, and symbolic merge APIs, including early termination;
+- `Store`/`AsyncStore` retained immutable reads and ordered shared batches, with
+  native `MemStore` support and owned-backend adapters;
+- packed `ReadNode` parsing for prefix-compressed, plain, and offset-table
+  layouts, with values and applicable keys borrowed from retained wire bytes;
+- a validated per-node common-prefix/order-word search accelerator that avoids
+  repeated full-key comparisons while retaining a full byte-order fallback;
+- hybrid cache entries that make packed nodes authoritative for reads and lazily
+  materialize owned nodes only for remaining write-side consumers;
 - owned core APIs adapted at their result boundary, with binding signatures
   unchanged;
-- bounded mutation application in the synchronous borrowed merge fallback;
+- packed structural diff traversal and bounded mutation application in the
+  synchronous borrowed merge fallback;
 - versioned/typed-map and write-session forwarding;
 - secondary-index borrowed wire views, forward/reverse posting scans, bounded
   source joins, and streaming extractor contracts;
-- proximity record/vector wire views and borrowed exact/authoritative record
-  scans; and
+- proximity record/vector views, borrowed exact/authoritative record scans,
+  retained native candidates, and callback-scoped authoritative reranking for
+  native, eligible, HNSW, PQ, and composite paths; and
 - identical Rust/Dolt benchmark runners with process isolation, workload/result
   validation, source/binary provenance, and retained raw output.
 
-Intentional staged boundaries:
+### Post-implementation performance evidence
 
-- async diff scanning is borrowed, but async conflict iteration and merge retain
-  one owned conflict or an owned diff staging set so no public borrowed view can
-  cross an await;
-- secondary-index build extraction and proximity candidate/rerank handles have
-  their public/internal foundations, while the existing builders and search
-  result boundaries remain owned;
-- decoded `Node` remains the phase-one read representation. Large random point
-  workloads show that packed read nodes and cache-footprint reduction are the
-  next required optimization; result-copy elimination alone is not sufficient
-  to guarantee the 1.5x point-read target at million-key working sets.
+On 2026-07-16, the final release binary was measured with one worker and the
+same deterministic in-memory fresh/random workload, key/value generator,
+100,000 point targets, full scan, digest, and result-count checks as the frozen
+Dolt Go comparator. Each cell below is the median of three successful runs.
+The final Rust reruns followed the profiling-guided search optimization; the
+frozen Dolt medians were measured minutes earlier on the same machine.
+
+| Records | Operation | Rust | Dolt Go | Rust speedup |
+|---:|---|---:|---:|---:|
+| 1M | write | 601 ns/op | 2,314 ns/op | 3.85x |
+| 1M | point read | 478 ns/op | 1,368 ns/op | 2.86x |
+| 1M | range scan | 5.02 ns/row | 25.0 ns/row | 4.98x |
+| 5M | write | 763 ns/op | 4,927 ns/op | 6.46x |
+| 5M | point read | 876 ns/op | 1,613 ns/op | 1.84x |
+| 5M | range scan | 5.54 ns/row | 38.2 ns/row | 6.89x |
+| 10M | write | 767 ns/op | 9,411 ns/op | 12.27x |
+| 10M | point read | 975 ns/op | 1,573 ns/op | 1.61x |
+| 10M | range scan | 6.04 ns/row | 37.8 ns/row | 6.27x |
+
+All compared rows reported identical workload digests and validated result
+counts. These measurements establish the requested 1.5x point-read floor for
+these representative large random workloads; they do not imply the same ratio
+for an unmeasured machine, store, key distribution, or proximity backend.
+
+A separate absolute 5,000-record, 128-dimension release run measured exact
+SIMD search at 265 microseconds, PQ search at 1.07 milliseconds, and HNSW
+search at 11.26 milliseconds. Those values are not presented as speedups
+because no equivalent pre-change proximity baseline was retained.
+
+Verification after the final optimization passed 479 library tests, the full
+integration suite, 97 documentation tests, and strict all-feature Clippy.
+
+Remaining staged migration and hardening:
+
+- eliminate remaining owned staging in async conflict/merge paths where doing so
+  does not permit a borrow to cross an await;
+- migrate every secondary-index build/verify/repair/replace/bundle path to the
+  streaming foundation and measure each projection/source-join workload;
+- extend retained-candidate accounting to any future proximity accelerator and
+  add repeatable before/after baselines for native, eligible, HNSW, PQ, SQ8,
+  and composite search independently;
+- run Miri/fuzz and allocation-count gates in addition to the completed
+  malformed-input, cache, full-feature, and cross-language checks; and
+- report any scale/workload that misses the desired 1.5x ratio without
+  extrapolation or fabricated results.
 
 These boundaries do not weaken correctness or lifetime guarantees. They are
 explicit optimization milestones under the unchanged APIs above.
@@ -2534,10 +2884,10 @@ without changing their external contract.
 No cache state, node handle, read session, scratch buffer, or borrowed view is
 serialized. Reopen behavior depends only on existing roots and formats.
 
-If a future packed read representation can decode the current bytes, it is an
-in-process implementation change. If a new wire layout/default is required, it
-must define format identity, coexistence, migration, conformance fixtures, and
-rollback independently.
+The packed read representation decodes the current bytes and is an in-process
+implementation choice. If a new wire layout/default is required, it must define
+format identity, coexistence or deliberate hard cutover, migration, conformance
+fixtures, and rollback independently.
 
 ## Risks and Mitigations
 
@@ -2562,9 +2912,11 @@ guards are intentionally avoided.
 
 ### Packed representation complexity
 
-The `ReadNode` boundary is introduced without committing to packed bytes.
-Decoded `Node` remains the reference implementation. Packed work occurs only
-after correctness fixtures and measured need.
+Packed `ReadNode` is the canonical read representation, while decoded `Node`
+remains the semantic and write-side reference. The mitigation is strict parser
+validation, identical fixtures for every layout, owned/packed differential
+tests, isolated unsafe access, and lazy owned materialization for algorithms not
+yet migrated. Persisted bytes are not changed by this choice.
 
 ### Zero-copy vector slowdown
 
@@ -2591,35 +2943,48 @@ The program design is successfully implemented when:
 
 1. Safe Rust prevents every borrowed view from escaping its callback.
 2. Warm reusable-session point hits and steady-state scans meet allocation gates.
-3. Unbounded cache hits perform no eviction bookkeeping and require no exclusive
+3. Native shared stores preserve one immutable byte allocation from store
+   through packed node and callback, while owned stores incur only their defined
+   boundary adaptation.
+4. Packed parsing accepts and rejects exactly the same canonical node set as the
+   owned decoder for every supported layout; unsafe hot access passes its stated
+   proof, Miri, fuzz, and differential gates.
+5. Unbounded cache hits perform no eviction bookkeeping and require no exclusive
    cache lock.
-4. Repeated reads retain the exact root directly and use session-local leaf
-   locality without global atomics.
-5. Existing owned core APIs pass byte/order/error/cursor equivalence tests.
-6. Cache eviction, clear, concurrency, corruption, and reentrancy tests pass.
-7. Borrowed diff and conflict scans match owned/model results, including
+6. Repeated reads retain the exact root directly and use bounded session-local
+   route and adaptive leaf locality without global atomics.
+7. Existing owned core APIs pass byte/order/error/cursor equivalence tests.
+8. Cache eviction, clear, concurrency, corruption, and reentrancy tests pass.
+9. Borrowed diff and conflict scans match owned/model results, including
    misaligned trees.
-8. Merge avoids owned Diff/Conflict layers on its native path and preserves
+10. Merge avoids owned Diff/Conflict layers on its native path and preserves
    canonical results and structural reuse.
-9. Async traversal never holds borrowed data across `.await`.
-10. Language bindings and persisted fixtures remain compatible.
-11. Secondary-index and proximity view contracts are implementable without a
-    core lifetime/cache redesign and pass their focused foundation tests when
-    adopted.
-12. The full benchmark matrix and raw results are published without fabricated
+11. Async traversal never holds borrowed data across `.await`.
+12. Language bindings and persisted fixtures remain compatible.
+13. Secondary-index query/source-join paths use borrowed views and bounded
+    scratch; build and maintenance paths consume the same streaming foundation
+    without an eager full-source or full-posting materialization.
+14. Proximity exact, native, eligible, HNSW, PQ, SQ8, and composite paths use
+    retained candidates and authoritative borrowed reranking; candidate bytes
+    are bounded/accounted and only final neighbors own application data.
+15. Proof, sync, GC, verification, and content-walk APIs inspect retained views
+    but return self-contained owned artifacts.
+16. The full benchmark matrix and raw results are published without fabricated
     ratios, failed validations, or omitted regressions.
-13. Rust reaches the 1.5x target where measurements prove it; any misses are
+17. Rust reaches the 1.5x target where measurements prove it; any misses are
     reported honestly with profiles and the next ranked bottleneck.
 
 ## Final Recommendation
 
-Adopt callback-scoped borrowed reads and a reusable root-bound `ReadSession` as
-the canonical internal architecture. Preserve owned APIs as explicit boundary
-adapters, fix cache policy overhead independently of data ownership, and migrate
-diff/merge before expanding into secondary-index and proximity consumers.
+Adopt packed retained nodes, callback-scoped borrowed views, and a reusable
+root-bound `ReadSession` as the canonical internal architecture. Preserve owned
+APIs as explicit boundary adapters, fix cache policy overhead independently of
+data ownership, and require diff/merge, secondary-index, and proximity consumers
+to compose over the same retained-handle protocol.
 
 This sequence attacks the measured point-read and range-scan bottlenecks first,
 keeps correctness and compatibility intact, and establishes a stable handle,
 codec-view, and traversal foundation for every higher-level prolly API. Packed
-nodes, unsafe SIMD, or wire-format changes remain measured later optimizations,
-not prerequisites or assumptions.
+nodes are part of that foundation. Unsafe SIMD, decoded-vector caches, metadata
+tuning, and wire-format changes remain measured, separately validated
+optimizations rather than assumptions.

--- a/docs/superpowers/specs/2026-07-15-prolly-zero-copy-read-architecture-design.md
+++ b/docs/superpowers/specs/2026-07-15-prolly-zero-copy-read-architecture-design.md
@@ -2481,6 +2481,46 @@ These are adoption gates, not phase-one blockers.
 - compare cold decode time, warm point/range performance, RSS, and write impact;
 - change defaults or persisted formats only through a separate approved design.
 
+## Implementation Record (2026-07-16)
+
+The first implementation follows this design without changing persisted bytes
+or existing owned/binding signatures. The implementation anchor is
+`src/prolly/read.rs`; its module documentation references this design directly.
+
+Delivered now:
+
+- callback-scoped `EntryRef`, `ValueRefView`, `DiffRef`, and `ConflictRef`;
+- reusable synchronous and async read sessions, retained roots, session-local
+  recent leaves, and a fixed-size weak route-node table;
+- borrowed point, multi-get, forward/reverse range, prefix, bound, rank, select,
+  diff, conflict, and symbolic merge APIs, including early termination;
+- owned core APIs adapted at their result boundary, with binding signatures
+  unchanged;
+- bounded mutation application in the synchronous borrowed merge fallback;
+- versioned/typed-map and write-session forwarding;
+- secondary-index borrowed wire views, forward/reverse posting scans, bounded
+  source joins, and streaming extractor contracts;
+- proximity record/vector wire views and borrowed exact/authoritative record
+  scans; and
+- identical Rust/Dolt benchmark runners with process isolation, workload/result
+  validation, source/binary provenance, and retained raw output.
+
+Intentional staged boundaries:
+
+- async diff scanning is borrowed, but async conflict iteration and merge retain
+  one owned conflict or an owned diff staging set so no public borrowed view can
+  cross an await;
+- secondary-index build extraction and proximity candidate/rerank handles have
+  their public/internal foundations, while the existing builders and search
+  result boundaries remain owned;
+- decoded `Node` remains the phase-one read representation. Large random point
+  workloads show that packed read nodes and cache-footprint reduction are the
+  next required optimization; result-copy elimination alone is not sufficient
+  to guarantee the 1.5x point-read target at million-key working sets.
+
+These boundaries do not weaken correctness or lifetime guarantees. They are
+explicit optimization milestones under the unchanged APIs above.
+
 ## Compatibility and Migration
 
 Phases 1 through 6 are additive at the public Rust API and make no persisted

--- a/docs/superpowers/specs/2026-07-15-prolly-zero-copy-read-architecture-design.md
+++ b/docs/superpowers/specs/2026-07-15-prolly-zero-copy-read-architecture-design.md
@@ -1,0 +1,1639 @@
+# Prolly Zero-Copy Read Architecture
+
+**Status:** Proposed for review
+
+**Date:** 2026-07-15
+
+**Scope:** Program-level design for a safe zero-copy read substrate across the
+core prolly tree, diff and merge, versioned maps, secondary indexes, proximity
+maps, async execution, and language bindings. The core point-read and range-scan
+work is implementation-ready. Secondary-index and proximity-map sections define
+the extension contracts that immediate work must preserve; they do not require
+those consumers to migrate in the first delivery.
+
+## Summary
+
+The Rust implementation currently pays ownership and cache-management costs on
+read paths that Dolt's Go implementation avoids. A warm point read takes an
+exclusive node-cache lock, updates eviction metadata even when the cache is
+unbounded, hashes the root CID on every request, and clones the returned value.
+A range scan clones every key and value and clones the key a second time to
+maintain a resumable cursor. Diff and merge repeat the same pattern at a larger
+scale by materializing owned `Diff`, `Conflict`, lookup-result, and `Mutation`
+buffers.
+
+This design makes callback-scoped borrowed views the canonical Rust read
+mechanism. Existing owned APIs remain source-compatible wrappers and allocate
+only at their explicit ownership boundary. A reusable `ReadSession` retains the
+decoded root directly, keeps a session-local recent leaf, and traverses immutable
+`Arc`-backed node handles. Cache hits use a read-only path when eviction is
+disabled, and no cache lock remains held during traversal callbacks.
+
+The same foundation supplies:
+
+- zero-allocation warm point reads and steady-state range scans;
+- borrowed structural diff and conflict views;
+- merge decisions that select base, left, or right without cloning values;
+- borrowed secondary-index payload views and allocation-reusing composite-key
+  decoding;
+- borrowed proximity-record views, safe encoded-vector access, and bounded
+  candidate handles;
+- synchronous callbacks inside async traversal without references crossing an
+  `.await`;
+- owned language-binding and persistence boundaries with no API break.
+
+"Zero-copy" in this design has a precise scope. Phase one avoids copying values
+that are already present in a decoded cached node. A cold store read still owns
+the bytes returned by `Store::get`, and the current `Node::from_bytes` still
+decodes keys and values. A later read-node representation may retain packed
+encoded bytes, but it is not required for the first performance gate and does
+not change the wire format.
+
+Correctness is non-negotiable. Borrowed references cannot escape their callback,
+cached content is immutable and fully validated before admission, snapshots stay
+root-bound, visitor reentrancy never occurs under a cache lock, and every owned
+legacy result must be byte-for-byte equivalent to the borrowed traversal it
+wraps.
+
+## Relationship to Existing Designs
+
+This document extends the existing architecture rather than replacing it:
+
+- `docs/architecture.md` remains authoritative for immutable snapshots,
+  content addressing, storage, diff, and merge semantics.
+- `docs/superpowers/specs/2026-07-14-production-engine-foundation-design.md`
+  remains authoritative for deployment profiles, limits, errors, metrics, and
+  binding requirements.
+- `docs/superpowers/specs/2026-07-14-secondary-index-production-improvements-design.md`
+  remains authoritative for indexed-collection consistency, bounded queries,
+  and secondary-index persistence.
+- `docs/superpowers/specs/2026-07-15-proximity-enhancements-design.md` remains
+  authoritative for proximity planning, authoritative reranking, search
+  runtime policy, and accelerator lifecycle.
+- `docs/prolly-go-rust-benchmark.md` defines the initial cross-language workload
+  and correctness digest.
+
+Where those designs require an owned serialized page, cursor, proof, manifest,
+or binding value, this design does not weaken that requirement. It removes
+intermediate ownership inside the Rust process.
+
+## Current Evidence
+
+### Cross-language benchmark
+
+The existing one-worker, in-memory comparison uses identical deterministic
+string keys, values from 1 through 100 bytes, append/random/clustered workloads,
+a 30% mixed mutation phase, and post-write point reads and full range scans.
+
+For the repeated one-million-key fresh/random workload, the current median is:
+
+| Operation | Rust | Dolt Go | Current leader |
+|---|---:|---:|---:|
+| Point read | 1,563 ns/op | 1,436 ns/op | Dolt 1.09x |
+| Range scan | 173 ns/row | 112 ns/row | Dolt 1.55x |
+
+To beat the observed Dolt median by 1.5x, Rust must reach no more than
+957 ns/point read and 74.6 ns/scanned row on that workload. A 2x result requires
+no more than 718 ns/point read and 55.9 ns/scanned row. These are targets, not
+predicted or fabricated results.
+
+### Point-read path
+
+The current synchronous path in `src/prolly/mod.rs`:
+
+1. probes process-global recent-leaf state using atomics and a lock;
+2. starts from a root CID rather than a retained root node;
+3. takes the node cache's exclusive `RwLock::write` guard for every hit;
+4. performs `contains_key` followed by `get_mut`, hashing the CID twice;
+5. advances generation-LRU state and appends an access-log record even when the
+   default cache has no node or byte limit;
+6. clones an `Arc<Node>` for every level;
+7. clones the leaf value into a new `Vec<u8>`.
+
+A five-second optimized sample of the existing point-read benchmark attributed
+roughly 30% of sampled point-read time to node-cache lookup/bookkeeping and
+roughly 14% to leaf-value allocation/copy. That benchmark used a more local
+access pattern than the cross-language random workload, so the sample is
+bottleneck evidence, not a replacement comparison result.
+
+### Range path
+
+`RangeIter` owns its start and end bounds, holds an `Arc<Node>` traversal stack,
+and yields `Result<(Vec<u8>, Vec<u8>), Error>`. Each row currently:
+
+1. clones the leaf key;
+2. clones the leaf value;
+3. clones the returned key again into `last_key` for cursor resumption.
+
+Node-cache work is amortized across a leaf, so per-row ownership dominates more
+strongly than it does for point reads.
+
+### Diff and merge
+
+Structural diff prunes identical subtrees correctly, but changed leaf entries
+become owned `Diff` values and are often queued in `VecDeque<Diff>`. Misaligned
+subtree fallback collects both subtrees into owned entry vectors and then clones
+again into `Diff` results.
+
+Merge already has valuable fast paths: identical roots and unchanged branches
+reuse complete trees, aligned structural merge can reuse child CIDs, and one
+leaf path uses `Cow<[u8]>`. Its fallback path still commonly materializes:
+
+```text
+owned right Diff list
+  -> owned batched left values
+  -> owned Conflict
+  -> owned Mutation list
+  -> rewritten Node values
+```
+
+### Secondary indexes
+
+Secondary-index exact, prefix, and range convenience methods collect complete
+owned result sets. Physical `(term, primary_key)` keys are decoded into two new
+vectors, and index projection envelopes copy their payload. `records()` first
+owns all index matches and then owns every source lookup value.
+
+### Proximity maps
+
+An exact proximity lookup owns the directory value, decodes the vector into a
+new `Vec<f32>`, and owns the application value. Search paths frequently copy
+keys, candidate vectors, and authoritative directory records. Search results
+must be owned, but most intermediate candidates do not need to be.
+
+## Goals
+
+1. Make a warm cached `get_with` hit allocate zero bytes for the returned value.
+2. Make steady-state `scan_range` allocate zero bytes per emitted row.
+3. Retain a tree root directly for repeated reads, matching Dolt's root-node
+   ownership model without changing persisted `Tree` handles.
+4. Remove exclusive cache locking, duplicate hashing, and eviction bookkeeping
+   from unbounded-cache hits.
+5. Make borrowed traversal the internal source of truth for owned core APIs.
+6. Provide borrowed diff and conflict events without materializing a result per
+   change.
+7. Remove avoidable merge copies while preserving structural CID reuse and
+   exact three-way semantics.
+8. Establish codec/view contracts that secondary indexes and proximity maps can
+   adopt without another foundational API redesign.
+9. Preserve synchronous, async, versioned, transaction, proof, and language
+   binding correctness.
+10. Measure allocation counts, latency, throughput, cache behavior, and peak
+    memory honestly across the existing benchmark matrix.
+
+## Non-Goals
+
+The first implementation does not:
+
+- promise zero-copy across an FFI, WASM, serialization, or process boundary;
+- return a free-standing `&[u8]` whose lifetime is detached from a callback or
+  read handle;
+- change the persisted node, secondary-index, proximity, proof, cursor, or
+  manifest format;
+- make `Store::get` borrowed; stores continue to return owned bytes;
+- make a standard Rust `Iterator` yield references tied to each mutable
+  `next()` call;
+- allow an async visitor to retain borrowed content across `.await`;
+- guarantee the 1.5x-to-2x performance target before measurements demonstrate
+  it;
+- implement secondary-index or proximity-map migration in the first core
+  delivery;
+- use unsafe lifetime extension, self-referential structures, or transmute;
+- weaken full validation, snapshot isolation, resource budgets, or deterministic
+  result ordering for speed.
+
+## Terminology and Copy Boundaries
+
+### Borrowed read
+
+A borrowed read exposes a slice into an immutable decoded or packed content
+handle while that handle is strongly retained. The slice is valid only for the
+lexical callback invocation.
+
+### Zero allocation per item
+
+Traversal setup may allocate a path stack, bounds, or reusable scratch space.
+"Zero allocation per item" means no heap allocation proportional to each
+visited entry once traversal is established. Scratch buffers may grow to a
+bounded high-water mark and then be reused.
+
+### Decoded zero-copy
+
+The initial `Arc<Node>` cache already owns decoded `Vec<Vec<u8>>` keys and
+values. Borrowing those vectors avoids an additional result copy. This is the
+phase-one meaning of zero-copy.
+
+### Packed zero-copy
+
+A later `ReadNode` may retain `Arc<[u8]>` encoded bytes and offsets so values,
+and keys under suitable layouts, can be borrowed without constructing a
+`Vec<Vec<u8>>`. Prefix-compressed keys may still require reconstruction into a
+contiguous arena or reusable scratch buffer.
+
+### Required ownership
+
+Ownership remains required when data must outlive its content handle, cross a
+language/process boundary, be serialized, be persisted, remain in a result heap
+after its backing node is released, or represent a newly synthesized value.
+
+## Correctness Invariants
+
+The following are release-blocking:
+
+1. A `ReadSession` is bound to exactly one immutable tree root and persisted
+   `TreeFormat` for its complete lifetime.
+2. No safe public API permits a borrowed key, value, vector, projection, diff,
+   or conflict slice to outlive the callback in which it is supplied.
+3. A node or typed content object is fully length-, format-, structure-, and
+   CID-validated before it is admitted to a shared cache.
+4. A cache entry is immutable after publication. Eviction removes cache
+   reachability but never invalidates an active `Arc` handle.
+5. No node-cache or typed-content-cache lock is held while invoking application
+   code, a resolver, an extractor, a distance callback, or another store API.
+6. Owned legacy APIs return the same bytes, ordering, cardinality, cursor
+   semantics, error semantics, and snapshot identity as before.
+7. Forward scans remain ascending and reverse scans remain descending under raw
+   byte ordering. Start bounds are inclusive and end bounds are exclusive.
+8. A resumable cursor is materialized only from the last successfully delivered
+   entry and resumes strictly after or before it according to direction.
+9. A stopped or failed visitor does not mutate persisted tree state. Partial
+   delivery before a later read error is explicit in the streaming contract.
+10. Diff continues to prune equal CIDs and emits exactly one ordered event per
+    logical change.
+11. Merge results remain byte-for-byte and CID-equivalent to a clean application
+    of the same logical decisions under the configured canonical format.
+12. Secondary-index queries remain bound to the selected source version, index
+    version, definition fingerprint, direction, and logical bounds.
+13. Proximity search continues to rerank returned candidates using authoritative
+    vectors and preserves deterministic key tie-breaking.
+14. Logical work and budget accounting do not change with cache warmth.
+15. Unsafe code is not required for the initial architecture.
+
+## Alternatives Considered
+
+### Runtime `ReadMode::Borrowed | Owned`
+
+This cannot make an API returning `Vec<u8>` zero-copy. Rust return types do not
+change at runtime, and a mode branch would add overhead without removing the
+required final allocation. It is rejected.
+
+### Change `get` to return a guard
+
+Returning `Option<ValueGuard>` could borrow safely by retaining the leaf node,
+but it breaks every Rust caller and language binding, makes values retain whole
+nodes for arbitrary durations, complicates cache-byte accounting, and makes
+ergonomics worse for simple reads. It is not the compatibility path.
+
+### Lending iterators as the only scan API
+
+An inherent `next(&mut self) -> Result<Option<EntryRef<'_>>, Error>` can be safe,
+but it is not a standard `Iterator`, interacts awkwardly with combinators, and
+would still require a separate callback form for diff, merge, and bindings.
+The architecture leaves room for a future `BorrowedRangeCursor`, but callback
+scans are the primary interface.
+
+### Copy everything but optimize the allocator
+
+Arena or slab allocation could lower allocator overhead, but it would continue
+copying every byte, retain unnecessary memory, and leave the cache/root gap
+untouched. It may complement owned wrappers but is not the core solution.
+
+### Immediately replace the node wire format
+
+Packed offsets are attractive, but a format cutover would combine lifetime,
+cache, API, persistence, migration, and performance risks. The selected design
+first removes result ownership and cache overhead without a wire change, then
+uses measurements to justify a read representation or format change.
+
+## Architecture Overview
+
+```text
+Tree + Prolly manager
+        |
+        v
+  ReadSession ------------------- direct root NodeHandle
+        |                         session-local recent leaf
+        |                         request-local metrics
+        v
+  Borrowed traversal core
+   |       |       |       |
+   |       |       |       +------ scan_diff / scan_conflicts
+   |       |       +-------------- scan_range / reverse / prefix
+   |       +---------------------- get_many_with / select_with
+   +------------------------------ get_with / contains
+        |
+        v
+  EntryRef / DiffRef / ConflictRef
+        |
+        +---- native callback: no result copy
+        |
+        +---- legacy Rust API: clone once at owned boundary
+        |
+        +---- binding/page/proof: serialize owned result
+
+NodeHandle obtains immutable content through:
+
+  Disabled cache | Unbounded read-mostly cache | Bounded cache
+        |                    |                         |
+        +--------------------+-------------------------+
+                             |
+                       validated node load
+                             |
+                  Decoded Node now, ReadNode later
+```
+
+## API Coverage and Adoption Policy
+
+Borrowed traversal is the default internal implementation, not a runtime mode
+that changes public return types. The complete API surface adopts it as follows:
+
+| API family | Borrowed/internal behavior | Existing external boundary |
+|---|---|---|
+| `get`, `contains_key` | `get_with`; presence does not copy value | `get` returns owned `Vec<u8>` |
+| `get_many` | route to leaf locations and lend each value | ordered owned result vector |
+| `range`, `prefix`, reverse scans | callback traversal over `EntryRef` | owned iterator/page/cursor |
+| `len`, `rank` | direct-root scalar traversal | unchanged scalar |
+| `select`, first/last, lower/upper bound | internal entry callback | clone one returned entry |
+| large-value envelope inspection | parse borrowed stored bytes | resolved blob remains owned |
+| typed/value-codec reads | decode inside callback | typed owned result |
+| versioned/historical snapshots | snapshot-retained read session | unchanged owned conveniences |
+| transactions/write sessions | borrowed overlay/base merge | unchanged owned results |
+| cursor navigation | manager-backed node handles | legacy store-only cursor remains compatible |
+| diff/range-diff | `DiffRef` visitor | owned diff, iterator, page, proof |
+| conflicts/merge | `ConflictRef` and symbolic decisions | legacy owned resolver/error |
+| patch/CRDT comparison | borrowed point/diff inputs | persisted patch/result remains owned |
+| stats/debug/verification | borrowed traversal and scalar aggregation | owned report structures/text |
+| proof generation/verification | borrowed node/entry inspection | proofs remain self-contained and owned |
+| sync/GC/content walking | borrow decoded nodes while collecting CIDs | transfer manifests and CID sets own data |
+| secondary-index query/build | borrowed match/projection/source views | pages, cursors, bundles remain owned |
+| proximity exact/search/build | record/vector views and candidate handles | `Neighbor`, result, proof remain owned |
+| async equivalents | sync callback after each await | owned streams/pages unchanged |
+| language bindings/WASM | serialize directly from borrowed internals | foreign values remain owned |
+
+Write APIs necessarily create persisted bytes. `put`, `delete`, `batch`, append,
+builders, range delete, and merge should accept crate-private borrowed mutation
+views where internal producers already have slices, avoiding intermediate
+copies. Public owned `Mutation` remains unchanged. A future public
+`batch_borrowed` is justified only by write benchmarks; it is not required for
+the read architecture.
+
+The existing public `Cursor::at_item(&Store, ...)` has no manager and therefore
+cannot use the decoded manager cache or direct-root session. It remains a
+low-level compatibility API, while `Prolly::cursor`, `range_cursor`, and all new
+performance APIs route through manager-backed traversal. Documentation must not
+present the store-only cursor as the preferred high-throughput path.
+
+## Core Types
+
+Names in this section are the intended public direction. Exact module placement
+may follow repository conventions, but lifetime and ownership semantics are
+normative.
+
+### Entry view
+
+```rust,ignore
+#[derive(Clone, Copy, Debug)]
+pub struct EntryRef<'a> {
+    key: &'a [u8],
+    value: &'a [u8],
+}
+
+impl<'a> EntryRef<'a> {
+    pub fn key(&self) -> &'a [u8];
+    pub fn value(&self) -> &'a [u8];
+    pub fn to_owned(self) -> (Vec<u8>, Vec<u8>);
+}
+```
+
+Fields remain private so later read-node representations can preserve invariants
+without changing construction sites. `EntryRef` is copyable, but the compiler
+still prevents it from escaping its callback lifetime.
+
+### Read session
+
+```rust,ignore
+pub struct ReadSession<'manager, 'tree, S: Store> {
+    manager: &'manager Prolly<S>,
+    tree: &'tree Tree,
+    root: Option<NodeHandle>,
+    recent_leaf: Option<LeafWindow>,
+    local_metrics: LocalReadMetrics,
+}
+
+impl<S: Store> Prolly<S> {
+    pub fn read<'manager, 'tree>(
+        &'manager self,
+        tree: &'tree Tree,
+    ) -> Result<ReadSession<'manager, 'tree, S>, Error>;
+}
+```
+
+`read()` validates that the tree format matches the manager and loads the root
+once. Empty trees produce a session with no root and no store read. A session is
+intended for one worker and its hot tree. It is movable but not concurrently
+mutated; callers create one session per worker. The manager cache remains shared.
+
+The session owns no persisted state and does not alter tree identity. Dropping it
+releases its root and recent-leaf handles and flushes any local metric aggregate.
+
+### Node handle and representation boundary
+
+```rust,ignore
+#[derive(Clone)]
+pub(crate) struct NodeHandle(Arc<CachedNode>);
+
+pub(crate) struct CachedNode {
+    cid: Cid,
+    encoded_bytes: usize,
+    retained_bytes: usize,
+    repr: ReadNode,
+}
+
+pub(crate) enum ReadNode {
+    Decoded(Node),
+    // Later, without changing traversal callers:
+    // Packed(PackedNode),
+}
+```
+
+Traversal code accesses `ReadNode` through concrete inlineable methods:
+
+```rust,ignore
+fn len(&self) -> usize;
+fn level(&self) -> u8;
+fn is_leaf(&self) -> bool;
+fn key(&self, index: usize, scratch: &mut KeyScratch) -> Result<&[u8], Error>;
+fn value(&self, index: usize) -> Result<&[u8], Error>;
+fn child_cid(&self, index: usize) -> Result<Cid, Error>;
+fn child_count(&self, index: usize) -> Result<u64, Error>;
+fn search(&self, key: &[u8], scratch: &mut KeyScratch) -> Result<SearchResult, Error>;
+```
+
+This is not a trait object and introduces no virtual call per key comparison.
+Phase one wraps the existing `Node`. Later packed and prefix-key representations
+can be selected by an enum branch outside tight per-entry loops or specialized
+by layout.
+
+Write paths may continue using owned `Node` during early phases. Read and write
+representations must share validation fixtures and canonical encoding tests.
+
+## Public Core Read API
+
+### Point read
+
+```rust,ignore
+impl<S: Store> ReadSession<'_, '_, S> {
+    pub fn get_with<R>(
+        &mut self,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error>;
+
+    pub fn contains_key(&mut self, key: &[u8]) -> Result<bool, Error>;
+}
+
+impl<S: Store> Prolly<S> {
+    pub fn get_with<R>(
+        &self,
+        tree: &Tree,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error>;
+}
+```
+
+The callback runs exactly once for an exact hit and never for a miss. `R` cannot
+borrow from the callback value because its type is independent of that value's
+lifetime. It may be a checksum, decoded application object, comparison result,
+or owned copy. A caller that needs fallible decoding returns `Result<R, E>` and
+transposes the nested result.
+
+The existing API becomes:
+
+```rust,ignore
+pub fn get(&self, tree: &Tree, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+    self.get_with(tree, key, <[u8]>::to_vec)
+}
+```
+
+`contains_key` stops after exact-key validation and never clones the value.
+
+### Range scan
+
+The simple full-delivery API is:
+
+```rust,ignore
+impl<S: Store> ReadSession<'_, '_, S> {
+    pub fn scan_range(
+        &mut self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+
+    pub fn scan_prefix(
+        &mut self,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+}
+```
+
+An early-stop form uses `std::ops::ControlFlow` and returns both the number of
+delivered entries and the break value:
+
+```rust,ignore
+pub struct ScanOutcome<B> {
+    pub visited: u64,
+    pub break_value: Option<B>,
+}
+
+pub fn scan_range_until<B>(
+    &mut self,
+    start: &[u8],
+    end: Option<&[u8]>,
+    visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+) -> Result<ScanOutcome<B>, Error>;
+```
+
+A visitor with its own error uses `Break(error)` and handles the break value
+after the tree operation returns. This keeps engine read errors and application
+errors separate without boxing or constraining the application's error type.
+
+Reverse counterparts use a separate specialized loop rather than a per-row
+direction branch:
+
+```rust,ignore
+pub fn scan_range_reverse(...);
+pub fn scan_prefix_reverse(...);
+```
+
+### Cursor semantics
+
+The zero-copy scanner tracks the last delivered location as `(NodeHandle,
+index)`, not an owned `last_key`. It clones a key only when the caller requests a
+cursor, a page boundary is reached, or an owned iterator wrapper must expose its
+existing resumability API. This removes the current second key copy from every
+row.
+
+The existing `RangeIter` remains a standard owned iterator. It delegates its
+navigation to the same traversal core and calls `EntryRef::to_owned()` once per
+item. It does not become the foundation for borrowed scans because the
+`Iterator` trait cannot express its per-`next` borrow.
+
+### Multi-get
+
+Multi-get requires special lifetime handling because results may reside in
+different leaves. The read substrate records lightweight locations rather than
+owned values:
+
+```rust,ignore
+struct ValueLocation {
+    node: NodeHandle,
+    index: usize,
+}
+```
+
+`get_many_with` preserves caller order, including duplicates, and invokes the
+visitor once per input position:
+
+```rust,ignore
+pub fn get_many_with<K>(
+    &mut self,
+    keys: &[K],
+    visit: impl for<'value> FnMut(usize, &[u8], Option<&'value [u8]>),
+) -> Result<(), Error>
+where
+    K: AsRef<[u8]>;
+```
+
+Routing still batches shared ancestors and leaves. Duplicate inputs share the
+same leaf handle. The temporary location vector is O(number of requested keys),
+but values are not copied. A future unordered/event form may reduce location
+storage for callers that do not require input ordering; it is not needed for
+compatibility.
+
+The existing `get_many` visits locations in input order and clones only present
+values into its result vector.
+
+### Rank, select, and bounds
+
+`len` and `rank` already return scalars and benefit automatically from direct
+root retention and cache improvements. Add internal `select_with`,
+`lower_bound_with`, `upper_bound_with`, `first_entry_with`, and
+`last_entry_with` primitives. Public additions should be limited to demonstrated
+native demand; existing owned methods delegate to these primitives and clone one
+final entry.
+
+Large-value reference parsing uses `get_with` so inline/envelope inspection does
+not first clone stored bytes. Resolving an external blob still returns owned
+bytes because the blob-store contract is owned.
+
+## Point-Read Algorithm
+
+For a reusable session:
+
+1. If the tree is empty, return `None`.
+2. Check the session-local recent leaf using its first and last key. This uses no
+   atomics or global lock.
+3. Start with the session's retained root handle.
+4. Search the current node for the greatest key less than or equal to the query.
+5. For an internal node, load its child handle after releasing all cache locks.
+6. For a leaf, verify exact key equality.
+7. Store the leaf in the session-local recent-leaf window.
+8. Invoke the callback with the leaf value slice while the leaf handle is alive.
+
+Random reads pay one predictable recent-leaf bounds check. Clustered and
+sequential reads can avoid the complete root-to-leaf traversal. The existing
+process-global atomics and `RwLock<Option<RecentLeafRead>>` are removed from the
+new session path. The convenience `Prolly::get_with` uses an ephemeral session;
+high-throughput users and benchmarks use a reusable session.
+
+The root is never looked up in the cache after session construction. This is the
+direct counterpart of Dolt retaining `StaticMap.Root`.
+
+## Range-Scan Algorithm
+
+The scanner owns a traversal stack of `(NodeHandle, next_index)` and bound
+metadata. It allocates the stack once to tree height. On each leaf:
+
+1. binary-search the first relevant key only when entering the initial leaf;
+2. walk entries linearly;
+3. compare the key with the exclusive end bound;
+4. construct `EntryRef` directly from the live leaf handle;
+5. invoke the visitor;
+6. increment the index without copying key or value;
+7. load the next leaf only when the current leaf is exhausted.
+
+Stores that prefer batch reads may prefetch child frontiers, but prefetching may
+not alter logical order, errors, budgets, or callback delivery. Prefetched node
+handles can be evicted from the cache while retained by the scan.
+
+Bounds supplied by the caller remain borrowed for the duration of the call.
+Owned iterator/page wrappers copy bounds because they outlive the initiating
+call.
+
+## Node Cache and Loading
+
+### Explicit cache modes
+
+The cache implementation selects one mode at manager construction:
+
+```rust,ignore
+enum NodeCacheMode {
+    Disabled,
+    Unbounded(UnboundedNodeCache),
+    Bounded(BoundedNodeCache),
+}
+```
+
+The mode is runtime-only and does not affect tree identity.
+
+### Unbounded fast path
+
+The default runtime configuration currently has no node or byte limit. In this
+mode:
+
+- hits take a shared read lock;
+- lookup performs one hash-table probe;
+- no generation is advanced;
+- no access-log entry is appended;
+- no compaction or eviction check runs;
+- the ready `NodeHandle` is cloned and the lock is released before traversal.
+
+Insertion takes the write lock only on a miss. A second lookup after decoding
+handles a concurrent winner and avoids replacing an equivalent ready handle.
+
+Because CIDs are SHA-256 content hashes, a cache-specific hasher may fold the
+already-random 32 bytes instead of applying SipHash again. The implementation
+must use enough CID bits and include collision tests; equality still compares
+the complete CID. This optimization is accepted only after a microbenchmark and
+adversarial collision review.
+
+### Bounded cache
+
+Bounded mode retains eviction recency, pinning, byte accounting, and current
+configuration semantics. Its first correction is a single hash lookup per hit.
+Contention improvements may shard ready entries and use approximate segmented
+LRU/CLOCK metadata, but eviction policy is a performance property, never a
+correctness property.
+
+No bounded-cache hit may hold a global exclusive lock while hashing unrelated
+CIDs. A staged implementation may initially retain the existing lock for
+bounded mode while the unbounded mode receives the fast path, then measure
+whether sharding is justified.
+
+### Load coalescing
+
+Concurrent misses for one CID should share one decode operation. A cache slot is
+either `Loading` or `Ready`. The owner reads and validates bytes; waiters observe
+the same success or error. Errors are never cached. No store I/O occurs while a
+cache shard lock is held.
+
+Sync waiters use a condition-backed slot. Async waiters use a shared future or
+notification primitive. Load coalescing is a later core milestone unless
+contention profiling makes it necessary for the point-read gate.
+
+### Validation before admission
+
+On a miss:
+
+1. fetch owned bytes from the store;
+2. compute `Cid::from_bytes(bytes)` and require equality with the requested CID;
+3. decode the node under explicit size and entry limits;
+4. validate sorted keys, key/value cardinality, child counts, level, leaf flag,
+   and persisted format;
+5. require the node format to equal the session tree format;
+6. calculate encoded and retained decoded byte weights;
+7. publish an immutable `CachedNode`.
+
+If existing store conformance intentionally delegates CID validation elsewhere,
+the final implementation spec may avoid duplicate SHA-256 only when that
+validation is statically guaranteed. Untrusted or custom stores must fail
+closed.
+
+### Metrics
+
+Global atomics on every node hit can become visible after other overhead is
+removed. A `ReadSession` accumulates plain local counters and flushes them in one
+operation at method/session boundaries. Metrics retain their documented totals.
+Diagnostic per-node tracing is optional and disabled on the benchmark path.
+
+Allocation metrics distinguish:
+
+- traversal setup allocations;
+- per-entry result allocations;
+- cold decode allocations;
+- owned compatibility-boundary allocations;
+- cache retained and externally pinned bytes.
+
+## Diff Architecture
+
+### Borrowed diff view
+
+```rust,ignore
+#[derive(Clone, Copy, Debug)]
+pub enum DiffRef<'a> {
+    Added { key: &'a [u8], value: &'a [u8] },
+    Removed { key: &'a [u8], value: &'a [u8] },
+    Changed {
+        key: &'a [u8],
+        old: &'a [u8],
+        new: &'a [u8],
+    },
+}
+```
+
+Public visitor primitives mirror range scans:
+
+```rust,ignore
+pub fn scan_diff(
+    &self,
+    base: &Tree,
+    other: &Tree,
+    visit: impl for<'diff> FnMut(DiffRef<'diff>),
+) -> Result<u64, Error>;
+
+pub fn scan_range_diff(...);
+pub fn scan_diff_until<B>(...);
+```
+
+The walker retains the base and other node handles while invoking a changed
+event. It does not queue borrowed events. Added and removed subtree walks invoke
+the visitor directly from each leaf.
+
+### Misaligned subtree fallback
+
+The current fallback collects complete subtrees into `Vec<(Vec<u8>, Vec<u8>)>`.
+Replace it with two bounded borrowed leaf cursors:
+
+1. create a cursor for each subtree/span;
+2. compare current borrowed keys;
+3. emit removed/added/changed inline;
+4. advance only the relevant cursor;
+5. release exhausted leaf handles.
+
+Scratch and stack memory are O(tree height plus prefetched frontier), not
+O(subtree entries). Ordering matches the existing merge of sorted entry vectors.
+
+### Owned compatibility
+
+`diff()` and `range_diff()` collect `DiffRef::to_owned()` results. The existing
+`stream_diff()` remains an owned standard iterator. Diff pages, structural
+checkpoints, proofs, and serialized sync artifacts own all data. They may use
+borrowed traversal internally and clone once at emission/checkpoint boundaries.
+
+Append-only detection continues to use structural CIDs and borrowed right-edge
+walks. It must not first construct an owned append diff merely to decide whether
+the path applies.
+
+## Merge Architecture
+
+### Borrowed conflict view
+
+```rust,ignore
+#[derive(Clone, Copy, Debug)]
+pub struct ConflictRef<'a> {
+    pub key: &'a [u8],
+    pub base: Option<&'a [u8]>,
+    pub left: Option<&'a [u8]>,
+    pub right: Option<&'a [u8]>,
+}
+```
+
+`scan_conflicts` consumes borrowed right-side diffs and borrowed left lookups.
+It constructs an owned `Conflict` only for the legacy iterator or when an
+unresolved conflict is returned in `Error::Conflict`.
+
+### Zero-copy resolver decisions
+
+```rust,ignore
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MergeDecision {
+    UseBase,
+    UseLeft,
+    UseRight,
+    Value(Vec<u8>),
+    Delete,
+    Unresolved,
+}
+
+pub trait BorrowedMergeResolver: Send + Sync {
+    fn resolve(&self, conflict: ConflictRef<'_>) -> MergeDecision;
+}
+```
+
+`UseBase`, `UseLeft`, and `UseRight` select an existing slice without copying.
+`Value` is used only when application code synthesizes new bytes. Built-in
+prefer-left, prefer-right, delete-wins, and equivalent-value resolvers use
+symbolic decisions.
+
+The existing `Resolver = Box<dyn Fn(&Conflict) -> Resolution>` remains valid.
+Its adapter builds an owned `Conflict` only for an actual conflict, calls the
+legacy resolver, and consumes its owned resolution.
+
+### Streaming merge application
+
+Merge should not require an owned right-diff vector. The structural walker
+drives merge directly:
+
+1. reuse complete roots or subtrees whenever one side matches base or both
+   sides match;
+2. compare aligned leaves using borrowed values;
+3. for changed keys, read left through the same retained read session;
+4. apply non-conflicting selections directly to a rolling canonical builder;
+5. invoke a borrowed resolver only for genuine conflicts;
+6. materialize an owned value only for a rewritten output node or synthesized
+   resolution.
+
+A new or rewritten persisted node must ultimately own or encode its bytes. The
+target is no temporary Diff/Conflict/Mutation copy and at most one required
+copy/encoding into output. Complete unchanged nodes retain their existing CID.
+
+Sparse fallback may initially retain a bounded owned mutation batch if the
+current canonical batch editor requires random access. That batch must be
+bounded and filled from borrowed events without first owning `Diff` and
+`Conflict` layers. A later `push_borrowed(key, value)` rolling builder can encode
+directly from slices.
+
+### Merge correctness
+
+Property tests compare the borrowed merge engine with a simple three-way model
+and the legacy engine over inserts, updates, deletes, additions on both sides,
+all resolver decisions, misaligned chunk boundaries, and every node layout.
+For identical logical decisions, resulting roots must match a clean canonical
+rebuild where the existing API promises CID equivalence.
+
+## Versioned Maps, Snapshots, Transactions, and Write Sessions
+
+`MapSnapshot` and historical snapshots already bind an immutable `Tree`. They
+gain `read()` and borrowed convenience methods that delegate to a core
+`ReadSession`. A snapshot may cache its root handle for repeated reads because
+its tree never changes.
+
+`VersionedMap::get`, `get_at`, `range`, `prefix`, and page APIs retain existing
+owned signatures. Native additions expose `get_with`, `scan_range`, and
+`scan_prefix`. Typed maps decode inside `get_with`, avoiding an intermediate
+`Vec<u8>` before producing the owned typed value.
+
+Transaction and write-session overlays require a two-source read view:
+
+- an overlay upsert can lend its in-memory value directly;
+- an overlay delete returns no value;
+- an absent overlay key delegates to the base `ReadSession`;
+- ordered overlay/base range merge invokes a visitor while the selected source
+  entry is alive;
+- owned write-session APIs remain wrappers.
+
+No callback is invoked while a transaction/overlay mutex is held. The overlay
+entry must be copied into a short-lived stable handle or the lock released via a
+snapshot before application code runs.
+
+## Secondary-Index Foundation
+
+Secondary-index migration is not required in the first core delivery, but core
+interfaces must support it without redesign.
+
+### Borrowed stored-value view
+
+Add strict non-owning parsing:
+
+```rust,ignore
+pub enum IndexValueRef<'a> {
+    KeysOnly,
+    Included(&'a [u8]),
+    FullSource(&'a [u8]),
+}
+
+impl IndexValueRef<'_> {
+    pub fn decode(bytes: &[u8], limit: usize) -> Result<IndexValueRef<'_>, Error>;
+    pub fn to_owned(self) -> IndexValue;
+}
+```
+
+It validates magic, format version, tag, canonical length, limit, and trailing
+bytes exactly as `IndexValue::from_bytes`, but it borrows the payload.
+
+### Composite physical keys
+
+Physical index keys escape zero bytes, so arbitrary logical term and primary-key
+components cannot always be direct subslices of the encoded key. The decoder
+therefore provides a zero-allocation steady-state view using two reusable
+scratch buffers:
+
+```rust,ignore
+pub struct DecodedPhysicalIndexKeyRef<'a> {
+    pub term: &'a [u8],
+    pub primary_key: &'a [u8],
+}
+```
+
+For a component with no escape sequence, the view borrows the encoded key
+directly. When unescaping is required, it writes into a bounded session scratch
+buffer and lends that slice for the callback. Scratch capacity is limited by the
+existing term/key limits and reused across rows. The implementation must never
+describe escaped-key decoding as byte-zero-copy; it is allocation-free after
+scratch warmup.
+
+### Borrowed index match
+
+```rust,ignore
+pub struct SecondaryIndexMatchRef<'a> {
+    pub term: &'a [u8],
+    pub primary_key: &'a [u8],
+    pub projection: Option<&'a [u8]>,
+}
+```
+
+`SecondaryIndexSnapshot` gains `scan_exact`, `scan_prefix`, and `scan_range`
+visitor methods. They:
+
+1. build physical bounds once;
+2. use core `scan_range`;
+3. decode key components with reusable scratch;
+4. validate `IndexValueRef` against the descriptor projection mode;
+5. invoke the callback;
+6. discard or reuse scratch before the next entry.
+
+Existing eager methods and pages clone once into `SecondaryIndexMatch`. Cursors
+remain owned, snapshot-bound serialized values.
+
+### Source-record join
+
+`records()` currently owns all matches and all source values. A future
+`scan_records` uses bounded chunks:
+
+1. scan physical index matches into a bounded list of primary-key locations or
+   owned keys only where escaped decoding requires it;
+2. issue an ordered batched read against the exact source snapshot;
+3. invoke a callback with primary key, optional projection, and borrowed source
+   value;
+4. fail on a missing source record as `IndexCheckpointMismatch`;
+5. release the batch before continuing.
+
+Batch size and retained bytes obey `QueryBudget`. Exact posting lists preserve
+primary-key order; broader term ranges preserve physical `(term, primary_key)`
+order.
+
+### Extraction and builds
+
+The current extractor already receives borrowed primary-key and source-value
+slices but returns an owned `Vec<SecondaryIndexEntry>`. Introduce a streaming
+extractor/sink contract for future builds:
+
+```rust,ignore
+pub struct SecondaryIndexEntryRef<'a> {
+    pub term: &'a [u8],
+    pub projection: Option<&'a [u8]>,
+}
+
+pub trait StreamingSecondaryIndexExtractor: Send + Sync {
+    fn extract(
+        &self,
+        primary_key: &[u8],
+        source_value: &[u8],
+        emit: &mut dyn FnMut(SecondaryIndexEntryRef<'_>) -> Result<(), SecondaryIndexError>,
+    ) -> Result<(), SecondaryIndexError>;
+}
+```
+
+The legacy extractor adapts by iterating its owned result. A streaming extractor
+can derive terms into reusable application scratch and the index builder copies
+each final physical key/projection exactly once into its sort/run or output
+buffer. Source builds use `scan_range` and no longer clone the complete source
+record before extraction.
+
+### Secondary-index adoption gates
+
+Later migration must demonstrate:
+
+- exact owned/borrowed result equivalence for arbitrary escaped terms and keys;
+- zero steady-state allocations per `KeysOnly` match without escaped bytes;
+- bounded scratch and chunk memory for `Include`, `All`, and source joins;
+- unchanged cursor, snapshot, projection, and checkpoint validation;
+- no unbounded eager query path in production profiles.
+
+## Proximity-Map Foundation
+
+Proximity values combine encoded vectors and application bytes, so their safe
+zero-copy representation differs from ordinary key/value entries.
+
+### Stored record view
+
+```rust,ignore
+pub struct StoredRecordRef<'a> {
+    pub vector: EncodedVectorRef<'a>,
+    pub value: &'a [u8],
+}
+
+pub struct EncodedVectorRef<'a> {
+    bytes: &'a [u8],
+    dimensions: u32,
+}
+```
+
+`StoredRecordRef::decode` validates magic, version, encoding, dimensions,
+canonical varints, vector byte length, finite components, negative zero, value
+length, and trailing bytes without allocating the application value.
+
+The persisted vector starts after a variable-length header and is not guaranteed
+to be aligned for `f32`. It is little-endian encoded. The implementation must not
+cast it to `&[f32]` or rely on allocator alignment. `EncodedVectorRef` provides
+safe component access and iterators using byte loads. Optimized kernels may use
+unaligned SIMD loads when implemented safely for the target or decode into a
+reusable aligned scratch buffer.
+
+Whether direct encoded-byte kernels or reusable decoding is faster is decided by
+benchmarks. Re-decoding every component for repeated distance calculations may
+be slower than one bounded decode into cached aligned storage; "zero-copy" is
+not allowed to override measured end-to-end performance.
+
+### Exact lookup and scan
+
+`ProximityMap::read()` creates a lightweight proximity read session containing
+a core directory `ReadSession`, immutable proximity descriptor information, and
+reusable vector scratch. Future native APIs are:
+
+```rust,ignore
+pub struct ProximityReadSession<'a, S: Store> {
+    directory: ReadSession<'a, 'a, S>,
+    dimensions: u32,
+    vector_scratch: Vec<f32>,
+}
+
+pub fn get_with<R>(
+    &mut self,
+    key: &[u8],
+    read: impl FnOnce(StoredRecordRef<'_>) -> R,
+) -> Result<Option<R>, Error>;
+
+pub fn scan_records(
+    &mut self,
+    visit: impl for<'record> FnMut(&[u8], StoredRecordRef<'record>),
+) -> Result<u64, Error>;
+```
+
+`contains_key` performs the same strict record validation as today's `get`
+without allocating vector or value. Existing `get` converts one record to the
+owned `(Vec<f32>, Vec<u8>)` result.
+
+Build, verification, SQ8, PQ, and HNSW construction can consume
+`scan_records`. Components that need vectors beyond a callback copy them into a
+bounded build buffer or retain a typed decoded content handle.
+
+### Candidate handles
+
+Search results must own their `Neighbor` keys and values, but candidate heaps can
+avoid early copies. A bounded candidate identifies immutable backing content:
+
+```rust,ignore
+struct CandidateHandle {
+    source: CandidateSourceHandle,
+    index: usize,
+    distance: f64,
+}
+```
+
+`CandidateSourceHandle` retains an `Arc` to a decoded proximity node, graph
+record, PQ page, or directory leaf. Key and vector comparisons borrow through
+that handle. Only final accepted `k` neighbors clone key/value into
+`SearchResult`. Retained candidate bytes count against the request frontier and
+runtime pinned-byte budgets.
+
+For authoritative reranking, ordered directory multi-get returns record
+locations or invokes bounded callbacks rather than owning every full record.
+Result order and tie-breaking remain based on authoritative full-precision
+distance and key bytes.
+
+An optional future `visit_neighbors` can invoke a callback over final borrowed
+neighbors for native callers that do not need an owned result. It must still
+retain all required candidate handles until final sorting is complete.
+
+### Search runtime integration
+
+The existing qualified `SearchRuntime` cache remains authoritative for typed
+proximity and accelerator content. Core node cache and search runtime need not be
+one physical cache, but they share a handle protocol:
+
+- immutable `Arc` content;
+- qualified identity including store namespace, content kind, CID, and decoder
+  version;
+- validation before admission;
+- no lock during callbacks or distance work;
+- encoded plus retained decoded byte weights;
+- externally retained/pinned byte metrics;
+- error-not-cached and optional load coalescing semantics.
+
+Packed typed objects retain `Arc<[u8]>` plus validated offsets. Decoded aligned
+vectors retain `Arc<[f32]>`. Cache policy may choose either representation by
+content kind and measured reuse.
+
+### Proximity adoption gates
+
+Later migration must prove:
+
+- owned exact lookup equals `StoredRecordRef::to_owned` for every valid vector;
+- malformed formats fail identically without partial result delivery;
+- scalar and SIMD distance outputs remain bit/ordering compatible under current
+  tolerances and canonical tie rules;
+- warm/cold cache state cannot change plans, logical budgets, neighbors,
+  completion, or proofs;
+- candidate handle memory is bounded and accounted;
+- only final results or explicitly retained build/search state are owned.
+
+## Async Architecture
+
+`AsyncReadSession` mirrors the synchronous root-bound session. It may await node
+loads, but borrowed data is supplied only to a synchronous callback after the
+await completes:
+
+```rust,ignore
+pub async fn scan_range(
+    &mut self,
+    start: &[u8],
+    end: Option<&[u8]>,
+    visit: impl for<'entry> FnMut(EntryRef<'entry>),
+) -> Result<u64, Error>;
+```
+
+The callback cannot return a future borrowing the entry. An application that
+must await per item must copy the required bytes or use a bounded owned-page
+API. This restriction prevents references from crossing suspension points and
+keeps futures safely movable.
+
+Async prefetch and batched loads retain deterministic callback order. A task may
+load concurrently, but it commits results in key order. Cancellation is checked
+between loads and callbacks. Already delivered entries remain delivered; no
+borrow survives cancellation.
+
+Async diff, conflict inspection, secondary-index scans, and proximity record
+scans use the same synchronous callback rule. Async merge resolvers remain
+synchronous while holding borrowed conflict views. A truly async application
+resolver requires an owned conflict request/response workflow.
+
+## Language Bindings and WASM
+
+Existing UniFFI, Node, Python, Java, Kotlin, Swift, Ruby, Go, and WASM APIs remain
+owned. Foreign runtimes cannot safely retain Rust node-backed slices under the
+current contracts.
+
+Bindings still benefit internally:
+
+- point reads avoid an intermediate Rust `Vec` before filling the binding
+  buffer where the binding implementation permits direct serialization;
+- range and diff pages clone/serialize once into their foreign result rather
+  than cloning through an intermediate owned iterator;
+- typed decoders can parse borrowed Rust bytes before creating the final foreign
+  object;
+- cache and root improvements apply unchanged.
+
+Foreign callback streaming may be added for bounded-memory use, but it is not
+advertised as cross-language zero-copy. The foreign call normally copies into
+the target runtime, must remain synchronous, and must not reenter Rust while an
+internal lock is held.
+
+Generated binding signatures and conformance fixtures are unchanged during the
+core phase.
+
+## Error, Panic, and Reentrancy Semantics
+
+1. Tree/store/format errors return `Error` and stop traversal.
+2. Streaming APIs may have delivered earlier entries before a later store error.
+   Callers requiring all-or-nothing results use owned collection/page APIs.
+3. `scan_*_until` distinguishes an application break value from an engine error.
+4. A callback panic unwinds through immutable handles only. Cache maps and
+   traversal stacks remain structurally valid, and no persistent write occurs.
+5. A callback may call other public read APIs. This is safe because no cache,
+   overlay, transaction, or metrics lock is held during callback execution.
+6. Reentering the same `&mut ReadSession` is prevented by Rust borrowing. A
+   callback may use another session or manager convenience method.
+7. Resolver panic behavior remains Rust unwind behavior; transactional writes
+   have not been published at callback time.
+
+## Resource Ownership and Limits
+
+The architecture must bound:
+
+- traversal stack by validated tree height;
+- node entry counts and decoded bytes by format/profile limits;
+- cache encoded and retained decoded bytes;
+- active handle/pinned bytes separately from evictable cache bytes;
+- multi-get locations by input count and request limit;
+- diff frontier and fallback scratch by tree height/frontier policy;
+- merge rolling output and mutation fallback batches;
+- secondary-index key scratch, posting batch, source fetches, and result bytes;
+- proximity candidate handles, vector scratch, decoded-vector cache, and
+  authoritative rerank batch;
+- async in-flight loads and prefetch width.
+
+An object larger than its cache partition can be validated and used without
+admission. Cache eviction may temporarily leave memory retained by active
+handles; metrics expose this rather than violating lifetime safety.
+
+The default unbounded cache is preserved for compatibility in the immediate
+core phase, but production deployment profiles should provide explicit byte
+limits. "Unbounded" changes hit bookkeeping, not resource policy documentation.
+
+## Observability
+
+Add or derive the following metrics without changing logical results:
+
+- read sessions opened and empty sessions;
+- direct-root uses;
+- session recent-leaf hits/misses;
+- cache hits by mode;
+- cache read-lock and write-lock acquisitions;
+- cache lookup probes and eviction-log operations;
+- coalesced loads and waiters;
+- encoded, decoded, evictable, and externally retained bytes;
+- callback entries delivered and early stops;
+- owned-boundary key/value bytes copied;
+- cold decode allocations and bytes;
+- diff events visited versus owned;
+- conflict views versus owned conflicts;
+- merge reused CIDs, selected borrowed values, synthesized values, and output
+  bytes copied;
+- secondary-index scratch high-water and source-join batches;
+- proximity vector view decodes, aligned-scratch decodes, cached decoded vectors,
+  candidate pinned bytes, and final result copies.
+
+Benchmark-only allocation counters must be feature-gated or use a harness
+allocator so production allocation paths are not instrumented per operation.
+
+## Testing Strategy
+
+### API and lifetime compile tests
+
+- `get_with` and scan callbacks can consume slices and return owned/scalar data.
+- compile-fail tests prove a callback cannot store or return `EntryRef`,
+  `DiffRef`, `ConflictRef`, `IndexValueRef`, or `StoredRecordRef` beyond its
+  invocation;
+- async compile-fail tests prove borrowed entries cannot cross `.await`;
+- `ReadSession` is `Send` when its manager/store permit moving between threads,
+  but mutation requires exclusive access;
+- no initial API requires unsafe code.
+
+### Core equivalence properties
+
+For generated trees and all `NodeLayoutSpec` variants:
+
+- `get == get_with(...to_vec)` for hits and misses;
+- `get_many` equals ordered `get_with` for unique and duplicate inputs;
+- `range.collect()` equals `scan_range` collection;
+- forward/reverse scans are exact inverses under matching bounds;
+- prefix scans equal filtered full scans;
+- select/rank/bounds match a `BTreeMap` model;
+- cursors resume without duplicates or omissions;
+- empty, single-leaf, multi-level, and malformed trees behave correctly.
+
+Keys and values include empty values, embedded zero, `0xff`, long shared
+prefixes, maximum permitted lengths, and non-UTF-8 bytes.
+
+### Cache tests
+
+Run the same operations with disabled, unbounded, node-bounded, byte-bounded,
+and mixed bounded caches. Verify:
+
+- identical results and logical metrics;
+- eviction during an active callback cannot invalidate a slice;
+- `clear_cache` does not invalidate active sessions;
+- concurrent hit/miss/clear/load sequences do not deadlock;
+- one admitted node per CID under coalescing;
+- failed/corrupt loads are not cached;
+- CID and tree-format mismatches fail closed;
+- no application callback observes a held cache lock.
+
+Use loom or deterministic synchronization tests for cache slot state transitions
+where practical, plus stress tests under ThreadSanitizer-compatible builds.
+
+### Diff and merge properties
+
+- borrowed diff collected to owned equals existing diff and a `BTreeMap` model;
+- aligned and deliberately misaligned chunk boundaries emit identical diffs;
+- equal-root diff visits no entries;
+- stopped scans report the correct last delivered key;
+- borrowed conflict scan collected to owned equals legacy conflict streaming;
+- every merge decision matches the simple three-way model;
+- legacy and borrowed resolvers agree;
+- canonical roots match expected clean rebuilds;
+- resolver reentrancy and panic do not publish partial writes.
+
+### Secondary-index foundation tests
+
+- `IndexValueRef::to_owned == IndexValue::from_bytes`;
+- borrowed physical-key decoding equals owned decoding for every byte value;
+- scratch buffers stay bounded and are reused;
+- borrowed matches collected to owned equal exact/prefix/range/page results;
+- missing source records still fail snapshot validation;
+- projection tags, limits, cursors, and snapshot IDs remain strict.
+
+### Proximity foundation tests
+
+- `StoredRecordRef::to_owned == StoredRecord::decode`;
+- vector views reject every malformed header/component/trailing-byte case;
+- unaligned vector offsets never use an invalid `&[f32]` cast;
+- encoded and scratch distance paths agree with decoded scalar/SIMD results;
+- candidate handles preserve deterministic top-k and key ties;
+- owned search results and proofs remain unchanged;
+- cache eviction and cancellation cannot invalidate active vector/value views.
+
+### Miri, fuzzing, and sanitizers
+
+- run Miri over focused callback lifetime, cache eviction, and codec-view tests;
+- fuzz node, index-value, physical-index-key, and proximity-record view decoders;
+- compare owned and borrowed decoder acceptance/rejection sets;
+- run address/thread sanitizers or platform equivalents for concurrent cache and
+  async-load stress tests;
+- require no new unsafe block in phase one. Any later SIMD/packed unsafe code
+  receives isolated invariants, Miri-compatible fallbacks, and differential
+  tests.
+
+## Performance Evaluation
+
+### Measurement rules
+
+Performance claims use optimized release binaries, identical generated input,
+one worker for the primary comparison, correctness digests, and real elapsed
+time. Rust and Dolt run as separate processes. The runner records compiler,
+revision, OS, CPU, cache mode, allocation count, and RSS where available.
+
+Each reported result uses warmup and repeated measured runs. Medians are primary;
+dispersion and raw rows remain available. Implementation order is alternated or
+randomized to reduce thermal/order bias. A failed validation row is never used in
+a performance ratio.
+
+### Core matrix
+
+Retain the approved matrix:
+
+- sizes: 10K, 50K, 1M, 5M, 10M;
+- workloads: append, random, clustered;
+- phases: fresh build and 30% mixed mutation;
+- values: deterministic random length from 1 through 100 bytes;
+- post-write operations: point reads and full range scans;
+- primary storage: in-memory;
+- primary concurrency: one worker.
+
+Report separately:
+
+1. Dolt Go zero-copy callback/slice APIs;
+2. Rust `ReadSession::get_with` and `scan_range`;
+3. Rust convenience `Prolly::get_with` with ephemeral session;
+4. Rust legacy owned `get` and `range`;
+5. cold-cache and bounded-cache variants.
+
+Equivalent benchmark callbacks compute the same digest from borrowed bytes.
+Neither implementation may omit value consumption.
+
+### Allocation gates
+
+After warmup on an already decoded tree:
+
+- reusable-session `get_with`: zero allocations per hit;
+- `contains_key`: zero allocations per hit/miss;
+- `scan_range`: zero allocations per row after traversal setup;
+- cursor materialization: at most one key allocation per requested cursor;
+- borrowed aligned-leaf diff: zero allocations per emitted change after setup;
+- legacy `get`: exactly the ownership required for its returned value, with no
+  intermediate result copy;
+- legacy range: one owned key and one owned value per row, with no second cursor
+  key copy unless a cursor is requested.
+
+### Latency gates
+
+The desired cross-language gate is Rust at least 1.5x faster than Dolt for
+equivalent zero-copy point reads and range scans across representative 1M and
+larger workloads, with 2x aspirational. The implementation is not declared
+successful merely because it improves relative to the old Rust result.
+
+If the target is missed, profile in this order:
+
+1. remaining cache/hash/lock and global metric overhead;
+2. root/session and recent-leaf effectiveness;
+3. key comparison and binary-search cost;
+4. callback/inlining and traversal state cost;
+5. decoded `Vec<Vec<u8>>` locality;
+6. packed/arena read-node representation;
+7. node-size/chunking effects.
+
+Only one variable changes per diagnostic benchmark. Persisted format changes
+require their own design and compatibility decision.
+
+### Later consumer benchmarks
+
+Secondary-index benchmarks measure exact posting scans, broad term ranges,
+projection modes, escaped keys, source joins, and build extraction. Proximity
+benchmarks measure exact lookup, authoritative scan/build, eligible-exact,
+native hierarchy, PQ/HNSW reranking, vector dimensions, and candidate memory.
+These are adoption gates, not phase-one blockers.
+
+## Delivery Sequence
+
+### Phase 0: Benchmark and semantic lock
+
+- retain current Rust/Dolt baselines and raw results;
+- add allocation-count support and reusable-session benchmark columns;
+- freeze owned API equivalence fixtures and cursor semantics;
+- add compile-fail lifetime tests.
+
+### Phase 1: Core point-read substrate
+
+- introduce `EntryRef`, `NodeHandle`, decoded `ReadNode`, and `ReadSession`;
+- validate/load and retain the root;
+- implement session-local recent leaf;
+- implement `get_with` and allocation-free `contains_key`;
+- make owned `get` a wrapper;
+- implement unbounded-cache read-only hit path and single-probe bounded hit;
+- benchmark after each independently measurable change.
+
+### Phase 2: Core range substrate
+
+- implement shared forward borrowed traversal;
+- add `scan_range`, prefix, early-stop, and reverse variants;
+- track cursor location without per-row key clone;
+- adapt owned range, prefix, bounds, pages, and versioned snapshots;
+- verify zero per-row allocations and rerun the complete comparison matrix.
+
+### Phase 3: Multi-get, async, overlays, and bindings
+
+- implement location-based `get_many_with`;
+- adapt typed/versioned reads and write-session overlays;
+- add `AsyncReadSession` and synchronous borrowed callbacks;
+- route bindings through borrowed internals without changing generated APIs;
+- add load coalescing if concurrency profiling justifies it.
+
+### Phase 4: Diff and merge
+
+- add `DiffRef`, borrowed structural walker, and borrowed fallback cursors;
+- adapt owned diff/stream/page/proof boundaries;
+- add `ConflictRef`, `scan_conflicts`, and symbolic `MergeDecision`;
+- stream merge application and preserve canonical CID reuse;
+- benchmark diff density, append-only, sparse changes, misalignment, and conflict
+  workloads.
+
+### Phase 5: Secondary-index adoption
+
+- add borrowed index-value and physical-key views;
+- add borrowed query scans and bounded source joins;
+- adapt owned pages and bindings;
+- introduce streaming extractor/build sink when the bounded-build milestone is
+  implemented.
+
+### Phase 6: Proximity adoption
+
+- add stored-record and encoded-vector views;
+- migrate exact reads, verification, and authoritative scans;
+- introduce bounded candidate handles and borrowed rerank reads;
+- integrate handle accounting with `SearchRuntime`;
+- preserve owned search/proof boundaries.
+
+### Phase 7: Packed read-node evaluation
+
+- profile the optimized decoded path;
+- prototype packed `OffsetTable`/`Plain` values and prefix-key arenas behind
+  `ReadNode`;
+- compare cold decode time, warm point/range performance, RSS, and write impact;
+- change defaults or persisted formats only through a separate approved design.
+
+## Compatibility and Migration
+
+Phases 1 through 6 are additive at the public Rust API and make no persisted
+format change. Existing `get`, `get_many`, `range`, `prefix`, cursor/page, diff,
+merge, secondary-index, proximity, async, and binding signatures remain valid.
+
+New borrowed APIs are native Rust optimizations. Existing applications opt in by
+calling them or by reusing a `ReadSession`. Internal consumers may migrate
+without changing their external contract.
+
+No cache state, node handle, read session, scratch buffer, or borrowed view is
+serialized. Reopen behavior depends only on existing roots and formats.
+
+If a future packed read representation can decode the current bytes, it is an
+in-process implementation change. If a new wire layout/default is required, it
+must define format identity, coexistence, migration, conformance fixtures, and
+rollback independently.
+
+## Risks and Mitigations
+
+### API surface growth
+
+Adding borrowed variants for every convenience method would be noisy. The
+public surface centers on `ReadSession`, `get_with`, range/prefix scans,
+multi-get, diff, and conflict scans. Scalar/bounds helpers may remain internal
+until demand is demonstrated.
+
+### Callback ergonomics
+
+Callbacks are less composable than iterators. Owned iterators remain available,
+and a future lending cursor can be layered over the same traversal state. Clear
+examples cover checksum, decode-in-place, early stop, and collection.
+
+### Cache memory retained by handles
+
+Evicted entries can remain alive while sessions/scans/candidates retain `Arc`s.
+Budgets and metrics account for externally retained bytes. Long-lived public
+guards are intentionally avoided.
+
+### Packed representation complexity
+
+The `ReadNode` boundary is introduced without committing to packed bytes.
+Decoded `Node` remains the reference implementation. Packed work occurs only
+after correctness fixtures and measured need.
+
+### Zero-copy vector slowdown
+
+Byte-wise f32 decoding can cost more than copying once into aligned storage.
+Proximity uses measured representation choice and reusable/cached decoded
+vectors. Safety and end-to-end latency take precedence over a zero-copy label.
+
+### Partial streaming delivery
+
+A later store error can follow successful callback invocations. This is
+documented and tested. Owned/page APIs remain the choice for callers requiring
+an atomic result object.
+
+### Optimization changes error timing
+
+Prefetch, lazy decoding, and borrowed traversal may discover corruption at a
+different moment. Validation-before-admission and equivalence tests require the
+same acceptance/rejection set. Streaming APIs document partial delivery, while
+owned APIs preserve fail-without-returning-a-result behavior.
+
+## Acceptance Criteria
+
+The program design is successfully implemented when:
+
+1. Safe Rust prevents every borrowed view from escaping its callback.
+2. Warm reusable-session point hits and steady-state scans meet allocation gates.
+3. Unbounded cache hits perform no eviction bookkeeping and require no exclusive
+   cache lock.
+4. Repeated reads retain the exact root directly and use session-local leaf
+   locality without global atomics.
+5. Existing owned core APIs pass byte/order/error/cursor equivalence tests.
+6. Cache eviction, clear, concurrency, corruption, and reentrancy tests pass.
+7. Borrowed diff and conflict scans match owned/model results, including
+   misaligned trees.
+8. Merge avoids owned Diff/Conflict layers on its native path and preserves
+   canonical results and structural reuse.
+9. Async traversal never holds borrowed data across `.await`.
+10. Language bindings and persisted fixtures remain compatible.
+11. Secondary-index and proximity view contracts are implementable without a
+    core lifetime/cache redesign and pass their focused foundation tests when
+    adopted.
+12. The full benchmark matrix and raw results are published without fabricated
+    ratios, failed validations, or omitted regressions.
+13. Rust reaches the 1.5x target where measurements prove it; any misses are
+    reported honestly with profiles and the next ranked bottleneck.
+
+## Final Recommendation
+
+Adopt callback-scoped borrowed reads and a reusable root-bound `ReadSession` as
+the canonical internal architecture. Preserve owned APIs as explicit boundary
+adapters, fix cache policy overhead independently of data ownership, and migrate
+diff/merge before expanding into secondary-index and proximity consumers.
+
+This sequence attacks the measured point-read and range-scan bottlenecks first,
+keeps correctness and compatibility intact, and establishes a stable handle,
+codec-view, and traversal foundation for every higher-level prolly API. Packed
+nodes, unsafe SIMD, or wire-format changes remain measured later optimizations,
+not prerequisites or assumptions.

--- a/docs/superpowers/specs/2026-07-15-prolly-zero-copy-read-architecture-design.md
+++ b/docs/superpowers/specs/2026-07-15-prolly-zero-copy-read-architecture-design.md
@@ -383,11 +383,934 @@ low-level compatibility API, while `Prolly::cursor`, `range_cursor`, and all new
 performance APIs route through manager-backed traversal. Documentation must not
 present the store-only cursor as the preferred high-throughput path.
 
+## Normative API Change Set
+
+This section is the implementation contract for the API surface. Later sections
+define behavior and algorithms; if an illustrative signature later in the
+document is abbreviated, the signatures here take precedence. Core public
+read-view types live in `prolly::read` and are re-exported from the crate root
+beside the existing `Prolly`, `Tree`, `Diff`, and `Conflict` types. Deferred
+secondary-index and proximity views live in their domain modules and follow the
+crate's existing root re-export policy.
+
+The status labels used below are:
+
+- **add now**: public API delivered in core phases 1–4;
+- **update internally**: an existing public signature remains unchanged, but its
+  implementation must use the borrowed primitive and allocate only at its owned
+  boundary;
+- **crate-private**: foundation required now without a public stability promise;
+- **deferred public**: named and reserved for the secondary-index or proximity
+  phase, not required for the first core release;
+- **unchanged**: no signature, ownership, serialization, or binding change.
+
+### Public types added in core phases 1–4
+
+```rust,ignore
+pub struct EntryRef<'a> { /* private fields */ }
+
+impl<'a> EntryRef<'a> {
+    pub fn key(&self) -> &'a [u8];
+    pub fn value(&self) -> &'a [u8];
+    pub fn to_owned(self) -> KeyValue;
+}
+
+pub struct ScanOutcome<B> {
+    pub visited: u64,
+    pub break_value: Option<B>,
+}
+
+pub enum ValueRefView<'a> {
+    Inline(&'a [u8]),
+    Blob { cid: Cid, len: u64 },
+}
+
+impl ValueRefView<'_> {
+    pub fn to_owned(self) -> blob::ValueRef;
+}
+
+pub struct ReadSession<'manager, 'tree, S: Store> { /* private fields */ }
+
+#[derive(Clone, Copy, Debug)]
+pub enum DiffRef<'a> {
+    Added { key: &'a [u8], value: &'a [u8] },
+    Removed { key: &'a [u8], value: &'a [u8] },
+    Changed {
+        key: &'a [u8],
+        old: &'a [u8],
+        new: &'a [u8],
+    },
+}
+
+impl DiffRef<'_> {
+    pub fn key(&self) -> &[u8];
+    pub fn to_owned(self) -> Diff;
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ConflictRef<'a> {
+    pub key: &'a [u8],
+    pub base: Option<&'a [u8]>,
+    pub left: Option<&'a [u8]>,
+    pub right: Option<&'a [u8]>,
+}
+
+impl ConflictRef<'_> {
+    pub fn to_owned(self) -> Conflict;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MergeDecision {
+    UseBase,
+    UseLeft,
+    UseRight,
+    Value(Vec<u8>),
+    Delete,
+    Unresolved,
+}
+
+pub trait BorrowedMergeResolver: Send + Sync {
+    fn resolve(&self, conflict: ConflictRef<'_>) -> MergeDecision;
+}
+```
+
+`ValueRefView::Blob` owns its fixed-size CID because the CID parser already
+validates and materializes that small identifier. The potentially large inline
+payload remains borrowed. No public view contains a reference that can outlive
+its callback.
+
+### `Prolly` and `ReadSession` additions
+
+The root-bound session is the primary high-throughput interface. Direct
+`Prolly` visitor methods are one-shot conveniences that create a session and
+delegate to it; they do not contain a second traversal implementation.
+
+```rust,ignore
+impl<S: Store> Prolly<S> {
+    pub fn read<'manager, 'tree>(
+        &'manager self,
+        tree: &'tree Tree,
+    ) -> Result<ReadSession<'manager, 'tree, S>, Error>;
+
+    pub fn get_with<R>(
+        &self,
+        tree: &Tree,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error>;
+
+    pub fn contains_key(&self, tree: &Tree, key: &[u8]) -> Result<bool, Error>;
+
+    pub fn get_value_ref_with<R>(
+        &self,
+        tree: &Tree,
+        key: &[u8],
+        read: impl for<'value> FnOnce(ValueRefView<'value>) -> R,
+    ) -> Result<Option<R>, Error>;
+
+    pub fn get_many_with<K, F>(
+        &self,
+        tree: &Tree,
+        keys: &[K],
+        visit: F,
+    ) -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+        F: for<'value> FnMut(usize, &[u8], Option<&'value [u8]>);
+
+    pub fn select_with<R>(
+        &self,
+        tree: &Tree,
+        ordinal: u64,
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error>;
+
+    pub fn first_entry_with<R>(
+        &self,
+        tree: &Tree,
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error>;
+
+    pub fn last_entry_with<R>(
+        &self,
+        tree: &Tree,
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error>;
+
+    pub fn lower_bound_with<R>(
+        &self,
+        tree: &Tree,
+        key: &[u8],
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error>;
+
+    pub fn upper_bound_with<R>(
+        &self,
+        tree: &Tree,
+        key: &[u8],
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error>;
+
+    pub fn scan_range(
+        &self,
+        tree: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+
+    pub fn scan_range_until<B>(
+        &self,
+        tree: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+
+    pub fn scan_prefix(
+        &self,
+        tree: &Tree,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+
+    pub fn scan_prefix_until<B>(
+        &self,
+        tree: &Tree,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+
+    pub fn scan_range_reverse(
+        &self,
+        tree: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+
+    pub fn scan_range_reverse_until<B>(
+        &self,
+        tree: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+
+    pub fn scan_prefix_reverse(
+        &self,
+        tree: &Tree,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+
+    pub fn scan_prefix_reverse_until<B>(
+        &self,
+        tree: &Tree,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+}
+```
+
+`ReadSession` exposes the same operations without the `tree` parameter:
+
+```rust,ignore
+impl<S: Store> ReadSession<'_, '_, S> {
+    pub fn tree(&self) -> &Tree;
+    pub fn len(&self) -> Result<u64, Error>;
+    pub fn rank(&mut self, key: &[u8]) -> Result<u64, Error>;
+    pub fn get_with<R>(&mut self, key: &[u8], read: impl FnOnce(&[u8]) -> R)
+        -> Result<Option<R>, Error>;
+    pub fn get_value_ref_with<R>(
+        &mut self,
+        key: &[u8],
+        read: impl for<'value> FnOnce(ValueRefView<'value>) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub fn contains_key(&mut self, key: &[u8]) -> Result<bool, Error>;
+    pub fn get_many_with<K, F>(&mut self, keys: &[K], visit: F) -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+        F: for<'value> FnMut(usize, &[u8], Option<&'value [u8]>);
+    pub fn select_with<R>(
+        &mut self,
+        ordinal: u64,
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub fn first_entry_with<R>(
+        &mut self,
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub fn last_entry_with<R>(
+        &mut self,
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub fn lower_bound_with<R>(
+        &mut self,
+        key: &[u8],
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub fn upper_bound_with<R>(
+        &mut self,
+        key: &[u8],
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub fn scan_range(
+        &mut self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+    pub fn scan_range_until<B>(
+        &mut self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+    pub fn scan_prefix(
+        &mut self,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+    pub fn scan_prefix_until<B>(
+        &mut self,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+    pub fn scan_range_reverse(
+        &mut self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+    pub fn scan_range_reverse_until<B>(
+        &mut self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+    pub fn scan_prefix_reverse(
+        &mut self,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+    pub fn scan_prefix_reverse_until<B>(
+        &mut self,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+}
+```
+
+`get_many_with` invokes the callback exactly once per input position, in input
+order, including duplicate keys and misses. The key argument is the caller's
+input slice; the optional value is borrowed only for that invocation. Reverse
+ranges retain the existing half-open `[start, end)` semantics and merely change
+delivery order.
+
+### Diff and merge additions
+
+```rust,ignore
+impl<S: Store> Prolly<S> {
+    pub fn scan_diff(
+        &self,
+        base: &Tree,
+        other: &Tree,
+        visit: impl for<'diff> FnMut(DiffRef<'diff>),
+    ) -> Result<u64, Error>;
+
+    pub fn scan_diff_until<B>(
+        &self,
+        base: &Tree,
+        other: &Tree,
+        visit: impl for<'diff> FnMut(DiffRef<'diff>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+
+    pub fn scan_range_diff(
+        &self,
+        base: &Tree,
+        other: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'diff> FnMut(DiffRef<'diff>),
+    ) -> Result<u64, Error>;
+
+    pub fn scan_range_diff_until<B>(
+        &self,
+        base: &Tree,
+        other: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'diff> FnMut(DiffRef<'diff>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+
+    pub fn scan_conflicts(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        visit: impl for<'conflict> FnMut(ConflictRef<'conflict>),
+    ) -> Result<u64, Error>;
+
+    pub fn scan_conflicts_until<B>(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        visit: impl for<'conflict> FnMut(ConflictRef<'conflict>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+
+    pub fn merge_with(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        resolver: Option<&dyn BorrowedMergeResolver>,
+    ) -> Result<Tree, Error>;
+
+    pub fn merge_range_with(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        resolver: Option<&dyn BorrowedMergeResolver>,
+    ) -> Result<Tree, Error>;
+
+    pub fn merge_prefix_with(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        prefix: &[u8],
+        resolver: Option<&dyn BorrowedMergeResolver>,
+    ) -> Result<Tree, Error>;
+}
+```
+
+The `*_until` methods are the sole public early-stop variants; ordinary visitor
+methods delegate with `ControlFlow::Continue(())`. `merge_with` is intentionally
+distinct from the existing `merge(..., Option<Resolver>)`, so existing resolver
+closures keep their owned `Conflict` contract and source compatibility.
+
+### Versioned-map additions
+
+Snapshot methods reuse the core types rather than introduce snapshot-specific
+entry views. These are **add now** because secondary indexes already depend on
+`MapSnapshot` and need a stable zero-copy source-reader foundation.
+
+```rust,ignore
+impl<'snapshot, S: Store> MapSnapshot<'snapshot, S> {
+    pub fn read<'tree>(
+        &'tree self,
+    ) -> Result<ReadSession<'snapshot, 'tree, S>, Error>;
+    pub fn get_with<R>(
+        &self,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub fn get_value_ref_with<R>(
+        &self,
+        key: &[u8],
+        read: impl for<'value> FnOnce(ValueRefView<'value>) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub fn get_many_with<K, F>(&self, keys: &[K], visit: F) -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+        F: for<'value> FnMut(usize, &[u8], Option<&'value [u8]>);
+    pub fn scan_range(
+        &self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+    pub fn scan_prefix(
+        &self,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+}
+
+impl<'engine, S: Store> VersionedMap<'engine, S> {
+    pub fn get_with<R>(
+        &self,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub fn get_at_with<R>(
+        &self,
+        id: &MapVersionId,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub fn get_value_ref_with<R>(
+        &self,
+        key: &[u8],
+        read: impl for<'value> FnOnce(ValueRefView<'value>) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub fn get_value_ref_at_with<R>(
+        &self,
+        id: &MapVersionId,
+        key: &[u8],
+        read: impl for<'value> FnOnce(ValueRefView<'value>) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub fn scan_range(
+        &self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+    pub fn scan_prefix(
+        &self,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+    pub fn scan_range_at(
+        &self,
+        id: &MapVersionId,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+    pub fn scan_prefix_at(
+        &self,
+        id: &MapVersionId,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+}
+```
+
+`MapSnapshot::read` borrows the manager for `'snapshot` and the snapshot tree
+for `'tree`; the implementation may shorten the manager borrow to the method
+borrow if Rust's inferred variance permits a simpler concrete signature. The
+observable guarantee is that the session cannot outlive either snapshot input.
+The typed map decodes inside `get_with` internally; it does not expose encoded
+borrowed bytes through `TypedVersionedMap<K, V>`.
+
+### Async additions behind `async-store`
+
+The async API awaits node loads and then invokes a synchronous callback. It does
+not hold a borrowed value across `.await`, and it does not accept an async
+visitor. This makes callback lifetime safety identical to the synchronous API.
+
+```rust,ignore
+pub struct AsyncReadSession<'manager, 'tree, S: AsyncStore> { /* private */ }
+
+impl<S: AsyncStore> AsyncProlly<S> {
+    pub async fn read<'manager, 'tree>(
+        &'manager self,
+        tree: &'tree Tree,
+    ) -> Result<AsyncReadSession<'manager, 'tree, S>, Error>;
+    pub async fn get_with<R>(
+        &self,
+        tree: &Tree,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub async fn get_value_ref_with<R>(
+        &self,
+        tree: &Tree,
+        key: &[u8],
+        read: impl for<'value> FnOnce(ValueRefView<'value>) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub async fn get_many_with<K, F>(
+        &self,
+        tree: &Tree,
+        keys: &[K],
+        visit: F,
+    ) -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+        F: for<'value> FnMut(usize, &[u8], Option<&'value [u8]>);
+    pub async fn scan_range(
+        &self,
+        tree: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+    pub async fn scan_prefix(
+        &self,
+        tree: &Tree,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+    pub async fn scan_diff(
+        &self,
+        base: &Tree,
+        other: &Tree,
+        visit: impl for<'diff> FnMut(DiffRef<'diff>),
+    ) -> Result<u64, Error>;
+    pub async fn scan_conflicts(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        visit: impl for<'conflict> FnMut(ConflictRef<'conflict>),
+    ) -> Result<u64, Error>;
+}
+
+impl<S: AsyncStore> AsyncReadSession<'_, '_, S> {
+    pub async fn get_with<R>(
+        &mut self,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub async fn get_value_ref_with<R>(
+        &mut self,
+        key: &[u8],
+        read: impl for<'value> FnOnce(ValueRefView<'value>) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub async fn get_many_with<K, F>(&mut self, keys: &[K], visit: F)
+        -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+        F: for<'value> FnMut(usize, &[u8], Option<&'value [u8]>);
+    pub async fn scan_range(
+        &mut self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+    pub async fn scan_prefix(
+        &mut self,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error>;
+}
+```
+
+The complete async addition set is listed below. I/O methods have the matching
+synchronous signature above with `async fn`, `AsyncReadSession`, or the async
+snapshot type substituted; pure accessors such as `tree` remain synchronous and
+callbacks remain synchronous.
+
+| Async type | Added method names |
+|---|---|
+| `AsyncProlly` | `read`, `get_with`, `get_value_ref_with`, `get_many_with`, `scan_range`, `scan_range_until`, `scan_prefix`, `scan_prefix_until`, `scan_range_reverse`, `scan_range_reverse_until`, `scan_prefix_reverse`, `scan_prefix_reverse_until`, `scan_diff`, `scan_diff_until`, `scan_range_diff`, `scan_range_diff_until`, `scan_conflicts`, `scan_conflicts_until`, `merge_with`, `merge_range_with`, `merge_prefix_with` |
+| `AsyncReadSession` | `tree`, `len`, `rank`, `get_with`, `get_value_ref_with`, `contains_key`, `get_many_with`, `select_with`, `first_entry_with`, `last_entry_with`, `lower_bound_with`, `upper_bound_with`, `scan_range`, `scan_range_until`, `scan_prefix`, `scan_prefix_until`, `scan_range_reverse`, `scan_range_reverse_until`, `scan_prefix_reverse`, `scan_prefix_reverse_until` |
+| `AsyncMapSnapshot` | `read`, `get_with`, `get_value_ref_with`, `get_many_with`, `scan_range`, `scan_prefix` |
+| `AsyncVersionedMap` | `get_with`, `get_at_with`, `get_value_ref_with`, `get_value_ref_at_with`, `scan_range`, `scan_prefix`, `scan_range_at`, `scan_prefix_at` |
+
+Async borrowed merge resolvers execute only after all values for one conflict
+are retained and before the next await. There is no async borrowed resolver
+trait; an application that must await resolution uses the existing owned
+conflict workflow.
+
+### Existing public methods updated internally
+
+No method in this table changes its signature. Each must become a thin owned or
+scalar adapter over the new foundation, so optimizations benefit the entire API
+instead of only callers that opt into visitors.
+
+| Type/module | Existing methods routed through borrowed traversal |
+|---|---|
+| `Prolly` | `get`, `get_value_ref`, `get_large_value`, `get_many`, `len`, `rank`, `select`, `first_entry`, `last_entry`, `lower_bound`, `upper_bound`, `range`, `prefix`, `range_after`, `range_from_cursor`, `prefix_page`, `range_page`, `reverse_page`, `prefix_reverse_page`, `reverse_range_page`, `cursor`, `cursor_window`, `range_cursor` |
+| diff/merge | `diff`, `range_diff`, `diff_from_cursor`, `diff_page`, `structural_diff_page`, `diff_cursor`, `stream_diff`, `stream_conflicts`, `merge`, `merge_explain`, `merge_range`, `merge_prefix`, CRDT merge variants |
+| writes/transactions | `put`, `put_large_value`, `delete`, `delete_range`, all batch/append/parallel-batch variants, write-session reads and overlay/base ordered merge |
+| maintenance | stats, debug comparison, verification, proofs, reachability, missing-node planning/copying, export/import, and GC walkers use `ReadNode`/`NodeHandle` accessors, but keep their owned reports and artifacts |
+| `MapSnapshot` | `get`, `get_value_ref`, `get_large_value`, `contains_key`, `get_many`, `first_entry`, `last_entry`, `lower_bound`, `upper_bound`, `range`, `stream_range`, `prefix`, `stream_prefix`, `range_page`, `prefix_page`, `reverse_page`, `prefix_reverse_page`, `reverse_scan`, `prefix_reverse_scan`, `cursor_window`, stats/debug/proof/sync helpers |
+| `VersionedMap` | current and historical `get`, `get_large_value`, `contains_key`, `get_many`, `range`, `prefix`, `range_page`, `prefix_page`, `get_at`, `get_many_at`, `range_at`, `prefix_at`, `range_page_at`, `prefix_page_at`, `diff`, and `changes_since` families |
+| async types | every async counterpart of the core, snapshot, versioned, diff, merge, cursor/page, proof, and maintenance families above |
+
+The legacy `RangeIter`, cursor, diff iterator, page, proof, `KeyValue`, `Diff`,
+`Conflict`, and blob result types still own their yielded data. They clone once
+when an item crosses that compatibility boundary; they must not trigger an
+additional intermediate clone inside traversal.
+
+### Crate-private foundation added now
+
+These names are implementation-oriented and may evolve without semver impact:
+
+| Area | Crate-private additions | Purpose |
+|---|---|---|
+| retained content | `NodeHandle`, `CachedNode`, `ReadNode` | keep validated bytes/decoded node alive for callback scope |
+| routing | `LeafWindow`, `KeyScratch`, `ValueLocation`, `ReadPath` | session-local recent leaf, reconstructed-key scratch, and point lookup location |
+| scans | `RangeTraversal`, `ReverseRangeTraversal`, `BorrowedLeafCursor` | bounded forward/reverse leaf traversal shared by visitors and owned adapters |
+| comparison | `BorrowedDiffWalker`, `BorrowedConflictWalker` | aligned and misaligned subtree streaming without eager vectors |
+| writes | `BorrowedMutation<'a>`, `BorrowedMutationSource` | remove temporary owned mutation/diff copies before final node encoding |
+| cache | `CachePolicy`, `CacheLookup`, `CacheAdmission`, `PinnedReadHandle` | separate read hits from bounded-policy bookkeeping and pin callback backing |
+| instrumentation | `LocalReadMetrics`, `AllocationClass` | aggregate hot-loop counters and distinguish required boundary allocation |
+
+The existing public `Store`, `AsyncStore`, `BlobStore`, `Tree`, `Config`, `Node`,
+`Mutation`, `Resolver`, `Resolution`, and persistence formats are **unchanged**.
+In particular, zero-copy does not require storage backends to return borrowed
+buffers, and it does not change canonical node CIDs.
+
+### Deferred secondary-index public API (phase 5)
+
+The core release reserves these names and semantics, but they are implemented
+only when secondary-index migration begins:
+
+```rust,ignore
+pub enum IndexValueRef<'a> {
+    KeysOnly,
+    Included(&'a [u8]),
+    FullSource(&'a [u8]),
+}
+
+impl<'a> IndexValueRef<'a> {
+    pub fn decode(bytes: &'a [u8], limit: usize) -> Result<Self, Error>;
+    pub fn to_owned(self) -> IndexValue;
+}
+
+pub struct DecodedPhysicalIndexKeyRef<'a> {
+    pub term: &'a [u8],
+    pub primary_key: &'a [u8],
+}
+
+pub struct SecondaryIndexMatchRef<'a> {
+    pub term: &'a [u8],
+    pub primary_key: &'a [u8],
+    pub projection: Option<&'a [u8]>,
+}
+
+impl SecondaryIndexMatchRef<'_> {
+    pub fn to_owned(self) -> SecondaryIndexMatch;
+}
+
+pub struct IndexedSourceRecordRef<'a> {
+    pub term: &'a [u8],
+    pub primary_key: &'a [u8],
+    pub projection: Option<&'a [u8]>,
+    pub source_value: &'a [u8],
+}
+
+impl IndexedSourceRecordRef<'_> {
+    pub fn to_owned(self) -> IndexedSourceRecord;
+}
+
+impl<'snapshot, S: Store> SecondaryIndexSnapshot<'snapshot, S> {
+    pub fn scan_exact(
+        &self,
+        term: &[u8],
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>),
+    ) -> Result<u64, Error>;
+    pub fn scan_prefix(
+        &self,
+        prefix: &[u8],
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>),
+    ) -> Result<u64, Error>;
+    pub fn scan_range(
+        &self,
+        start_term: &[u8],
+        end_term: Option<&[u8]>,
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>),
+    ) -> Result<u64, Error>;
+    pub fn scan_records(
+        &self,
+        term: &[u8],
+        visit: impl for<'row> FnMut(IndexedSourceRecordRef<'row>),
+    ) -> Result<u64, Error>;
+    pub fn scan_exact_until<B>(
+        &self,
+        term: &[u8],
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>)
+            -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+    pub fn scan_prefix_until<B>(
+        &self,
+        prefix: &[u8],
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>)
+            -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+    pub fn scan_range_until<B>(
+        &self,
+        start_term: &[u8],
+        end_term: Option<&[u8]>,
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>)
+            -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+    pub fn scan_records_until<B>(
+        &self,
+        term: &[u8],
+        visit: impl for<'row> FnMut(IndexedSourceRecordRef<'row>)
+            -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+    pub fn scan_exact_reverse(
+        &self,
+        term: &[u8],
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>),
+    ) -> Result<u64, Error>;
+    pub fn scan_prefix_reverse(
+        &self,
+        prefix: &[u8],
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>),
+    ) -> Result<u64, Error>;
+    pub fn scan_range_reverse(
+        &self,
+        start_term: &[u8],
+        end_term: Option<&[u8]>,
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>),
+    ) -> Result<u64, Error>;
+    pub fn scan_exact_reverse_until<B>(
+        &self,
+        term: &[u8],
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>)
+            -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+    pub fn scan_prefix_reverse_until<B>(
+        &self,
+        prefix: &[u8],
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>)
+            -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+    pub fn scan_range_reverse_until<B>(
+        &self,
+        start_term: &[u8],
+        end_term: Option<&[u8]>,
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>)
+            -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+}
+
+impl<'engine, S> IndexedMap<'engine, S>
+where
+    S: Store + ManifestStore + TransactionalStore,
+{
+    pub fn get_with<R>(
+        &self,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error>;
+}
+
+pub struct SecondaryIndexEntryRef<'a> {
+    pub term: &'a [u8],
+    pub projection: Option<&'a [u8]>,
+}
+
+pub trait StreamingSecondaryIndexExtractor: Send + Sync {
+    fn extract(
+        &self,
+        primary_key: &[u8],
+        source_value: &[u8],
+        emit: &mut dyn FnMut(SecondaryIndexEntryRef<'_>)
+            -> Result<(), SecondaryIndexError>,
+    ) -> Result<(), SecondaryIndexError>;
+}
+```
+
+`SecondaryIndexSnapshot::{exact,prefix,range,primary_keys,projected,records}`
+and all page/reverse-page methods become owned adapters. `IndexedMap::get`,
+build, verify, repair, replace, and mutation coordination consume core snapshot
+visitors internally. `IndexValueRef` and physical-key decoding validate exactly
+the same limits and canonical encoding as their owned counterparts. Escaped
+physical-key components may use bounded reusable scratch, so the guarantee is
+steady-state allocation-free decoding, not universal direct subslicing.
+Forward and reverse visitors preserve the exact logical ordering used by the
+corresponding owned page API. Early stop returns the last delivered count but
+does not manufacture a serialized cursor; callers that need resumability use
+the existing owned page/cursor boundary.
+
+### Deferred proximity-map public API (phase 6)
+
+Public views expose safe logical records. Byte-layout helpers remain
+crate-private so an alignment or encoding change does not leak into the API.
+
+```rust,ignore
+#[derive(Clone, Copy, Debug)]
+pub struct ProximityVectorRef<'a> { /* private encoded bytes and dimensions */ }
+
+impl ProximityVectorRef<'_> {
+    pub fn dimensions(&self) -> usize;
+    pub fn component(&self, index: usize) -> Option<f32>;
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = f32> + '_;
+    pub fn copy_to_slice(&self, output: &mut [f32]) -> Result<(), Error>;
+    pub fn to_vec(&self) -> Vec<f32>;
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ProximityRecordRef<'a> {
+    pub vector: ProximityVectorRef<'a>,
+    pub value: &'a [u8],
+}
+
+impl ProximityRecordRef<'_> {
+    pub fn to_owned(self) -> ExactProximityRecord;
+}
+
+pub struct ProximityReadSession<'map, S: Store> { /* private fields */ }
+
+impl<S: Store> ProximityMap<S> {
+    pub fn read(&self) -> Result<ProximityReadSession<'_, S>, Error>;
+    pub fn get_with<R>(
+        &self,
+        key: &[u8],
+        read: impl for<'record> FnOnce(ProximityRecordRef<'record>) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub fn scan_records(
+        &self,
+        visit: impl for<'record> FnMut(&[u8], ProximityRecordRef<'record>),
+    ) -> Result<u64, Error>;
+    pub fn scan_records_until<B>(
+        &self,
+        visit: impl for<'record> FnMut(&[u8], ProximityRecordRef<'record>)
+            -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+}
+
+impl<S: Store> ProximityReadSession<'_, S> {
+    pub fn get_with<R>(
+        &mut self,
+        key: &[u8],
+        read: impl for<'record> FnOnce(ProximityRecordRef<'record>) -> R,
+    ) -> Result<Option<R>, Error>;
+    pub fn contains_key(&mut self, key: &[u8]) -> Result<bool, Error>;
+    pub fn scan_records(
+        &mut self,
+        visit: impl for<'record> FnMut(&[u8], ProximityRecordRef<'record>),
+    ) -> Result<u64, Error>;
+    pub fn scan_records_until<B>(
+        &mut self,
+        visit: impl for<'record> FnMut(&[u8], ProximityRecordRef<'record>)
+            -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error>;
+}
+```
+
+`StoredRecordRef` and `EncodedVectorRef` are the crate-private wire views that
+back public `ProximityRecordRef` and `ProximityVectorRef`. They validate format,
+vector dimensions, finite canonical components, and value bounds before the
+callback.
+They never cast persisted bytes to `&[f32]`. `ProximityMap::{get,contains_key}`,
+rebuild/mutate, verification, exact search, SQ8/PQ/HNSW build, and async search
+then consume these views internally. Existing `ExactProximityRecord`,
+`Neighbor`, `SearchResult`, descriptors, proofs, and persisted accelerator
+artifacts remain owned and unchanged.
+
+`AsyncProximityMap` eventually gains `read`, `get_with`, and `scan_records`
+counterparts with synchronous post-await callbacks. Approximate-search callback
+results are deliberately not exposed: candidate heaps can use retained internal
+handles, but a public result must remain self-contained.
+
+### Source-file ownership and delivery
+
+| Source area | API/design ownership | Delivery phase |
+|---|---|---|
+| new `src/prolly/read.rs` plus root re-exports | public views, sessions, scan outcomes | 1–2 |
+| new/extracted `src/prolly/cache.rs`, existing `src/prolly/node.rs` | retained read handles, accounting, `ReadNode` accessors | 1 |
+| `src/prolly/mod.rs`, `range.rs`, `cursor.rs`, `blob.rs` | point/bound/scan visitors and owned adapters | 2 |
+| `src/prolly/diff.rs`, `error.rs`, merge/write modules | borrowed diff/conflict views, symbolic resolver, streaming apply | 3–4 |
+| `src/prolly/versioned_map.rs`, typed map layer, async modules | snapshot/session forwarding and decode-in-callback | 2–4 |
+| `src/prolly/secondary_index/{storage,snapshot,definition,coordinator}.rs` | deferred index views/query/build adoption | 5 |
+| `src/prolly/proximity/storage/record.rs`, `map.rs`, `search/`, `accelerator/`, `proof/` | deferred record/vector views and candidate handles | 6 |
+| language bindings and WASM adapters | no signature change; serialize/copy at FFI boundary | after each native phase |
+
+Every public borrowed-view addition requires rustdoc examples for both
+allocation-free consumption and explicit `to_owned` escape. Compile-fail
+doctests must prove
+that `EntryRef`, `DiffRef`, `ConflictRef`, secondary-index scratch views, and
+proximity record views cannot escape their callback. Existing binding APIs are
+regression-tested but do not expose Rust lifetimes.
+
 ## Core Types
 
-Names in this section are the intended public direction. Exact module placement
-may follow repository conventions, but lifetime and ownership semantics are
-normative.
+Names and behavior in this section explain the normative API set above. Core
+public read views live in `prolly::read` and are re-exported from the crate
+root; crate-private helpers follow the source-file ownership table.
 
 ### Entry view
 
@@ -517,6 +1440,13 @@ pub fn get(&self, tree: &Tree, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
 ```
 
 `contains_key` stops after exact-key validation and never clones the value.
+
+`get_value_ref_with` parses the large-value envelope while the stored leaf value
+is borrowed. Raw and envelope-inline payloads are lent as
+`ValueRefView::Inline`; blob references validate their CID and length without
+loading blob content. Existing `get_value_ref` converts the view once to owned
+`blob::ValueRef`, while `get_large_value` necessarily owns bytes returned by the
+separate `BlobStore` contract.
 
 ### Range scan
 
@@ -945,8 +1875,8 @@ pub enum IndexValueRef<'a> {
     FullSource(&'a [u8]),
 }
 
-impl IndexValueRef<'_> {
-    pub fn decode(bytes: &[u8], limit: usize) -> Result<IndexValueRef<'_>, Error>;
+impl<'a> IndexValueRef<'a> {
+    pub fn decode(bytes: &'a [u8], limit: usize) -> Result<Self, Error>;
     pub fn to_owned(self) -> IndexValue;
 }
 ```
@@ -1061,12 +1991,12 @@ zero-copy representation differs from ordinary key/value entries.
 ### Stored record view
 
 ```rust,ignore
-pub struct StoredRecordRef<'a> {
-    pub vector: EncodedVectorRef<'a>,
+pub(crate) struct StoredRecordRef<'a> {
+    vector: EncodedVectorRef<'a>,
     pub value: &'a [u8],
 }
 
-pub struct EncodedVectorRef<'a> {
+pub(crate) struct EncodedVectorRef<'a> {
     bytes: &'a [u8],
     dimensions: u32,
 }
@@ -1075,6 +2005,9 @@ pub struct EncodedVectorRef<'a> {
 `StoredRecordRef::decode` validates magic, version, encoding, dimensions,
 canonical varints, vector byte length, finite components, negative zero, value
 length, and trailing bytes without allocating the application value.
+After validation, it is wrapped as the public `ProximityRecordRef` and
+`ProximityVectorRef` defined by the normative API set. This keeps persisted
+byte-layout details private while preserving borrowed logical access.
 
 The persisted vector starts after a variable-length header and is not guaranteed
 to be aligned for `f32`. It is little-endian encoded. The implementation must not
@@ -1095,8 +2028,8 @@ a core directory `ReadSession`, immutable proximity descriptor information, and
 reusable vector scratch. Future native APIs are:
 
 ```rust,ignore
-pub struct ProximityReadSession<'a, S: Store> {
-    directory: ReadSession<'a, 'a, S>,
+pub struct ProximityReadSession<'map, S: Store> {
+    directory: ReadSession<'map, 'map, S>,
     dimensions: u32,
     vector_scratch: Vec<f32>,
 }
@@ -1104,12 +2037,12 @@ pub struct ProximityReadSession<'a, S: Store> {
 pub fn get_with<R>(
     &mut self,
     key: &[u8],
-    read: impl FnOnce(StoredRecordRef<'_>) -> R,
+    read: impl for<'record> FnOnce(ProximityRecordRef<'record>) -> R,
 ) -> Result<Option<R>, Error>;
 
 pub fn scan_records(
     &mut self,
-    visit: impl for<'record> FnMut(&[u8], StoredRecordRef<'record>),
+    visit: impl for<'record> FnMut(&[u8], ProximityRecordRef<'record>),
 ) -> Result<u64, Error>;
 ```
 
@@ -1172,7 +2105,8 @@ content kind and measured reuse.
 
 Later migration must prove:
 
-- owned exact lookup equals `StoredRecordRef::to_owned` for every valid vector;
+- owned exact lookup equals `ProximityRecordRef::to_owned` for every valid
+  vector;
 - malformed formats fail identically without partial result delivery;
 - scalar and SIMD distance outputs remain bit/ordering compatible under current
   tolerances and canonical tie rules;
@@ -1306,8 +2240,8 @@ allocator so production allocation paths are not instrumented per operation.
 
 - `get_with` and scan callbacks can consume slices and return owned/scalar data.
 - compile-fail tests prove a callback cannot store or return `EntryRef`,
-  `DiffRef`, `ConflictRef`, `IndexValueRef`, or `StoredRecordRef` beyond its
-  invocation;
+  `ValueRefView`, `DiffRef`, `ConflictRef`, `IndexValueRef`, or
+  `ProximityRecordRef` beyond its invocation;
 - async compile-fail tests prove borrowed entries cannot cross `.await`;
 - `ReadSession` is `Send` when its manager/store permit moving between threads,
   but mutation requires exclusive access;
@@ -1318,7 +2252,10 @@ allocator so production allocation paths are not instrumented per operation.
 For generated trees and all `NodeLayoutSpec` variants:
 
 - `get == get_with(...to_vec)` for hits and misses;
-- `get_many` equals ordered `get_with` for unique and duplicate inputs;
+- `get_value_ref` equals `get_value_ref_with(...to_owned)` for raw inline,
+  escaped inline, and blob envelopes, including malformed inputs;
+- `get_many` equals ordered `get_many_with` collection for unique and duplicate
+  inputs, hits, misses, and caller order;
 - `range.collect()` equals `scan_range` collection;
 - forward/reverse scans are exact inverses under matching bounds;
 - prefix scans equal filtered full scans;
@@ -1364,16 +2301,20 @@ where practical, plus stress tests under ThreadSanitizer-compatible builds.
 - borrowed physical-key decoding equals owned decoding for every byte value;
 - scratch buffers stay bounded and are reused;
 - borrowed matches collected to owned equal exact/prefix/range/page results;
+- reverse and early-stop visitors match reverse pages and the corresponding
+  forward-prefix subsets;
 - missing source records still fail snapshot validation;
 - projection tags, limits, cursors, and snapshot IDs remain strict.
 
 ### Proximity foundation tests
 
-- `StoredRecordRef::to_owned == StoredRecord::decode`;
+- `ProximityRecordRef::to_owned == StoredRecord::decode`;
 - vector views reject every malformed header/component/trailing-byte case;
 - unaligned vector offsets never use an invalid `&[f32]` cast;
 - encoded and scratch distance paths agree with decoded scalar/SIMD results;
 - candidate handles preserve deterministic top-k and key ties;
+- `scan_records_until` reports the exact delivered count and never exposes a
+  view after return;
 - owned search results and proofs remain unchanged;
 - cache eviction and cancellation cannot invalidate active vector/value views.
 
@@ -1478,10 +2419,12 @@ These are adoption gates, not phase-one blockers.
 
 ### Phase 1: Core point-read substrate
 
-- introduce `EntryRef`, `NodeHandle`, decoded `ReadNode`, and `ReadSession`;
+- introduce `EntryRef`, `ValueRefView`, `NodeHandle`, decoded `ReadNode`, and
+  `ReadSession`;
 - validate/load and retain the root;
 - implement session-local recent leaf;
-- implement `get_with` and allocation-free `contains_key`;
+- implement `get_with`, `get_value_ref_with`, allocation-free `contains_key`,
+  and callback-based select/bound entry reads;
 - make owned `get` a wrapper;
 - implement unbounded-cache read-only hit path and single-probe bounded hit;
 - benchmark after each independently measurable change.
@@ -1497,7 +2440,8 @@ These are adoption gates, not phase-one blockers.
 ### Phase 3: Multi-get, async, overlays, and bindings
 
 - implement location-based `get_many_with`;
-- adapt typed/versioned reads and write-session overlays;
+- add snapshot/versioned `get_with` and scan forwarding, then adapt typed reads
+  and write-session overlays;
 - add `AsyncReadSession` and synchronous borrowed callbacks;
 - route bindings through borrowed internals without changing generated APIs;
 - add load coalescing if concurrency profiling justifies it.
@@ -1513,15 +2457,17 @@ These are adoption gates, not phase-one blockers.
 
 ### Phase 5: Secondary-index adoption
 
-- add borrowed index-value and physical-key views;
-- add borrowed query scans and bounded source joins;
+- add `IndexValueRef`, `DecodedPhysicalIndexKeyRef`, and borrowed match views;
+- add `scan_exact`, `scan_prefix`, `scan_range`, bounded `scan_records`, and
+  `IndexedMap::get_with`;
 - adapt owned pages and bindings;
 - introduce streaming extractor/build sink when the bounded-build milestone is
   implemented.
 
 ### Phase 6: Proximity adoption
 
-- add stored-record and encoded-vector views;
+- add public `ProximityRecordRef`/`ProximityVectorRef` and private wire views;
+- add `ProximityReadSession`, `get_with`, and `scan_records`;
 - migrate exact reads, verification, and authoritative scans;
 - introduce bounded candidate handles and borrowed rerank reads;
 - integrate handle accounting with `SearchRuntime`;

--- a/scripts/run_prolly_comparison.sh
+++ b/scripts/run_prolly_comparison.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+OUT=${BENCH_OUT:-"$ROOT/performance-results/dolt-rust"}
+SIZES=${BENCH_SIZES:-"10000 50000 1000000 5000000 10000000"}
+RUNS=${BENCH_RUNS:-3}
+LARGE_RUNS=${BENCH_LARGE_RUNS:-2}
+
+case "$OUT" in
+    /*) ;;
+    *) OUT="$ROOT/$OUT" ;;
+esac
+
+mkdir -p "$OUT/bin" "$OUT/raw"
+
+RUST_HEAD=$(git -C "$ROOT" rev-parse --short=12 HEAD 2>/dev/null || printf unknown)
+RUST_SOURCE_HASH=$(
+    find "$ROOT/src" "$ROOT/benches" "$ROOT/Cargo.toml" -type f |
+        LC_ALL=C sort |
+        while IFS= read -r file; do shasum "$file"; done |
+        shasum | awk '{ print substr($1, 1, 12) }'
+)
+RUST_REV="${RUST_HEAD}+src.${RUST_SOURCE_HASH}"
+GO_HEAD=$(git -C "$ROOT/dolt" rev-parse --short=12 HEAD 2>/dev/null || printf unknown)
+GO_RUNNER_HASH=$(shasum "$ROOT/dolt/go/cmd/prolly-compare/main.go" | awk '{ print substr($1, 1, 12) }')
+GO_REV="${GO_HEAD}+runner.${GO_RUNNER_HASH}"
+
+RUST_TARGET=$(cargo metadata --manifest-path "$ROOT/Cargo.toml" --no-deps --format-version 1 |
+    sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+cargo build --manifest-path "$ROOT/Cargo.toml" --release --bin prolly_compare
+cp "$RUST_TARGET/release/prolly_compare" "$OUT/bin/rust-prolly-compare"
+
+(cd "$ROOT/dolt/go" && go build -trimpath -o "$OUT/bin/dolt-go-prolly-compare" ./cmd/prolly-compare)
+
+{
+    printf 'generated_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'host=%s\n' "$(hostname)"
+    printf 'os=%s\n' "$(uname -a)"
+    printf 'rust_revision=%s\n' "$RUST_REV"
+    printf 'go_revision=%s\n' "$GO_REV"
+    printf 'rust_binary_sha256=%s\n' "$(shasum -a 256 "$OUT/bin/rust-prolly-compare" | awk '{ print $1 }')"
+    printf 'go_binary_sha256=%s\n' "$(shasum -a 256 "$OUT/bin/dolt-go-prolly-compare" | awk '{ print $1 }')"
+    rustc -Vv
+    go version
+    printf 'sizes=%s\n' "$SIZES"
+    printf 'runs=%s\n' "$RUNS"
+    printf 'large_runs=%s\n' "$LARGE_RUNS"
+    printf 'worker_threads=1\n'
+    printf 'batch_size=whole_workload\n'
+    printf 'mutation_ratio=30%%\n'
+    printf 'mutation_insert_update_mix=50/50\n'
+} >"$OUT/machine.txt"
+
+printf 'implementation,revision,records,phase,workload,operation,operations,elapsed_ns,ns_per_op,ops_per_sec,workload_digest,result_count,validated,run\n' >"$OUT/results.csv"
+printf 'run,implementation,records,phase,workload,exit_status,stdout,stderr,time\n' >"$OUT/manifest.csv"
+
+run_one() {
+    implementation=$1
+    records=$2
+    phase=$3
+    workload=$4
+    run=$5
+    prefix="$OUT/raw/${implementation}-${records}-${phase}-${workload}-run${run}"
+
+    if [ "$implementation" = rust ]; then
+        binary="$OUT/bin/rust-prolly-compare"
+        revision=$RUST_REV
+    else
+        binary="$OUT/bin/dolt-go-prolly-compare"
+        revision=$GO_REV
+    fi
+
+    set +e
+    if /usr/bin/time -l true >/dev/null 2>&1; then
+        RAYON_NUM_THREADS=1 GOMAXPROCS=1 BENCH_REVISION="$revision" \
+            /usr/bin/time -l "$binary" --records "$records" --phase "$phase" --workload "$workload" \
+            >"$prefix.csv" 2>"$prefix.time"
+        status=$?
+    else
+        RAYON_NUM_THREADS=1 GOMAXPROCS=1 BENCH_REVISION="$revision" \
+            /usr/bin/time -v "$binary" --records "$records" --phase "$phase" --workload "$workload" \
+            >"$prefix.csv" 2>"$prefix.time"
+        status=$?
+    fi
+    set -e
+
+    : >"$prefix.stderr"
+    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+        "$run" "$implementation" "$records" "$phase" "$workload" "$status" \
+        "$prefix.csv" "$prefix.stderr" "$prefix.time" >>"$OUT/manifest.csv"
+    if [ "$status" -ne 0 ]; then
+        printf 'benchmark failed: %s %s %s %s run %s; see %s\n' \
+            "$implementation" "$records" "$phase" "$workload" "$run" "$prefix.time" >&2
+        return "$status"
+    fi
+    awk -v run="$run" 'NR > 1 { print $0 "," run }' "$prefix.csv" >>"$OUT/results.csv"
+}
+
+for records in $SIZES; do
+    repetitions=$RUNS
+    if [ "$records" -ge 5000000 ]; then
+        repetitions=$LARGE_RUNS
+    fi
+    run=1
+    while [ "$run" -le "$repetitions" ]; do
+        for phase in fresh mutation; do
+            for workload in append random clustered; do
+                if [ $(((run + records + ${#phase} + ${#workload}) % 2)) -eq 0 ]; then
+                    run_one rust "$records" "$phase" "$workload" "$run"
+                    run_one dolt-go "$records" "$phase" "$workload" "$run"
+                else
+                    run_one dolt-go "$records" "$phase" "$workload" "$run"
+                    run_one rust "$records" "$phase" "$workload" "$run"
+                fi
+            done
+        done
+        run=$((run + 1))
+    done
+done
+
+python3 "$ROOT/scripts/summarize_prolly_comparison.py" "$OUT/results.csv" "$OUT"
+printf 'comparison complete: %s/report.md\n' "$OUT"

--- a/scripts/summarize_prolly_comparison.py
+++ b/scripts/summarize_prolly_comparison.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Validate and summarize native Dolt-Go versus Rust prolly benchmark rows."""
+
+from __future__ import annotations
+
+import csv
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"invalid benchmark results: {message}")
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: summarize_prolly_comparison.py RESULTS.csv OUT_DIR")
+    source = Path(sys.argv[1])
+    out = Path(sys.argv[2])
+    rows = list(csv.DictReader(source.open(newline="", encoding="utf-8")))
+    if not rows:
+        fail("no measurement rows")
+
+    by_run: dict[tuple[str, ...], dict[str, dict[str, str]]] = defaultdict(dict)
+    for row in rows:
+        if row["validated"] != "true":
+            fail(f"unvalidated row: {row}")
+        key = (row["records"], row["phase"], row["workload"], row["operation"], row["run"])
+        implementation = row["implementation"]
+        if implementation in by_run[key]:
+            fail(f"duplicate {implementation} row for {key}")
+        by_run[key][implementation] = row
+
+    for key, pair in by_run.items():
+        if set(pair) != {"rust", "dolt-go"}:
+            fail(f"missing implementation for {key}: {sorted(pair)}")
+        rust, go = pair["rust"], pair["dolt-go"]
+        for field in ("operations", "workload_digest", "result_count"):
+            if rust[field] != go[field]:
+                fail(f"{field} mismatch for {key}: rust={rust[field]} go={go[field]}")
+
+    groups: dict[tuple[str, ...], dict[str, list[float]]] = defaultdict(lambda: defaultdict(list))
+    for row in rows:
+        key = (row["records"], row["phase"], row["workload"], row["operation"])
+        groups[key][row["implementation"]].append(float(row["ns_per_op"]))
+
+    summary_rows: list[dict[str, str]] = []
+    for key in sorted(groups, key=lambda item: (int(item[0]), item[1], item[2], item[3])):
+        values = groups[key]
+        rust = statistics.median(values["rust"])
+        go = statistics.median(values["dolt-go"])
+        winner = "rust" if rust < go else "dolt-go" if go < rust else "tie"
+        speedup = max(rust, go) / min(rust, go) if min(rust, go) else float("inf")
+        summary_rows.append(
+            {
+                "records": key[0],
+                "phase": key[1],
+                "workload": key[2],
+                "operation": key[3],
+                "runs": str(len(values["rust"])),
+                "rust_median_ns_per_op": f"{rust:.3f}",
+                "dolt_go_median_ns_per_op": f"{go:.3f}",
+                "winner": winner,
+                "winner_speedup": f"{speedup:.3f}",
+            }
+        )
+
+    fields = list(summary_rows[0])
+    with (out / "summary.csv").open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(summary_rows)
+
+    wins = defaultdict(int)
+    operation_wins: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for row in summary_rows:
+        wins[row["winner"]] += 1
+        operation_wins[row["operation"]][row["winner"]] += 1
+    run_counts = [int(row["runs"]) for row in summary_rows]
+    report = [
+        "# Dolt Go vs Rust Prolly Performance",
+        "",
+        "All figures are medians from process-isolated, single-worker, in-memory runs. "
+        "Lower nanoseconds per operation is better. Workload digests, operation counts, "
+        "result cardinalities, point-read values, and scan ordering/cardinality were validated.",
+        "",
+        f"Rust wins: {wins['rust']}; Dolt Go wins: {wins['dolt-go']}; ties: {wins['tie']}.",
+        "",
+        "| Operation | Rust wins | Dolt Go wins | Ties |",
+        "|---|---:|---:|---:|",
+    ]
+    for operation in ("write", "point_read", "range_scan"):
+        counts = operation_wins[operation]
+        report.append(
+            f"| {operation} | {counts['rust']} | {counts['dolt-go']} | {counts['tie']} |"
+        )
+    report.extend([
+        "",
+        f"Measured repetitions range from {min(run_counts)} to {max(run_counts)} per scenario.",
+    ])
+    if min(run_counts) < 3:
+        report.extend([
+            "",
+            "> Some scenarios have fewer than three repetitions. Treat their exact speedup "
+            "as provisional; the winner is a complete measured pass, not a confidence interval.",
+        ])
+    report.extend([
+        "",
+        "| Records | Phase | Workload | Operation | Runs | Rust ns/op | Dolt Go ns/op | Winner | Speedup |",
+        "|---:|---|---|---|---:|---:|---:|---|---:|",
+    ])
+    for row in summary_rows:
+        report.append(
+            "| {records} | {phase} | {workload} | {operation} | {runs} | "
+            "{rust_median_ns_per_op} | {dolt_go_median_ns_per_op} | {winner} | "
+            "{winner_speedup}x |".format(**row)
+        )
+    report.extend(
+        [
+            "",
+            "## Workload contract",
+            "",
+            "- Dataset sizes: 10K, 50K, 1M, 5M, and 10M base records.",
+            "- Keys: fixed-width, zero-padded UTF-8 strings; values: deterministic pseudo-random 1–100 byte payloads.",
+            "- Fresh workloads: ascending append order, uniform deterministic permutation, and permuted 1,000-key clusters.",
+            "- Mutation workloads: 30% of base size; random and clustered workloads use 50% inserts and 50% updates.",
+            "- Each build or mutation workload is submitted as one bulk write; fixture and tuple generation is excluded from write timing.",
+            "- Point reads use at most 100,000 validated existing keys after one untimed warm pass.",
+            "- Range scans traverse and validate the complete resulting tree.",
+            "- Both implementations use their product-default tree encoding and chunking policy.",
+            "",
+            "Raw process output is retained in `raw/`; `results.csv` contains normalized measurements.",
+        ]
+    )
+    (out / "report.md").write_text("\n".join(report) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bin/prolly-inspect.rs
+++ b/src/bin/prolly-inspect.rs
@@ -71,20 +71,22 @@ fn roots(prolly: &FileProlly, args: &[String]) -> CliResult<()> {
 fn stats(prolly: &FileProlly, args: &[String]) -> CliResult<()> {
     expect_arg_count("stats", args, 1)?;
     let tree = load_named_root(prolly, &args[0])?;
+    let reader = reader_for_tree(prolly, &tree);
     println!("root_name={}", debug_key(args[0].as_bytes()));
     println!("root={}", format_optional_cid(tree.root.as_ref()));
-    println!("{}", prolly.collect_stats(&tree).map_err(format_error)?);
+    println!("{}", reader.collect_stats(&tree).map_err(format_error)?);
     Ok(())
 }
 
 fn walk(prolly: &FileProlly, args: &[String]) -> CliResult<()> {
     expect_arg_count("walk", args, 1)?;
     let tree = load_named_root(prolly, &args[0])?;
+    let reader = reader_for_tree(prolly, &tree);
     println!("root_name={}", debug_key(args[0].as_bytes()));
     println!("root={}", format_optional_cid(tree.root.as_ref()));
     println!(
         "{}",
-        prolly.debug_tree(&tree).map_err(format_error)?.to_text()
+        reader.debug_tree(&tree).map_err(format_error)?.to_text()
     );
     Ok(())
 }
@@ -93,13 +95,14 @@ fn compare(prolly: &FileProlly, args: &[String]) -> CliResult<()> {
     expect_arg_count("compare", args, 2)?;
     let left = load_named_root(prolly, &args[0])?;
     let right = load_named_root(prolly, &args[1])?;
+    let reader = reader_for_tree(prolly, &left);
     println!("left_name={}", debug_key(args[0].as_bytes()));
     println!("left_root={}", format_optional_cid(left.root.as_ref()));
     println!("right_name={}", debug_key(args[1].as_bytes()));
     println!("right_root={}", format_optional_cid(right.root.as_ref()));
     println!(
         "{}",
-        prolly
+        reader
             .debug_compare_trees(&left, &right)
             .map_err(format_error)?
             .to_text()
@@ -116,7 +119,8 @@ fn changed(prolly: &FileProlly, args: &[String]) -> CliResult<()> {
     let span_size = parse_span_size(&args[2..])?;
     let base = load_named_root(prolly, &args[0])?;
     let other = load_named_root(prolly, &args[1])?;
-    let mut diffs = prolly.diff(&base, &other).map_err(format_error)?;
+    let reader = reader_for_tree(prolly, &base);
+    let mut diffs = reader.diff(&base, &other).map_err(format_error)?;
     diffs.sort_by(|left, right| left.key().cmp(right.key()));
 
     println!("base_name={}", debug_key(args[0].as_bytes()));
@@ -227,6 +231,10 @@ fn load_named_root(prolly: &FileProlly, name: &str) -> CliResult<Tree> {
         .load_named_root(name.as_bytes())
         .map_err(|err| format!("failed to load named root {name:?}: {err}"))?
         .ok_or_else(|| format!("named root not found: {name:?}"))
+}
+
+fn reader_for_tree(prolly: &FileProlly, tree: &Tree) -> FileProlly {
+    Prolly::new(prolly.store().clone(), tree.config.clone())
 }
 
 fn parse_span_size(args: &[String]) -> CliResult<usize> {

--- a/src/bin/prolly_compare.rs
+++ b/src/bin/prolly_compare.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use prolly::{Config, MemStore, Mutation, Prolly, Tree};
 
 const CLUSTER_SIZE: usize = 1_000;
-const POINT_READS: usize = 100_000;
+const DEFAULT_POINT_READS: usize = 100_000;
 const RANDOM_SEED: u64 = 0x6a09_e667_f3bc_c909;
 const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
 const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
@@ -158,7 +158,21 @@ fn run_scenario(args: &Args) -> ScenarioResult {
         "post-write cardinality mismatch"
     );
 
-    let targets = read_targets(args.phase, args.workload, args.records, write_operations);
+    let point_reads = env::var("PROLLY_COMPARE_POINT_READS")
+        .ok()
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .expect("PROLLY_COMPARE_POINT_READS must be an integer")
+        })
+        .unwrap_or(DEFAULT_POINT_READS);
+    let targets = read_targets(
+        args.phase,
+        args.workload,
+        args.records,
+        write_operations,
+        point_reads,
+    );
     for (key, expected) in &targets {
         assert_eq!(
             validation_reader
@@ -320,8 +334,9 @@ fn read_targets(
     workload: Workload,
     records: usize,
     writes: usize,
+    point_reads: usize,
 ) -> Vec<(Vec<u8>, Vec<u8>)> {
-    let count = POINT_READS.min(match phase {
+    let count = point_reads.min(match phase {
         Phase::Fresh => records,
         Phase::Mutation => records + writes,
     });

--- a/src/bin/prolly_compare.rs
+++ b/src/bin/prolly_compare.rs
@@ -1,0 +1,558 @@
+use std::env;
+use std::hint::black_box;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use prolly::{Config, MemStore, Mutation, Prolly, Tree};
+
+const CLUSTER_SIZE: usize = 1_000;
+const POINT_READS: usize = 100_000;
+const RANDOM_SEED: u64 = 0x6a09_e667_f3bc_c909;
+const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Phase {
+    Fresh,
+    Mutation,
+}
+
+impl Phase {
+    fn parse(value: &str) -> Self {
+        match value {
+            "fresh" => Self::Fresh,
+            "mutation" => Self::Mutation,
+            _ => panic!("invalid phase {value:?}; expected fresh or mutation"),
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Fresh => "fresh",
+            Self::Mutation => "mutation",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Workload {
+    Append,
+    Random,
+    Clustered,
+}
+
+impl Workload {
+    fn parse(value: &str) -> Self {
+        match value {
+            "append" => Self::Append,
+            "random" => Self::Random,
+            "clustered" => Self::Clustered,
+            _ => panic!("invalid workload {value:?}; expected append, random, or clustered"),
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Append => "append",
+            Self::Random => "random",
+            Self::Clustered => "clustered",
+        }
+    }
+}
+
+struct Args {
+    records: usize,
+    phase: Phase,
+    workload: Workload,
+}
+
+fn main() {
+    let args = parse_args();
+    assert!(
+        args.records >= CLUSTER_SIZE && args.records % CLUSTER_SIZE == 0,
+        "records must be a positive multiple of {CLUSTER_SIZE}"
+    );
+
+    let revision = env::var("BENCH_REVISION").unwrap_or_else(|_| "unknown".to_string());
+    let result = run_scenario(&args);
+
+    println!(
+        "implementation,revision,records,phase,workload,operation,operations,elapsed_ns,ns_per_op,ops_per_sec,workload_digest,result_count,validated"
+    );
+    emit(
+        &revision,
+        &args,
+        "write",
+        result.write_operations,
+        result.write_elapsed,
+        result.digest,
+        result.result_count,
+    );
+    emit(
+        &revision,
+        &args,
+        "point_read",
+        result.read_operations,
+        result.read_elapsed,
+        result.digest,
+        result.result_count,
+    );
+    emit(
+        &revision,
+        &args,
+        "range_scan",
+        result.scan_operations,
+        result.scan_elapsed,
+        result.digest,
+        result.result_count,
+    );
+}
+
+struct ScenarioResult {
+    write_operations: usize,
+    write_elapsed: Duration,
+    read_operations: usize,
+    read_elapsed: Duration,
+    scan_operations: usize,
+    scan_elapsed: Duration,
+    digest: u64,
+    result_count: usize,
+}
+
+fn run_scenario(args: &Args) -> ScenarioResult {
+    let store = Arc::new(MemStore::new());
+    let manager = Prolly::new(store, Config::default());
+    let (tree, write_operations, write_elapsed, digest, result_count) = match args.phase {
+        Phase::Fresh => {
+            let (tree, elapsed, digest) = build_fresh(&manager, args.records, args.workload);
+            (tree, args.records, elapsed, digest, args.records)
+        }
+        Phase::Mutation => {
+            let (base, _, _) = build_fresh(&manager, args.records, Workload::Append);
+            let writes = args.records * 30 / 100;
+            let (tree, elapsed, digest) =
+                apply_mutations(&manager, base, args.records, writes, args.workload);
+            let inserts = match args.workload {
+                Workload::Append => writes,
+                Workload::Random | Workload::Clustered => writes - writes / 2,
+            };
+            (tree, writes, elapsed, digest, args.records + inserts)
+        }
+    };
+
+    let mut validation_reader = manager.read(&tree).expect("validation reader opens");
+    let mut previous: Option<Vec<u8>> = None;
+    let actual_count = validation_reader
+        .scan_range(&[], None, |entry| {
+            if let Some(previous) = previous.as_ref() {
+                assert!(
+                    previous.as_slice() < entry.key(),
+                    "range keys are not strictly sorted"
+                );
+            }
+            previous = Some(entry.key().to_vec());
+        })
+        .expect("count range succeeds") as usize;
+    assert_eq!(
+        actual_count, result_count,
+        "post-write cardinality mismatch"
+    );
+
+    let targets = read_targets(args.phase, args.workload, args.records, write_operations);
+    for (key, expected) in &targets {
+        assert_eq!(
+            validation_reader
+                .get_with(key, |value| value == expected.as_slice())
+                .expect("warm point read succeeds"),
+            Some(true),
+            "warm point-read value mismatch for {:?}",
+            String::from_utf8_lossy(key)
+        );
+    }
+
+    let mut read_session = manager.read(&tree).expect("point read session opens");
+    let read_started = Instant::now();
+    let mut observed_bytes = 0usize;
+    for (key, expected) in &targets {
+        let found = read_session
+            .get_with(black_box(key), |value| {
+                assert_eq!(value, expected);
+                observed_bytes = observed_bytes.wrapping_add(value.len());
+                black_box(value);
+            })
+            .expect("point read succeeds")
+            .is_some();
+        assert!(found, "point-read key exists");
+    }
+    let read_elapsed = read_started.elapsed();
+    black_box(observed_bytes);
+
+    let scan_started = Instant::now();
+    let mut scan_count = 0usize;
+    let mut scanned_bytes = 0usize;
+    let mut scan_session = manager.read(&tree).expect("range scan session opens");
+    scan_session
+        .scan_range(&[], None, |entry| {
+            scanned_bytes = scanned_bytes
+                .wrapping_add(entry.key().len())
+                .wrapping_add(entry.value().len());
+            scan_count += 1;
+        })
+        .expect("range scan succeeds");
+    let scan_elapsed = scan_started.elapsed();
+    assert_eq!(scan_count, result_count, "range scan cardinality mismatch");
+    black_box(scanned_bytes);
+
+    ScenarioResult {
+        write_operations,
+        write_elapsed,
+        read_operations: targets.len(),
+        read_elapsed,
+        scan_operations: scan_count,
+        scan_elapsed,
+        digest,
+        result_count,
+    }
+}
+
+fn build_fresh(
+    manager: &Prolly<Arc<MemStore>>,
+    records: usize,
+    workload: Workload,
+) -> (Tree, Duration, u64) {
+    let mut tree = manager.create();
+    let mut elapsed = Duration::ZERO;
+    let mut digest = FNV_OFFSET;
+    let mut batch = Vec::with_capacity(records);
+
+    for index in 0..records {
+        let id = fresh_id(workload, index, records);
+        let key = key_for_position(id * 2);
+        let value = value_for_position(id * 2, 0);
+        digest = digest_operation(digest, &key, &value);
+        batch.push(Mutation::Upsert { key, val: value });
+        if index + 1 == records {
+            let started = Instant::now();
+            tree = manager
+                .batch(&tree, black_box(std::mem::take(&mut batch)))
+                .expect("fresh write batch succeeds");
+            elapsed += started.elapsed();
+        }
+    }
+    (tree, elapsed, digest)
+}
+
+fn apply_mutations(
+    manager: &Prolly<Arc<MemStore>>,
+    mut tree: Tree,
+    records: usize,
+    writes: usize,
+    workload: Workload,
+) -> (Tree, Duration, u64) {
+    let mut elapsed = Duration::ZERO;
+    let mut digest = FNV_OFFSET;
+    let mut batch = Vec::with_capacity(writes);
+
+    for index in 0..writes {
+        let position = mutation_position(workload, index, records, writes);
+        let key = key_for_position(position);
+        let value = value_for_position(position, 1);
+        digest = digest_operation(digest, &key, &value);
+        batch.push(Mutation::Upsert { key, val: value });
+        if index + 1 == writes {
+            let started = Instant::now();
+            tree = if workload == Workload::Append {
+                manager
+                    .append_batch(&tree, black_box(std::mem::take(&mut batch)))
+                    .expect("append batch succeeds")
+            } else {
+                manager
+                    .batch(&tree, black_box(std::mem::take(&mut batch)))
+                    .expect("mutation batch succeeds")
+            };
+            elapsed += started.elapsed();
+        }
+    }
+    (tree, elapsed, digest)
+}
+
+fn fresh_id(workload: Workload, index: usize, records: usize) -> usize {
+    match workload {
+        Workload::Append => index,
+        Workload::Random => permute(index, records, RANDOM_SEED ^ records as u64),
+        Workload::Clustered => {
+            let blocks = records / CLUSTER_SIZE;
+            let block = index / CLUSTER_SIZE;
+            let offset = index % CLUSTER_SIZE;
+            permute(block, blocks, RANDOM_SEED ^ 0xc1a5_7e2d) * CLUSTER_SIZE + offset
+        }
+    }
+}
+
+fn mutation_position(workload: Workload, index: usize, records: usize, writes: usize) -> usize {
+    match workload {
+        Workload::Append => records * 2 + index,
+        Workload::Random => {
+            let ordinal = index / 2;
+            if index % 2 == 0 {
+                permute(ordinal, records, RANDOM_SEED ^ 0xa11c_e001) * 2
+            } else {
+                permute(ordinal, records, RANDOM_SEED ^ 0x1a5e_2701) * 2 + 1
+            }
+        }
+        Workload::Clustered => {
+            let updates = writes / 2;
+            let inserts = writes - updates;
+            let width = updates.max(inserts);
+            let start = (records - width) / 2;
+            let ordinal = index / 2;
+            if index % 2 == 0 {
+                (start + ordinal) * 2
+            } else {
+                (start + ordinal) * 2 + 1
+            }
+        }
+    }
+}
+
+fn read_targets(
+    phase: Phase,
+    workload: Workload,
+    records: usize,
+    writes: usize,
+) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let count = POINT_READS.min(match phase {
+        Phase::Fresh => records,
+        Phase::Mutation => records + writes,
+    });
+    let mut targets = Vec::with_capacity(count);
+    for index in 0..count {
+        let (position, generation) = match phase {
+            Phase::Fresh => {
+                let id = permute(index % records, records, RANDOM_SEED ^ 0x5ead_0001);
+                (id * 2, 0)
+            }
+            Phase::Mutation => mutation_read_target(workload, index, records, writes),
+        };
+        targets.push((
+            key_for_position(position),
+            value_for_position(position, generation),
+        ));
+    }
+    targets
+}
+
+fn mutation_read_target(
+    workload: Workload,
+    index: usize,
+    records: usize,
+    writes: usize,
+) -> (usize, u64) {
+    match workload {
+        Workload::Append => {
+            if index % 2 == 0 {
+                let id = (index / 2) % records;
+                (id * 2, 0)
+            } else {
+                let id = (index / 2) % writes;
+                (records * 2 + id, 1)
+            }
+        }
+        Workload::Random | Workload::Clustered => {
+            let updates = writes / 2;
+            let inserts = writes - updates;
+            match index % 3 {
+                0 => {
+                    let op = 2 * ((index / 3) % updates);
+                    (mutation_position(workload, op, records, writes), 1)
+                }
+                1 => {
+                    let op = 2 * ((index / 3) % inserts) + 1;
+                    (mutation_position(workload, op, records, writes), 1)
+                }
+                _ => {
+                    let unchanged_ordinal = (index / 3) % (records - updates);
+                    let id = match workload {
+                        Workload::Random => permute(
+                            updates + unchanged_ordinal,
+                            records,
+                            RANDOM_SEED ^ 0xa11c_e001,
+                        ),
+                        Workload::Clustered => {
+                            let width = updates.max(inserts);
+                            let start = (records - width) / 2;
+                            unchanged_ordinal % start
+                        }
+                        Workload::Append => unreachable!(),
+                    };
+                    (id * 2, 0)
+                }
+            }
+        }
+    }
+}
+
+fn key_for_position(position: usize) -> Vec<u8> {
+    format!("key-{position:020}").into_bytes()
+}
+
+fn value_for_position(position: usize, generation: u64) -> Vec<u8> {
+    let mut state = mix64(position as u64 ^ generation.wrapping_mul(0x9e37_79b9_7f4a_7c15));
+    let len = (state % 100 + 1) as usize;
+    let mut value = Vec::with_capacity(len);
+    for index in 0..len {
+        state = mix64(state.wrapping_add(index as u64).wrapping_add(0x9e37_79b9));
+        value.push(state as u8);
+    }
+    value
+}
+
+fn permute(index: usize, count: usize, seed: u64) -> usize {
+    if count <= 1 {
+        return 0;
+    }
+    let mut multiplier = (mix64(seed) as usize % count) | 1;
+    while gcd(multiplier, count) != 1 {
+        multiplier = (multiplier + 2) % count;
+        if multiplier == 0 {
+            multiplier = 1;
+        }
+    }
+    let offset = mix64(seed ^ 0xd1b5_4a32_d192_ed03) as usize % count;
+    (multiplier * index + offset) % count
+}
+
+fn gcd(mut left: usize, mut right: usize) -> usize {
+    while right != 0 {
+        let remainder = left % right;
+        left = right;
+        right = remainder;
+    }
+    left
+}
+
+fn mix64(mut value: u64) -> u64 {
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+fn digest_operation(mut digest: u64, key: &[u8], value: &[u8]) -> u64 {
+    digest = digest_bytes(digest, &(key.len() as u32).to_be_bytes());
+    digest = digest_bytes(digest, key);
+    digest = digest_bytes(digest, &(value.len() as u32).to_be_bytes());
+    digest_bytes(digest, value)
+}
+
+fn digest_bytes(mut digest: u64, bytes: &[u8]) -> u64 {
+    for byte in bytes {
+        digest ^= u64::from(*byte);
+        digest = digest.wrapping_mul(FNV_PRIME);
+    }
+    digest
+}
+
+fn emit(
+    revision: &str,
+    args: &Args,
+    operation: &str,
+    operations: usize,
+    elapsed: Duration,
+    digest: u64,
+    result_count: usize,
+) {
+    let elapsed_ns = elapsed.as_nanos();
+    let ns_per_op = elapsed_ns as f64 / operations.max(1) as f64;
+    let ops_per_sec = operations as f64 * 1_000_000_000.0 / elapsed_ns.max(1) as f64;
+    println!(
+        "rust,{revision},{},{},{},{operation},{operations},{elapsed_ns},{ns_per_op:.3},{ops_per_sec:.3},{digest:016x},{result_count},true",
+        args.records,
+        args.phase.name(),
+        args.workload.name(),
+    );
+}
+
+fn parse_args() -> Args {
+    let mut records = None;
+    let mut phase = None;
+    let mut workload = None;
+    let mut args = env::args().skip(1);
+    while let Some(flag) = args.next() {
+        let value = args
+            .next()
+            .unwrap_or_else(|| panic!("missing value for {flag}"));
+        match flag.as_str() {
+            "--records" => records = Some(value.parse().expect("records must be an integer")),
+            "--phase" => phase = Some(Phase::parse(&value)),
+            "--workload" => workload = Some(Workload::parse(&value)),
+            _ => panic!("unknown argument {flag}"),
+        }
+    }
+    Args {
+        records: records.expect("--records is required"),
+        phase: phase.expect("--phase is required"),
+        workload: workload.expect("--workload is required"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn permutation_is_unique_for_requested_scales() {
+        for count in [10_000, 50_000, 1_000_000] {
+            let values = (0..count)
+                .map(|index| permute(index, count, RANDOM_SEED))
+                .collect::<BTreeSet<_>>();
+            assert_eq!(values.len(), count);
+            assert_eq!(values.first(), Some(&0));
+            assert_eq!(values.last(), Some(&(count - 1)));
+        }
+    }
+
+    #[test]
+    fn values_are_deterministic_and_within_requested_size() {
+        let first = value_for_position(42, 0);
+        assert_eq!(first, value_for_position(42, 0));
+        assert_ne!(first, value_for_position(42, 1));
+        assert!((1..=100).contains(&first.len()));
+    }
+
+    #[test]
+    fn mutation_mix_has_equal_updates_and_inserts() {
+        let records = 10_000;
+        let writes = records * 30 / 100;
+        let positions = (0..writes)
+            .map(|index| mutation_position(Workload::Random, index, records, writes))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            positions
+                .iter()
+                .filter(|position| **position % 2 == 0)
+                .count(),
+            1_500
+        );
+        assert_eq!(
+            positions
+                .iter()
+                .filter(|position| **position % 2 == 1)
+                .count(),
+            1_500
+        );
+        assert_eq!(positions.iter().collect::<BTreeSet<_>>().len(), writes);
+    }
+
+    #[test]
+    fn workload_contract_has_stable_digest() {
+        let mut digest = FNV_OFFSET;
+        for index in 0..10_000 {
+            let id = fresh_id(Workload::Random, index, 10_000);
+            let key = key_for_position(id * 2);
+            let value = value_for_position(id * 2, 0);
+            digest = digest_operation(digest, &key, &value);
+        }
+        assert_eq!(digest, 0x0041_97dd_790a_1245);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,13 +356,14 @@ pub use prolly::proximity::{
     ProductQuantizationConfig, ProductQuantizationQuality, ProductQuantizer, ProximityBuildStats,
     ProximityConfig, ProximityFilter, ProximityMap, ProximityMembershipProof,
     ProximityMembershipVerification, ProximityMutation, ProximityMutationStats,
-    ProximityProofFilter, ProximityRecord, ProximitySearchClaim, ProximitySearchEvent,
-    ProximitySearchProof, ProximitySearchRequest, ProximitySearchStats,
-    ProximitySearchVerification, ProximityStructuralProof, ProximityStructuralVerification,
-    ProximityTree, ProximityVerification, QueryKernel, ScalarQuantizationConfig, SearchBackend,
-    SearchBudget, SearchCompletion, SearchIo, SearchOptions, SearchPlan, SearchPlanSummary,
-    SearchPolicy, SearchRequest, SearchResult, SearchRuntime, SearchRuntimePolicy,
-    StoreCacheNamespace, VectorStorageConfig, SEARCH_PLAN_FORMAT_VERSION,
+    ProximityProofFilter, ProximityReadSession, ProximityRecord, ProximityRecordRef,
+    ProximitySearchClaim, ProximitySearchEvent, ProximitySearchProof, ProximitySearchRequest,
+    ProximitySearchStats, ProximitySearchVerification, ProximityStructuralProof,
+    ProximityStructuralVerification, ProximityTree, ProximityVectorRef, ProximityVerification,
+    QueryKernel, ScalarQuantizationConfig, SearchBackend, SearchBudget, SearchCompletion, SearchIo,
+    SearchOptions, SearchPlan, SearchPlanSummary, SearchPolicy, SearchRequest, SearchResult,
+    SearchRuntime, SearchRuntimePolicy, StoreCacheNamespace, VectorStorageConfig,
+    SEARCH_PLAN_FORMAT_VERSION,
 };
 #[cfg(feature = "async-store")]
 pub use prolly::proximity::{
@@ -372,22 +373,30 @@ pub use prolly::proximity::{
 pub use prolly::range::{
     CursorWindow, RangeCursor, RangeIter, RangePage, ReverseCursor, ReversePage,
 };
+#[cfg(feature = "async-store")]
+pub use prolly::read::AsyncReadSession;
+pub use prolly::read::{
+    BorrowedMergeResolver, ConflictRef, DiffRef, EntryRef, MergeDecision, ReadSession, ScanOutcome,
+    ValueRefView,
+};
 pub use prolly::secondary_index::{
     catalog_checkpoint_key, catalog_checkpoints_prefix, catalog_current_key,
     catalog_descriptor_key, catalog_format_key, catalog_map_id, catalog_retired_key,
-    control_record_key, control_root_name, decode_physical_index_key, descriptor_fingerprint,
-    index_map_id, physical_index_key, term_bounds_exact, term_bounds_prefix, term_bounds_range,
-    ActiveIndexControl, ActiveIndexHealth, DecodedPhysicalIndexKey, IndexBuildResult,
-    IndexCheckpoint, IndexControl, IndexProjection, IndexValue, IndexVerification,
+    control_record_key, control_root_name, decode_physical_index_key,
+    decode_physical_index_key_ref, descriptor_fingerprint, index_map_id, physical_index_key,
+    term_bounds_exact, term_bounds_prefix, term_bounds_range, ActiveIndexControl,
+    ActiveIndexHealth, DecodedPhysicalIndexKey, DecodedPhysicalIndexKeyRef, IndexBuildResult,
+    IndexCheckpoint, IndexControl, IndexProjection, IndexValue, IndexValueRef, IndexVerification,
     IndexedHeadRecord, IndexedMap, IndexedMapEditor, IndexedMapHealth, IndexedMapMetricsSnapshot,
     IndexedMapUpdate, IndexedRetentionResult, IndexedSnapshot, IndexedSnapshotBundle,
     IndexedSnapshotBundleIndex, IndexedSnapshotBundleSummary, IndexedSnapshotBundleVerification,
-    IndexedSnapshotId, IndexedSourceRecord, IndexedVersion, ProjectedIndexEntry, SecondaryIndex,
-    SecondaryIndexBuilder, SecondaryIndexCursor, SecondaryIndexDescriptor, SecondaryIndexDirection,
-    SecondaryIndexEntry, SecondaryIndexError, SecondaryIndexExtractor, SecondaryIndexLimits,
-    SecondaryIndexMatch, SecondaryIndexPage, SecondaryIndexRegistry, SecondaryIndexSnapshot,
-    TermBounds, INDEXED_SNAPSHOT_BUNDLE_FORMAT_VERSION, INDEX_PHYSICAL_LAYOUT_VERSION,
-    SECONDARY_INDEX_FORMAT_VERSION,
+    IndexedSnapshotId, IndexedSourceRecord, IndexedSourceRecordRef, IndexedVersion,
+    ProjectedIndexEntry, SecondaryIndex, SecondaryIndexBuilder, SecondaryIndexCursor,
+    SecondaryIndexDescriptor, SecondaryIndexDirection, SecondaryIndexEntry, SecondaryIndexEntryRef,
+    SecondaryIndexError, SecondaryIndexExtractor, SecondaryIndexLimits, SecondaryIndexMatch,
+    SecondaryIndexMatchRef, SecondaryIndexPage, SecondaryIndexRegistry, SecondaryIndexSnapshot,
+    StreamingSecondaryIndexExtractor, TermBounds, INDEXED_SNAPSHOT_BUNDLE_FORMAT_VERSION,
+    INDEX_PHYSICAL_LAYOUT_VERSION, SECONDARY_INDEX_FORMAT_VERSION,
 };
 pub use prolly::snapshot::{
     snapshot_id_from_name, snapshot_root_name, SnapshotManager, SnapshotNamespace, SnapshotRoot,

--- a/src/prolly/blob.rs
+++ b/src/prolly/blob.rs
@@ -13,6 +13,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::cid::Cid;
 use super::error::Error;
+use super::read::ValueRefView;
 
 const VALUE_REF_MAGIC: &[u8; 4] = b"PLVB";
 const VALUE_REF_VERSION: u8 = 1;
@@ -20,6 +21,50 @@ const VALUE_REF_INLINE: u8 = 0;
 const VALUE_REF_BLOB: u8 = 1;
 const VALUE_REF_HEADER_LEN: usize = 6;
 const U64_LEN: usize = 8;
+
+/// Parse stored bytes into a callback-scoped borrowed value-reference view.
+pub(crate) fn value_ref_view_from_stored_bytes(bytes: &[u8]) -> Result<ValueRefView<'_>, Error> {
+    if !bytes.starts_with(VALUE_REF_MAGIC) {
+        return Ok(ValueRefView::Inline(bytes));
+    }
+    if bytes.len() < VALUE_REF_HEADER_LEN {
+        return Err(value_ref_error("value reference header is truncated"));
+    }
+    if bytes[4] != VALUE_REF_VERSION {
+        return Err(value_ref_error(format!(
+            "unsupported value reference version {}",
+            bytes[4]
+        )));
+    }
+
+    match bytes[5] {
+        VALUE_REF_INLINE => {
+            let mut offset = VALUE_REF_HEADER_LEN;
+            let len = usize::try_from(read_u64(bytes, &mut offset, "inline value length")?)
+                .map_err(|_| value_ref_error("inline value length exceeds platform limits"))?;
+            if bytes.len().saturating_sub(offset) != len {
+                return Err(value_ref_error(
+                    "inline value length does not match payload",
+                ));
+            }
+            Ok(ValueRefView::Inline(&bytes[offset..]))
+        }
+        VALUE_REF_BLOB => {
+            let expected_len = VALUE_REF_HEADER_LEN + 32 + U64_LEN;
+            if bytes.len() != expected_len {
+                return Err(value_ref_error("blob reference length is invalid"));
+            }
+            let mut cid = [0u8; 32];
+            cid.copy_from_slice(&bytes[VALUE_REF_HEADER_LEN..VALUE_REF_HEADER_LEN + 32]);
+            let mut offset = VALUE_REF_HEADER_LEN + 32;
+            let len = read_u64(bytes, &mut offset, "blob length")?;
+            Ok(ValueRefView::Blob { cid: Cid(cid), len })
+        }
+        tag => Err(value_ref_error(format!(
+            "unknown value reference tag {tag}"
+        ))),
+    }
+}
 
 /// Default maximum value size stored directly in leaf nodes by large-value
 /// helpers.

--- a/src/prolly/diff.rs
+++ b/src/prolly/diff.rs
@@ -120,7 +120,7 @@ use serde::{Deserialize, Serialize};
 use super::batch::{get_max_key, BatchWriteCollector};
 use super::cid::Cid;
 use super::error::{Conflict, Diff, Error, Mutation, Resolution, Resolver};
-use super::node::Node;
+use super::node::{Node, ReadNode};
 use super::range::RangeCursor;
 use super::read::{BorrowedMergeResolver, ConflictRef, DiffRef, MergeDecision, ScanOutcome};
 #[cfg(feature = "async-store")]
@@ -965,11 +965,11 @@ pub(crate) fn stream_diff<'a, S: Store>(
 /// materializes complete subtree entries.
 struct BorrowedSubtreeCursor<'a, S: Store> {
     prolly: &'a Prolly<S>,
-    stack: Vec<(Arc<Node>, usize)>,
+    stack: Vec<(Arc<ReadNode>, usize)>,
 }
 
 impl<'a, S: Store> BorrowedSubtreeCursor<'a, S> {
-    fn new(prolly: &'a Prolly<S>, root: Arc<Node>) -> Result<Self, Error> {
+    fn new(prolly: &'a Prolly<S>, root: Arc<ReadNode>) -> Result<Self, Error> {
         let mut cursor = Self {
             prolly,
             stack: Vec::new(),
@@ -978,20 +978,47 @@ impl<'a, S: Store> BorrowedSubtreeCursor<'a, S> {
         Ok(cursor)
     }
 
+    fn new_at(prolly: &'a Prolly<S>, mut node: Arc<ReadNode>, start: &[u8]) -> Result<Self, Error> {
+        let mut stack = Vec::new();
+        loop {
+            if node.is_leaf() {
+                let index = match node.search(start) {
+                    Ok(index) | Err(index) => index,
+                };
+                let at_end = index >= node.len();
+                stack.push((node, index));
+                let mut cursor = Self { prolly, stack };
+                if at_end {
+                    cursor.advance()?;
+                }
+                return Ok(cursor);
+            }
+            if node.is_empty() {
+                return Err(Error::InvalidNode);
+            }
+            let index = match node.search(start) {
+                Ok(index) => index,
+                Err(index) => index.saturating_sub(1),
+            };
+            let child = prolly.load_read_arc(&node.child_cid(index)?)?;
+            stack.push((node, index));
+            node = child;
+        }
+    }
+
     fn current(&self) -> Result<Option<BorrowedEntry<'_>>, Error> {
         let Some((node, index)) = self.stack.last() else {
             return Ok(None);
         };
-        ensure_node_value_count(node)?;
-        if !node.leaf {
+        if !node.is_leaf() {
             return Err(Error::InvalidNode);
         }
         if *index >= node.len() {
             return Ok(None);
         }
         Ok(Some((
-            node.keys.get(*index).ok_or(Error::InvalidNode)?,
-            node_value(node, *index)?,
+            node.key(*index).ok_or(Error::InvalidNode)?,
+            node.value(*index).ok_or(Error::InvalidNode)?,
         )))
     }
 
@@ -999,8 +1026,7 @@ impl<'a, S: Store> BorrowedSubtreeCursor<'a, S> {
         let Some((leaf, index)) = self.stack.last_mut() else {
             return Ok(false);
         };
-        ensure_node_value_count(leaf)?;
-        if !leaf.leaf {
+        if !leaf.is_leaf() {
             return Err(Error::InvalidNode);
         }
         *index += 1;
@@ -1010,8 +1036,7 @@ impl<'a, S: Store> BorrowedSubtreeCursor<'a, S> {
 
         self.stack.pop();
         while let Some((parent, index)) = self.stack.last_mut() {
-            ensure_node_value_count(parent)?;
-            if parent.leaf {
+            if parent.is_leaf() {
                 return Err(Error::InvalidNode);
             }
             *index += 1;
@@ -1019,19 +1044,16 @@ impl<'a, S: Store> BorrowedSubtreeCursor<'a, S> {
                 self.stack.pop();
                 continue;
             }
-            let child = self
-                .prolly
-                .load_arc(&child_cid_validated(parent, *index)?)?;
+            let child = self.prolly.load_read_arc(&parent.child_cid(*index)?)?;
             self.descend_leftmost(child)?;
             return Ok(true);
         }
         Ok(false)
     }
 
-    fn descend_leftmost(&mut self, mut node: Arc<Node>) -> Result<(), Error> {
+    fn descend_leftmost(&mut self, mut node: Arc<ReadNode>) -> Result<(), Error> {
         loop {
-            ensure_node_value_count(&node)?;
-            if node.leaf {
+            if node.is_leaf() {
                 if !node.is_empty() {
                     self.stack.push((node, 0));
                 }
@@ -1040,7 +1062,7 @@ impl<'a, S: Store> BorrowedSubtreeCursor<'a, S> {
             if node.is_empty() {
                 return Err(Error::InvalidNode);
             }
-            let child = self.prolly.load_arc(&child_cid_validated(&node, 0)?)?;
+            let child = self.prolly.load_read_arc(&node.child_cid(0)?)?;
             self.stack.push((node, 0));
             node = child;
         }
@@ -1050,7 +1072,7 @@ impl<'a, S: Store> BorrowedSubtreeCursor<'a, S> {
 #[cfg(feature = "async-store")]
 struct AsyncBorrowedSubtreeCursor<'a, S: AsyncStore> {
     prolly: &'a AsyncProlly<S>,
-    stack: Vec<(Arc<Node>, usize)>,
+    stack: Vec<(Arc<ReadNode>, usize)>,
 }
 
 #[cfg(feature = "async-store")]
@@ -1059,7 +1081,7 @@ where
     S: AsyncStore,
     S::Error: Send + Sync,
 {
-    async fn new(prolly: &'a AsyncProlly<S>, root: Arc<Node>) -> Result<Self, Error> {
+    async fn new(prolly: &'a AsyncProlly<S>, root: Arc<ReadNode>) -> Result<Self, Error> {
         let mut cursor = Self {
             prolly,
             stack: Vec::new(),
@@ -1068,20 +1090,51 @@ where
         Ok(cursor)
     }
 
+    async fn new_at(
+        prolly: &'a AsyncProlly<S>,
+        mut node: Arc<ReadNode>,
+        start: &[u8],
+    ) -> Result<Self, Error> {
+        let mut stack = Vec::new();
+        loop {
+            if node.is_leaf() {
+                let index = match node.search(start) {
+                    Ok(index) | Err(index) => index,
+                };
+                let at_end = index >= node.len();
+                stack.push((node, index));
+                let mut cursor = Self { prolly, stack };
+                if at_end {
+                    cursor.advance().await?;
+                }
+                return Ok(cursor);
+            }
+            if node.is_empty() {
+                return Err(Error::InvalidNode);
+            }
+            let index = match node.search(start) {
+                Ok(index) => index,
+                Err(index) => index.saturating_sub(1),
+            };
+            let child = prolly.load_read_arc(&node.child_cid(index)?).await?;
+            stack.push((node, index));
+            node = child;
+        }
+    }
+
     fn current(&self) -> Result<Option<BorrowedEntry<'_>>, Error> {
         let Some((node, index)) = self.stack.last() else {
             return Ok(None);
         };
-        ensure_node_value_count(node)?;
-        if !node.leaf {
+        if !node.is_leaf() {
             return Err(Error::InvalidNode);
         }
         if *index >= node.len() {
             return Ok(None);
         }
         Ok(Some((
-            node.keys.get(*index).ok_or(Error::InvalidNode)?,
-            node_value(node, *index)?,
+            node.key(*index).ok_or(Error::InvalidNode)?,
+            node.value(*index).ok_or(Error::InvalidNode)?,
         )))
     }
 
@@ -1089,8 +1142,7 @@ where
         let Some((leaf, index)) = self.stack.last_mut() else {
             return Ok(false);
         };
-        ensure_node_value_count(leaf)?;
-        if !leaf.leaf {
+        if !leaf.is_leaf() {
             return Err(Error::InvalidNode);
         }
         *index += 1;
@@ -1100,8 +1152,7 @@ where
 
         self.stack.pop();
         while let Some((parent, index)) = self.stack.last_mut() {
-            ensure_node_value_count(parent)?;
-            if parent.leaf {
+            if parent.is_leaf() {
                 return Err(Error::InvalidNode);
             }
             *index += 1;
@@ -1111,7 +1162,7 @@ where
             }
             let child = self
                 .prolly
-                .load_arc(&child_cid_validated(parent, *index)?)
+                .load_read_arc(&parent.child_cid(*index)?)
                 .await?;
             self.descend_leftmost(child).await?;
             return Ok(true);
@@ -1119,10 +1170,9 @@ where
         Ok(false)
     }
 
-    async fn descend_leftmost(&mut self, mut node: Arc<Node>) -> Result<(), Error> {
+    async fn descend_leftmost(&mut self, mut node: Arc<ReadNode>) -> Result<(), Error> {
         loop {
-            ensure_node_value_count(&node)?;
-            if node.leaf {
+            if node.is_leaf() {
                 if !node.is_empty() {
                     self.stack.push((node, 0));
                 }
@@ -1131,10 +1181,7 @@ where
             if node.is_empty() {
                 return Err(Error::InvalidNode);
             }
-            let child = self
-                .prolly
-                .load_arc(&child_cid_validated(&node, 0)?)
-                .await?;
+            let child = self.prolly.load_read_arc(&node.child_cid(0)?).await?;
             self.stack.push((node, 0));
             node = child;
         }
@@ -1184,38 +1231,39 @@ where
 }
 
 fn visit_leaf_diff<F, B>(
-    base: &Node,
-    other: &Node,
+    base: &ReadNode,
+    other: &ReadNode,
     visitor: &mut BorrowedDiffVisitor<F, B>,
 ) -> Result<(), Error>
 where
     F: for<'diff> FnMut(DiffRef<'diff>) -> ControlFlow<B>,
 {
-    ensure_node_value_count(base)?;
-    ensure_node_value_count(other)?;
+    if !base.is_leaf() || !other.is_leaf() {
+        return Err(Error::InvalidNode);
+    }
     let mut base_index = 0usize;
     let mut other_index = 0usize;
     while base_index < base.len() && other_index < other.len() && !visitor.done {
-        let base_key = &base.keys[base_index];
-        let other_key = &other.keys[other_index];
+        let base_key = base.key(base_index).ok_or(Error::InvalidNode)?;
+        let other_key = other.key(other_index).ok_or(Error::InvalidNode)?;
         match base_key.cmp(other_key) {
             std::cmp::Ordering::Less => {
                 visitor.emit(DiffRef::Removed {
                     key: base_key,
-                    value: node_value(base, base_index)?,
+                    value: base.value(base_index).ok_or(Error::InvalidNode)?,
                 });
                 base_index += 1;
             }
             std::cmp::Ordering::Greater => {
                 visitor.emit(DiffRef::Added {
                     key: other_key,
-                    value: node_value(other, other_index)?,
+                    value: other.value(other_index).ok_or(Error::InvalidNode)?,
                 });
                 other_index += 1;
             }
             std::cmp::Ordering::Equal => {
-                let old = node_value(base, base_index)?;
-                let new = node_value(other, other_index)?;
+                let old = base.value(base_index).ok_or(Error::InvalidNode)?;
+                let new = other.value(other_index).ok_or(Error::InvalidNode)?;
                 if old != new {
                     visitor.emit(DiffRef::Changed {
                         key: base_key,
@@ -1230,15 +1278,15 @@ where
     }
     while base_index < base.len() && !visitor.done {
         visitor.emit(DiffRef::Removed {
-            key: &base.keys[base_index],
-            value: node_value(base, base_index)?,
+            key: base.key(base_index).ok_or(Error::InvalidNode)?,
+            value: base.value(base_index).ok_or(Error::InvalidNode)?,
         });
         base_index += 1;
     }
     while other_index < other.len() && !visitor.done {
         visitor.emit(DiffRef::Added {
-            key: &other.keys[other_index],
-            value: node_value(other, other_index)?,
+            key: other.key(other_index).ok_or(Error::InvalidNode)?,
+            value: other.value(other_index).ok_or(Error::InvalidNode)?,
         });
         other_index += 1;
     }
@@ -1247,8 +1295,8 @@ where
 
 fn visit_subtree_diff<S, F, B>(
     prolly: &Prolly<S>,
-    base: Arc<Node>,
-    other: Arc<Node>,
+    base: Arc<ReadNode>,
+    other: Arc<ReadNode>,
     visitor: &mut BorrowedDiffVisitor<F, B>,
 ) -> Result<(), Error>
 where
@@ -1302,11 +1350,76 @@ where
     Ok(())
 }
 
+fn visit_subtree_diff_range<S, F, B>(
+    prolly: &Prolly<S>,
+    base: Arc<ReadNode>,
+    other: Arc<ReadNode>,
+    start: &[u8],
+    end: Option<&[u8]>,
+    visitor: &mut BorrowedDiffVisitor<F, B>,
+) -> Result<(), Error>
+where
+    S: Store,
+    F: for<'diff> FnMut(DiffRef<'diff>) -> ControlFlow<B>,
+{
+    let mut base = BorrowedSubtreeCursor::new_at(prolly, base, start)?;
+    let mut other = BorrowedSubtreeCursor::new_at(prolly, other, start)?;
+    while !visitor.done {
+        let base_entry = base
+            .current()?
+            .filter(|(key, _)| end.map_or(true, |end| *key < end));
+        let other_entry = other
+            .current()?
+            .filter(|(key, _)| end.map_or(true, |end| *key < end));
+        match (base_entry, other_entry) {
+            (Some((base_key, base_value)), Some((other_key, other_value))) => {
+                match base_key.cmp(other_key) {
+                    std::cmp::Ordering::Less => {
+                        visitor.emit(DiffRef::Removed {
+                            key: base_key,
+                            value: base_value,
+                        });
+                        base.advance()?;
+                    }
+                    std::cmp::Ordering::Greater => {
+                        visitor.emit(DiffRef::Added {
+                            key: other_key,
+                            value: other_value,
+                        });
+                        other.advance()?;
+                    }
+                    std::cmp::Ordering::Equal => {
+                        if base_value != other_value {
+                            visitor.emit(DiffRef::Changed {
+                                key: base_key,
+                                old: base_value,
+                                new: other_value,
+                            });
+                        }
+                        base.advance()?;
+                        other.advance()?;
+                    }
+                }
+            }
+            (Some((key, value)), None) => {
+                visitor.emit(DiffRef::Removed { key, value });
+                base.advance()?;
+            }
+            (None, Some((key, value))) => {
+                visitor.emit(DiffRef::Added { key, value });
+                other.advance()?;
+            }
+            (None, None) => break,
+        }
+    }
+    Ok(())
+}
+
 #[cfg(feature = "async-store")]
 async fn visit_async_subtree_diff<S, F, B>(
     prolly: &AsyncProlly<S>,
-    base: Arc<Node>,
-    other: Arc<Node>,
+    base: Arc<ReadNode>,
+    other: Arc<ReadNode>,
     visitor: &mut BorrowedDiffVisitor<F, B>,
 ) -> Result<(), Error>
 where
@@ -1382,60 +1495,318 @@ where
     Ok(())
 }
 
+#[cfg(feature = "async-store")]
+async fn visit_async_subtree_diff_range<S, F, B>(
+    prolly: &AsyncProlly<S>,
+    base: Arc<ReadNode>,
+    other: Arc<ReadNode>,
+    start: &[u8],
+    end: Option<&[u8]>,
+    visitor: &mut BorrowedDiffVisitor<F, B>,
+) -> Result<(), Error>
+where
+    S: AsyncStore,
+    S::Error: Send + Sync,
+    F: for<'diff> FnMut(DiffRef<'diff>) -> ControlFlow<B>,
+{
+    enum Advance {
+        Base,
+        Other,
+        Both,
+        Done,
+    }
+
+    let mut base = AsyncBorrowedSubtreeCursor::new_at(prolly, base, start).await?;
+    let mut other = AsyncBorrowedSubtreeCursor::new_at(prolly, other, start).await?;
+    while !visitor.done {
+        let advance = {
+            let base_entry = base
+                .current()?
+                .filter(|(key, _)| end.map_or(true, |end| *key < end));
+            let other_entry = other
+                .current()?
+                .filter(|(key, _)| end.map_or(true, |end| *key < end));
+            match (base_entry, other_entry) {
+                (Some((base_key, base_value)), Some((other_key, other_value))) => {
+                    match base_key.cmp(other_key) {
+                        std::cmp::Ordering::Less => {
+                            visitor.emit(DiffRef::Removed {
+                                key: base_key,
+                                value: base_value,
+                            });
+                            Advance::Base
+                        }
+                        std::cmp::Ordering::Greater => {
+                            visitor.emit(DiffRef::Added {
+                                key: other_key,
+                                value: other_value,
+                            });
+                            Advance::Other
+                        }
+                        std::cmp::Ordering::Equal => {
+                            if base_value != other_value {
+                                visitor.emit(DiffRef::Changed {
+                                    key: base_key,
+                                    old: base_value,
+                                    new: other_value,
+                                });
+                            }
+                            Advance::Both
+                        }
+                    }
+                }
+                (Some((key, value)), None) => {
+                    visitor.emit(DiffRef::Removed { key, value });
+                    Advance::Base
+                }
+                (None, Some((key, value))) => {
+                    visitor.emit(DiffRef::Added { key, value });
+                    Advance::Other
+                }
+                (None, None) => Advance::Done,
+            }
+        };
+        match advance {
+            Advance::Base => {
+                base.advance().await?;
+            }
+            Advance::Other => {
+                other.advance().await?;
+            }
+            Advance::Both => {
+                base.advance().await?;
+                other.advance().await?;
+            }
+            Advance::Done => break,
+        }
+    }
+    Ok(())
+}
+
+enum BorrowedDiffFrame {
+    Structural(DiffFrame),
+    LocalRange {
+        base: Arc<ReadNode>,
+        other: Arc<ReadNode>,
+        start: Vec<u8>,
+        end: Option<Vec<u8>>,
+    },
+}
+
 fn borrowed_internal_frames(
-    base: &Node,
-    other: &Node,
+    base: &Arc<ReadNode>,
+    other: &Arc<ReadNode>,
     span_end: Option<&[u8]>,
-) -> Result<Option<Vec<DiffFrame>>, Error> {
-    ensure_node_value_count(base)?;
-    ensure_node_value_count(other)?;
+) -> Result<Vec<BorrowedDiffFrame>, Error> {
+    if base.is_leaf() || other.is_leaf() {
+        return Err(Error::InvalidNode);
+    }
     let mut frames = Vec::with_capacity(base.len().max(other.len()));
     let mut base_index = 0usize;
     let mut other_index = 0usize;
     while base_index < base.len() && other_index < other.len() {
-        let base_start = base.keys[base_index].as_slice();
-        let other_start = other.keys[other_index].as_slice();
-        let base_end = child_span_end(base, base_index, span_end);
-        let other_end = child_span_end(other, other_index, span_end);
+        let base_start = base.key(base_index).ok_or(Error::InvalidNode)?;
+        let other_start = other.key(other_index).ok_or(Error::InvalidNode)?;
+        let base_end = packed_child_span_end(base, base_index, span_end);
+        let other_end = packed_child_span_end(other, other_index, span_end);
+        if base_start == other_start
+            && base.child_cid(base_index)? == other.child_cid(other_index)?
+        {
+            base_index += 1;
+            other_index += 1;
+            continue;
+        }
         if base_start == other_start && base_end == other_end {
-            let base_cid = child_cid_validated(base, base_index)?;
-            let other_cid = child_cid_validated(other, other_index)?;
+            let base_cid = base.child_cid(base_index)?;
+            let other_cid = other.child_cid(other_index)?;
             if base_cid != other_cid {
-                frames.push(DiffFrame::Compare {
+                frames.push(BorrowedDiffFrame::Structural(DiffFrame::Compare {
                     base_cid,
                     other_cid,
                     span_end: base_end.map(<[u8]>::to_vec),
-                });
+                }));
             }
             base_index += 1;
             other_index += 1;
         } else if span_ends_before_or_at(base_end, other_start) {
-            frames.push(DiffFrame::Removed {
-                cid: child_cid_validated(base, base_index)?,
-            });
+            frames.push(BorrowedDiffFrame::Structural(DiffFrame::Removed {
+                cid: base.child_cid(base_index)?,
+            }));
             base_index += 1;
         } else if span_ends_before_or_at(other_end, base_start) {
-            frames.push(DiffFrame::Added {
-                cid: child_cid_validated(other, other_index)?,
-            });
+            frames.push(BorrowedDiffFrame::Structural(DiffFrame::Added {
+                cid: other.child_cid(other_index)?,
+            }));
+            other_index += 1;
+        } else if base_end == other_end {
+            let base_cid = base.child_cid(base_index)?;
+            let other_cid = other.child_cid(other_index)?;
+            if base_cid != other_cid {
+                frames.push(BorrowedDiffFrame::Structural(DiffFrame::Compare {
+                    base_cid,
+                    other_cid,
+                    span_end: base_end.map(<[u8]>::to_vec),
+                }));
+            }
+            base_index += 1;
             other_index += 1;
         } else {
-            return Ok(None);
+            let start = base_start.min(other_start).to_vec();
+            let resync = packed_next_shared_child_start(base, base_index, other, other_index)?;
+            let end = match resync {
+                Some((next_base, _)) => {
+                    Some(base.key(next_base).ok_or(Error::InvalidNode)?.to_vec())
+                }
+                None => span_end.map(<[u8]>::to_vec),
+            };
+            frames.push(BorrowedDiffFrame::LocalRange {
+                base: base.clone(),
+                other: other.clone(),
+                start,
+                end,
+            });
+            if let Some((next_base, next_other)) = resync {
+                base_index = next_base;
+                other_index = next_other;
+            } else {
+                base_index = base.len();
+                other_index = other.len();
+            }
         }
     }
     while base_index < base.len() {
-        frames.push(DiffFrame::Removed {
-            cid: child_cid_validated(base, base_index)?,
-        });
+        frames.push(BorrowedDiffFrame::Structural(DiffFrame::Removed {
+            cid: base.child_cid(base_index)?,
+        }));
         base_index += 1;
     }
     while other_index < other.len() {
-        frames.push(DiffFrame::Added {
-            cid: child_cid_validated(other, other_index)?,
-        });
+        frames.push(BorrowedDiffFrame::Structural(DiffFrame::Added {
+            cid: other.child_cid(other_index)?,
+        }));
         other_index += 1;
     }
-    Ok(Some(frames))
+    Ok(frames)
+}
+
+fn packed_next_shared_child_start(
+    base: &ReadNode,
+    base_index: usize,
+    other: &ReadNode,
+    other_index: usize,
+) -> Result<Option<(usize, usize)>, Error> {
+    let mut left = base_index + 1;
+    let mut right = other_index + 1;
+    while left < base.len() && right < other.len() {
+        match base
+            .key(left)
+            .ok_or(Error::InvalidNode)?
+            .cmp(other.key(right).ok_or(Error::InvalidNode)?)
+        {
+            std::cmp::Ordering::Less => left += 1,
+            std::cmp::Ordering::Greater => right += 1,
+            std::cmp::Ordering::Equal => return Ok(Some((left, right))),
+        }
+    }
+    Ok(None)
+}
+
+fn packed_child_span_end<'a>(
+    node: &'a ReadNode,
+    index: usize,
+    span_end: Option<&'a [u8]>,
+) -> Option<&'a [u8]> {
+    node.key(index + 1).or(span_end)
+}
+
+fn packed_child_diff_frames(node: &ReadNode, kind: DiffFrameKind) -> Result<Vec<DiffFrame>, Error> {
+    if node.is_leaf() {
+        return Err(Error::InvalidNode);
+    }
+    (0..node.len())
+        .map(|index| Ok(kind.frame(node.child_cid(index)?)))
+        .collect()
+}
+
+fn prefetch_borrowed_frame_roots<S: Store>(
+    prolly: &Prolly<S>,
+    frames: &[BorrowedDiffFrame],
+) -> Result<(), Error> {
+    if frames.len() <= 1 {
+        return Ok(());
+    }
+    let mut seen = HashSet::with_capacity(frames.len().saturating_mul(2));
+    let mut cids = Vec::with_capacity(frames.len().saturating_mul(2));
+    for frame in frames {
+        match frame {
+            BorrowedDiffFrame::Structural(DiffFrame::Compare {
+                base_cid,
+                other_cid,
+                ..
+            }) => {
+                if seen.insert(base_cid.clone()) {
+                    cids.push(base_cid.clone());
+                }
+                if seen.insert(other_cid.clone()) {
+                    cids.push(other_cid.clone());
+                }
+            }
+            BorrowedDiffFrame::Structural(DiffFrame::Added { cid })
+            | BorrowedDiffFrame::Structural(DiffFrame::Removed { cid }) => {
+                if seen.insert(cid.clone()) {
+                    cids.push(cid.clone());
+                }
+            }
+            BorrowedDiffFrame::LocalRange { .. } => {}
+        }
+    }
+    if !cids.is_empty() {
+        let _ = prolly.load_many_read_ordered(&cids)?;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "async-store")]
+async fn prefetch_async_borrowed_frame_roots<S>(
+    prolly: &AsyncProlly<S>,
+    frames: &[BorrowedDiffFrame],
+) -> Result<(), Error>
+where
+    S: AsyncStore,
+    S::Error: Send + Sync,
+{
+    if frames.len() <= 1 {
+        return Ok(());
+    }
+    let mut seen = HashSet::with_capacity(frames.len().saturating_mul(2));
+    let mut cids = Vec::with_capacity(frames.len().saturating_mul(2));
+    for frame in frames {
+        match frame {
+            BorrowedDiffFrame::Structural(DiffFrame::Compare {
+                base_cid,
+                other_cid,
+                ..
+            }) => {
+                if seen.insert(base_cid.clone()) {
+                    cids.push(base_cid.clone());
+                }
+                if seen.insert(other_cid.clone()) {
+                    cids.push(other_cid.clone());
+                }
+            }
+            BorrowedDiffFrame::Structural(DiffFrame::Added { cid })
+            | BorrowedDiffFrame::Structural(DiffFrame::Removed { cid }) => {
+                if seen.insert(cid.clone()) {
+                    cids.push(cid.clone());
+                }
+            }
+            BorrowedDiffFrame::LocalRange { .. } => {}
+        }
+    }
+    if !cids.is_empty() {
+        let _ = prolly.load_many_read_ordered(&cids).await?;
+    }
+    Ok(())
 }
 
 fn scan_diff_borrowed<S, F, B>(
@@ -1467,55 +1838,55 @@ where
         break_value: None,
         done: false,
     };
-    let mut stack = initial_diff_stack(base, other);
+    let mut stack = initial_diff_stack(base, other)
+        .into_iter()
+        .map(BorrowedDiffFrame::Structural)
+        .collect::<Vec<_>>();
     while let Some(frame) = stack.pop() {
         if visitor.done {
             break;
         }
         match frame {
-            DiffFrame::Compare {
+            BorrowedDiffFrame::Structural(DiffFrame::Compare {
                 base_cid,
                 other_cid,
                 span_end,
-            } => {
+            }) => {
                 if base_cid == other_cid {
                     continue;
                 }
-                let nodes = prolly.load_many_ordered(&[base_cid, other_cid])?;
+                let nodes = prolly.load_many_read_ordered(&[base_cid, other_cid])?;
                 let base_node = nodes[0].clone();
                 let other_node = nodes[1].clone();
-                match (base_node.leaf, other_node.leaf) {
+                match (base_node.is_leaf(), other_node.is_leaf()) {
                     (true, true) => visit_leaf_diff(&base_node, &other_node, &mut visitor)?,
-                    (false, false) if base_node.level == other_node.level => {
-                        match borrowed_internal_frames(
-                            &base_node,
-                            &other_node,
-                            span_end.as_deref(),
-                        )? {
-                            Some(frames) => stack.extend(frames.into_iter().rev()),
-                            None => {
-                                visit_subtree_diff(prolly, base_node, other_node, &mut visitor)?
-                            }
-                        }
+                    (false, false) if base_node.level() == other_node.level() => {
+                        let frames =
+                            borrowed_internal_frames(&base_node, &other_node, span_end.as_deref())?;
+                        prefetch_borrowed_frame_roots(prolly, &frames)?;
+                        stack.extend(frames.into_iter().rev());
                     }
                     _ => visit_subtree_diff(prolly, base_node, other_node, &mut visitor)?,
                 }
             }
-            DiffFrame::Added { ref cid } | DiffFrame::Removed { ref cid } => {
-                let added = matches!(frame, DiffFrame::Added { .. });
-                let node = prolly.load_arc(cid)?;
-                if node.leaf {
-                    ensure_node_value_count(&node)?;
+            BorrowedDiffFrame::Structural(DiffFrame::Added { ref cid })
+            | BorrowedDiffFrame::Structural(DiffFrame::Removed { ref cid }) => {
+                let added = matches!(
+                    &frame,
+                    BorrowedDiffFrame::Structural(DiffFrame::Added { .. })
+                );
+                let node = prolly.load_read_arc(cid)?;
+                if node.is_leaf() {
                     for index in 0..node.len() {
                         let diff = if added {
                             DiffRef::Added {
-                                key: &node.keys[index],
-                                value: node_value(&node, index)?,
+                                key: node.key(index).ok_or(Error::InvalidNode)?,
+                                value: node.value(index).ok_or(Error::InvalidNode)?,
                             }
                         } else {
                             DiffRef::Removed {
-                                key: &node.keys[index],
-                                value: node_value(&node, index)?,
+                                key: node.key(index).ok_or(Error::InvalidNode)?,
+                                value: node.value(index).ok_or(Error::InvalidNode)?,
                             }
                         };
                         if !visitor.emit(diff) {
@@ -1528,10 +1899,22 @@ where
                     } else {
                         DiffFrameKind::Removed
                     };
-                    let mut frames = child_diff_frames(&node, kind)?;
+                    let mut frames = packed_child_diff_frames(&node, kind)?
+                        .into_iter()
+                        .map(BorrowedDiffFrame::Structural)
+                        .collect::<Vec<_>>();
+                    prefetch_borrowed_frame_roots(prolly, &frames)?;
                     frames.reverse();
                     stack.extend(frames);
                 }
+            }
+            BorrowedDiffFrame::LocalRange {
+                base,
+                other,
+                start,
+                end,
+            } => {
+                visit_subtree_diff_range(prolly, base, other, &start, end.as_deref(), &mut visitor)?
             }
         }
     }
@@ -1569,42 +1952,35 @@ where
         break_value: None,
         done: false,
     };
-    let mut stack = initial_diff_stack(base, other);
+    let mut stack = initial_diff_stack(base, other)
+        .into_iter()
+        .map(BorrowedDiffFrame::Structural)
+        .collect::<Vec<_>>();
     while let Some(frame) = stack.pop() {
         if visitor.done {
             break;
         }
         match frame {
-            DiffFrame::Compare {
+            BorrowedDiffFrame::Structural(DiffFrame::Compare {
                 base_cid,
                 other_cid,
                 span_end,
-            } => {
+            }) => {
                 if base_cid == other_cid {
                     continue;
                 }
-                let nodes = prolly.load_many_ordered(&[base_cid, other_cid]).await?;
+                let nodes = prolly
+                    .load_many_read_ordered(&[base_cid, other_cid])
+                    .await?;
                 let base_node = nodes[0].clone();
                 let other_node = nodes[1].clone();
-                match (base_node.leaf, other_node.leaf) {
+                match (base_node.is_leaf(), other_node.is_leaf()) {
                     (true, true) => visit_leaf_diff(&base_node, &other_node, &mut visitor)?,
-                    (false, false) if base_node.level == other_node.level => {
-                        match borrowed_internal_frames(
-                            &base_node,
-                            &other_node,
-                            span_end.as_deref(),
-                        )? {
-                            Some(frames) => stack.extend(frames.into_iter().rev()),
-                            None => {
-                                visit_async_subtree_diff(
-                                    prolly,
-                                    base_node,
-                                    other_node,
-                                    &mut visitor,
-                                )
-                                .await?
-                            }
-                        }
+                    (false, false) if base_node.level() == other_node.level() => {
+                        let frames =
+                            borrowed_internal_frames(&base_node, &other_node, span_end.as_deref())?;
+                        prefetch_async_borrowed_frame_roots(prolly, &frames).await?;
+                        stack.extend(frames.into_iter().rev());
                     }
                     _ => {
                         visit_async_subtree_diff(prolly, base_node, other_node, &mut visitor)
@@ -1612,21 +1988,24 @@ where
                     }
                 }
             }
-            DiffFrame::Added { ref cid } | DiffFrame::Removed { ref cid } => {
-                let added = matches!(frame, DiffFrame::Added { .. });
-                let node = prolly.load_arc(cid).await?;
-                if node.leaf {
-                    ensure_node_value_count(&node)?;
+            BorrowedDiffFrame::Structural(DiffFrame::Added { ref cid })
+            | BorrowedDiffFrame::Structural(DiffFrame::Removed { ref cid }) => {
+                let added = matches!(
+                    &frame,
+                    BorrowedDiffFrame::Structural(DiffFrame::Added { .. })
+                );
+                let node = prolly.load_read_arc(cid).await?;
+                if node.is_leaf() {
                     for index in 0..node.len() {
                         let diff = if added {
                             DiffRef::Added {
-                                key: &node.keys[index],
-                                value: node_value(&node, index)?,
+                                key: node.key(index).ok_or(Error::InvalidNode)?,
+                                value: node.value(index).ok_or(Error::InvalidNode)?,
                             }
                         } else {
                             DiffRef::Removed {
-                                key: &node.keys[index],
-                                value: node_value(&node, index)?,
+                                key: node.key(index).ok_or(Error::InvalidNode)?,
+                                value: node.value(index).ok_or(Error::InvalidNode)?,
                             }
                         };
                         if !visitor.emit(diff) {
@@ -1639,10 +2018,30 @@ where
                     } else {
                         DiffFrameKind::Removed
                     };
-                    let mut frames = child_diff_frames(&node, kind)?;
+                    let mut frames = packed_child_diff_frames(&node, kind)?
+                        .into_iter()
+                        .map(BorrowedDiffFrame::Structural)
+                        .collect::<Vec<_>>();
+                    prefetch_async_borrowed_frame_roots(prolly, &frames).await?;
                     frames.reverse();
                     stack.extend(frames);
                 }
+            }
+            BorrowedDiffFrame::LocalRange {
+                base,
+                other,
+                start,
+                end,
+            } => {
+                visit_async_subtree_diff_range(
+                    prolly,
+                    base,
+                    other,
+                    &start,
+                    end.as_deref(),
+                    &mut visitor,
+                )
+                .await?
             }
         }
     }
@@ -2235,11 +2634,9 @@ pub fn compute_diff<S: Store>(
     base: &Tree,
     other: &Tree,
 ) -> Result<Vec<Diff>, Error> {
-    if let Some(diffs) = try_append_only_diff(prolly, base, other)? {
-        return Ok(diffs);
-    }
-
-    compute_localized_diff(prolly, base, other).map(|(diffs, _)| diffs)
+    let mut diffs = Vec::new();
+    prolly.scan_diff(base, other, |diff| diffs.push(diff.to_owned()))?;
+    Ok(diffs)
 }
 
 fn compute_diff_with_stats<S: Store>(
@@ -2571,25 +2968,8 @@ pub fn compute_range_diff<S: Store>(
     start: &[u8],
     end: Option<&[u8]>,
 ) -> Result<Vec<Diff>, Error> {
-    if end.is_some_and(|end| end <= start) || base.root == other.root {
-        return Ok(Vec::new());
-    }
-
     let mut diffs = Vec::new();
-
-    match (&base.root, &other.root) {
-        (Some(base_cid), Some(other_cid)) => {
-            diff_range_nodes(prolly, base_cid, other_cid, None, start, end, &mut diffs)?;
-        }
-        (Some(base_cid), None) => {
-            collect_removed_range_from_cid(prolly, base_cid, None, start, end, &mut diffs)?;
-        }
-        (None, Some(other_cid)) => {
-            collect_added_range_from_cid(prolly, other_cid, None, start, end, &mut diffs)?;
-        }
-        (None, None) => {}
-    }
-
+    prolly.scan_range_diff(base, other, start, end, |diff| diffs.push(diff.to_owned()))?;
     Ok(diffs)
 }
 
@@ -2603,40 +2983,10 @@ where
     S: AsyncStore,
     S::Error: Send + Sync,
 {
-    if base.root == other.root {
-        return Ok(Vec::new());
-    }
-
     let mut diffs = Vec::new();
-    let mut stack = initial_diff_stack(base, other);
-
-    while let Some(frame) = stack.pop() {
-        match frame {
-            DiffFrame::Compare {
-                base_cid,
-                other_cid,
-                span_end,
-            } => {
-                process_async_diff_compare(
-                    prolly,
-                    base_cid,
-                    other_cid,
-                    span_end.as_deref(),
-                    &mut stack,
-                    &mut diffs,
-                    None,
-                )
-                .await?;
-            }
-            DiffFrame::Added { cid } => {
-                process_async_added(prolly, cid, &mut stack, &mut diffs, None).await?;
-            }
-            DiffFrame::Removed { cid } => {
-                process_async_removed(prolly, cid, &mut stack, &mut diffs, None).await?;
-            }
-        }
-    }
-
+    prolly
+        .scan_diff(base, other, |diff| diffs.push(diff.to_owned()))
+        .await?;
     Ok(diffs)
 }
 
@@ -2720,74 +3070,10 @@ where
     S: AsyncStore,
     S::Error: Send + Sync,
 {
-    if end.is_some_and(|end| end <= start) || base.root == other.root {
-        return Ok(Vec::new());
-    }
-
     let mut diffs = Vec::new();
-    let mut stack = match (&base.root, &other.root) {
-        (Some(base_cid), Some(other_cid)) => vec![RangeDiffFrame::Compare {
-            base_cid: base_cid.clone(),
-            other_cid: other_cid.clone(),
-            span_end: None,
-        }],
-        (Some(base_cid), None) => vec![RangeDiffFrame::Removed {
-            cid: base_cid.clone(),
-            span_end: None,
-        }],
-        (None, Some(other_cid)) => vec![RangeDiffFrame::Added {
-            cid: other_cid.clone(),
-            span_end: None,
-        }],
-        (None, None) => Vec::new(),
-    };
-
-    while let Some(frame) = stack.pop() {
-        match frame {
-            RangeDiffFrame::Compare {
-                base_cid,
-                other_cid,
-                span_end,
-            } => {
-                process_async_range_compare(
-                    prolly,
-                    base_cid,
-                    other_cid,
-                    span_end.as_deref(),
-                    start,
-                    end,
-                    &mut stack,
-                    &mut diffs,
-                )
-                .await?;
-            }
-            RangeDiffFrame::Added { cid, span_end } => {
-                let node = prolly.load_arc(&cid).await?;
-                collect_added_range_from_node_async(
-                    prolly,
-                    &node,
-                    span_end.as_deref(),
-                    start,
-                    end,
-                    &mut diffs,
-                )
-                .await?;
-            }
-            RangeDiffFrame::Removed { cid, span_end } => {
-                let node = prolly.load_arc(&cid).await?;
-                collect_removed_range_from_node_async(
-                    prolly,
-                    &node,
-                    span_end.as_deref(),
-                    start,
-                    end,
-                    &mut diffs,
-                )
-                .await?;
-            }
-        }
-    }
-
+    prolly
+        .scan_range_diff(base, other, start, end, |diff| diffs.push(diff.to_owned()))
+        .await?;
     Ok(diffs)
 }
 
@@ -3101,6 +3387,7 @@ where
 
 #[cfg(feature = "async-store")]
 #[derive(Clone)]
+#[allow(dead_code)]
 enum RangeDiffFrame {
     Compare {
         base_cid: Cid,
@@ -3312,6 +3599,7 @@ where
 
 #[cfg(feature = "async-store")]
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
 async fn process_async_range_compare<S>(
     prolly: &AsyncProlly<S>,
     base_cid: Cid,
@@ -3370,6 +3658,7 @@ where
 
 #[cfg(feature = "async-store")]
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
 async fn enqueue_async_internal_range_diff<S>(
     prolly: &AsyncProlly<S>,
     base: &Node,
@@ -3531,6 +3820,7 @@ where
 }
 
 #[cfg(feature = "async-store")]
+#[allow(dead_code)]
 async fn prefetch_async_range_frame_roots<S>(
     prolly: &AsyncProlly<S>,
     frames: &[RangeDiffFrame],
@@ -3574,6 +3864,7 @@ where
     Ok(())
 }
 
+#[allow(dead_code)]
 fn diff_range_nodes<S: Store>(
     prolly: &Prolly<S>,
     base_cid: &Cid,
@@ -3614,6 +3905,7 @@ fn diff_range_nodes<S: Store>(
     }
 }
 
+#[allow(dead_code)]
 fn load_range_diff_node_pair<S: Store>(
     prolly: &Prolly<S>,
     base_cid: &Cid,
@@ -3627,6 +3919,7 @@ fn load_range_diff_node_pair<S: Store>(
     Ok((prolly.load_arc(base_cid)?, prolly.load_arc(other_cid)?))
 }
 
+#[allow(dead_code)]
 fn diff_internal_nodes_range<S: Store>(
     prolly: &Prolly<S>,
     base: &Node,
@@ -3822,6 +4115,7 @@ fn diff_leaf_nodes(base: &Node, other: &Node, diffs: &mut Vec<Diff>) -> Result<(
     Ok(())
 }
 
+#[allow(dead_code)]
 fn diff_leaf_nodes_range(
     base: &Node,
     other: &Node,
@@ -4088,6 +4382,7 @@ fn collect_added_from_node<S: Store>(
     Ok(())
 }
 
+#[allow(dead_code)]
 fn collect_added_range_from_cid<S: Store>(
     prolly: &Prolly<S>,
     cid: &Cid,
@@ -4100,6 +4395,7 @@ fn collect_added_range_from_cid<S: Store>(
     collect_added_range_from_node(prolly, &node, span_end, range_start, range_end, diffs)
 }
 
+#[allow(dead_code)]
 fn collect_added_range_from_node<S: Store>(
     prolly: &Prolly<S>,
     node: &Node,
@@ -4143,6 +4439,7 @@ fn collect_added_range_from_node<S: Store>(
     Ok(())
 }
 
+#[allow(dead_code)]
 fn collect_removed_range_from_cid<S: Store>(
     prolly: &Prolly<S>,
     cid: &Cid,
@@ -4155,6 +4452,7 @@ fn collect_removed_range_from_cid<S: Store>(
     collect_removed_range_from_node(prolly, &node, span_end, range_start, range_end, diffs)
 }
 
+#[allow(dead_code)]
 fn collect_removed_range_from_node<S: Store>(
     prolly: &Prolly<S>,
     node: &Node,
@@ -4241,6 +4539,7 @@ where
 }
 
 #[cfg(feature = "async-store")]
+#[allow(dead_code)]
 async fn diff_collected_nodes_range_async<S>(
     prolly: &AsyncProlly<S>,
     base: &Node,
@@ -4309,6 +4608,7 @@ where
 }
 
 #[cfg(feature = "async-store")]
+#[allow(dead_code)]
 async fn collect_entries_range_from_node_async<S>(
     prolly: &AsyncProlly<S>,
     node: &Node,
@@ -4357,6 +4657,7 @@ where
 }
 
 #[cfg(feature = "async-store")]
+#[allow(dead_code)]
 async fn collect_added_range_from_node_async<S>(
     prolly: &AsyncProlly<S>,
     node: &Node,
@@ -4389,6 +4690,7 @@ where
 }
 
 #[cfg(feature = "async-store")]
+#[allow(dead_code)]
 async fn collect_removed_range_from_node_async<S>(
     prolly: &AsyncProlly<S>,
     node: &Node,

--- a/src/prolly/diff.rs
+++ b/src/prolly/diff.rs
@@ -106,9 +106,12 @@
 //! - **Different roots**: O(changed subtrees) when chunk boundaries align, with
 //!   a local full-scan fallback when boundaries diverge
 
+use std::borrow::Cow;
 #[cfg(test)]
 use std::collections::BTreeMap;
 use std::collections::{HashSet, VecDeque};
+use std::ops::ControlFlow;
+use std::sync::Arc;
 
 #[cfg(feature = "async-store")]
 use futures_util::stream::{self, Stream};
@@ -119,6 +122,7 @@ use super::cid::Cid;
 use super::error::{Conflict, Diff, Error, Mutation, Resolution, Resolver};
 use super::node::Node;
 use super::range::RangeCursor;
+use super::read::{BorrowedMergeResolver, ConflictRef, DiffRef, MergeDecision, ScanOutcome};
 #[cfg(feature = "async-store")]
 use super::store::AsyncStore;
 use super::store::Store;
@@ -129,9 +133,11 @@ use super::AsyncProlly;
 use super::Prolly;
 
 type ChildSpanCid<'a> = (Option<&'a [u8]>, Cid);
+type BorrowedEntry<'a> = (&'a [u8], &'a [u8]);
 const DIFF_COLLECTION_PREFETCH_PARALLELISM: usize = 16;
 const DIFF_FRAME_PREFETCH_PARALLELISM: usize = 16;
 const MERGE_FRONTIER_PREFETCH_PARALLELISM: usize = 16;
+const BORROWED_MERGE_MUTATION_BATCH: usize = 4096;
 
 /// A bounded page of diff results.
 ///
@@ -422,15 +428,97 @@ impl<'a> MergeTraceRecorder<'a> {
         conflict: &Conflict,
         resolution: &Resolution,
     ) {
-        self.record(MergeTraceEvent::ResolverCalled {
-            stage,
-            key: conflict.key.clone(),
-            resolution: MergeResolutionKind::from(resolution),
-        });
+        self.record_resolver_kind(stage, &conflict.key, MergeResolutionKind::from(resolution));
+    }
+
+    fn record_resolver_kind(
+        &mut self,
+        stage: MergeTraceStage,
+        key: &[u8],
+        resolution: MergeResolutionKind,
+    ) {
+        // Avoid constructing owned diagnostic data when tracing is disabled.
+        if self.trace.is_some() {
+            self.record(MergeTraceEvent::ResolverCalled {
+                stage,
+                key: key.to_vec(),
+                resolution,
+            });
+        }
     }
 
     fn record_fallback(&mut self, reason: MergeFallbackReason) {
         self.record(MergeTraceEvent::Fallback { reason });
+    }
+}
+
+#[derive(Clone, Copy)]
+enum MergeResolverRef<'a> {
+    Legacy(&'a dyn Fn(&Conflict) -> Resolution),
+    Borrowed(&'a dyn BorrowedMergeResolver),
+}
+
+fn resolve_conflict<'value>(
+    resolver: Option<MergeResolverRef<'_>>,
+    conflict: ConflictRef<'value>,
+    stage: MergeTraceStage,
+    recorder: &mut MergeTraceRecorder<'_>,
+) -> Result<Option<Cow<'value, [u8]>>, Conflict> {
+    match resolver {
+        Some(MergeResolverRef::Borrowed(resolve)) => {
+            let decision = resolve.resolve(conflict);
+            let (selected, kind) = match decision {
+                MergeDecision::UseBase => (
+                    conflict.base.map(Cow::Borrowed),
+                    if conflict.base.is_some() {
+                        MergeResolutionKind::Value
+                    } else {
+                        MergeResolutionKind::Delete
+                    },
+                ),
+                MergeDecision::UseLeft => (
+                    conflict.left.map(Cow::Borrowed),
+                    if conflict.left.is_some() {
+                        MergeResolutionKind::Value
+                    } else {
+                        MergeResolutionKind::Delete
+                    },
+                ),
+                MergeDecision::UseRight => (
+                    conflict.right.map(Cow::Borrowed),
+                    if conflict.right.is_some() {
+                        MergeResolutionKind::Value
+                    } else {
+                        MergeResolutionKind::Delete
+                    },
+                ),
+                MergeDecision::Value(value) => {
+                    (Some(Cow::Owned(value)), MergeResolutionKind::Value)
+                }
+                MergeDecision::Delete => (None, MergeResolutionKind::Delete),
+                MergeDecision::Unresolved => {
+                    recorder.record_resolver_kind(
+                        stage,
+                        conflict.key,
+                        MergeResolutionKind::Unresolved,
+                    );
+                    return Err(conflict.to_owned());
+                }
+            };
+            recorder.record_resolver_kind(stage, conflict.key, kind);
+            Ok(selected)
+        }
+        Some(MergeResolverRef::Legacy(resolve)) => {
+            let owned = conflict.to_owned();
+            let resolution = resolve(&owned);
+            recorder.record_resolver(stage, &owned, &resolution);
+            match resolution {
+                Resolution::Value(value) => Ok(Some(Cow::Owned(value))),
+                Resolution::Delete => Ok(None),
+                Resolution::Unresolved => Err(owned),
+            }
+        }
+        None => Err(conflict.to_owned()),
     }
 }
 
@@ -870,6 +958,968 @@ pub(crate) fn stream_diff<'a, S: Store>(
     other: &Tree,
 ) -> StructuralDiffIter<'a, S> {
     StructuralDiffIter::new(prolly, base, other)
+}
+
+/// A retained cursor over one subtree used only for boundary-misaligned
+/// borrowed diff fallback. It keeps memory bounded by tree height and never
+/// materializes complete subtree entries.
+struct BorrowedSubtreeCursor<'a, S: Store> {
+    prolly: &'a Prolly<S>,
+    stack: Vec<(Arc<Node>, usize)>,
+}
+
+impl<'a, S: Store> BorrowedSubtreeCursor<'a, S> {
+    fn new(prolly: &'a Prolly<S>, root: Arc<Node>) -> Result<Self, Error> {
+        let mut cursor = Self {
+            prolly,
+            stack: Vec::new(),
+        };
+        cursor.descend_leftmost(root)?;
+        Ok(cursor)
+    }
+
+    fn current(&self) -> Result<Option<BorrowedEntry<'_>>, Error> {
+        let Some((node, index)) = self.stack.last() else {
+            return Ok(None);
+        };
+        ensure_node_value_count(node)?;
+        if !node.leaf {
+            return Err(Error::InvalidNode);
+        }
+        if *index >= node.len() {
+            return Ok(None);
+        }
+        Ok(Some((
+            node.keys.get(*index).ok_or(Error::InvalidNode)?,
+            node_value(node, *index)?,
+        )))
+    }
+
+    fn advance(&mut self) -> Result<bool, Error> {
+        let Some((leaf, index)) = self.stack.last_mut() else {
+            return Ok(false);
+        };
+        ensure_node_value_count(leaf)?;
+        if !leaf.leaf {
+            return Err(Error::InvalidNode);
+        }
+        *index += 1;
+        if *index < leaf.len() {
+            return Ok(true);
+        }
+
+        self.stack.pop();
+        while let Some((parent, index)) = self.stack.last_mut() {
+            ensure_node_value_count(parent)?;
+            if parent.leaf {
+                return Err(Error::InvalidNode);
+            }
+            *index += 1;
+            if *index >= parent.len() {
+                self.stack.pop();
+                continue;
+            }
+            let child = self
+                .prolly
+                .load_arc(&child_cid_validated(parent, *index)?)?;
+            self.descend_leftmost(child)?;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    fn descend_leftmost(&mut self, mut node: Arc<Node>) -> Result<(), Error> {
+        loop {
+            ensure_node_value_count(&node)?;
+            if node.leaf {
+                if !node.is_empty() {
+                    self.stack.push((node, 0));
+                }
+                return Ok(());
+            }
+            if node.is_empty() {
+                return Err(Error::InvalidNode);
+            }
+            let child = self.prolly.load_arc(&child_cid_validated(&node, 0)?)?;
+            self.stack.push((node, 0));
+            node = child;
+        }
+    }
+}
+
+#[cfg(feature = "async-store")]
+struct AsyncBorrowedSubtreeCursor<'a, S: AsyncStore> {
+    prolly: &'a AsyncProlly<S>,
+    stack: Vec<(Arc<Node>, usize)>,
+}
+
+#[cfg(feature = "async-store")]
+impl<'a, S> AsyncBorrowedSubtreeCursor<'a, S>
+where
+    S: AsyncStore,
+    S::Error: Send + Sync,
+{
+    async fn new(prolly: &'a AsyncProlly<S>, root: Arc<Node>) -> Result<Self, Error> {
+        let mut cursor = Self {
+            prolly,
+            stack: Vec::new(),
+        };
+        cursor.descend_leftmost(root).await?;
+        Ok(cursor)
+    }
+
+    fn current(&self) -> Result<Option<BorrowedEntry<'_>>, Error> {
+        let Some((node, index)) = self.stack.last() else {
+            return Ok(None);
+        };
+        ensure_node_value_count(node)?;
+        if !node.leaf {
+            return Err(Error::InvalidNode);
+        }
+        if *index >= node.len() {
+            return Ok(None);
+        }
+        Ok(Some((
+            node.keys.get(*index).ok_or(Error::InvalidNode)?,
+            node_value(node, *index)?,
+        )))
+    }
+
+    async fn advance(&mut self) -> Result<bool, Error> {
+        let Some((leaf, index)) = self.stack.last_mut() else {
+            return Ok(false);
+        };
+        ensure_node_value_count(leaf)?;
+        if !leaf.leaf {
+            return Err(Error::InvalidNode);
+        }
+        *index += 1;
+        if *index < leaf.len() {
+            return Ok(true);
+        }
+
+        self.stack.pop();
+        while let Some((parent, index)) = self.stack.last_mut() {
+            ensure_node_value_count(parent)?;
+            if parent.leaf {
+                return Err(Error::InvalidNode);
+            }
+            *index += 1;
+            if *index >= parent.len() {
+                self.stack.pop();
+                continue;
+            }
+            let child = self
+                .prolly
+                .load_arc(&child_cid_validated(parent, *index)?)
+                .await?;
+            self.descend_leftmost(child).await?;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    async fn descend_leftmost(&mut self, mut node: Arc<Node>) -> Result<(), Error> {
+        loop {
+            ensure_node_value_count(&node)?;
+            if node.leaf {
+                if !node.is_empty() {
+                    self.stack.push((node, 0));
+                }
+                return Ok(());
+            }
+            if node.is_empty() {
+                return Err(Error::InvalidNode);
+            }
+            let child = self
+                .prolly
+                .load_arc(&child_cid_validated(&node, 0)?)
+                .await?;
+            self.stack.push((node, 0));
+            node = child;
+        }
+    }
+}
+
+struct BorrowedDiffVisitor<F, B> {
+    visit: F,
+    start: Option<Vec<u8>>,
+    end: Option<Vec<u8>>,
+    visited: u64,
+    break_value: Option<B>,
+    done: bool,
+}
+
+impl<F, B> BorrowedDiffVisitor<F, B>
+where
+    F: for<'diff> FnMut(DiffRef<'diff>) -> ControlFlow<B>,
+{
+    fn emit(&mut self, diff: DiffRef<'_>) -> bool {
+        if self.done {
+            return false;
+        }
+        let key = diff.key();
+        if self.start.as_deref().is_some_and(|start| key < start) {
+            return true;
+        }
+        if self.end.as_deref().is_some_and(|end| key >= end) {
+            self.done = true;
+            return false;
+        }
+        self.visited = self.visited.saturating_add(1);
+        if let ControlFlow::Break(value) = (self.visit)(diff) {
+            self.break_value = Some(value);
+            self.done = true;
+            return false;
+        }
+        true
+    }
+
+    fn finish(self) -> ScanOutcome<B> {
+        match self.break_value {
+            Some(value) => ScanOutcome::stopped(self.visited, value),
+            None => ScanOutcome::complete(self.visited),
+        }
+    }
+}
+
+fn visit_leaf_diff<F, B>(
+    base: &Node,
+    other: &Node,
+    visitor: &mut BorrowedDiffVisitor<F, B>,
+) -> Result<(), Error>
+where
+    F: for<'diff> FnMut(DiffRef<'diff>) -> ControlFlow<B>,
+{
+    ensure_node_value_count(base)?;
+    ensure_node_value_count(other)?;
+    let mut base_index = 0usize;
+    let mut other_index = 0usize;
+    while base_index < base.len() && other_index < other.len() && !visitor.done {
+        let base_key = &base.keys[base_index];
+        let other_key = &other.keys[other_index];
+        match base_key.cmp(other_key) {
+            std::cmp::Ordering::Less => {
+                visitor.emit(DiffRef::Removed {
+                    key: base_key,
+                    value: node_value(base, base_index)?,
+                });
+                base_index += 1;
+            }
+            std::cmp::Ordering::Greater => {
+                visitor.emit(DiffRef::Added {
+                    key: other_key,
+                    value: node_value(other, other_index)?,
+                });
+                other_index += 1;
+            }
+            std::cmp::Ordering::Equal => {
+                let old = node_value(base, base_index)?;
+                let new = node_value(other, other_index)?;
+                if old != new {
+                    visitor.emit(DiffRef::Changed {
+                        key: base_key,
+                        old,
+                        new,
+                    });
+                }
+                base_index += 1;
+                other_index += 1;
+            }
+        }
+    }
+    while base_index < base.len() && !visitor.done {
+        visitor.emit(DiffRef::Removed {
+            key: &base.keys[base_index],
+            value: node_value(base, base_index)?,
+        });
+        base_index += 1;
+    }
+    while other_index < other.len() && !visitor.done {
+        visitor.emit(DiffRef::Added {
+            key: &other.keys[other_index],
+            value: node_value(other, other_index)?,
+        });
+        other_index += 1;
+    }
+    Ok(())
+}
+
+fn visit_subtree_diff<S, F, B>(
+    prolly: &Prolly<S>,
+    base: Arc<Node>,
+    other: Arc<Node>,
+    visitor: &mut BorrowedDiffVisitor<F, B>,
+) -> Result<(), Error>
+where
+    S: Store,
+    F: for<'diff> FnMut(DiffRef<'diff>) -> ControlFlow<B>,
+{
+    let mut base = BorrowedSubtreeCursor::new(prolly, base)?;
+    let mut other = BorrowedSubtreeCursor::new(prolly, other)?;
+    while !visitor.done {
+        match (base.current()?, other.current()?) {
+            (Some((base_key, base_value)), Some((other_key, other_value))) => {
+                match base_key.cmp(other_key) {
+                    std::cmp::Ordering::Less => {
+                        visitor.emit(DiffRef::Removed {
+                            key: base_key,
+                            value: base_value,
+                        });
+                        base.advance()?;
+                    }
+                    std::cmp::Ordering::Greater => {
+                        visitor.emit(DiffRef::Added {
+                            key: other_key,
+                            value: other_value,
+                        });
+                        other.advance()?;
+                    }
+                    std::cmp::Ordering::Equal => {
+                        if base_value != other_value {
+                            visitor.emit(DiffRef::Changed {
+                                key: base_key,
+                                old: base_value,
+                                new: other_value,
+                            });
+                        }
+                        base.advance()?;
+                        other.advance()?;
+                    }
+                }
+            }
+            (Some((key, value)), None) => {
+                visitor.emit(DiffRef::Removed { key, value });
+                base.advance()?;
+            }
+            (None, Some((key, value))) => {
+                visitor.emit(DiffRef::Added { key, value });
+                other.advance()?;
+            }
+            (None, None) => break,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "async-store")]
+async fn visit_async_subtree_diff<S, F, B>(
+    prolly: &AsyncProlly<S>,
+    base: Arc<Node>,
+    other: Arc<Node>,
+    visitor: &mut BorrowedDiffVisitor<F, B>,
+) -> Result<(), Error>
+where
+    S: AsyncStore,
+    S::Error: Send + Sync,
+    F: for<'diff> FnMut(DiffRef<'diff>) -> ControlFlow<B>,
+{
+    enum Advance {
+        Base,
+        Other,
+        Both,
+        Done,
+    }
+
+    let mut base = AsyncBorrowedSubtreeCursor::new(prolly, base).await?;
+    let mut other = AsyncBorrowedSubtreeCursor::new(prolly, other).await?;
+    while !visitor.done {
+        let advance = {
+            match (base.current()?, other.current()?) {
+                (Some((base_key, base_value)), Some((other_key, other_value))) => {
+                    match base_key.cmp(other_key) {
+                        std::cmp::Ordering::Less => {
+                            visitor.emit(DiffRef::Removed {
+                                key: base_key,
+                                value: base_value,
+                            });
+                            Advance::Base
+                        }
+                        std::cmp::Ordering::Greater => {
+                            visitor.emit(DiffRef::Added {
+                                key: other_key,
+                                value: other_value,
+                            });
+                            Advance::Other
+                        }
+                        std::cmp::Ordering::Equal => {
+                            if base_value != other_value {
+                                visitor.emit(DiffRef::Changed {
+                                    key: base_key,
+                                    old: base_value,
+                                    new: other_value,
+                                });
+                            }
+                            Advance::Both
+                        }
+                    }
+                }
+                (Some((key, value)), None) => {
+                    visitor.emit(DiffRef::Removed { key, value });
+                    Advance::Base
+                }
+                (None, Some((key, value))) => {
+                    visitor.emit(DiffRef::Added { key, value });
+                    Advance::Other
+                }
+                (None, None) => Advance::Done,
+            }
+        };
+        match advance {
+            Advance::Base => {
+                base.advance().await?;
+            }
+            Advance::Other => {
+                other.advance().await?;
+            }
+            Advance::Both => {
+                base.advance().await?;
+                other.advance().await?;
+            }
+            Advance::Done => break,
+        }
+    }
+    Ok(())
+}
+
+fn borrowed_internal_frames(
+    base: &Node,
+    other: &Node,
+    span_end: Option<&[u8]>,
+) -> Result<Option<Vec<DiffFrame>>, Error> {
+    ensure_node_value_count(base)?;
+    ensure_node_value_count(other)?;
+    let mut frames = Vec::with_capacity(base.len().max(other.len()));
+    let mut base_index = 0usize;
+    let mut other_index = 0usize;
+    while base_index < base.len() && other_index < other.len() {
+        let base_start = base.keys[base_index].as_slice();
+        let other_start = other.keys[other_index].as_slice();
+        let base_end = child_span_end(base, base_index, span_end);
+        let other_end = child_span_end(other, other_index, span_end);
+        if base_start == other_start && base_end == other_end {
+            let base_cid = child_cid_validated(base, base_index)?;
+            let other_cid = child_cid_validated(other, other_index)?;
+            if base_cid != other_cid {
+                frames.push(DiffFrame::Compare {
+                    base_cid,
+                    other_cid,
+                    span_end: base_end.map(<[u8]>::to_vec),
+                });
+            }
+            base_index += 1;
+            other_index += 1;
+        } else if span_ends_before_or_at(base_end, other_start) {
+            frames.push(DiffFrame::Removed {
+                cid: child_cid_validated(base, base_index)?,
+            });
+            base_index += 1;
+        } else if span_ends_before_or_at(other_end, base_start) {
+            frames.push(DiffFrame::Added {
+                cid: child_cid_validated(other, other_index)?,
+            });
+            other_index += 1;
+        } else {
+            return Ok(None);
+        }
+    }
+    while base_index < base.len() {
+        frames.push(DiffFrame::Removed {
+            cid: child_cid_validated(base, base_index)?,
+        });
+        base_index += 1;
+    }
+    while other_index < other.len() {
+        frames.push(DiffFrame::Added {
+            cid: child_cid_validated(other, other_index)?,
+        });
+        other_index += 1;
+    }
+    Ok(Some(frames))
+}
+
+fn scan_diff_borrowed<S, F, B>(
+    prolly: &Prolly<S>,
+    base: &Tree,
+    other: &Tree,
+    start: Option<&[u8]>,
+    end: Option<&[u8]>,
+    visit: F,
+) -> Result<ScanOutcome<B>, Error>
+where
+    S: Store,
+    F: for<'diff> FnMut(DiffRef<'diff>) -> ControlFlow<B>,
+{
+    if start.zip(end).is_some_and(|(start, end)| end <= start) {
+        return Ok(ScanOutcome::complete(0));
+    }
+    if base.config.format != other.config.format || base.config.format != prolly.config.format {
+        return Err(Error::FormatMismatch {
+            expected: prolly.config.format.digest()?,
+            actual: other.config.format.digest()?,
+        });
+    }
+    let mut visitor = BorrowedDiffVisitor {
+        visit,
+        start: start.map(<[u8]>::to_vec),
+        end: end.map(<[u8]>::to_vec),
+        visited: 0,
+        break_value: None,
+        done: false,
+    };
+    let mut stack = initial_diff_stack(base, other);
+    while let Some(frame) = stack.pop() {
+        if visitor.done {
+            break;
+        }
+        match frame {
+            DiffFrame::Compare {
+                base_cid,
+                other_cid,
+                span_end,
+            } => {
+                if base_cid == other_cid {
+                    continue;
+                }
+                let nodes = prolly.load_many_ordered(&[base_cid, other_cid])?;
+                let base_node = nodes[0].clone();
+                let other_node = nodes[1].clone();
+                match (base_node.leaf, other_node.leaf) {
+                    (true, true) => visit_leaf_diff(&base_node, &other_node, &mut visitor)?,
+                    (false, false) if base_node.level == other_node.level => {
+                        match borrowed_internal_frames(
+                            &base_node,
+                            &other_node,
+                            span_end.as_deref(),
+                        )? {
+                            Some(frames) => stack.extend(frames.into_iter().rev()),
+                            None => {
+                                visit_subtree_diff(prolly, base_node, other_node, &mut visitor)?
+                            }
+                        }
+                    }
+                    _ => visit_subtree_diff(prolly, base_node, other_node, &mut visitor)?,
+                }
+            }
+            DiffFrame::Added { ref cid } | DiffFrame::Removed { ref cid } => {
+                let added = matches!(frame, DiffFrame::Added { .. });
+                let node = prolly.load_arc(cid)?;
+                if node.leaf {
+                    ensure_node_value_count(&node)?;
+                    for index in 0..node.len() {
+                        let diff = if added {
+                            DiffRef::Added {
+                                key: &node.keys[index],
+                                value: node_value(&node, index)?,
+                            }
+                        } else {
+                            DiffRef::Removed {
+                                key: &node.keys[index],
+                                value: node_value(&node, index)?,
+                            }
+                        };
+                        if !visitor.emit(diff) {
+                            break;
+                        }
+                    }
+                } else {
+                    let kind = if added {
+                        DiffFrameKind::Added
+                    } else {
+                        DiffFrameKind::Removed
+                    };
+                    let mut frames = child_diff_frames(&node, kind)?;
+                    frames.reverse();
+                    stack.extend(frames);
+                }
+            }
+        }
+    }
+    Ok(visitor.finish())
+}
+
+#[cfg(feature = "async-store")]
+async fn scan_diff_borrowed_async<S, F, B>(
+    prolly: &AsyncProlly<S>,
+    base: &Tree,
+    other: &Tree,
+    start: Option<&[u8]>,
+    end: Option<&[u8]>,
+    visit: F,
+) -> Result<ScanOutcome<B>, Error>
+where
+    S: AsyncStore,
+    S::Error: Send + Sync,
+    F: for<'diff> FnMut(DiffRef<'diff>) -> ControlFlow<B>,
+{
+    if start.zip(end).is_some_and(|(start, end)| end <= start) {
+        return Ok(ScanOutcome::complete(0));
+    }
+    if base.config.format != other.config.format || base.config.format != prolly.config().format {
+        return Err(Error::FormatMismatch {
+            expected: prolly.config().format.digest()?,
+            actual: other.config.format.digest()?,
+        });
+    }
+    let mut visitor = BorrowedDiffVisitor {
+        visit,
+        start: start.map(<[u8]>::to_vec),
+        end: end.map(<[u8]>::to_vec),
+        visited: 0,
+        break_value: None,
+        done: false,
+    };
+    let mut stack = initial_diff_stack(base, other);
+    while let Some(frame) = stack.pop() {
+        if visitor.done {
+            break;
+        }
+        match frame {
+            DiffFrame::Compare {
+                base_cid,
+                other_cid,
+                span_end,
+            } => {
+                if base_cid == other_cid {
+                    continue;
+                }
+                let nodes = prolly.load_many_ordered(&[base_cid, other_cid]).await?;
+                let base_node = nodes[0].clone();
+                let other_node = nodes[1].clone();
+                match (base_node.leaf, other_node.leaf) {
+                    (true, true) => visit_leaf_diff(&base_node, &other_node, &mut visitor)?,
+                    (false, false) if base_node.level == other_node.level => {
+                        match borrowed_internal_frames(
+                            &base_node,
+                            &other_node,
+                            span_end.as_deref(),
+                        )? {
+                            Some(frames) => stack.extend(frames.into_iter().rev()),
+                            None => {
+                                visit_async_subtree_diff(
+                                    prolly,
+                                    base_node,
+                                    other_node,
+                                    &mut visitor,
+                                )
+                                .await?
+                            }
+                        }
+                    }
+                    _ => {
+                        visit_async_subtree_diff(prolly, base_node, other_node, &mut visitor)
+                            .await?
+                    }
+                }
+            }
+            DiffFrame::Added { ref cid } | DiffFrame::Removed { ref cid } => {
+                let added = matches!(frame, DiffFrame::Added { .. });
+                let node = prolly.load_arc(cid).await?;
+                if node.leaf {
+                    ensure_node_value_count(&node)?;
+                    for index in 0..node.len() {
+                        let diff = if added {
+                            DiffRef::Added {
+                                key: &node.keys[index],
+                                value: node_value(&node, index)?,
+                            }
+                        } else {
+                            DiffRef::Removed {
+                                key: &node.keys[index],
+                                value: node_value(&node, index)?,
+                            }
+                        };
+                        if !visitor.emit(diff) {
+                            break;
+                        }
+                    }
+                } else {
+                    let kind = if added {
+                        DiffFrameKind::Added
+                    } else {
+                        DiffFrameKind::Removed
+                    };
+                    let mut frames = child_diff_frames(&node, kind)?;
+                    frames.reverse();
+                    stack.extend(frames);
+                }
+            }
+        }
+    }
+    Ok(visitor.finish())
+}
+
+impl<S: Store> Prolly<S> {
+    /// Visit structural differences without allocating owned diff records.
+    pub fn scan_diff(
+        &self,
+        base: &Tree,
+        other: &Tree,
+        mut visit: impl for<'diff> FnMut(DiffRef<'diff>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_diff_until(base, other, |diff| {
+                visit(diff);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    /// Visit structural differences with callback-controlled early termination.
+    pub fn scan_diff_until<B>(
+        &self,
+        base: &Tree,
+        other: &Tree,
+        visit: impl for<'diff> FnMut(DiffRef<'diff>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        scan_diff_borrowed(self, base, other, None, None, visit)
+    }
+
+    /// Visit differences whose keys fall in `[start, end)`.
+    pub fn scan_range_diff(
+        &self,
+        base: &Tree,
+        other: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        mut visit: impl for<'diff> FnMut(DiffRef<'diff>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_range_diff_until(base, other, start, end, |diff| {
+                visit(diff);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    /// Visit a range of differences with early termination.
+    pub fn scan_range_diff_until<B>(
+        &self,
+        base: &Tree,
+        other: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'diff> FnMut(DiffRef<'diff>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        scan_diff_borrowed(self, base, other, Some(start), end, visit)
+    }
+
+    /// Visit only genuine three-way conflicts without allocating `Conflict`.
+    pub fn scan_conflicts(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        mut visit: impl for<'conflict> FnMut(ConflictRef<'conflict>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_conflicts_until(base, left, right, |conflict| {
+                visit(conflict);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    /// Visit genuine conflicts with callback-controlled early termination.
+    pub fn scan_conflicts_until<B>(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        mut visit: impl for<'conflict> FnMut(ConflictRef<'conflict>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        enum Break<B> {
+            User(B),
+            Engine(Error),
+        }
+
+        let mut left = self.read(left)?;
+        let mut conflicts = 0u64;
+        let outcome = self.scan_diff_until(base, right, |diff| {
+            let (key, base_value, right_value) = match diff {
+                DiffRef::Added { key, value } => (key, None, Some(value)),
+                DiffRef::Removed { key, value } => (key, Some(value), None),
+                DiffRef::Changed { key, old, new } => (key, Some(old), Some(new)),
+            };
+
+            let mut inspect = |left_value: Option<&[u8]>| {
+                if left_value == base_value || left_value == right_value {
+                    return ControlFlow::Continue(());
+                }
+                conflicts = conflicts.saturating_add(1);
+                match visit(ConflictRef {
+                    key,
+                    base: base_value,
+                    left: left_value,
+                    right: right_value,
+                }) {
+                    ControlFlow::Continue(()) => ControlFlow::Continue(()),
+                    ControlFlow::Break(value) => ControlFlow::Break(Break::User(value)),
+                }
+            };
+
+            match left.get_with(key, |value| inspect(Some(value))) {
+                Ok(Some(flow)) => flow,
+                Ok(None) => inspect(None),
+                Err(error) => ControlFlow::Break(Break::Engine(error)),
+            }
+        })?;
+
+        match outcome.break_value {
+            Some(Break::User(value)) => Ok(ScanOutcome::stopped(conflicts, value)),
+            Some(Break::Engine(error)) => Err(error),
+            None => Ok(ScanOutcome::complete(conflicts)),
+        }
+    }
+}
+
+#[cfg(feature = "async-store")]
+impl<S> AsyncProlly<S>
+where
+    S: AsyncStore,
+    S::Error: Send + Sync,
+{
+    /// Visit async structural differences without owned diff records.
+    pub async fn scan_diff(
+        &self,
+        base: &Tree,
+        other: &Tree,
+        mut visit: impl for<'diff> FnMut(DiffRef<'diff>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_diff_until(base, other, |diff| {
+                visit(diff);
+                ControlFlow::<()>::Continue(())
+            })
+            .await?
+            .visited)
+    }
+
+    /// Visit async structural differences with early termination.
+    pub async fn scan_diff_until<B>(
+        &self,
+        base: &Tree,
+        other: &Tree,
+        visit: impl for<'diff> FnMut(DiffRef<'diff>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        scan_diff_borrowed_async(self, base, other, None, None, visit).await
+    }
+
+    /// Visit async differences in `[start, end)` without owned records.
+    pub async fn scan_range_diff(
+        &self,
+        base: &Tree,
+        other: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        mut visit: impl for<'diff> FnMut(DiffRef<'diff>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_range_diff_until(base, other, start, end, |diff| {
+                visit(diff);
+                ControlFlow::<()>::Continue(())
+            })
+            .await?
+            .visited)
+    }
+
+    /// Visit async range differences with early termination.
+    pub async fn scan_range_diff_until<B>(
+        &self,
+        base: &Tree,
+        other: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'diff> FnMut(DiffRef<'diff>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        scan_diff_borrowed_async(self, base, other, Some(start), end, visit).await
+    }
+
+    /// Visit async three-way conflicts through a callback-scoped view.
+    ///
+    /// The current async iterator retains one owned conflict at a time so no
+    /// borrowed node data crosses an await. The callback API is stable for a
+    /// future retained-node-handle implementation and never accumulates all
+    /// conflicts in memory.
+    pub async fn scan_conflicts(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        mut visit: impl for<'conflict> FnMut(ConflictRef<'conflict>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_conflicts_until(base, left, right, |conflict| {
+                visit(conflict);
+                ControlFlow::<()>::Continue(())
+            })
+            .await?
+            .visited)
+    }
+
+    /// Visit async conflicts with callback-controlled early termination.
+    pub async fn scan_conflicts_until<B>(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        mut visit: impl for<'conflict> FnMut(ConflictRef<'conflict>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        let mut conflicts = AsyncConflictIter::new(self, base, left, right);
+        let mut visited = 0u64;
+        while let Some(conflict) = conflicts.next().await {
+            let conflict = conflict?;
+            visited = visited.saturating_add(1);
+            let view = ConflictRef {
+                key: &conflict.key,
+                base: conflict.base.as_deref(),
+                left: conflict.left.as_deref(),
+                right: conflict.right.as_deref(),
+            };
+            if let ControlFlow::Break(value) = visit(view) {
+                return Ok(ScanOutcome::stopped(visited, value));
+            }
+        }
+        Ok(ScanOutcome::complete(visited))
+    }
+
+    /// Async merge with a callback-scoped symbolic conflict resolver.
+    pub async fn merge_with(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        resolver: Option<&dyn BorrowedMergeResolver>,
+    ) -> Result<Tree, Error> {
+        merge_trees_borrowed_async(self, base, left, right, resolver).await
+    }
+
+    /// Async range merge with a borrowed conflict resolver.
+    pub async fn merge_range_with(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        resolver: Option<&dyn BorrowedMergeResolver>,
+    ) -> Result<Tree, Error> {
+        merge_trees_range_borrowed_async(self, base, left, right, start, end, resolver).await
+    }
+
+    /// Async prefix merge with a borrowed conflict resolver.
+    pub async fn merge_prefix_with(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        prefix: &[u8],
+        resolver: Option<&dyn BorrowedMergeResolver>,
+    ) -> Result<Tree, Error> {
+        let (start, end) = super::key::prefix_range(prefix);
+        self.merge_range_with(base, left, right, &start, end.as_deref(), resolver)
+            .await
+    }
 }
 
 pub(crate) fn structural_diff_page<S: Store>(
@@ -1765,6 +2815,114 @@ where
 
     let right_diff = compute_async_diff(prolly, base, right).await?;
     merge_trees_with_right_diff_async(prolly, left, &right_diff, resolver).await
+}
+
+/// Async three-way merge using callback-scoped conflict views.
+///
+/// Async diff entries are currently retained as owned staging records because
+/// node-backed views may not cross store awaits. Symbolic decisions still avoid
+/// constructing the legacy `Conflict` on successfully resolved conflicts.
+#[cfg(feature = "async-store")]
+pub async fn merge_trees_borrowed_async<S>(
+    prolly: &AsyncProlly<S>,
+    base: &Tree,
+    left: &Tree,
+    right: &Tree,
+    resolver: Option<&dyn BorrowedMergeResolver>,
+) -> Result<Tree, Error>
+where
+    S: AsyncStore,
+    S::Error: Send + Sync,
+{
+    if left.root == right.root {
+        return Ok(left.clone());
+    }
+    if left.root == base.root {
+        return Ok(right.clone());
+    }
+    if right.root == base.root {
+        return Ok(left.clone());
+    }
+
+    let right_diff = compute_async_diff(prolly, base, right).await?;
+    merge_trees_with_right_diff_borrowed_async(prolly, left, &right_diff, resolver).await
+}
+
+/// Async range merge using callback-scoped conflict views.
+#[cfg(feature = "async-store")]
+pub async fn merge_trees_range_borrowed_async<S>(
+    prolly: &AsyncProlly<S>,
+    base: &Tree,
+    left: &Tree,
+    right: &Tree,
+    start: &[u8],
+    end: Option<&[u8]>,
+    resolver: Option<&dyn BorrowedMergeResolver>,
+) -> Result<Tree, Error>
+where
+    S: AsyncStore,
+    S::Error: Send + Sync,
+{
+    if left.root == right.root || right.root == base.root || end.is_some_and(|end| end <= start) {
+        return Ok(left.clone());
+    }
+
+    let right_diff = compute_async_range_diff(prolly, base, right, start, end).await?;
+    merge_trees_with_right_diff_borrowed_async(prolly, left, &right_diff, resolver).await
+}
+
+#[cfg(feature = "async-store")]
+async fn merge_trees_with_right_diff_borrowed_async<S>(
+    prolly: &AsyncProlly<S>,
+    left: &Tree,
+    right_diff: &[Diff],
+    resolver: Option<&dyn BorrowedMergeResolver>,
+) -> Result<Tree, Error>
+where
+    S: AsyncStore,
+    S::Error: Send + Sync,
+{
+    let right_changes = build_merge_change_refs(right_diff);
+    let keys = right_changes
+        .iter()
+        .map(|entry| entry.key)
+        .collect::<Vec<_>>();
+    let left_values = prolly.get_many(left, &keys).await?;
+    let mut mutations = Vec::with_capacity(right_changes.len());
+
+    for (entry, left_value) in right_changes.iter().zip(left_values) {
+        if left_value.as_deref() == entry.base {
+            push_change_mutation(&mut mutations, entry.key, entry.value);
+            continue;
+        }
+        if option_bytes_eq(&left_value, entry.value) {
+            continue;
+        }
+
+        let conflict = ConflictRef {
+            key: entry.key,
+            base: entry.base,
+            left: left_value.as_deref(),
+            right: entry.value,
+        };
+        let mut recorder = MergeTraceRecorder::disabled();
+        let selected = resolve_conflict(
+            resolver.map(MergeResolverRef::Borrowed),
+            conflict,
+            MergeTraceStage::Batch,
+            &mut recorder,
+        )
+        .map_err(Error::Conflict)?;
+        if selected.as_deref() != left_value.as_deref() {
+            push_change_mutation(&mut mutations, entry.key, selected.as_deref());
+        }
+    }
+
+    if mutations.is_empty() {
+        Ok(left.clone())
+    } else {
+        prolly.batch(left, mutations).await
+    }
 }
 
 /// Perform an async three-way merge and return structured trace events with the result.
@@ -3429,6 +4587,146 @@ pub fn merge_trees<S: Store>(
     merge_trees_with_right_diff(prolly, base, left, &right_diff, resolver)
 }
 
+/// Perform a three-way merge whose resolver inspects callback-scoped values.
+///
+/// The structural path can select an existing base/left/right value without
+/// constructing an owned conflict. Shape-misaligned changes stream directly
+/// into the mutation layer, avoiding an intermediate owned diff vector.
+pub fn merge_trees_borrowed<S: Store>(
+    prolly: &Prolly<S>,
+    base: &Tree,
+    left: &Tree,
+    right: &Tree,
+    resolver: Option<&dyn BorrowedMergeResolver>,
+) -> Result<Tree, Error> {
+    if left.root == right.root {
+        return Ok(left.clone());
+    }
+    if left.root == base.root {
+        return Ok(right.clone());
+    }
+    if right.root == base.root {
+        return Ok(left.clone());
+    }
+
+    let mut recorder = MergeTraceRecorder::disabled();
+    if let Some(merged) = try_structural_merge_traced(
+        prolly,
+        base,
+        left,
+        right,
+        resolver.map(MergeResolverRef::Borrowed),
+        &mut recorder,
+    )? {
+        return Ok(merged);
+    }
+
+    merge_borrowed_diff_range(prolly, base, left, right, &[], None, resolver)
+}
+
+/// Merge right-side changes in `[start, end)` using a borrowed resolver.
+pub fn merge_trees_range_borrowed<S: Store>(
+    prolly: &Prolly<S>,
+    base: &Tree,
+    left: &Tree,
+    right: &Tree,
+    start: &[u8],
+    end: Option<&[u8]>,
+    resolver: Option<&dyn BorrowedMergeResolver>,
+) -> Result<Tree, Error> {
+    if left.root == right.root || right.root == base.root || end.is_some_and(|end| end <= start) {
+        return Ok(left.clone());
+    }
+    merge_borrowed_diff_range(prolly, base, left, right, start, end, resolver)
+}
+
+fn merge_borrowed_diff_range<S: Store>(
+    prolly: &Prolly<S>,
+    base: &Tree,
+    left: &Tree,
+    right: &Tree,
+    start: &[u8],
+    end: Option<&[u8]>,
+    resolver: Option<&dyn BorrowedMergeResolver>,
+) -> Result<Tree, Error> {
+    let mut left_reader = prolly.read(left)?;
+    let mut merged = left.clone();
+    let mut mutations = Vec::with_capacity(BORROWED_MERGE_MUTATION_BATCH);
+    let mut applied = false;
+    let mut merge_error = None;
+
+    let outcome = prolly.scan_range_diff_until(base, right, start, end, |diff| {
+        let (key, base_value, right_value) = match diff {
+            DiffRef::Added { key, value } => (key, None, Some(value)),
+            DiffRef::Removed { key, value } => (key, Some(value), None),
+            DiffRef::Changed { key, old, new } => (key, Some(old), Some(new)),
+        };
+
+        let mut resolution_result = Ok(());
+        let lookup_result = left_reader.get_many_with(&[key], |_, _, left_value| {
+            resolution_result = (|| {
+                if left_value == base_value {
+                    push_change_mutation(&mut mutations, key, right_value);
+                    if mutations.len() == BORROWED_MERGE_MUTATION_BATCH {
+                        merged = prolly.batch(&merged, std::mem::take(&mut mutations))?;
+                        mutations.reserve(BORROWED_MERGE_MUTATION_BATCH);
+                        applied = true;
+                    }
+                    return Ok(());
+                }
+                if left_value == right_value {
+                    return Ok(());
+                }
+
+                let conflict = ConflictRef {
+                    key,
+                    base: base_value,
+                    left: left_value,
+                    right: right_value,
+                };
+                let mut recorder = MergeTraceRecorder::disabled();
+                let selected = resolve_conflict(
+                    resolver.map(MergeResolverRef::Borrowed),
+                    conflict,
+                    MergeTraceStage::Batch,
+                    &mut recorder,
+                )
+                .map_err(Error::Conflict)?;
+
+                if selected.as_deref() != left_value {
+                    push_change_mutation(&mut mutations, key, selected.as_deref());
+                    if mutations.len() == BORROWED_MERGE_MUTATION_BATCH {
+                        merged = prolly.batch(&merged, std::mem::take(&mut mutations))?;
+                        mutations.reserve(BORROWED_MERGE_MUTATION_BATCH);
+                        applied = true;
+                    }
+                }
+                Ok(())
+            })();
+        });
+
+        let result = lookup_result.and(resolution_result);
+        match result {
+            Ok(()) => ControlFlow::Continue(()),
+            Err(error) => {
+                merge_error = Some(error);
+                ControlFlow::Break(())
+            }
+        }
+    })?;
+
+    if let Some(error) = merge_error {
+        return Err(error);
+    }
+    debug_assert!(outcome.break_value.is_none());
+
+    if !mutations.is_empty() {
+        merged = prolly.batch(&merged, mutations)?;
+        applied = true;
+    }
+    Ok(if applied { merged } else { left.clone() })
+}
+
 /// Perform a three-way merge and return structured trace events with the result.
 ///
 /// Unlike [`merge_trees`], this function keeps the trace even if the merge
@@ -3480,7 +4778,7 @@ fn merge_trees_explain_result<S: Store>(
             base,
             left,
             right,
-            resolver.as_deref(),
+            resolver.as_deref().map(MergeResolverRef::Legacy),
             &mut recorder,
         )?
     };
@@ -3523,7 +4821,14 @@ fn try_structural_merge<S: Store>(
     resolver: Option<&dyn Fn(&Conflict) -> Resolution>,
 ) -> Result<Option<Tree>, Error> {
     let mut recorder = MergeTraceRecorder::disabled();
-    try_structural_merge_traced(prolly, base, left, right, resolver, &mut recorder)
+    try_structural_merge_traced(
+        prolly,
+        base,
+        left,
+        right,
+        resolver.map(MergeResolverRef::Legacy),
+        &mut recorder,
+    )
 }
 
 fn try_structural_merge_traced<S: Store>(
@@ -3531,7 +4836,7 @@ fn try_structural_merge_traced<S: Store>(
     base: &Tree,
     left: &Tree,
     right: &Tree,
-    resolver: Option<&dyn Fn(&Conflict) -> Resolution>,
+    resolver: Option<MergeResolverRef<'_>>,
     recorder: &mut MergeTraceRecorder<'_>,
 ) -> Result<Option<Tree>, Error> {
     let (Some(base_cid), Some(left_cid), Some(right_cid)) = (&base.root, &left.root, &right.root)
@@ -3587,7 +4892,7 @@ fn try_structural_merge_cids<S: Store>(
     base_cid: &Cid,
     left_cid: &Cid,
     right_cid: &Cid,
-    resolver: Option<&dyn Fn(&Conflict) -> Resolution>,
+    resolver: Option<MergeResolverRef<'_>>,
     collector: &mut BatchWriteCollector,
     recorder: &mut MergeTraceRecorder<'_>,
 ) -> Result<Option<StructuralMergeResult>, Error> {
@@ -3642,7 +4947,7 @@ fn try_structural_merge_internal<S: Store>(
     base_cid: &Cid,
     left_cid: &Cid,
     right_cid: &Cid,
-    resolver: Option<&dyn Fn(&Conflict) -> Resolution>,
+    resolver: Option<MergeResolverRef<'_>>,
     collector: &mut BatchWriteCollector,
     recorder: &mut MergeTraceRecorder<'_>,
 ) -> Result<Option<StructuralMergeResult>, Error> {
@@ -3772,12 +5077,10 @@ fn try_structural_merge_leaf<S: Store>(
     base_cid: &Cid,
     left_cid: &Cid,
     right_cid: &Cid,
-    resolver: Option<&dyn Fn(&Conflict) -> Resolution>,
+    resolver: Option<MergeResolverRef<'_>>,
     collector: &mut BatchWriteCollector,
     recorder: &mut MergeTraceRecorder<'_>,
 ) -> Result<Option<StructuralMergeResult>, Error> {
-    use std::borrow::Cow;
-
     ensure_node_value_count(base)?;
     ensure_node_value_count(left)?;
     ensure_node_value_count(right)?;
@@ -3799,26 +5102,17 @@ fn try_structural_merge_leaf<S: Store>(
         } else if right_val == base_val {
             Some(Cow::Borrowed(left_val.as_slice()))
         } else {
-            let conflict = Conflict {
-                key: base.keys[idx].clone(),
-                base: Some(base_val.clone()),
-                left: Some(left_val.clone()),
-                right: Some(right_val.clone()),
+            let conflict = ConflictRef {
+                key: &base.keys[idx],
+                base: Some(base_val),
+                left: Some(left_val),
+                right: Some(right_val),
             };
-            if let Some(resolve) = resolver {
-                let resolution = resolve(&conflict);
-                recorder.record_resolver(MergeTraceStage::Structural, &conflict, &resolution);
-                match resolution {
-                    Resolution::Value(value) => Some(Cow::Owned(value)),
-                    Resolution::Delete => {
-                        deleted_any = true;
-                        None
-                    }
-                    Resolution::Unresolved => return Err(Error::Conflict(conflict)),
-                }
-            } else {
-                return Err(Error::Conflict(conflict));
-            }
+            let selected =
+                resolve_conflict(resolver, conflict, MergeTraceStage::Structural, recorder)
+                    .map_err(Error::Conflict)?;
+            deleted_any |= selected.is_none();
+            selected
         };
 
         let selected_bytes = selected.as_deref();

--- a/src/prolly/mod.rs
+++ b/src/prolly/mod.rs
@@ -88,14 +88,17 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 use std::collections::{hash_map::Entry, HashMap, HashSet, VecDeque};
+use std::hash::{BuildHasherDefault, Hasher};
+#[cfg(any(feature = "async-store", test))]
 use std::ops::Range;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const PARALLEL_NODE_DECODE_THRESHOLD: usize = 16;
 const GET_MANY_PREFETCH_PARALLELISM: usize = 16;
+#[cfg(any(feature = "async-store", test))]
 const GET_MANY_BOUNDARY_ROUTE_MIN_POSITIONS: usize = 32;
 const STATS_FRONTIER_PREFETCH_PARALLELISM: usize = 16;
 const RECENT_LEAF_MISS_SAMPLE_INTERVAL: usize = 16;
@@ -188,6 +191,7 @@ use manifest::{
     NamedRootUpdate, RootManifest,
 };
 use node::Node;
+use node::ReadNode;
 use stats::{StatsComparison, TreeStats};
 #[cfg(feature = "async-store")]
 use store::AsyncStore;
@@ -223,6 +227,7 @@ impl InlinePositions {
         }
     }
 
+    #[cfg(any(feature = "async-store", test))]
     fn with_rest_capacity(first: usize, rest_capacity: usize) -> Self {
         Self {
             first,
@@ -247,6 +252,7 @@ impl InlinePositions {
         1 + self.rest.len()
     }
 
+    #[cfg(any(feature = "async-store", test))]
     fn at(&self, offset: usize) -> usize {
         if offset == 0 {
             self.first
@@ -289,10 +295,10 @@ impl MissingNodeBatch {
     }
 }
 
-fn plan_cached_nodes(
+fn plan_cached_nodes<T>(
     cids: &[Cid],
-    mut lookup: impl FnMut(&Cid) -> Option<Arc<Node>>,
-) -> (Vec<Option<Arc<Node>>>, Option<MissingNodeBatch>, usize) {
+    mut lookup: impl FnMut(&Cid) -> Option<Arc<T>>,
+) -> (Vec<Option<Arc<T>>>, Option<MissingNodeBatch>, usize) {
     let mut nodes = Vec::with_capacity(cids.len());
     let mut missing = MissingNodeBatch::with_capacity(cids.len());
     let mut cache_hits = 0usize;
@@ -309,17 +315,59 @@ fn plan_cached_nodes(
     (nodes, missing, cache_hits)
 }
 
+fn read_node_from_shared(bytes: Arc<[u8]>) -> Result<ReadNode, Error> {
+    ReadNode::from_shared(bytes).map_err(|error| match error {
+        Error::Deserialize(_) => Error::InvalidNode,
+        other => other,
+    })
+}
+
 struct NodeCacheEntry {
-    node: Arc<Node>,
+    owned: OnceLock<Arc<Node>>,
+    read: OnceLock<Arc<ReadNode>>,
     generation: u64,
     bytes: usize,
     pinned: bool,
 }
 
+/// Hashes the first 64 bits of a content digest for in-process cache routing.
+///
+/// CIDs are SHA-256 outputs, so their first word is already uniformly
+/// distributed. HashMap still compares the complete CID on a hash collision;
+/// this changes only bucket selection, not identity or correctness.
+#[derive(Default)]
+struct CidCacheHasher {
+    prefix: u64,
+    filled: u8,
+}
+
+impl Hasher for CidCacheHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.prefix
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let remaining = 8usize.saturating_sub(usize::from(self.filled));
+        for &byte in bytes.iter().take(remaining) {
+            self.prefix |= u64::from(byte) << (u32::from(self.filled) * 8);
+            self.filled += 1;
+        }
+    }
+
+    // Array/slice Hash implementations may prefix their length. Every key in
+    // this table is one fixed-width CID, so the prefix contains no entropy.
+    #[inline]
+    fn write_usize(&mut self, _value: usize) {}
+}
+
+type CidNodeCacheMap = HashMap<Cid, NodeCacheEntry, BuildHasherDefault<CidCacheHasher>>;
+
 struct NodeCache {
     max_nodes: Option<usize>,
     max_bytes: Option<usize>,
-    nodes: HashMap<Cid, NodeCacheEntry>,
+    nodes: CidNodeCacheMap,
     access_log: VecDeque<(Cid, u64)>,
     next_generation: u64,
     bytes: usize,
@@ -330,7 +378,7 @@ impl NodeCache {
         Self {
             max_nodes,
             max_bytes,
-            nodes: HashMap::new(),
+            nodes: CidNodeCacheMap::default(),
             access_log: VecDeque::new(),
             next_generation: 0,
             bytes: 0,
@@ -369,7 +417,28 @@ impl NodeCache {
 
     #[inline]
     fn peek(&self, cid: &Cid) -> Option<Arc<Node>> {
-        self.nodes.get(cid).map(|entry| entry.node.clone())
+        self.nodes.get(cid).map(|entry| {
+            entry
+                .owned
+                .get_or_init(|| {
+                    Arc::new(
+                        entry
+                            .read
+                            .get()
+                            .expect("cache entry has one representation")
+                            .as_ref()
+                            .to_owned(),
+                    )
+                })
+                .clone()
+        })
+    }
+
+    #[inline]
+    fn peek_read(&self, cid: &Cid) -> Option<Arc<ReadNode>> {
+        self.nodes
+            .get(cid)
+            .and_then(|entry| entry.read.get().cloned())
     }
 
     fn clear(&mut self) -> usize {
@@ -395,7 +464,35 @@ impl NodeCache {
                 .get_mut(cid)
                 .expect("node was checked before generation update");
             entry.generation = generation;
-            entry.node.clone()
+            entry
+                .owned
+                .get_or_init(|| {
+                    Arc::new(
+                        entry
+                            .read
+                            .get()
+                            .expect("cache entry has one representation")
+                            .as_ref()
+                            .to_owned(),
+                    )
+                })
+                .clone()
+        };
+        self.access_log.push_back((cid.clone(), generation));
+        self.compact_access_log_if_needed();
+        Some(node)
+    }
+
+    fn get_read(&mut self, cid: &Cid) -> Option<Arc<ReadNode>> {
+        if self.is_unbounded() {
+            return self.peek_read(cid);
+        }
+        self.nodes.get(cid).and_then(|entry| entry.read.get())?;
+        let generation = self.next_generation();
+        let node = {
+            let entry = self.nodes.get_mut(cid).expect("read node was checked");
+            entry.generation = generation;
+            entry.read.get().expect("read node was checked").clone()
         };
         self.access_log.push_back((cid.clone(), generation));
         self.compact_access_log_if_needed();
@@ -403,14 +500,14 @@ impl NodeCache {
     }
 
     fn insert(&mut self, cid: Cid, node: Arc<Node>, bytes: usize) -> usize {
-        self.insert_with_pin(cid, node, bytes, false).1
+        self.insert_owned_with_pin(cid, node, bytes, false).1
     }
 
     fn insert_pinned(&mut self, cid: Cid, node: Arc<Node>, bytes: usize) -> (bool, usize) {
-        self.insert_with_pin(cid, node, bytes, true)
+        self.insert_owned_with_pin(cid, node, bytes, true)
     }
 
-    fn insert_with_pin(
+    fn insert_owned_with_pin(
         &mut self,
         cid: Cid,
         node: Arc<Node>,
@@ -422,23 +519,25 @@ impl NodeCache {
         }
 
         let generation = self.next_generation();
-        let mut newly_pinned = pinned;
-        if let Some(previous) = self.nodes.insert(
+        let owned = OnceLock::new();
+        owned.set(node).expect("new owned cache slot");
+        let previous = self.nodes.insert(
             cid.clone(),
             NodeCacheEntry {
-                node,
+                owned,
+                read: OnceLock::new(),
                 generation,
                 bytes,
                 pinned,
             },
-        ) {
-            newly_pinned = pinned && !previous.pinned;
-            let entry = self
-                .nodes
-                .get_mut(&cid)
-                .expect("entry was inserted before preserving pin state");
-            entry.pinned = previous.pinned || pinned;
+        );
+        let newly_pinned = pinned && previous.as_ref().map_or(true, |entry| !entry.pinned);
+        if let Some(previous) = previous {
             self.bytes = self.bytes.saturating_sub(previous.bytes);
+            self.nodes
+                .get_mut(&cid)
+                .expect("replacement cache entry")
+                .pinned |= previous.pinned;
         }
         self.bytes = self.bytes.saturating_add(bytes);
         if self.is_unbounded() {
@@ -446,6 +545,51 @@ impl NodeCache {
         }
         self.access_log.push_back((cid, generation));
 
+        let evicted = self.evict_to_limit();
+        self.compact_access_log_if_needed();
+        (newly_pinned, evicted)
+    }
+
+    fn insert_read(&mut self, cid: Cid, node: Arc<ReadNode>) -> usize {
+        self.insert_read_with_pin(cid, node, false).1
+    }
+
+    fn insert_read_with_pin(
+        &mut self,
+        cid: Cid,
+        node: Arc<ReadNode>,
+        pinned: bool,
+    ) -> (bool, usize) {
+        if self.is_disabled() {
+            return (false, self.clear());
+        }
+        let generation = self.next_generation();
+        let retained = node.retained_bytes();
+        let read = OnceLock::new();
+        read.set(node).expect("new packed cache slot");
+        let previous = self.nodes.insert(
+            cid.clone(),
+            NodeCacheEntry {
+                owned: OnceLock::new(),
+                read,
+                generation,
+                bytes: retained,
+                pinned,
+            },
+        );
+        let newly_pinned = pinned && previous.as_ref().map_or(true, |entry| !entry.pinned);
+        if let Some(previous) = previous {
+            self.bytes = self.bytes.saturating_sub(previous.bytes);
+            self.nodes
+                .get_mut(&cid)
+                .expect("replacement cache entry")
+                .pinned |= previous.pinned;
+        }
+        self.bytes = self.bytes.saturating_add(retained);
+        if self.is_unbounded() {
+            return (newly_pinned, 0);
+        }
+        self.access_log.push_back((cid, generation));
         let evicted = self.evict_to_limit();
         self.compact_access_log_if_needed();
         (newly_pinned, evicted)
@@ -754,7 +898,7 @@ pub struct Prolly<S: Store> {
 
 struct RecentLeafRead {
     root: Cid,
-    node: Arc<Node>,
+    node: Arc<ReadNode>,
 }
 
 /// Async Prolly tree manager.
@@ -1172,12 +1316,12 @@ impl<S: Store> Prolly<S> {
         self.get_with(tree, key, <[u8]>::to_vec)
     }
 
-    fn maybe_cache_recent_leaf(&self, root: &Cid, node: Arc<Node>) {
+    fn maybe_cache_recent_leaf(&self, root: &Cid, node: Arc<ReadNode>) {
         if self
             .node_cache
             .read()
             .map_or(true, |cache| cache.is_disabled())
-            || node.keys.is_empty()
+            || node.is_empty()
             || self.recent_leaf_misses.fetch_add(1, Ordering::Relaxed)
                 % RECENT_LEAF_MISS_SAMPLE_INTERVAL
                 != 0
@@ -1203,20 +1347,18 @@ impl<S: Store> Prolly<S> {
     }
 
     pub(crate) fn subtree_count(&self, cid: &Cid) -> Result<u64, Error> {
-        let node = self.load_arc(cid)?;
-        if node.leaf {
-            return Ok(node.keys.len() as u64);
+        let node = self.load_read_arc(cid)?;
+        if node.is_leaf() {
+            return Ok(node.len() as u64);
         }
-        if node.keys.len() != node.vals.len() {
-            return Err(Error::InvalidNode);
-        }
-        if node.child_counts.len() == node.len() && node.child_counts.iter().all(|count| *count > 0)
-        {
-            return Ok(node.child_counts.iter().copied().sum());
+        if (0..node.len()).all(|index| node.child_count(index).is_some_and(|count| count > 0)) {
+            return Ok((0..node.len())
+                .map(|index| node.child_count(index).expect("checked child count"))
+                .sum());
         }
         let mut total = 0u64;
         for index in 0..node.len() {
-            total = total.saturating_add(self.subtree_count(&child_cid_at(&node, index)?)?);
+            total = total.saturating_add(self.subtree_count(&node.child_cid(index)?)?);
         }
         Ok(total)
     }
@@ -3164,6 +3306,181 @@ impl<S: Store> Prolly<S> {
         Ok(node)
     }
 
+    /// Load the immutable packed representation used by read-only traversals.
+    pub(crate) fn load_read_arc(&self, cid: &Cid) -> Result<Arc<ReadNode>, Error> {
+        let unbounded = if let Ok(cache) = self.node_cache.read() {
+            if cache.is_unbounded() {
+                if let Some(node) = cache.peek_read(cid) {
+                    self.metrics.add_cache_hits(1);
+                    return Ok(node);
+                }
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if !unbounded {
+            if let Ok(mut cache) = self.node_cache.write() {
+                if let Some(node) = cache.get_read(cid) {
+                    self.metrics.add_cache_hits(1);
+                    return Ok(node);
+                }
+            }
+        }
+
+        // Nodes admitted by a write already have an owned representation. Turn
+        // it into the packed form without issuing a redundant store read.
+        let owned = if self.store.has_native_shared_reads() {
+            None
+        } else if let Ok(mut cache) = self.node_cache.write() {
+            cache.get(cid)
+        } else {
+            None
+        };
+        if let Some(owned) = owned {
+            let packed = Arc::new(read_node_from_shared(Arc::from(owned.to_bytes()))?);
+            if let Ok(mut cache) = self.node_cache.write() {
+                let evictions = cache.insert_read(cid.clone(), packed.clone());
+                self.metrics.add_cache_evictions(evictions);
+            }
+            self.metrics.add_cache_hits(1);
+            return Ok(packed);
+        }
+
+        self.metrics.add_cache_misses(1);
+        let bytes = self
+            .store
+            .get_shared(cid.as_bytes())
+            .map_err(|e| Error::Store(Box::new(e)))?
+            .ok_or_else(|| Error::NotFound(cid.clone()))?;
+        self.metrics.record_point_read(bytes.len());
+        let actual = Cid::from_bytes(&bytes);
+        if actual != *cid {
+            return Err(Error::CidMismatch {
+                expected: cid.clone(),
+                actual,
+            });
+        }
+        let node = Arc::new(read_node_from_shared(bytes)?);
+        if let Ok(mut cache) = self.node_cache.write() {
+            let evictions = cache.insert_read(cid.clone(), node.clone());
+            self.metrics.add_cache_evictions(evictions);
+        }
+        Ok(node)
+    }
+
+    pub(crate) fn load_many_read_ordered(&self, cids: &[Cid]) -> Result<Vec<Arc<ReadNode>>, Error> {
+        if cids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let unbounded_plan = self.node_cache.read().ok().and_then(|cache| {
+            cache
+                .is_unbounded()
+                .then(|| plan_cached_nodes(cids, |cid| cache.peek_read(cid)))
+        });
+        let (mut nodes, missing, hits) = if let Some(plan) = unbounded_plan {
+            plan
+        } else if let Ok(mut cache) = self.node_cache.write() {
+            plan_cached_nodes(cids, |cid| cache.get_read(cid))
+        } else {
+            plan_cached_nodes(cids, |_| None)
+        };
+        self.metrics.add_cache_hits(hits);
+        if let Some(MissingNodeBatch {
+            cids: missing_cids,
+            positions,
+            ..
+        }) = missing
+        {
+            if missing_cids.len() == 1 && !self.store.prefers_batch_reads() {
+                let node = self.load_read_arc(&missing_cids[0])?;
+                for position in positions.into_iter().next().ok_or(Error::InvalidNode)? {
+                    nodes[position] = Some(node.clone());
+                }
+            } else {
+                self.metrics.add_cache_misses(missing_cids.len());
+                let loaded = if missing_cids.len() <= GET_MANY_PREFETCH_PARALLELISM {
+                    let keys = missing_cids
+                        .iter()
+                        .map(|cid| cid.as_bytes() as &[u8])
+                        .collect::<Vec<_>>();
+                    let loaded = self
+                        .store
+                        .batch_get_shared_ordered_unique(&keys)
+                        .map_err(|error| Error::Store(Box::new(error)))?;
+                    let loaded_bytes = loaded.iter().flatten().map(|bytes| bytes.len()).sum();
+                    let loaded_nodes = loaded.iter().flatten().count();
+                    self.metrics
+                        .record_batch_read(keys.len(), loaded_bytes, loaded_nodes);
+                    loaded
+                } else {
+                    let chunk_size = missing_cids.len().div_ceil(GET_MANY_PREFETCH_PARALLELISM);
+                    missing_cids
+                        .par_chunks(chunk_size)
+                        .map(|chunk| {
+                            let keys = chunk
+                                .iter()
+                                .map(|cid| cid.as_bytes() as &[u8])
+                                .collect::<Vec<_>>();
+                            let loaded = self
+                                .store
+                                .batch_get_shared_ordered_unique(&keys)
+                                .map_err(|error| Error::Store(Box::new(error)))?;
+                            if loaded.len() != chunk.len() {
+                                return Err(Error::InvalidNode);
+                            }
+                            let loaded_bytes =
+                                loaded.iter().flatten().map(|bytes| bytes.len()).sum();
+                            let loaded_nodes = loaded.iter().flatten().count();
+                            self.metrics
+                                .record_batch_read(keys.len(), loaded_bytes, loaded_nodes);
+                            Ok(loaded)
+                        })
+                        .collect::<Result<Vec<_>, Error>>()?
+                        .into_iter()
+                        .flatten()
+                        .collect()
+                };
+                if loaded.len() != missing_cids.len() {
+                    return Err(Error::InvalidNode);
+                }
+                let decoded = missing_cids
+                    .into_iter()
+                    .zip(loaded)
+                    .map(|(cid, bytes)| {
+                        let bytes = bytes.ok_or_else(|| Error::NotFound(cid.clone()))?;
+                        let actual = Cid::from_bytes(&bytes);
+                        if actual != cid {
+                            return Err(Error::CidMismatch {
+                                expected: cid,
+                                actual,
+                            });
+                        }
+                        let node = Arc::new(read_node_from_shared(bytes)?);
+                        Ok((node, cid))
+                    })
+                    .collect::<Result<Vec<_>, Error>>()?;
+                let mut cache = self.node_cache.write().ok();
+                let mut evictions = 0usize;
+                for ((node, cid), positions) in decoded.into_iter().zip(positions) {
+                    if let Some(cache) = cache.as_mut() {
+                        evictions += cache.insert_read(cid, node.clone());
+                    }
+                    for position in positions {
+                        nodes[position] = Some(node.clone());
+                    }
+                }
+                self.metrics.add_cache_evictions(evictions);
+            }
+        }
+        nodes
+            .into_iter()
+            .collect::<Option<Vec<_>>>()
+            .ok_or(Error::InvalidNode)
+    }
+
     fn load_arc_pinned(&self, cid: &Cid) -> Result<(Arc<Node>, bool), Error> {
         if let Ok(mut cache) = self.node_cache.write() {
             if let Some(node) = cache.get(cid) {
@@ -3359,24 +3676,6 @@ impl<S: Store> Prolly<S> {
             let evictions = cache.insert(cid, Arc::new(node), bytes);
             self.metrics.add_cache_evictions(evictions);
         }
-    }
-
-    pub(crate) fn cached_node_arc(&self, cid: &Cid) -> Option<Arc<Node>> {
-        let unbounded_node = self
-            .node_cache
-            .read()
-            .ok()
-            .and_then(|cache| cache.is_unbounded().then(|| cache.peek(cid)).flatten());
-        let node = unbounded_node.or_else(|| {
-            self.node_cache
-                .write()
-                .ok()
-                .and_then(|mut cache| cache.get(cid))
-        });
-        if node.is_some() {
-            self.metrics.add_cache_hits(1);
-        }
-        node
     }
 
     pub(crate) fn cached_rightmost_path(
@@ -3942,36 +4241,36 @@ impl<S: Store> Prolly<S> {
         Ok(path)
     }
 
-    /// Find the path from root to the key using shared cached nodes.
-    pub(crate) fn find_path_arcs(
+    /// Find a read-only path using the canonical packed representation.
+    pub(crate) fn find_read_path_arcs(
         &self,
         tree: &Tree,
         key: &[u8],
-    ) -> Result<Vec<(Arc<Node>, usize)>, Error> {
+    ) -> Result<Vec<(Arc<ReadNode>, usize)>, Error> {
         let mut path = Vec::new();
-
         let Some(root_cid) = &tree.root else {
             return Ok(path);
         };
-
         let mut cid = root_cid.clone();
         loop {
-            let node = self.load_arc(&cid)?;
-            let idx = match node.search(key) {
-                Ok(i) => i,
-                Err(i) => i.saturating_sub(1),
-            };
-
-            path.push((node.clone(), idx));
-
-            if node.leaf {
-                break;
+            let node = self.load_read_arc(&cid)?;
+            if node.is_empty() {
+                if node.is_leaf() {
+                    path.push((node, 0));
+                    return Ok(path);
+                }
+                return Err(Error::InvalidNode);
             }
-
-            cid = child_cid_at(&node, idx)?;
+            let index = match node.search(key) {
+                Ok(index) => index,
+                Err(index) => index.saturating_sub(1),
+            };
+            path.push((node.clone(), index));
+            if node.is_leaf() {
+                return Ok(path);
+            }
+            cid = node.child_cid(index)?;
         }
-
-        Ok(path)
     }
 
     fn find_path_hint_entries(
@@ -6752,6 +7051,145 @@ where
         Ok(node)
     }
 
+    pub(crate) async fn load_read_arc(&self, cid: &Cid) -> Result<Arc<ReadNode>, Error> {
+        let unbounded = if let Ok(cache) = self.node_cache.read() {
+            if cache.is_unbounded() {
+                if let Some(node) = cache.peek_read(cid) {
+                    self.metrics.add_cache_hits(1);
+                    return Ok(node);
+                }
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if !unbounded {
+            if let Ok(mut cache) = self.node_cache.write() {
+                if let Some(node) = cache.get_read(cid) {
+                    self.metrics.add_cache_hits(1);
+                    return Ok(node);
+                }
+            }
+        }
+        let owned = if self.store.has_native_shared_reads() {
+            None
+        } else if let Ok(mut cache) = self.node_cache.write() {
+            cache.get(cid)
+        } else {
+            None
+        };
+        if let Some(owned) = owned {
+            let packed = Arc::new(read_node_from_shared(Arc::from(owned.to_bytes()))?);
+            if let Ok(mut cache) = self.node_cache.write() {
+                let evictions = cache.insert_read(cid.clone(), packed.clone());
+                self.metrics.add_cache_evictions(evictions);
+            }
+            self.metrics.add_cache_hits(1);
+            return Ok(packed);
+        }
+
+        self.metrics.add_cache_misses(1);
+        let bytes = self
+            .store
+            .get_shared(cid.as_bytes())
+            .await
+            .map_err(|e| Error::Store(Box::new(e)))?
+            .ok_or_else(|| Error::NotFound(cid.clone()))?;
+        self.metrics.record_point_read(bytes.len());
+        let actual = Cid::from_bytes(&bytes);
+        if actual != *cid {
+            return Err(Error::CidMismatch {
+                expected: cid.clone(),
+                actual,
+            });
+        }
+        let node = Arc::new(read_node_from_shared(bytes)?);
+        if let Ok(mut cache) = self.node_cache.write() {
+            let evictions = cache.insert_read(cid.clone(), node.clone());
+            self.metrics.add_cache_evictions(evictions);
+        }
+        Ok(node)
+    }
+
+    pub(crate) async fn load_many_read_ordered(
+        &self,
+        cids: &[Cid],
+    ) -> Result<Vec<Arc<ReadNode>>, Error> {
+        if cids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let unbounded_plan = self.node_cache.read().ok().and_then(|cache| {
+            cache
+                .is_unbounded()
+                .then(|| plan_cached_nodes(cids, |cid| cache.peek_read(cid)))
+        });
+        let (mut nodes, missing, hits) = if let Some(plan) = unbounded_plan {
+            plan
+        } else if let Ok(mut cache) = self.node_cache.write() {
+            plan_cached_nodes(cids, |cid| cache.get_read(cid))
+        } else {
+            plan_cached_nodes(cids, |_| None)
+        };
+        self.metrics.add_cache_hits(hits);
+        if let Some(MissingNodeBatch {
+            cids: missing_cids,
+            positions,
+            ..
+        }) = missing
+        {
+            let keys = missing_cids
+                .iter()
+                .map(|cid| cid.as_bytes() as &[u8])
+                .collect::<Vec<_>>();
+            self.metrics.add_cache_misses(keys.len());
+            let loaded = self
+                .store
+                .batch_get_shared_ordered_unique(&keys)
+                .await
+                .map_err(|error| Error::Store(Box::new(error)))?;
+            if loaded.len() != missing_cids.len() {
+                return Err(Error::InvalidNode);
+            }
+            let loaded_bytes = loaded.iter().flatten().map(|bytes| bytes.len()).sum();
+            let loaded_nodes = loaded.iter().flatten().count();
+            self.metrics
+                .record_batch_read(keys.len(), loaded_bytes, loaded_nodes);
+            let decoded = missing_cids
+                .into_iter()
+                .zip(loaded)
+                .map(|(cid, bytes)| {
+                    let bytes = bytes.ok_or_else(|| Error::NotFound(cid.clone()))?;
+                    let actual = Cid::from_bytes(&bytes);
+                    if actual != cid {
+                        return Err(Error::CidMismatch {
+                            expected: cid,
+                            actual,
+                        });
+                    }
+                    let node = Arc::new(read_node_from_shared(bytes)?);
+                    Ok((node, cid))
+                })
+                .collect::<Result<Vec<_>, Error>>()?;
+            let mut cache = self.node_cache.write().ok();
+            let mut evictions = 0usize;
+            for ((node, cid), positions) in decoded.into_iter().zip(positions) {
+                if let Some(cache) = cache.as_mut() {
+                    evictions += cache.insert_read(cid, node.clone());
+                }
+                for position in positions {
+                    nodes[position] = Some(node.clone());
+                }
+            }
+            self.metrics.add_cache_evictions(evictions);
+        }
+        nodes
+            .into_iter()
+            .collect::<Option<Vec<_>>>()
+            .ok_or(Error::InvalidNode)
+    }
+
     async fn load_arc_pinned(&self, cid: &Cid) -> Result<(Arc<Node>, bool), Error> {
         if let Ok(mut cache) = self.node_cache.write() {
             if let Some(node) = cache.get(cid) {
@@ -6922,18 +7360,6 @@ where
             .ok_or(Error::InvalidNode)
     }
 
-    pub(crate) fn cached_node_arc(&self, cid: &Cid) -> Option<Arc<Node>> {
-        let node = self
-            .node_cache
-            .write()
-            .ok()
-            .and_then(|mut cache| cache.get(cid));
-        if node.is_some() {
-            self.metrics.add_cache_hits(1);
-        }
-        node
-    }
-
     fn cache_node(&self, cid: Cid, node: Node) {
         if let Ok(mut cache) = self.node_cache.write() {
             let bytes = node.encoded_len();
@@ -6969,35 +7395,35 @@ where
         Ok(path)
     }
 
-    pub(crate) async fn find_path_arcs(
+    pub(crate) async fn find_read_path_arcs(
         &self,
         tree: &Tree,
         key: &[u8],
-    ) -> Result<Vec<(Arc<Node>, usize)>, Error> {
+    ) -> Result<Vec<(Arc<ReadNode>, usize)>, Error> {
         let mut path = Vec::new();
-
         let Some(root_cid) = &tree.root else {
             return Ok(path);
         };
-
         let mut cid = root_cid.clone();
         loop {
-            let node = self.load_arc(&cid).await?;
-            let idx = match node.search(key) {
-                Ok(i) => i,
-                Err(i) => i.saturating_sub(1),
-            };
-
-            path.push((node.clone(), idx));
-
-            if node.leaf {
-                break;
+            let node = self.load_read_arc(&cid).await?;
+            if node.is_empty() {
+                if node.is_leaf() {
+                    path.push((node, 0));
+                    return Ok(path);
+                }
+                return Err(Error::InvalidNode);
             }
-
-            cid = child_cid_at(&node, idx)?;
+            let index = match node.search(key) {
+                Ok(index) => index,
+                Err(index) => index.saturating_sub(1),
+            };
+            path.push((node.clone(), index));
+            if node.is_leaf() {
+                return Ok(path);
+            }
+            cid = node.child_cid(index)?;
         }
-
-        Ok(path)
     }
 
     fn build_internal_level_from_summaries(
@@ -7854,6 +8280,7 @@ fn keys_are_sorted<K: AsRef<[u8]>>(keys: &[K]) -> bool {
         .all(|pair| pair[0].as_ref() <= pair[1].as_ref())
 }
 
+#[cfg(any(feature = "async-store", test))]
 fn route_key_positions_to_children<K: AsRef<[u8]>>(
     node: &Node,
     positions: InlinePositions,
@@ -7892,6 +8319,7 @@ fn route_key_positions_to_children<K: AsRef<[u8]>>(
     Ok(frames)
 }
 
+#[cfg(any(feature = "async-store", test))]
 fn route_key_positions_to_children_by_boundary<K: AsRef<[u8]>>(
     node: &Node,
     positions: InlinePositions,
@@ -7934,6 +8362,7 @@ fn route_key_positions_to_children_by_boundary<K: AsRef<[u8]>>(
     Ok(frames)
 }
 
+#[cfg(any(feature = "async-store", test))]
 fn lower_bound_position_key<K: AsRef<[u8]>>(
     positions: &InlinePositions,
     keys: &[K],
@@ -7955,6 +8384,7 @@ fn lower_bound_position_key<K: AsRef<[u8]>>(
     left
 }
 
+#[cfg(any(feature = "async-store", test))]
 fn inline_positions_from_range(
     positions: &InlinePositions,
     range: Range<usize>,
@@ -7970,6 +8400,7 @@ fn inline_positions_from_range(
     bucket
 }
 
+#[cfg(any(feature = "async-store", test))]
 fn child_index_for_lookup_key(node: &Node, key: &[u8]) -> usize {
     node.keys
         .partition_point(|candidate| candidate.as_slice() <= key)
@@ -9643,9 +10074,12 @@ mod tests {
             config: Config::default(),
         };
 
-        let err = prolly.range(&tree, &[], None).unwrap().next().unwrap();
+        let err = match prolly.range(&tree, &[], None) {
+            Ok(_) => panic!("malformed leaf should fail during packed-node validation"),
+            Err(err) => err,
+        };
 
-        assert!(matches!(err, Err(Error::InvalidNode)));
+        assert!(matches!(err, Error::InvalidNode));
     }
 
     #[test]
@@ -9665,14 +10099,12 @@ mod tests {
             config: Config::default(),
         };
 
-        let mut iter = prolly.range(&tree, &[], None).unwrap();
-        assert_eq!(
-            iter.next().unwrap().unwrap(),
-            (b"a".to_vec(), b"1".to_vec())
-        );
-        let err = iter.next().unwrap();
+        let err = match prolly.range(&tree, &[], None) {
+            Ok(_) => panic!("malformed internal node should fail during packed-node validation"),
+            Err(err) => err,
+        };
 
-        assert!(matches!(err, Err(Error::InvalidNode)));
+        assert!(matches!(err, Error::InvalidNode));
     }
 
     #[test]

--- a/src/prolly/mod.rs
+++ b/src/prolly/mod.rs
@@ -99,8 +99,6 @@ const GET_MANY_PREFETCH_PARALLELISM: usize = 16;
 const GET_MANY_BOUNDARY_ROUTE_MIN_POSITIONS: usize = 32;
 const STATS_FRONTIER_PREFETCH_PARALLELISM: usize = 16;
 const RECENT_LEAF_MISS_SAMPLE_INTERVAL: usize = 16;
-const RECENT_LEAF_PROBE_INTERVAL: usize = 16;
-const RECENT_LEAF_HOT_READS: usize = 256;
 #[cfg(feature = "async-store")]
 const ASYNC_NODE_PREFETCH_BATCH_SIZE: usize = 64;
 
@@ -141,6 +139,7 @@ pub mod policy;
 pub mod proof;
 pub mod proximity;
 pub(crate) mod range_delete;
+pub mod read;
 pub mod snapshot;
 pub mod splice;
 pub mod stats;
@@ -290,6 +289,26 @@ impl MissingNodeBatch {
     }
 }
 
+fn plan_cached_nodes(
+    cids: &[Cid],
+    mut lookup: impl FnMut(&Cid) -> Option<Arc<Node>>,
+) -> (Vec<Option<Arc<Node>>>, Option<MissingNodeBatch>, usize) {
+    let mut nodes = Vec::with_capacity(cids.len());
+    let mut missing = MissingNodeBatch::with_capacity(cids.len());
+    let mut cache_hits = 0usize;
+    for (position, cid) in cids.iter().enumerate() {
+        if let Some(node) = lookup(cid) {
+            cache_hits += 1;
+            nodes.push(Some(node));
+        } else {
+            nodes.push(None);
+            missing.record(cid, position);
+        }
+    }
+    let missing = (!missing.cids.is_empty()).then_some(missing);
+    (nodes, missing, cache_hits)
+}
+
 struct NodeCacheEntry {
     node: Arc<Node>,
     generation: u64,
@@ -338,6 +357,21 @@ impl NodeCache {
             .sum()
     }
 
+    #[inline]
+    fn is_unbounded(&self) -> bool {
+        self.max_nodes.is_none() && self.max_bytes.is_none()
+    }
+
+    #[inline]
+    fn is_disabled(&self) -> bool {
+        self.max_nodes == Some(0) || self.max_bytes == Some(0)
+    }
+
+    #[inline]
+    fn peek(&self, cid: &Cid) -> Option<Arc<Node>> {
+        self.nodes.get(cid).map(|entry| entry.node.clone())
+    }
+
     fn clear(&mut self) -> usize {
         let evicted = self.nodes.len();
         self.nodes.clear();
@@ -347,6 +381,9 @@ impl NodeCache {
     }
 
     fn get(&mut self, cid: &Cid) -> Option<Arc<Node>> {
+        if self.is_unbounded() {
+            return self.peek(cid);
+        }
         if !self.nodes.contains_key(cid) {
             return None;
         }
@@ -404,6 +441,9 @@ impl NodeCache {
             self.bytes = self.bytes.saturating_sub(previous.bytes);
         }
         self.bytes = self.bytes.saturating_add(bytes);
+        if self.is_unbounded() {
+            return (newly_pinned, 0);
+        }
         self.access_log.push_back((cid, generation));
 
         let evicted = self.evict_to_limit();
@@ -708,16 +748,12 @@ pub struct Prolly<S: Store> {
     node_cache: RwLock<NodeCache>,
     recent_leaf: RwLock<Option<RecentLeafRead>>,
     recent_leaf_misses: AtomicUsize,
-    recent_leaf_probes: AtomicUsize,
-    recent_leaf_hot_reads: AtomicUsize,
     rightmost_path_cache: RwLock<Option<(Cid, Vec<CachedRightmostPathEntry>)>>,
     metrics: ProllyMetrics,
 }
 
 struct RecentLeafRead {
     root: Cid,
-    first_key: Vec<u8>,
-    last_key: Vec<u8>,
     node: Arc<Node>,
 }
 
@@ -1063,8 +1099,6 @@ impl<S: Store> Prolly<S> {
             node_cache: RwLock::new(NodeCache::new(node_cache_max_nodes, node_cache_max_bytes)),
             recent_leaf: RwLock::new(None),
             recent_leaf_misses: AtomicUsize::new(0),
-            recent_leaf_probes: AtomicUsize::new(0),
-            recent_leaf_hot_reads: AtomicUsize::new(0),
             rightmost_path_cache: RwLock::new(None),
             metrics: ProllyMetrics::default(),
         }
@@ -1135,90 +1169,24 @@ impl<S: Store> Prolly<S> {
     /// * `Ok(None)` if the key does not exist
     /// * `Err` on storage or deserialization errors
     pub fn get(&self, tree: &Tree, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
-        let Some(root_cid) = &tree.root else {
-            return Ok(None);
-        };
-        if let Some(result) = self.probe_recent_leaf(root_cid, key) {
-            return result;
-        }
-
-        let mut cid = root_cid.clone();
-        loop {
-            let node = self.load_arc(&cid)?;
-            let idx = match node.search(key) {
-                Ok(i) => i,
-                Err(i) => {
-                    if i == 0 {
-                        return Ok(None);
-                    } else {
-                        i - 1
-                    }
-                }
-            };
-
-            if node.leaf {
-                self.maybe_cache_recent_leaf(root_cid, node.clone());
-                return if node.keys.get(idx).map(|k| k.as_slice()) == Some(key) {
-                    Ok(Some(leaf_value_at(&node, idx)?))
-                } else {
-                    Ok(None)
-                };
-            }
-
-            // Descend to child
-            cid = child_cid_at(&node, idx)?;
-        }
-    }
-
-    fn probe_recent_leaf(&self, root: &Cid, key: &[u8]) -> Option<Result<Option<Vec<u8>>, Error>> {
-        let hot = self
-            .recent_leaf_hot_reads
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
-                remaining.checked_sub(1)
-            })
-            .is_ok();
-        if !hot
-            && self.recent_leaf_probes.fetch_add(1, Ordering::Relaxed) % RECENT_LEAF_PROBE_INTERVAL
-                != 0
-        {
-            return None;
-        }
-        let recent = self.recent_leaf.read().ok()?;
-        let recent = recent.as_ref()?;
-        if &recent.root != root
-            || key < recent.first_key.as_slice()
-            || key > recent.last_key.as_slice()
-        {
-            return None;
-        }
-        self.recent_leaf_hot_reads
-            .store(RECENT_LEAF_HOT_READS, Ordering::Relaxed);
-        self.metrics.add_cache_hits(1);
-        Some(match recent.node.search(key) {
-            Ok(index) => leaf_value_at(&recent.node, index).map(Some),
-            Err(_) => Ok(None),
-        })
+        self.get_with(tree, key, <[u8]>::to_vec)
     }
 
     fn maybe_cache_recent_leaf(&self, root: &Cid, node: Arc<Node>) {
-        if node.keys.is_empty()
+        if self
+            .node_cache
+            .read()
+            .map_or(true, |cache| cache.is_disabled())
+            || node.keys.is_empty()
             || self.recent_leaf_misses.fetch_add(1, Ordering::Relaxed)
                 % RECENT_LEAF_MISS_SAMPLE_INTERVAL
                 != 0
         {
             return;
         }
-        let Some(first_key) = node.keys.first().cloned() else {
-            return;
-        };
-        let Some(last_key) = node.keys.last().cloned() else {
-            return;
-        };
         if let Ok(mut recent) = self.recent_leaf.write() {
             *recent = Some(RecentLeafRead {
                 root: root.clone(),
-                first_key,
-                last_key,
                 node,
             });
         }
@@ -1226,75 +1194,15 @@ impl<S: Store> Prolly<S> {
 
     /// Return the number of logical key/value entries in the tree.
     pub fn len(&self, tree: &Tree) -> Result<u64, Error> {
-        match &tree.root {
-            Some(root) => self.subtree_count(root),
-            None => Ok(0),
-        }
+        self.read(tree)?.len()
     }
 
     /// Return the number of keys strictly less than `key`.
     pub fn rank(&self, tree: &Tree, key: &[u8]) -> Result<u64, Error> {
-        let Some(mut cid) = tree.root.clone() else {
-            return Ok(0);
-        };
-        let mut rank = 0u64;
-        loop {
-            let node = self.load_arc(&cid)?;
-            if node.leaf {
-                rank += node
-                    .keys
-                    .partition_point(|candidate| candidate.as_slice() < key)
-                    as u64;
-                return Ok(rank);
-            }
-            if node.keys.is_empty() || node.keys.len() != node.vals.len() {
-                return Err(Error::InvalidNode);
-            }
-            let insertion = node
-                .keys
-                .partition_point(|candidate| candidate.as_slice() <= key);
-            if insertion == 0 {
-                return Ok(rank);
-            }
-            let child_index = insertion - 1;
-            for index in 0..child_index {
-                rank = rank.saturating_add(self.child_count_at(&node, index)?);
-            }
-            cid = child_cid_at(&node, child_index)?;
-        }
+        self.read(tree)?.rank(key)
     }
 
-    /// Return the zero-based entry at `ordinal`, or `None` when out of range.
-    pub fn select(&self, tree: &Tree, mut ordinal: u64) -> Result<Option<KeyValue>, Error> {
-        let Some(mut cid) = tree.root.clone() else {
-            return Ok(None);
-        };
-        loop {
-            let node = self.load_arc(&cid)?;
-            if node.leaf {
-                let index = usize::try_from(ordinal).map_err(|_| Error::InvalidNode)?;
-                let Some(key) = node.keys.get(index).cloned() else {
-                    return Ok(None);
-                };
-                return Ok(Some((key, leaf_value_at(&node, index)?)));
-            }
-            let mut selected = None;
-            for index in 0..node.len() {
-                let count = self.child_count_at(&node, index)?;
-                if ordinal < count {
-                    selected = Some(index);
-                    break;
-                }
-                ordinal -= count;
-            }
-            let Some(index) = selected else {
-                return Ok(None);
-            };
-            cid = child_cid_at(&node, index)?;
-        }
-    }
-
-    fn subtree_count(&self, cid: &Cid) -> Result<u64, Error> {
+    pub(crate) fn subtree_count(&self, cid: &Cid) -> Result<u64, Error> {
         let node = self.load_arc(cid)?;
         if node.leaf {
             return Ok(node.keys.len() as u64);
@@ -1313,53 +1221,29 @@ impl<S: Store> Prolly<S> {
         Ok(total)
     }
 
-    fn child_count_at(&self, node: &Node, index: usize) -> Result<u64, Error> {
-        match node.child_counts.get(index).copied() {
-            Some(count) if count > 0 => Ok(count),
-            _ => self.subtree_count(&child_cid_at(node, index)?),
-        }
+    /// Return the zero-based entry at `ordinal`, or `None` when out of range.
+    pub fn select(&self, tree: &Tree, ordinal: u64) -> Result<Option<KeyValue>, Error> {
+        self.select_with(tree, ordinal, |entry| entry.to_owned())
     }
 
     /// Return the first key-value entry in key order.
     pub fn first_entry(&self, tree: &Tree) -> Result<Option<KeyValue>, Error> {
-        self.lower_bound(tree, &[])
+        self.first_entry_with(tree, |entry| entry.to_owned())
     }
 
     /// Return the last key-value entry in key order.
     pub fn last_entry(&self, tree: &Tree) -> Result<Option<KeyValue>, Error> {
-        let Some(root_cid) = &tree.root else {
-            return Ok(None);
-        };
-
-        let mut cid = root_cid.clone();
-        loop {
-            let node = self.load_arc(&cid)?;
-            let idx = node.len().checked_sub(1).ok_or(Error::InvalidNode)?;
-
-            if node.leaf {
-                let key = node.keys.get(idx).cloned().ok_or(Error::InvalidNode)?;
-                let value = leaf_value_at(&node, idx)?;
-                return Ok(Some((key, value)));
-            }
-
-            cid = child_cid_at(&node, idx)?;
-        }
+        self.last_entry_with(tree, |entry| entry.to_owned())
     }
 
     /// Return the first entry whose key is greater than or equal to `key`.
     pub fn lower_bound(&self, tree: &Tree, key: &[u8]) -> Result<Option<KeyValue>, Error> {
-        match self.range(tree, key, None)?.next() {
-            Some(entry) => entry.map(Some),
-            None => Ok(None),
-        }
+        self.lower_bound_with(tree, key, |entry| entry.to_owned())
     }
 
     /// Return the first entry whose key is strictly greater than `key`.
     pub fn upper_bound(&self, tree: &Tree, key: &[u8]) -> Result<Option<KeyValue>, Error> {
-        match self.range_after(tree, key, None)?.next() {
-            Some(entry) => entry.map(Some),
-            None => Ok(None),
-        }
+        self.upper_bound_with(tree, key, |entry| entry.to_owned())
     }
 
     /// Get a stored large-value reference by key.
@@ -1368,9 +1252,7 @@ impl<S: Store> Prolly<S> {
     /// can inspect trees that mix ordinary raw values and offloaded blob
     /// references.
     pub fn get_value_ref(&self, tree: &Tree, key: &[u8]) -> Result<Option<blob::ValueRef>, Error> {
-        self.get(tree, key)?
-            .map(|value| blob::ValueRef::from_stored_bytes(&value))
-            .transpose()
+        self.get_value_ref_with(tree, key, |value| value.to_owned())
     }
 
     /// Get a value by key, resolving offloaded blob references when present.
@@ -1423,50 +1305,9 @@ impl<S: Store> Prolly<S> {
         keys: &[K],
     ) -> Result<Vec<Option<Vec<u8>>>, Error> {
         let mut values = vec![None; keys.len()];
-        let Some(root_cid) = &tree.root else {
-            return Ok(values);
-        };
-
-        if keys.is_empty() {
-            return Ok(values);
-        }
-
-        let positions = InlinePositions::from_vec(sorted_key_positions(keys))
-            .expect("keys is non-empty after early return");
-
-        let mut frames = vec![KeyLookupFrame {
-            cid: root_cid.clone(),
-            positions,
-        }];
-
-        while !frames.is_empty() {
-            let cids = frames
-                .iter()
-                .map(|frame| frame.cid.clone())
-                .collect::<Vec<_>>();
-            let nodes = if self.store.prefers_batch_reads() {
-                self.load_many_ordered_with_parallelism(&cids, GET_MANY_PREFETCH_PARALLELISM)?
-            } else {
-                self.load_many_ordered(&cids)?
-            };
-            let mut next_frames = Vec::new();
-
-            for (frame, node) in frames.into_iter().zip(nodes) {
-                if node.leaf {
-                    fill_leaf_lookup_values(&node, frame.positions, keys, &mut values)?;
-                    continue;
-                }
-
-                next_frames.extend(route_key_positions_to_children(
-                    &node,
-                    frame.positions,
-                    keys,
-                )?);
-            }
-
-            frames = next_frames;
-        }
-
+        self.get_many_with(tree, keys, |position, _, value| {
+            values[position] = value.map(<[u8]>::to_vec);
+        })?;
         Ok(values)
     }
 
@@ -1979,6 +1820,20 @@ impl<S: Store> Prolly<S> {
         diff::merge_trees(self, base, left, right, resolver)
     }
 
+    /// Merge two trees with a callback-scoped zero-copy conflict resolver.
+    ///
+    /// Symbolic `UseBase`, `UseLeft`, and `UseRight` decisions avoid copying
+    /// conflict values before the final persisted output node is encoded.
+    pub fn merge_with(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        resolver: Option<&dyn read::BorrowedMergeResolver>,
+    ) -> Result<Tree, Error> {
+        diff::merge_trees_borrowed(self, base, left, right, resolver)
+    }
+
     /// Perform a three-way merge and return structured diagnostic trace events.
     ///
     /// This is the diagnostics-oriented counterpart to [`Prolly::merge`]. The
@@ -2067,6 +1922,19 @@ impl<S: Store> Prolly<S> {
         diff::merge_trees_range(self, base, left, right, start, end, resolver)
     }
 
+    /// Merge right-side changes in `[start, end)` with borrowed conflicts.
+    pub fn merge_range_with(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        resolver: Option<&dyn read::BorrowedMergeResolver>,
+    ) -> Result<Tree, Error> {
+        diff::merge_trees_range_borrowed(self, base, left, right, start, end, resolver)
+    }
+
     /// Merge only right-side changes whose keys start with `prefix`.
     ///
     /// This is a convenience wrapper over [`Prolly::merge_range`] using the
@@ -2081,6 +1949,19 @@ impl<S: Store> Prolly<S> {
     ) -> Result<Tree, Error> {
         let (start, end) = key::prefix_range(prefix);
         self.merge_range(base, left, right, &start, end.as_deref(), resolver)
+    }
+
+    /// Merge right-side changes with `prefix` using borrowed conflicts.
+    pub fn merge_prefix_with(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+        prefix: &[u8],
+        resolver: Option<&dyn read::BorrowedMergeResolver>,
+    ) -> Result<Tree, Error> {
+        let (start, end) = key::prefix_range(prefix);
+        self.merge_range_with(base, left, right, &start, end.as_deref(), resolver)
     }
 
     /// Collect comprehensive statistics about a tree
@@ -3244,10 +3125,25 @@ impl<S: Store> Prolly<S> {
 
     /// Load a node by its CID, reusing the in-process immutable node cache.
     pub(crate) fn load_arc(&self, cid: &Cid) -> Result<Arc<Node>, Error> {
-        if let Ok(mut cache) = self.node_cache.write() {
-            if let Some(node) = cache.get(cid) {
-                self.metrics.add_cache_hits(1);
-                return Ok(node);
+        let unbounded = if let Ok(cache) = self.node_cache.read() {
+            if cache.is_unbounded() {
+                if let Some(node) = cache.peek(cid) {
+                    self.metrics.add_cache_hits(1);
+                    return Ok(node);
+                }
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if !unbounded {
+            if let Ok(mut cache) = self.node_cache.write() {
+                if let Some(node) = cache.get(cid) {
+                    self.metrics.add_cache_hits(1);
+                    return Ok(node);
+                }
             }
         }
 
@@ -3313,50 +3209,25 @@ impl<S: Store> Prolly<S> {
             return Ok(Vec::new());
         }
 
-        let mut nodes: Vec<Option<Arc<Node>>>;
-        let mut missing: Option<MissingNodeBatch>;
-        if let Ok(mut cache) = self.node_cache.write() {
-            let mut cache_hits = 0usize;
-            let mut cached_nodes = Vec::with_capacity(cids.len());
-            let mut first_miss = None;
-            for (idx, cid) in cids.iter().enumerate() {
-                if let Some(node) = cache.get(cid) {
-                    cache_hits += 1;
-                    cached_nodes.push(node.clone());
-                } else {
-                    first_miss = Some(idx);
-                    break;
-                }
-            }
-
-            let Some(first_miss) = first_miss else {
-                self.metrics.add_cache_hits(cache_hits);
-                return Ok(cached_nodes);
-            };
-
-            nodes = Vec::with_capacity(cids.len());
-            nodes.extend(cached_nodes.into_iter().map(Some));
-            nodes.resize_with(cids.len(), || None);
-            missing = Some(MissingNodeBatch::with_capacity(cids.len() - first_miss));
-            if let Some(missing_batch) = missing.as_mut() {
-                missing_batch.record(&cids[first_miss], first_miss);
-                for (idx, cid) in cids.iter().enumerate().skip(first_miss + 1) {
-                    if let Some(node) = cache.get(cid) {
-                        cache_hits += 1;
-                        nodes[idx] = Some(node.clone());
-                    } else {
-                        missing_batch.record(cid, idx);
-                    }
-                }
-            }
-            self.metrics.add_cache_hits(cache_hits);
+        let unbounded_plan = self.node_cache.read().ok().and_then(|cache| {
+            cache
+                .is_unbounded()
+                .then(|| plan_cached_nodes(cids, |cid| cache.peek(cid)))
+        });
+        let (mut nodes, missing, cache_hits) = if let Some(plan) = unbounded_plan {
+            plan
+        } else if let Ok(mut cache) = self.node_cache.write() {
+            plan_cached_nodes(cids, |cid| cache.get(cid))
         } else {
-            nodes = vec![None; cids.len()];
-            let mut missing_batch = MissingNodeBatch::with_capacity(cids.len());
-            for (idx, cid) in cids.iter().enumerate() {
-                missing_batch.record(cid, idx);
-            }
-            missing = Some(missing_batch);
+            plan_cached_nodes(cids, |_| None)
+        };
+        self.metrics.add_cache_hits(cache_hits);
+
+        if missing.is_none() {
+            return nodes
+                .into_iter()
+                .collect::<Option<Vec<_>>>()
+                .ok_or(Error::InvalidNode);
         }
 
         if let Some(MissingNodeBatch {
@@ -3491,11 +3362,17 @@ impl<S: Store> Prolly<S> {
     }
 
     pub(crate) fn cached_node_arc(&self, cid: &Cid) -> Option<Arc<Node>> {
-        let node = self
+        let unbounded_node = self
             .node_cache
-            .write()
+            .read()
             .ok()
-            .and_then(|mut cache| cache.get(cid));
+            .and_then(|cache| cache.is_unbounded().then(|| cache.peek(cid)).flatten());
+        let node = unbounded_node.or_else(|| {
+            self.node_cache
+                .write()
+                .ok()
+                .and_then(|mut cache| cache.get(cid))
+        });
         if node.is_some() {
             self.metrics.add_cache_hits(1);
         }
@@ -3534,8 +3411,6 @@ impl<S: Store> Prolly<S> {
             *recent = None;
         }
         self.recent_leaf_misses.store(0, Ordering::Relaxed);
-        self.recent_leaf_probes.store(0, Ordering::Relaxed);
-        self.recent_leaf_hot_reads.store(0, Ordering::Relaxed);
         if let Ok(mut cache) = self.rightmost_path_cache.write() {
             *cache = None;
         }
@@ -6837,10 +6712,25 @@ where
     }
 
     pub(crate) async fn load_arc(&self, cid: &Cid) -> Result<Arc<Node>, Error> {
-        if let Ok(mut cache) = self.node_cache.write() {
-            if let Some(node) = cache.get(cid) {
-                self.metrics.add_cache_hits(1);
-                return Ok(node);
+        let unbounded = if let Ok(cache) = self.node_cache.read() {
+            if cache.is_unbounded() {
+                if let Some(node) = cache.peek(cid) {
+                    self.metrics.add_cache_hits(1);
+                    return Ok(node);
+                }
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if !unbounded {
+            if let Ok(mut cache) = self.node_cache.write() {
+                if let Some(node) = cache.get(cid) {
+                    self.metrics.add_cache_hits(1);
+                    return Ok(node);
+                }
             }
         }
 
@@ -6943,50 +6833,25 @@ where
             return Ok(Vec::new());
         }
 
-        let mut nodes: Vec<Option<Arc<Node>>>;
-        let mut missing: Option<MissingNodeBatch>;
-        if let Ok(mut cache) = self.node_cache.write() {
-            let mut cache_hits = 0usize;
-            let mut cached_nodes = Vec::with_capacity(cids.len());
-            let mut first_miss = None;
-            for (idx, cid) in cids.iter().enumerate() {
-                if let Some(node) = cache.get(cid) {
-                    cache_hits += 1;
-                    cached_nodes.push(node.clone());
-                } else {
-                    first_miss = Some(idx);
-                    break;
-                }
-            }
-
-            let Some(first_miss) = first_miss else {
-                self.metrics.add_cache_hits(cache_hits);
-                return Ok(cached_nodes);
-            };
-
-            nodes = Vec::with_capacity(cids.len());
-            nodes.extend(cached_nodes.into_iter().map(Some));
-            nodes.resize_with(cids.len(), || None);
-            missing = Some(MissingNodeBatch::with_capacity(cids.len() - first_miss));
-            if let Some(missing_batch) = missing.as_mut() {
-                missing_batch.record(&cids[first_miss], first_miss);
-                for (idx, cid) in cids.iter().enumerate().skip(first_miss + 1) {
-                    if let Some(node) = cache.get(cid) {
-                        cache_hits += 1;
-                        nodes[idx] = Some(node.clone());
-                    } else {
-                        missing_batch.record(cid, idx);
-                    }
-                }
-            }
-            self.metrics.add_cache_hits(cache_hits);
+        let unbounded_plan = self.node_cache.read().ok().and_then(|cache| {
+            cache
+                .is_unbounded()
+                .then(|| plan_cached_nodes(cids, |cid| cache.peek(cid)))
+        });
+        let (mut nodes, missing, cache_hits) = if let Some(plan) = unbounded_plan {
+            plan
+        } else if let Ok(mut cache) = self.node_cache.write() {
+            plan_cached_nodes(cids, |cid| cache.get(cid))
         } else {
-            nodes = vec![None; cids.len()];
-            let mut missing_batch = MissingNodeBatch::with_capacity(cids.len());
-            for (idx, cid) in cids.iter().enumerate() {
-                missing_batch.record(cid, idx);
-            }
-            missing = Some(missing_batch);
+            plan_cached_nodes(cids, |_| None)
+        };
+        self.metrics.add_cache_hits(cache_hits);
+
+        if missing.is_none() {
+            return nodes
+                .into_iter()
+                .collect::<Option<Vec<_>>>()
+                .ok_or(Error::InvalidNode);
         }
 
         if let Some(MissingNodeBatch {
@@ -7927,6 +7792,7 @@ fn path_index_for_key(node: &Node, key: &[u8]) -> usize {
     }
 }
 
+#[cfg(feature = "async-store")]
 fn fill_leaf_lookup_values<K: AsRef<[u8]>>(
     node: &Node,
     positions: InlinePositions,
@@ -8122,6 +7988,7 @@ fn reverse_scan_end<'a>(
     }
 }
 
+#[cfg(feature = "async-store")]
 fn leaf_value_at(node: &Node, idx: usize) -> Result<Vec<u8>, Error> {
     node.vals.get(idx).cloned().ok_or(Error::InvalidNode)
 }

--- a/src/prolly/node.rs
+++ b/src/prolly/node.rs
@@ -1,6 +1,8 @@
 //! Node structure and builder for Prolly Trees
 
 use serde::{Deserialize, Serialize};
+use std::mem;
+use std::sync::Arc;
 
 use super::cid::Cid;
 use super::encoding::{Encoding, INIT_LEVEL};
@@ -25,6 +27,370 @@ pub struct Node {
     pub level: u8,
     /// Persisted settings that determine tree shape and node bytes.
     pub format: TreeFormat,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ReadEntryMeta {
+    key_start: u32,
+    key_len: u32,
+    value_start: u32,
+    value_len: u32,
+    child_count: u64,
+    key_order: u64,
+}
+
+/// Immutable packed node used by read-only traversals.
+///
+/// Values, and keys in the plain and offset-table layouts, point directly into
+/// the retained encoded object. Prefix-compressed keys are reconstructed once
+/// into one contiguous arena instead of one allocation per key.
+#[derive(Debug)]
+pub(crate) struct ReadNode {
+    bytes: Arc<[u8]>,
+    prefix_keys: Option<Arc<[u8]>>,
+    entries: Box<[ReadEntryMeta]>,
+    common_prefix_len: u32,
+    leaf: bool,
+    level: u8,
+    format: TreeFormat,
+}
+
+impl ReadNode {
+    pub(crate) fn from_shared(bytes: Arc<[u8]>) -> Result<Self, Error> {
+        let (format, leaf, level, entries, prefix_keys) = {
+            let mut cursor = CompactCursor::new(&bytes);
+            cursor.expect_magic()?;
+            let version = cursor.read_varint()?;
+            if version != COMPACT_VERSION {
+                return Err(compact_error(format!(
+                    "unsupported compact node version {version}"
+                )));
+            }
+            let format_len = cursor.read_usize("tree format length")?;
+            let format = if format_len == 0 {
+                TreeFormat::default()
+            } else {
+                TreeFormat::from_canonical_bytes(cursor.read_bytes(format_len)?)?
+            };
+            format.validate()?;
+            let leaf = match cursor.read_varint()? {
+                0 => false,
+                1 => true,
+                other => return Err(compact_error(format!("invalid leaf flag {other}"))),
+            };
+            let level = cursor.read_u8_varint("level")?;
+            let entry_count = cursor.read_usize("entry_count")?;
+            let mut entries = Vec::with_capacity(entry_count);
+            let mut prefix_keys: Option<Arc<[u8]>> = None;
+
+            match &format.node_layout {
+                NodeLayoutSpec::PrefixCompressed => {
+                    let mut arena = Vec::<u8>::new();
+                    let mut previous_start = 0usize;
+                    let mut previous_len = 0usize;
+                    for _ in 0..entry_count {
+                        let shared = cursor.read_usize("shared key prefix length")?;
+                        if shared > previous_len {
+                            return Err(compact_error("shared key prefix exceeds previous key"));
+                        }
+                        let suffix_len = cursor.read_usize("key suffix length")?;
+                        let key_start = arena.len();
+                        if shared > 0 {
+                            arena.extend_from_within(previous_start..previous_start + shared);
+                        }
+                        arena.extend_from_slice(cursor.read_bytes(suffix_len)?);
+                        let key_len = shared
+                            .checked_add(suffix_len)
+                            .ok_or_else(|| compact_error("key length overflow"))?;
+                        let value_len = cursor.read_usize("value length")?;
+                        let value_start = cursor.position();
+                        cursor.read_bytes(value_len)?;
+                        let child_count = if leaf { 0 } else { cursor.read_varint()? };
+                        entries.push(ReadEntryMeta {
+                            key_start: compact_u32(key_start, "key offset")?,
+                            key_len: compact_u32(key_len, "key length")?,
+                            value_start: compact_u32(value_start, "value offset")?,
+                            value_len: compact_u32(value_len, "value length")?,
+                            child_count,
+                            key_order: 0,
+                        });
+                        previous_start = key_start;
+                        previous_len = key_len;
+                    }
+                    prefix_keys = Some(Arc::from(arena.into_boxed_slice()));
+                }
+                NodeLayoutSpec::Plain => {
+                    for _ in 0..entry_count {
+                        let key_len = cursor.read_usize("key length")?;
+                        let key_start = cursor.position();
+                        cursor.read_bytes(key_len)?;
+                        let value_len = cursor.read_usize("value length")?;
+                        let value_start = cursor.position();
+                        cursor.read_bytes(value_len)?;
+                        let child_count = if leaf { 0 } else { cursor.read_varint()? };
+                        entries.push(ReadEntryMeta {
+                            key_start: compact_u32(key_start, "key offset")?,
+                            key_len: compact_u32(key_len, "key length")?,
+                            value_start: compact_u32(value_start, "value offset")?,
+                            value_len: compact_u32(value_len, "value length")?,
+                            child_count,
+                            key_order: 0,
+                        });
+                    }
+                }
+                NodeLayoutSpec::OffsetTable => {
+                    let mut offsets = Vec::with_capacity(entry_count);
+                    for _ in 0..entry_count {
+                        let key_offset = cursor.read_usize("key offset")?;
+                        let key_len = cursor.read_usize("key length")?;
+                        let value_offset = cursor.read_usize("value offset")?;
+                        let value_len = cursor.read_usize("value length")?;
+                        let child_count = if leaf { 0 } else { cursor.read_varint()? };
+                        offsets.push((key_offset, key_len, value_offset, value_len, child_count));
+                    }
+                    let payload_len = cursor.read_usize("payload length")?;
+                    let payload_start = cursor.position();
+                    let payload = cursor.read_bytes(payload_len)?;
+                    for (key_offset, key_len, value_offset, value_len, child_count) in offsets {
+                        slice_payload(payload, key_offset, key_len, "key")?;
+                        slice_payload(payload, value_offset, value_len, "value")?;
+                        let key_start = payload_start
+                            .checked_add(key_offset)
+                            .ok_or_else(|| compact_error("key offset overflow"))?;
+                        let value_start = payload_start
+                            .checked_add(value_offset)
+                            .ok_or_else(|| compact_error("value offset overflow"))?;
+                        entries.push(ReadEntryMeta {
+                            key_start: compact_u32(key_start, "key offset")?,
+                            key_len: compact_u32(key_len, "key length")?,
+                            value_start: compact_u32(value_start, "value offset")?,
+                            value_len: compact_u32(value_len, "value length")?,
+                            child_count,
+                            key_order: 0,
+                        });
+                    }
+                }
+                NodeLayoutSpec::Custom { id, .. } => {
+                    return Err(Error::InvalidFormat(format!(
+                        "node layout '{id}' has no registered codec"
+                    )));
+                }
+            }
+            if !cursor.is_done() {
+                return Err(compact_error("trailing bytes in compact node"));
+            }
+            (format, leaf, level, entries, prefix_keys)
+        };
+
+        let mut entries = entries;
+        let key_source = prefix_keys.as_deref().unwrap_or(bytes.as_ref());
+        let common_prefix_len = match (entries.first(), entries.last()) {
+            (Some(first), Some(last)) => {
+                let first = read_slice(key_source, first.key_start, first.key_len)
+                    .ok_or(Error::InvalidNode)?;
+                let last = read_slice(key_source, last.key_start, last.key_len)
+                    .ok_or(Error::InvalidNode)?;
+                first
+                    .iter()
+                    .zip(last)
+                    .take_while(|(left, right)| left == right)
+                    .count()
+            }
+            _ => 0,
+        };
+        for entry in &mut entries {
+            let key =
+                read_slice(key_source, entry.key_start, entry.key_len).ok_or(Error::InvalidNode)?;
+            entry.key_order = key_order_word(key, common_prefix_len);
+        }
+
+        let node = Self {
+            bytes,
+            prefix_keys,
+            entries: entries.into_boxed_slice(),
+            common_prefix_len: compact_u32(common_prefix_len, "common key prefix length")?,
+            leaf,
+            level,
+            format,
+        };
+        node.validate()?;
+        Ok(node)
+    }
+
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    #[inline]
+    pub(crate) fn is_leaf(&self) -> bool {
+        self.leaf
+    }
+
+    #[inline]
+    pub(crate) fn level(&self) -> u8 {
+        self.level
+    }
+
+    #[inline]
+    pub(crate) fn format(&self) -> &TreeFormat {
+        &self.format
+    }
+
+    #[inline]
+    pub(crate) fn key(&self, index: usize) -> Option<&[u8]> {
+        let entry = self.entries.get(index)?;
+        let source = self.prefix_keys.as_deref().unwrap_or(&self.bytes);
+        read_slice(source, entry.key_start, entry.key_len)
+    }
+
+    #[inline]
+    pub(crate) fn value(&self, index: usize) -> Option<&[u8]> {
+        let entry = self.entries.get(index)?;
+        read_slice(&self.bytes, entry.value_start, entry.value_len)
+    }
+
+    #[inline]
+    pub(crate) fn child_count(&self, index: usize) -> Option<u64> {
+        (!self.leaf)
+            .then(|| self.entries.get(index).map(|entry| entry.child_count))
+            .flatten()
+    }
+
+    pub(crate) fn child_cid(&self, index: usize) -> Result<Cid, Error> {
+        let value = self.value(index).ok_or(Error::InvalidNode)?;
+        let bytes: [u8; 32] = value.try_into().map_err(|_| Error::InvalidNode)?;
+        Ok(Cid(bytes))
+    }
+
+    #[inline]
+    pub(crate) fn search(&self, key: &[u8]) -> Result<usize, usize> {
+        let source = self.prefix_keys.as_deref().unwrap_or(&self.bytes);
+        let common_prefix_len = self.common_prefix_len as usize;
+        if common_prefix_len > 0 {
+            // Every key has this prefix because the first and last sorted keys
+            // have it. A query that diverges inside it is outside the node's
+            // complete key interval and needs no entry-level comparisons.
+            let first = unsafe { self.entries.get_unchecked(0) };
+            let common = unsafe {
+                std::slice::from_raw_parts(
+                    source.as_ptr().add(first.key_start as usize),
+                    common_prefix_len,
+                )
+            };
+            let shared = key.len().min(common_prefix_len);
+            match key[..shared].cmp(&common[..shared]) {
+                std::cmp::Ordering::Less => return Err(0),
+                std::cmp::Ordering::Greater => return Err(self.len()),
+                std::cmp::Ordering::Equal if key.len() < common_prefix_len => return Err(0),
+                std::cmp::Ordering::Equal => {}
+            }
+        }
+        let query_order = key_order_word(key, common_prefix_len);
+        let mut left = 0usize;
+        let mut right = self.len();
+        while left < right {
+            let mid = left + (right - left) / 2;
+            // SAFETY: `mid < self.len()` by the binary-search invariant, and
+            // construction validated this immutable metadata range against
+            // `source` before the node was published.
+            let candidate = unsafe {
+                let entry = self.entries.get_unchecked(mid);
+                match entry.key_order.cmp(&query_order) {
+                    std::cmp::Ordering::Less => {
+                        left = mid + 1;
+                        continue;
+                    }
+                    std::cmp::Ordering::Greater => {
+                        right = mid;
+                        continue;
+                    }
+                    std::cmp::Ordering::Equal => {}
+                }
+                std::slice::from_raw_parts(
+                    source.as_ptr().add(entry.key_start as usize),
+                    entry.key_len as usize,
+                )
+            };
+            match candidate.cmp(key) {
+                std::cmp::Ordering::Less => left = mid + 1,
+                std::cmp::Ordering::Greater => right = mid,
+                std::cmp::Ordering::Equal => return Ok(mid),
+            }
+        }
+        Err(left)
+    }
+
+    pub(crate) fn to_owned(&self) -> Node {
+        Node {
+            keys: (0..self.len())
+                .map(|index| self.key(index).expect("validated read node").to_vec())
+                .collect(),
+            vals: (0..self.len())
+                .map(|index| self.value(index).expect("validated read node").to_vec())
+                .collect(),
+            child_counts: if self.leaf {
+                Vec::new()
+            } else {
+                self.entries.iter().map(|entry| entry.child_count).collect()
+            },
+            leaf: self.leaf,
+            level: self.level,
+            format: self.format.clone(),
+        }
+    }
+
+    pub(crate) fn retained_bytes(&self) -> usize {
+        self.bytes
+            .len()
+            .saturating_add(self.prefix_keys.as_ref().map_or(0, |keys| keys.len()))
+            .saturating_add(
+                self.entries
+                    .len()
+                    .saturating_mul(mem::size_of::<ReadEntryMeta>()),
+            )
+    }
+
+    fn validate(&self) -> Result<(), Error> {
+        if !self.leaf && self.entries.is_empty() {
+            return Err(Error::InvalidNode);
+        }
+        let mut previous: Option<&[u8]> = None;
+        for index in 0..self.len() {
+            let key = self.key(index).ok_or(Error::InvalidNode)?;
+            self.value(index).ok_or(Error::InvalidNode)?;
+            if previous.is_some_and(|previous| previous >= key) {
+                return Err(Error::InvalidNode);
+            }
+            previous = Some(key);
+        }
+        Ok(())
+    }
+}
+
+#[inline]
+fn key_order_word(key: &[u8], prefix_len: usize) -> u64 {
+    let suffix = key.get(prefix_len..).unwrap_or_default();
+    let mut word = [0u8; 8];
+    let copied = suffix.len().min(word.len());
+    word[..copied].copy_from_slice(&suffix[..copied]);
+    u64::from_be_bytes(word)
+}
+
+fn compact_u32(value: usize, field: &str) -> Result<u32, Error> {
+    u32::try_from(value).map_err(|_| compact_error(format!("{field} exceeds u32")))
+}
+
+#[inline]
+fn read_slice(bytes: &[u8], start: u32, len: u32) -> Option<&[u8]> {
+    let start = start as usize;
+    let end = start.checked_add(len as usize)?;
+    bytes.get(start..end)
 }
 
 impl Default for Node {
@@ -526,6 +892,11 @@ impl<'a> CompactCursor<'a> {
     fn is_done(&self) -> bool {
         self.pos == self.data.len()
     }
+
+    #[inline]
+    fn position(&self) -> usize {
+        self.pos
+    }
 }
 
 /// Builder pattern for Node construction
@@ -724,6 +1095,104 @@ mod tests {
         assert!(bytes.starts_with(COMPACT_MAGIC));
         let restored = Node::from_bytes(&bytes).unwrap();
         assert_eq!(node, restored);
+    }
+
+    #[test]
+    fn packed_read_node_matches_owned_node_for_every_builtin_layout() {
+        for layout in [
+            NodeLayoutSpec::PrefixCompressed,
+            NodeLayoutSpec::Plain,
+            NodeLayoutSpec::OffsetTable,
+        ] {
+            let format = TreeFormat {
+                node_layout: layout.clone(),
+                ..TreeFormat::default()
+            };
+            let node = Node::builder()
+                .keys(vec![
+                    b"alpha/0001".to_vec(),
+                    b"alpha/0002".to_vec(),
+                    b"beta/0003".to_vec(),
+                ])
+                .vals(vec![b"one".to_vec(), b"two".to_vec(), b"three".to_vec()])
+                .leaf(true)
+                .tree_format(format)
+                .build();
+            let bytes = Arc::<[u8]>::from(node.to_bytes());
+            let packed = ReadNode::from_shared(bytes)
+                .unwrap_or_else(|error| panic!("packed {layout:?} failed: {error}"));
+
+            assert_eq!(packed.to_owned(), node);
+            assert_eq!(packed.search(b"alpha/0002"), Ok(1));
+            assert_eq!(packed.search(b"alpha/0003"), Err(2));
+            assert!(packed.retained_bytes() >= node.to_bytes().len());
+        }
+    }
+
+    #[test]
+    fn packed_search_accelerator_preserves_full_byte_order() {
+        let keys = vec![
+            b"shared-prefix-00000000".to_vec(),
+            b"shared-prefix-00000000\0".to_vec(),
+            b"shared-prefix-00000000x".to_vec(),
+            b"shared-prefix-00000001".to_vec(),
+            b"shared-prefix-99999999".to_vec(),
+        ];
+        let queries: &[&[u8]] = &[
+            b"before-prefix",
+            b"shared",
+            b"shared-prefix-00000000",
+            b"shared-prefix-00000000\0",
+            b"shared-prefix-00000000a",
+            b"shared-prefix-00000001",
+            b"shared-prefix-50000000",
+            b"z-after-prefix",
+        ];
+
+        for layout in [
+            NodeLayoutSpec::PrefixCompressed,
+            NodeLayoutSpec::Plain,
+            NodeLayoutSpec::OffsetTable,
+        ] {
+            let node = Node::builder()
+                .keys(keys.clone())
+                .vals(vec![Vec::new(); keys.len()])
+                .tree_format(TreeFormat {
+                    node_layout: layout,
+                    ..TreeFormat::default()
+                })
+                .build();
+            let packed = ReadNode::from_shared(Arc::from(node.to_bytes())).unwrap();
+            for query in queries {
+                assert_eq!(packed.search(query), node.search(query), "query={query:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn packed_read_node_rejects_structural_corruption() {
+        let node = Node::builder()
+            .keys(vec![b"a".to_vec(), b"b".to_vec()])
+            .vals(vec![b"1".to_vec(), b"2".to_vec()])
+            .build();
+        let mut trailing = node.to_bytes();
+        trailing.push(0);
+        assert!(ReadNode::from_shared(Arc::from(trailing)).is_err());
+
+        let unsorted = Node::builder()
+            .keys(vec![b"b".to_vec(), b"a".to_vec()])
+            .vals(vec![b"1".to_vec(), b"2".to_vec()])
+            .build();
+        assert!(ReadNode::from_shared(Arc::from(unsorted.to_bytes())).is_err());
+
+        let invalid_internal = Node::builder()
+            .keys(Vec::new())
+            .vals(Vec::new())
+            .child_counts(Vec::new())
+            .leaf(false)
+            .level(1)
+            .build();
+        assert!(ReadNode::from_shared(Arc::from(invalid_internal.to_bytes())).is_err());
     }
 
     #[test]

--- a/src/prolly/proximity/accelerator/hnsw/search.rs
+++ b/src/prolly/proximity/accelerator/hnsw/search.rs
@@ -3,9 +3,12 @@ use super::HnswIndex;
 use crate::prolly::error::Error;
 use crate::prolly::proximity::distance::{prepare_vector, query_score};
 use crate::prolly::proximity::search::PreparedFilter;
-use crate::prolly::proximity::search::{EligibilityCardinality, SearchPlan, SearchPlanSummary};
+use crate::prolly::proximity::search::{
+    retained_candidate_bytes, EligibilityCardinality, RerankCandidate, SearchPlan,
+    SearchPlanSummary,
+};
 use crate::prolly::proximity::{
-    Neighbor, ProximityMap, ProximitySearchStats, SearchCompletion, SearchRequest, SearchResult,
+    ProximityMap, ProximitySearchStats, SearchCompletion, SearchRequest, SearchResult,
 };
 use crate::prolly::store::Store;
 use std::cmp::{Ordering, Reverse};
@@ -267,11 +270,10 @@ where
 
     let mut candidates = eligible.into_vec();
     candidates.sort();
-    let mut neighbors = Vec::with_capacity(request.k.min(candidates.len()));
+    let mut reranked = Vec::with_capacity(candidates.len());
+    let mut vector_scratch = vec![0.0f32; map.tree().config.dimensions as usize];
+    let mut directory = map.directory_manager().read(&map.tree().directory)?;
     for candidate in candidates {
-        if neighbors.len() == request.k {
-            break;
-        }
         if state.distance_exhausted() {
             state.completion = SearchCompletion::BudgetExhausted;
             break;
@@ -284,12 +286,13 @@ where
             state.completion = SearchCompletion::BudgetExhausted;
             break;
         }
-        let Some((record, bytes)) = map.get_stored(&candidate.key)? else {
+        let Some(handle) = directory.get_handle(&candidate.key)? else {
             return Err(Error::InvalidProximityObject {
                 kind: "HNSW",
                 reason: "result key is absent from authoritative directory".to_owned(),
             });
         };
+        let bytes = handle.value()?.len();
         if request
             .budget
             .max_committed_bytes
@@ -298,25 +301,34 @@ where
             state.completion = SearchCompletion::BudgetExhausted;
             break;
         }
+        let record = crate::prolly::proximity::storage::StoredRecordRef::decode(
+            handle.value()?,
+            map.tree().config.dimensions,
+        )?;
+        crate::prolly::proximity::ProximityVectorRef::from_encoded(record.vector)
+            .copy_to_slice(&mut vector_scratch)?;
+        let Some(distance) = state.distance(&query, &vector_scratch) else {
+            state.completion = SearchCompletion::BudgetExhausted;
+            break;
+        };
         state.stats.nodes_read += 1;
         state.stats.bytes_read = state.stats.bytes_read.saturating_add(bytes);
         state.stats.committed_bytes = state.stats.committed_bytes.saturating_add(bytes);
-        let Some(distance) = state.distance(&query, &record.vector) else {
-            break;
-        };
         state.stats.reranked_candidates += 1;
-        neighbors.push(Neighbor {
-            key: candidate.key,
-            value: record.value,
-            distance,
-        });
+        reranked.push(RerankCandidate::new(handle, &candidate.key, distance)?);
     }
-    neighbors.sort_by(|left, right| {
+    state.stats.candidate_handles_peak = reranked.len();
+    state.stats.candidate_retained_bytes_peak = retained_candidate_bytes(&reranked);
+    reranked.sort_by(|left, right| {
         left.distance
             .total_cmp(&right.distance)
-            .then_with(|| left.key.cmp(&right.key))
+            .then_with(|| left.key().cmp(right.key()))
     });
-    neighbors.truncate(request.k);
+    let neighbors = reranked
+        .into_iter()
+        .take(request.k)
+        .map(|candidate| candidate.into_neighbor(map.tree().config.dimensions))
+        .collect::<Result<Vec<_>, Error>>()?;
     Ok(SearchResult {
         neighbors,
         stats: state.stats,

--- a/src/prolly/proximity/accelerator/pq.rs
+++ b/src/prolly/proximity/accelerator/pq.rs
@@ -4,13 +4,15 @@ use crate::prolly::config::Config;
 use crate::prolly::encoding::Encoding;
 use crate::prolly::error::Error;
 use crate::prolly::proximity::distance::{prepare_vector, query_score};
-use crate::prolly::proximity::search::{EligibilityCardinality, PreparedFilter};
+use crate::prolly::proximity::search::{
+    retained_candidate_bytes, EligibilityCardinality, PreparedFilter, RerankCandidate,
+};
 use crate::prolly::proximity::storage::codec::{
     put_cid, put_f32, put_f64, put_varint, Reader, MAX_OBJECT_ENTRIES,
 };
 use crate::prolly::proximity::storage::StoredRecord;
 use crate::prolly::proximity::{
-    BuildParallelism, DistanceMetric, Neighbor, ProximityMap, ProximitySearchStats, SearchBackend,
+    BuildParallelism, DistanceMetric, ProximityMap, ProximitySearchStats, SearchBackend,
     SearchCompletion, SearchPolicy, SearchRequest, SearchResult,
 };
 use crate::prolly::store::Store;
@@ -574,7 +576,9 @@ where
         approximate.sort();
         let shortlist = approximate.len();
 
-        let mut reranked = Vec::<(Vec<u8>, Vec<u8>, f64)>::with_capacity(shortlist);
+        let mut reranked = Vec::<RerankCandidate>::with_capacity(shortlist);
+        let mut vector_scratch = vec![0.0f32; map.tree().config.dimensions as usize];
+        let mut directory = map.directory_manager().read(&map.tree().directory)?;
         for candidate in approximate {
             if budget_exhausted(&request, &stats)
                 || request
@@ -585,9 +589,12 @@ where
                 completion = SearchCompletion::BudgetExhausted;
                 break;
             }
-            let (record, bytes) = map.get_stored(&candidate.key)?.ok_or_else(|| {
-                invalid_object("PQ code key is absent from authoritative directory")
-            })?;
+            let Some(handle) = directory.get_handle(&candidate.key)? else {
+                return Err(invalid_object(
+                    "PQ code key is absent from authoritative directory",
+                ));
+            };
+            let bytes = handle.value()?.len();
             if request
                 .budget
                 .max_committed_bytes
@@ -596,28 +603,32 @@ where
                 completion = SearchCompletion::BudgetExhausted;
                 break;
             }
+            let record = crate::prolly::proximity::storage::StoredRecordRef::decode(
+                handle.value()?,
+                map.tree().config.dimensions,
+            )?;
+            crate::prolly::proximity::ProximityVectorRef::from_encoded(record.vector)
+                .copy_to_slice(&mut vector_scratch)?;
+            let distance = query_score(request.kernel, self.metric, &query, &vector_scratch);
             stats.nodes_read += 1;
             stats.bytes_read = stats.bytes_read.saturating_add(bytes);
             stats.committed_bytes = stats.committed_bytes.saturating_add(bytes);
             stats.distance_evaluations += 1;
-            let distance = query_score(request.kernel, self.metric, &query, &record.vector);
-            reranked.push((candidate.key, record.value, distance));
+            reranked.push(RerankCandidate::new(handle, &candidate.key, distance)?);
         }
         stats.reranked_candidates = reranked.len();
+        stats.candidate_handles_peak = reranked.len();
+        stats.candidate_retained_bytes_peak = retained_candidate_bytes(&reranked);
         reranked.sort_by(|left, right| {
-            left.2
-                .total_cmp(&right.2)
-                .then_with(|| left.0.cmp(&right.0))
+            left.distance
+                .total_cmp(&right.distance)
+                .then_with(|| left.key().cmp(right.key()))
         });
         let neighbors = reranked
             .into_iter()
             .take(request.k)
-            .map(|(key, value, distance)| Neighbor {
-                key,
-                value,
-                distance,
-            })
-            .collect();
+            .map(|candidate| candidate.into_neighbor(map.tree().config.dimensions))
+            .collect::<Result<Vec<_>, Error>>()?;
         Ok(SearchResult {
             neighbors,
             stats,

--- a/src/prolly/proximity/map.rs
+++ b/src/prolly/proximity/map.rs
@@ -11,8 +11,9 @@ use super::cache::{ContentCache, DEFAULT_PROXIMITY_CACHE_NODES};
 use super::distance::{prepare_vector, query_score, score};
 use super::mutation::{mutate_hierarchy, LogicalEdit};
 use super::search::{
-    adaptive_should_stop, insert_top_k, plan_search, AdaptiveContext, FrontierEntry,
-    PreparedFilter, SearchCandidate, SearchPlan,
+    adaptive_should_stop, insert_reranked_top_k, insert_top_k, plan_search,
+    retained_candidate_bytes, retained_search_candidate_bytes, AdaptiveContext, FrontierEntry,
+    PreparedFilter, RerankCandidate, SearchCandidate, SearchPlan,
 };
 use super::storage::quantized::ScalarQuantized;
 use super::storage::vector::ExternalVector;
@@ -723,16 +724,43 @@ where
             request.query,
             self.tree.config.dimensions,
         )?;
+        enum CompositeValue {
+            Owned { value: Vec<u8>, distance: f64 },
+            Retained(RerankCandidate),
+        }
+        impl CompositeValue {
+            fn distance(&self) -> f64 {
+                match self {
+                    Self::Owned { distance, .. } => *distance,
+                    Self::Retained(candidate) => candidate.distance,
+                }
+            }
+        }
         let mut delta_seen = 0usize;
-        let mut merged = BTreeMap::<Vec<u8>, Neighbor>::new();
+        let mut merged = BTreeMap::<Vec<u8>, CompositeValue>::new();
         for neighbor in base_result.neighbors.drain(..) {
-            if merged.insert(neighbor.key.clone(), neighbor).is_some() {
+            if merged
+                .insert(
+                    neighbor.key,
+                    CompositeValue::Owned {
+                        value: neighbor.value,
+                        distance: neighbor.distance,
+                    },
+                )
+                .is_some()
+            {
                 return Err(Error::InvalidProximityObject {
                     kind: "composite base",
                     reason: "base executor returned a duplicate key".to_owned(),
                 });
             }
         }
+        let mut vector_scratch = vec![0.0f32; self.tree.config.dimensions as usize];
+        let mut current_directory = current
+            .directory_manager()
+            .read(&current.tree().directory)?;
+        let mut retained_backings = HashSet::new();
+        let mut retained_bytes = 0usize;
         for entry in delta_manager.range(&composite.delta_tree, &[], None)? {
             let (key, bytes) = entry?;
             delta_seen += 1;
@@ -748,7 +776,7 @@ where
                 completion = SearchCompletion::BudgetExhausted;
                 break;
             }
-            let record = StoredRecord::decode(&bytes, self.tree.config.dimensions)?;
+            let record = StoredRecordRef::decode(&bytes, self.tree.config.dimensions)?;
             stats.nodes_read += 1;
             stats.bytes_read += bytes.len();
             stats.committed_bytes += bytes.len();
@@ -773,45 +801,56 @@ where
                 completion = SearchCompletion::BudgetExhausted;
                 break;
             }
-            let Some((authoritative, authoritative_bytes)) = current.get_stored(&key)? else {
+            let Some(handle) = current_directory.get_handle(&key)? else {
                 return Err(Error::InvalidProximityObject {
                     kind: "composite delta",
                     reason: "delta key is absent from current source".to_owned(),
                 });
             };
-            if record.vector != authoritative.vector {
-                return Err(Error::InvalidProximityObject {
-                    kind: "composite delta",
-                    reason: "delta vector disagrees with current source".to_owned(),
-                });
-            }
+            let authoritative_bytes = handle.value()?.len();
             if request.budget.max_committed_bytes.is_some_and(|limit| {
                 stats.committed_bytes.saturating_add(authoritative_bytes) > limit
             }) {
                 completion = SearchCompletion::BudgetExhausted;
                 break;
             }
+            let authoritative =
+                StoredRecordRef::decode(handle.value()?, self.tree.config.dimensions)?;
+            if !encoded_vectors_equal(authoritative.vector, record.vector) {
+                return Err(Error::InvalidProximityObject {
+                    kind: "composite delta",
+                    reason: "delta vector disagrees with current source".to_owned(),
+                });
+            }
+            ProximityVectorRef::from_encoded(record.vector).copy_to_slice(&mut vector_scratch)?;
+            let distance = query_score(
+                request.kernel,
+                self.tree.config.metric,
+                &query,
+                &vector_scratch,
+            );
             stats.nodes_read += 1;
             stats.bytes_read += authoritative_bytes;
             stats.committed_bytes += authoritative_bytes;
             stats.distance_evaluations += 1;
             stats.reranked_candidates += 1;
-            let neighbor = Neighbor {
-                key: key.clone(),
-                value: authoritative.value,
-                distance: query_score(
-                    request.kernel,
-                    self.tree.config.metric,
-                    &query,
-                    &authoritative.vector,
-                ),
-            };
-            if merged.insert(key, neighbor).is_some() {
+            let candidate = RerankCandidate::new(handle, &key, distance)?;
+            if retained_backings.insert(candidate.backing_id()) {
+                retained_bytes = retained_bytes.saturating_add(candidate.retained_bytes());
+            }
+            if merged
+                .insert(key, CompositeValue::Retained(candidate))
+                .is_some()
+            {
                 return Err(Error::InvalidProximityObject {
                     kind: "composite accelerator",
                     reason: "delta key was not shadowed from the base".to_owned(),
                 });
             }
+            stats.candidate_handles_peak =
+                stats.candidate_handles_peak.max(retained_backings.len());
+            stats.candidate_retained_bytes_peak =
+                stats.candidate_retained_bytes_peak.max(retained_bytes);
         }
         if completion != SearchCompletion::BudgetExhausted && delta_seen != *delta_records {
             return Err(Error::InvalidProximityObject {
@@ -819,13 +858,31 @@ where
                 reason: "delta tree cardinality disagrees with manifest".to_owned(),
             });
         }
-        let mut neighbors = merged.into_values().collect::<Vec<_>>();
-        neighbors.sort_by(|left, right| {
-            left.distance
-                .total_cmp(&right.distance)
-                .then_with(|| left.key.cmp(&right.key))
+        let mut candidates = merged.into_iter().collect::<Vec<_>>();
+        candidates.sort_by(|(left_key, left), (right_key, right)| {
+            left.distance()
+                .total_cmp(&right.distance())
+                .then_with(|| left_key.cmp(right_key))
         });
-        neighbors.truncate((*merge_target).min(request.k));
+        candidates.truncate((*merge_target).min(request.k));
+        let neighbors = candidates
+            .into_iter()
+            .map(|(key, candidate)| match candidate {
+                CompositeValue::Owned { value, distance } => Ok(Neighbor {
+                    key,
+                    value,
+                    distance,
+                }),
+                CompositeValue::Retained(candidate) => {
+                    let record = candidate.record(self.tree.config.dimensions)?;
+                    Ok(Neighbor {
+                        key,
+                        value: record.value.to_vec(),
+                        distance: candidate.distance,
+                    })
+                }
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
         Ok(SearchResult {
             neighbors,
             stats,
@@ -868,7 +925,9 @@ where
         } else {
             SearchCompletion::Exact
         };
-        let mut candidates = Vec::<(Vec<u8>, Vec<u8>, f64)>::with_capacity(candidate_limit);
+        let mut candidates = Vec::<RerankCandidate>::with_capacity(candidate_limit);
+        let mut vector_scratch = vec![0.0f32; self.tree.config.dimensions as usize];
+        let mut directory = self.directory.read(&self.tree.directory)?;
         for key in keys {
             if request
                 .budget
@@ -883,7 +942,7 @@ where
                 break;
             }
             stats.nodes_read += 1;
-            let Some(bytes) = self.directory.get(&self.tree.directory, key)? else {
+            let Some(handle) = directory.get_handle(key)? else {
                 if source_bound {
                     return Err(Error::InvalidProximityObject {
                         kind: "eligible keys",
@@ -894,42 +953,42 @@ where
                 }
                 continue;
             };
+            let bytes = handle.value()?.len();
             if request
                 .budget
                 .max_committed_bytes
-                .is_some_and(|limit| stats.committed_bytes.saturating_add(bytes.len()) > limit)
+                .is_some_and(|limit| stats.committed_bytes.saturating_add(bytes) > limit)
             {
                 completion = SearchCompletion::BudgetExhausted;
                 break;
             }
-            stats.bytes_read = stats.bytes_read.saturating_add(bytes.len());
-            stats.committed_bytes = stats.committed_bytes.saturating_add(bytes.len());
-            let record = StoredRecord::decode(&bytes, self.tree.config.dimensions)?;
+            let record = StoredRecordRef::decode(handle.value()?, self.tree.config.dimensions)?;
+            ProximityVectorRef::from_encoded(record.vector).copy_to_slice(&mut vector_scratch)?;
+            stats.bytes_read = stats.bytes_read.saturating_add(bytes);
+            stats.committed_bytes = stats.committed_bytes.saturating_add(bytes);
             stats.distance_evaluations += 1;
             let distance = query_score(
                 request.kernel,
                 self.tree.config.metric,
                 &query,
-                &record.vector,
+                &vector_scratch,
             );
-            candidates.push((key.clone(), record.value, distance));
-            candidates.sort_by(|left, right| {
-                left.2
-                    .total_cmp(&right.2)
-                    .then_with(|| left.0.cmp(&right.0))
-            });
-            candidates.truncate(candidate_limit);
+            insert_reranked_top_k(
+                &mut candidates,
+                RerankCandidate::new(handle, key, distance)?,
+                candidate_limit,
+            );
             stats.frontier_peak = stats.frontier_peak.max(candidates.len());
+            stats.candidate_handles_peak = stats.candidate_handles_peak.max(candidates.len());
+            stats.candidate_retained_bytes_peak = stats
+                .candidate_retained_bytes_peak
+                .max(retained_candidate_bytes(&candidates));
         }
         stats.reranked_candidates = stats.distance_evaluations;
         let neighbors = candidates
             .into_iter()
-            .map(|(key, value, distance)| Neighbor {
-                key,
-                value,
-                distance,
-            })
-            .collect();
+            .map(|candidate| candidate.into_neighbor(self.tree.config.dimensions))
+            .collect::<Result<Vec<_>, Error>>()?;
         Ok(SearchResult {
             neighbors,
             stats,
@@ -1173,11 +1232,7 @@ where
                     }
                     insert_top_k(
                         &mut candidates,
-                        SearchCandidate {
-                            key: entry.key.clone(),
-                            vector: entry.vector.inline()?.to_vec(),
-                            score: leaf_score,
-                        },
+                        SearchCandidate::new(node.clone(), entry_index, leaf_score),
                         request.k,
                     );
                 }
@@ -1187,32 +1242,56 @@ where
             }
         }
 
-        let keys: Vec<_> = candidates
+        stats.candidate_handles_peak = stats.candidate_handles_peak.max(candidates.len());
+        stats.candidate_retained_bytes_peak = stats
+            .candidate_retained_bytes_peak
+            .max(retained_search_candidate_bytes(&candidates));
+        let keys = candidates
             .iter()
-            .map(|candidate| candidate.key.clone())
-            .collect();
-        let values = self.directory.get_many(&self.tree.directory, &keys)?;
+            .map(SearchCandidate::key)
+            .collect::<Result<Vec<_>, Error>>()?;
         if use_scalar_quantization {
             stats.reranked_candidates = candidates.len();
         }
         let mut neighbors = Vec::with_capacity(candidates.len());
-        for (candidate, stored) in candidates.into_iter().zip(values) {
-            let bytes = stored.ok_or_else(|| Error::InvalidProximityObject {
-                kind: "node",
-                reason: "leaf key is absent from exact directory".to_owned(),
-            })?;
-            let record = StoredRecord::decode(&bytes, self.tree.config.dimensions)?;
-            if record.vector != candidate.vector {
-                return Err(Error::InvalidProximityObject {
-                    kind: "node",
-                    reason: "leaf vector disagrees with exact directory".to_owned(),
-                });
+        let mut rerank_error = None;
+        let mut directory = self.directory.read(&self.tree.directory)?;
+        directory.get_many_with(&keys, |position, _, stored| {
+            if rerank_error.is_some() {
+                return;
             }
-            neighbors.push(Neighbor {
-                key: candidate.key,
-                value: record.value,
-                distance: candidate.score,
-            });
+            let result = (|| {
+                let candidate =
+                    candidates
+                        .get(position)
+                        .ok_or_else(|| Error::InvalidProximityObject {
+                            kind: "candidate",
+                            reason: "directory multi-get returned an invalid position".to_owned(),
+                        })?;
+                let bytes = stored.ok_or_else(|| Error::InvalidProximityObject {
+                    kind: "node",
+                    reason: "leaf key is absent from exact directory".to_owned(),
+                })?;
+                let record = StoredRecordRef::decode(bytes, self.tree.config.dimensions)?;
+                if !encoded_vector_matches(record.vector, candidate.vector()?) {
+                    return Err(Error::InvalidProximityObject {
+                        kind: "node",
+                        reason: "leaf vector disagrees with exact directory".to_owned(),
+                    });
+                }
+                neighbors.push(Neighbor {
+                    key: candidate.key()?.to_vec(),
+                    value: record.value.to_vec(),
+                    distance: candidate.score,
+                });
+                Ok(())
+            })();
+            if let Err(error) = result {
+                rerank_error = Some(error);
+            }
+        })?;
+        if let Some(error) = rerank_error {
+            return Err(error);
         }
         if let Some(trace) = trace {
             trace.push(super::proof::ProximitySearchEvent::Completed(completion));
@@ -1365,31 +1444,6 @@ where
 
     pub(crate) fn store_clone(&self) -> S {
         self.store.clone()
-    }
-
-    pub(crate) fn get_stored(&self, key: &[u8]) -> Result<Option<(StoredRecord, usize)>, Error> {
-        self.directory
-            .get_with(&self.tree.directory, key, |bytes| {
-                let len = bytes.len();
-                let view = StoredRecordRef::decode(bytes, self.tree.config.dimensions)?;
-                Ok((
-                    StoredRecord {
-                        vector: view
-                            .vector
-                            .bytes
-                            .chunks_exact(4)
-                            .map(|component| {
-                                f32::from_bits(u32::from_le_bytes(
-                                    component.try_into().expect("validated vector component"),
-                                ))
-                            })
-                            .collect(),
-                        value: view.value.to_vec(),
-                    },
-                    len,
-                ))
-            })?
-            .transpose()
     }
 
     pub(super) fn directory_manager(&self) -> &Prolly<S> {
@@ -1755,6 +1809,34 @@ fn add_search_stats(total: &mut ProximitySearchStats, added: &ProximitySearchSta
         .reranked_candidates
         .saturating_add(added.reranked_candidates);
     total.frontier_peak = total.frontier_peak.max(added.frontier_peak);
+    total.candidate_handles_peak = total
+        .candidate_handles_peak
+        .max(added.candidate_handles_peak);
+    total.candidate_retained_bytes_peak = total
+        .candidate_retained_bytes_peak
+        .max(added.candidate_retained_bytes_peak);
+}
+
+pub(super) fn encoded_vector_matches(
+    encoded: super::storage::EncodedVectorRef<'_>,
+    expected: &[f32],
+) -> bool {
+    encoded.dimensions as usize == expected.len()
+        && encoded
+            .bytes
+            .chunks_exact(4)
+            .zip(expected)
+            .all(|(bytes, expected)| {
+                u32::from_le_bytes(bytes.try_into().expect("validated vector component"))
+                    == expected.to_bits()
+            })
+}
+
+pub(super) fn encoded_vectors_equal(
+    left: super::storage::EncodedVectorRef<'_>,
+    right: super::storage::EncodedVectorRef<'_>,
+) -> bool {
+    left.dimensions == right.dimensions && left.bytes == right.bytes
 }
 
 fn load_content<S: Store>(store: &S, cid: &Cid) -> Result<Vec<u8>, Error> {

--- a/src/prolly/proximity/map.rs
+++ b/src/prolly/proximity/map.rs
@@ -2,6 +2,7 @@ use super::super::builder::BatchBuilder;
 use super::super::cid::Cid;
 use super::super::config::Config;
 use super::super::error::{Error, Mutation as TreeMutation};
+use super::super::read::{ReadSession, ScanOutcome};
 use super::super::splice::{splice, SpliceStats};
 use super::super::store::Store;
 use super::super::Prolly;
@@ -15,15 +16,19 @@ use super::search::{
 };
 use super::storage::quantized::ScalarQuantized;
 use super::storage::vector::ExternalVector;
-use super::storage::{Descriptor, PhysicalNodeKind, ProximityNode, StoredRecord, VectorRef};
+use super::storage::{
+    Descriptor, PhysicalNodeKind, ProximityNode, StoredRecord, StoredRecordRef, VectorRef,
+};
 use super::vector::promotion_level;
 use super::{
     AcceleratorSet, BuildParallelism, DistanceMetric, ExactProximityRecord, Neighbor,
     ProximityBuildStats, ProximityConfig, ProximityMutation, ProximityMutationStats,
-    ProximityRecord, ProximitySearchStats, ProximityTree, ProximityVerification, SearchBackend,
-    SearchBudget, SearchCompletion, SearchIo, SearchPolicy, SearchRequest, SearchResult,
+    ProximityRecord, ProximityRecordRef, ProximitySearchStats, ProximityTree, ProximityVectorRef,
+    ProximityVerification, SearchBackend, SearchBudget, SearchCompletion, SearchIo, SearchPolicy,
+    SearchRequest, SearchResult,
 };
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashSet};
+use std::ops::ControlFlow;
 use std::sync::{Arc, Mutex};
 
 /// Immutable exact-key directory plus deterministic ANN hierarchy.
@@ -32,6 +37,72 @@ pub struct ProximityMap<S: Store> {
     directory: Prolly<S>,
     tree: ProximityTree,
     node_cache: Mutex<ContentCache<ProximityNode>>,
+}
+
+/// Reusable exact-read context over one immutable proximity map.
+pub struct ProximityReadSession<'map, S: Store> {
+    directory: ReadSession<'map, 'map, S>,
+    dimensions: u32,
+}
+
+impl<S: Store> ProximityReadSession<'_, S> {
+    pub fn get_with<R>(
+        &mut self,
+        key: &[u8],
+        read: impl for<'record> FnOnce(ProximityRecordRef<'record>) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.directory
+            .get_with(key, |bytes| {
+                let stored = StoredRecordRef::decode(bytes, self.dimensions)?;
+                Ok(read(ProximityRecordRef {
+                    vector: ProximityVectorRef::from_encoded(stored.vector),
+                    value: stored.value,
+                }))
+            })?
+            .transpose()
+    }
+
+    pub fn contains_key(&mut self, key: &[u8]) -> Result<bool, Error> {
+        Ok(self.get_with(key, |_| ())?.is_some())
+    }
+
+    pub fn scan_records(
+        &mut self,
+        mut visit: impl for<'record> FnMut(&[u8], ProximityRecordRef<'record>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_records_until(|key, record| {
+                visit(key, record);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    pub fn scan_records_until<B>(
+        &mut self,
+        mut visit: impl for<'record> FnMut(&[u8], ProximityRecordRef<'record>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        let dimensions = self.dimensions;
+        let outcome = self.directory.scan_range_until(&[], None, |entry| {
+            let stored = match StoredRecordRef::decode(entry.value(), dimensions) {
+                Ok(stored) => stored,
+                Err(error) => return ControlFlow::Break(Err(error)),
+            };
+            let record = ProximityRecordRef {
+                vector: ProximityVectorRef::from_encoded(stored.vector),
+                value: stored.value,
+            };
+            match visit(entry.key(), record) {
+                ControlFlow::Continue(()) => ControlFlow::Continue(()),
+                ControlFlow::Break(value) => ControlFlow::Break(Ok(value)),
+            }
+        })?;
+        match outcome.break_value {
+            Some(Ok(value)) => Ok(ScanOutcome::stopped(outcome.visited, value)),
+            Some(Err(error)) => Err(error),
+            None => Ok(ScanOutcome::complete(outcome.visited)),
+        }
+    }
 }
 
 impl<S> ProximityMap<S>
@@ -174,18 +245,45 @@ where
 
     /// Exact key lookup through the authoritative ordered directory.
     pub fn get(&self, key: &[u8]) -> Result<Option<ExactProximityRecord>, Error> {
-        self.directory
-            .get(&self.tree.directory, key)?
-            .map(|bytes| {
-                let record = StoredRecord::decode(&bytes, self.tree.config.dimensions)?;
-                Ok((record.vector, record.value))
-            })
-            .transpose()
+        self.get_with(key, |record| record.to_owned())
+    }
+
+    /// Open a reusable zero-copy exact-read session.
+    pub fn read(&self) -> Result<ProximityReadSession<'_, S>, Error> {
+        Ok(ProximityReadSession {
+            directory: self.directory.read(&self.tree.directory)?,
+            dimensions: self.tree.config.dimensions,
+        })
+    }
+
+    /// Inspect one exact record without allocating its vector or value.
+    pub fn get_with<R>(
+        &self,
+        key: &[u8],
+        read: impl for<'record> FnOnce(ProximityRecordRef<'record>) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.read()?.get_with(key, read)
+    }
+
+    /// Visit every exact record in key order without allocating records.
+    pub fn scan_records(
+        &self,
+        visit: impl for<'record> FnMut(&[u8], ProximityRecordRef<'record>),
+    ) -> Result<u64, Error> {
+        self.read()?.scan_records(visit)
+    }
+
+    /// Visit exact records with callback-directed early termination.
+    pub fn scan_records_until<B>(
+        &self,
+        visit: impl for<'record> FnMut(&[u8], ProximityRecordRef<'record>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.read()?.scan_records_until(visit)
     }
 
     /// Exact key membership through the authoritative ordered directory.
     pub fn contains_key(&self, key: &[u8]) -> Result<bool, Error> {
-        Ok(self.get(key)?.is_some())
+        self.read()?.contains_key(key)
     }
 
     /// Canonical full rebuild after applying a sorted-unique logical mutation batch.
@@ -1270,14 +1368,28 @@ where
     }
 
     pub(crate) fn get_stored(&self, key: &[u8]) -> Result<Option<(StoredRecord, usize)>, Error> {
-        let Some(bytes) = self.directory.get(&self.tree.directory, key)? else {
-            return Ok(None);
-        };
-        let len = bytes.len();
-        Ok(Some((
-            StoredRecord::decode(&bytes, self.tree.config.dimensions)?,
-            len,
-        )))
+        self.directory
+            .get_with(&self.tree.directory, key, |bytes| {
+                let len = bytes.len();
+                let view = StoredRecordRef::decode(bytes, self.tree.config.dimensions)?;
+                Ok((
+                    StoredRecord {
+                        vector: view
+                            .vector
+                            .bytes
+                            .chunks_exact(4)
+                            .map(|component| {
+                                f32::from_bits(u32::from_le_bytes(
+                                    component.try_into().expect("validated vector component"),
+                                ))
+                            })
+                            .collect(),
+                        value: view.value.to_vec(),
+                    },
+                    len,
+                ))
+            })?
+            .transpose()
     }
 
     pub(super) fn directory_manager(&self) -> &Prolly<S> {
@@ -1293,17 +1405,30 @@ where
         directory: &super::super::tree::Tree,
     ) -> Result<BTreeMap<Vec<u8>, ProximityRecord>, Error> {
         let mut records = BTreeMap::new();
-        for entry in self.directory.range(directory, &[], None)? {
-            let (key, bytes) = entry?;
-            let stored = StoredRecord::decode(&bytes, self.tree.config.dimensions)?;
-            records.insert(
-                key.clone(),
-                ProximityRecord {
-                    key,
-                    vector: stored.vector,
-                    value: stored.value,
-                },
-            );
+        let mut decode_error = None;
+        self.directory
+            .scan_range_until(directory, &[], None, |entry| {
+                let stored =
+                    match StoredRecordRef::decode(entry.value(), self.tree.config.dimensions) {
+                        Ok(stored) => stored,
+                        Err(error) => {
+                            decode_error = Some(error);
+                            return ControlFlow::Break(());
+                        }
+                    };
+                let key = entry.key().to_vec();
+                records.insert(
+                    key.clone(),
+                    ProximityRecord {
+                        key,
+                        vector: ProximityVectorRef::from_encoded(stored.vector).to_vec(),
+                        value: stored.value.to_vec(),
+                    },
+                );
+                ControlFlow::Continue(())
+            })?;
+        if let Some(error) = decode_error {
+            return Err(error);
         }
         Ok(records)
     }

--- a/src/prolly/proximity/mod.rs
+++ b/src/prolly/proximity/mod.rs
@@ -419,6 +419,11 @@ pub struct ProximitySearchStats {
     pub quantized_distance_evaluations: usize,
     pub reranked_candidates: usize,
     pub frontier_peak: usize,
+    /// Maximum number of retained authoritative directory records awaiting
+    /// final top-k materialization.
+    pub candidate_handles_peak: usize,
+    /// Maximum unique packed-leaf bytes retained by authoritative candidates.
+    pub candidate_retained_bytes_peak: usize,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/prolly/proximity/mod.rs
+++ b/src/prolly/proximity/mod.rs
@@ -38,7 +38,7 @@ pub use accelerator::{
     AsyncProductQuantizer,
 };
 pub use build::{BuildParallelism, ProximityBuildStats};
-pub use map::ProximityMap;
+pub use map::{ProximityMap, ProximityReadSession};
 pub use proof::{
     ProximityMembershipProof, ProximityMembershipVerification, ProximityProofFilter,
     ProximitySearchClaim, ProximitySearchEvent, ProximitySearchProof, ProximitySearchRequest,
@@ -320,6 +320,77 @@ pub struct ProximityRecord {
 
 /// Vector and application value returned by an exact-key lookup.
 pub type ExactProximityRecord = (Vec<f32>, Vec<u8>);
+
+/// Safe borrowed view of little-endian persisted vector components.
+#[derive(Clone, Copy, Debug)]
+pub struct ProximityVectorRef<'a> {
+    bytes: &'a [u8],
+    dimensions: u32,
+}
+
+impl<'a> ProximityVectorRef<'a> {
+    pub(crate) fn from_encoded(vector: storage::EncodedVectorRef<'a>) -> Self {
+        Self {
+            bytes: vector.bytes,
+            dimensions: vector.dimensions,
+        }
+    }
+
+    pub fn dimensions(&self) -> usize {
+        self.dimensions as usize
+    }
+
+    pub fn component(&self, index: usize) -> Option<f32> {
+        if index >= self.dimensions() {
+            return None;
+        }
+        let start = index.checked_mul(4)?;
+        let bytes: [u8; 4] = self.bytes.get(start..start + 4)?.try_into().ok()?;
+        Some(f32::from_bits(u32::from_le_bytes(bytes)))
+    }
+
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = f32> + '_ {
+        self.bytes.chunks_exact(4).map(|bytes| {
+            f32::from_bits(u32::from_le_bytes(
+                bytes.try_into().expect("validated vector component"),
+            ))
+        })
+    }
+
+    pub fn copy_to_slice(&self, output: &mut [f32]) -> Result<(), Error> {
+        if output.len() != self.dimensions() {
+            return Err(Error::InvalidProximityObject {
+                kind: "record",
+                reason: format!(
+                    "output dimensions {} do not match record dimensions {}",
+                    output.len(),
+                    self.dimensions()
+                ),
+            });
+        }
+        for (slot, component) in output.iter_mut().zip(self.iter()) {
+            *slot = component;
+        }
+        Ok(())
+    }
+
+    pub fn to_vec(&self) -> Vec<f32> {
+        self.iter().collect()
+    }
+}
+
+/// Callback-scoped exact proximity record.
+#[derive(Clone, Copy, Debug)]
+pub struct ProximityRecordRef<'a> {
+    pub vector: ProximityVectorRef<'a>,
+    pub value: &'a [u8],
+}
+
+impl ProximityRecordRef<'_> {
+    pub fn to_owned(self) -> ExactProximityRecord {
+        (self.vector.to_vec(), self.value.to_vec())
+    }
+}
 
 /// One immutable-map mutation. `None` deletes the key.
 #[derive(Clone, Debug, PartialEq)]

--- a/src/prolly/proximity/proof/search.rs
+++ b/src/prolly/proximity/proof/search.rs
@@ -76,8 +76,8 @@ impl ProximityProofFilter {
         match self {
             Self::All => true,
             Self::KeyRange { start, end } => {
-                start.as_ref().map_or(true, |start| key >= start)
-                    && end.as_ref().map_or(true, |end| key < end)
+                start.as_ref().map_or(true, |start| key >= start.as_slice())
+                    && end.as_ref().map_or(true, |end| key < end.as_slice())
             }
             Self::Prefix(prefix) => key.starts_with(prefix),
             Self::EligibleKeys(keys) | Self::SecondaryEligible { keys, .. } => keys

--- a/src/prolly/proximity/search/async.rs
+++ b/src/prolly/proximity/search/async.rs
@@ -1,6 +1,7 @@
 use super::{
-    adaptive_should_stop, engine::insert_top_k, AdaptiveContext, FrontierEntry, PreparedFilter,
-    SearchCandidate, SearchRequest,
+    adaptive_should_stop, engine::insert_top_k, insert_reranked_top_k, retained_candidate_bytes,
+    retained_search_candidate_bytes, AdaptiveContext, FrontierEntry, PreparedFilter,
+    RerankCandidate, SearchCandidate, SearchRequest,
 };
 use crate::prolly::cid::Cid;
 use crate::prolly::error::Error;
@@ -13,9 +14,7 @@ use crate::prolly::proximity::accelerator::{
 use crate::prolly::proximity::distance::{prepare_vector, query_score};
 use crate::prolly::proximity::storage::quantized::ScalarQuantized;
 use crate::prolly::proximity::storage::vector::ExternalVector;
-use crate::prolly::proximity::storage::{
-    Descriptor, PhysicalNodeKind, ProximityNode, StoredRecord, VectorRef,
-};
+use crate::prolly::proximity::storage::{Descriptor, PhysicalNodeKind, ProximityNode, VectorRef};
 use crate::prolly::proximity::{
     DistanceMetric, Neighbor, ProximitySearchStats, ProximityTree, SearchBackend, SearchCompletion,
     SearchPolicy, SearchResult,
@@ -181,7 +180,9 @@ where
         } else {
             SearchCompletion::Exact
         };
-        let mut ranked = Vec::<(Vec<u8>, Vec<u8>, f64)>::with_capacity(limit);
+        let mut ranked = Vec::<RerankCandidate>::with_capacity(limit);
+        let mut vector_scratch = vec![0.0f32; self.tree.config.dimensions as usize];
+        let mut directory = self.directory.read(&self.tree.directory).await?;
         for key in keys {
             if let Some(stopped) = stop_reason(control) {
                 completion = stopped;
@@ -191,7 +192,7 @@ where
                 completion = SearchCompletion::BudgetExhausted;
                 break;
             }
-            let Some(bytes) = self.directory.get(&self.tree.directory, key).await? else {
+            let Some(handle) = directory.get_handle(key).await? else {
                 if *source_bound {
                     return Err(Error::InvalidProximityObject {
                         kind: "eligible keys",
@@ -200,35 +201,46 @@ where
                 }
                 continue;
             };
+            let bytes = handle.value()?.len();
             if request
                 .budget
                 .max_committed_bytes
-                .is_some_and(|maximum| stats.committed_bytes.saturating_add(bytes.len()) > maximum)
+                .is_some_and(|maximum| stats.committed_bytes.saturating_add(bytes) > maximum)
             {
                 completion = SearchCompletion::BudgetExhausted;
                 break;
-            }
-            let record = StoredRecord::decode(&bytes, self.tree.config.dimensions)?;
-            stats.nodes_read += 1;
-            stats.bytes_read += bytes.len();
-            stats.committed_bytes += bytes.len();
-            stats.distance_evaluations += 1;
+            };
+            let record = crate::prolly::proximity::storage::StoredRecordRef::decode(
+                handle.value()?,
+                self.tree.config.dimensions,
+            )?;
+            crate::prolly::proximity::ProximityVectorRef::from_encoded(record.vector)
+                .copy_to_slice(&mut vector_scratch)?;
             let distance = query_score(
                 request.kernel,
                 self.tree.config.metric,
                 &query,
-                &record.vector,
+                &vector_scratch,
             );
-            insert_ranked(&mut ranked, (key.clone(), record.value, distance), limit);
+            insert_reranked_top_k(
+                &mut ranked,
+                RerankCandidate::new(handle, key, distance)?,
+                limit,
+            );
+            stats.nodes_read += 1;
+            stats.bytes_read += bytes;
+            stats.committed_bytes += bytes;
+            stats.distance_evaluations += 1;
+            stats.candidate_handles_peak = stats.candidate_handles_peak.max(ranked.len());
+            stats.candidate_retained_bytes_peak = stats
+                .candidate_retained_bytes_peak
+                .max(retained_candidate_bytes(&ranked));
         }
+        stats.reranked_candidates = stats.distance_evaluations;
         let neighbors = ranked
             .into_iter()
-            .map(|(key, value, distance)| Neighbor {
-                key,
-                value,
-                distance,
-            })
-            .collect();
+            .map(|candidate| candidate.into_neighbor(self.tree.config.dimensions))
+            .collect::<Result<Vec<_>, Error>>()?;
         Ok(SearchResult {
             neighbors,
             stats,
@@ -465,6 +477,7 @@ where
                 }
                 entry.vector = VectorRef::Inline(external.vector);
             }
+            let node = Arc::new(node);
             let quantizer = if use_scalar_quantization && node.kind.has_children(node.level) {
                 let config = self
                     .tree
@@ -616,11 +629,7 @@ where
                     };
                     insert_top_k(
                         &mut candidates,
-                        SearchCandidate {
-                            key: entry.key.clone(),
-                            vector: entry.vector.inline()?.to_vec(),
-                            score: leaf_score,
-                        },
+                        SearchCandidate::new(node.clone(), entry_index, leaf_score),
                         request.k,
                     );
                 }
@@ -633,26 +642,35 @@ where
         if use_scalar_quantization {
             stats.reranked_candidates = candidates.len();
         }
+        stats.candidate_handles_peak = stats.candidate_handles_peak.max(candidates.len());
+        stats.candidate_retained_bytes_peak = stats
+            .candidate_retained_bytes_peak
+            .max(retained_search_candidate_bytes(&candidates));
         let mut neighbors = Vec::with_capacity(candidates.len());
+        let mut directory_session = self.directory.read(&self.tree.directory).await?;
         for candidate in candidates {
-            let bytes = self
-                .directory
-                .get(&self.tree.directory, &candidate.key)
-                .await?
-                .ok_or_else(|| Error::InvalidProximityObject {
+            // This is the final owned result key; no borrowed candidate slice
+            // crosses the directory await.
+            let key = candidate.key()?.to_vec();
+            let handle = directory_session.get_handle(&key).await?.ok_or_else(|| {
+                Error::InvalidProximityObject {
                     kind: "node",
                     reason: "leaf key is absent from exact directory".to_owned(),
-                })?;
-            let record = StoredRecord::decode(&bytes, self.tree.config.dimensions)?;
-            if record.vector != candidate.vector {
+                }
+            })?;
+            let record = crate::prolly::proximity::storage::StoredRecordRef::decode(
+                handle.value()?,
+                self.tree.config.dimensions,
+            )?;
+            if !super::super::map::encoded_vector_matches(record.vector, candidate.vector()?) {
                 return Err(Error::InvalidProximityObject {
                     kind: "node",
                     reason: "leaf vector disagrees with exact directory".to_owned(),
                 });
             }
             neighbors.push(Neighbor {
-                key: candidate.key,
-                value: record.value,
+                key,
+                value: record.value.to_vec(),
                 distance: candidate.score,
             });
         }
@@ -794,26 +812,6 @@ fn budget_stops_record(
             .is_some_and(|limit| stats.committed_bytes.saturating_add(bytes) > limit)
 }
 
-fn insert_ranked(
-    ranked: &mut Vec<(Vec<u8>, Vec<u8>, f64)>,
-    value: (Vec<u8>, Vec<u8>, f64),
-    limit: usize,
-) {
-    if limit == 0 {
-        return;
-    }
-    let index = ranked
-        .binary_search_by(|candidate| {
-            candidate
-                .2
-                .total_cmp(&value.2)
-                .then_with(|| candidate.0.cmp(&value.0))
-        })
-        .unwrap_or_else(|index| index);
-    ranked.insert(index, value);
-    ranked.truncate(limit);
-}
-
 #[derive(Clone, Debug)]
 struct AsyncRanked {
     distance: f64,
@@ -938,7 +936,9 @@ where
     }
     let mut approximate = approximate.into_vec();
     approximate.sort();
-    let mut reranked = Vec::with_capacity(approximate.len());
+    let mut reranked = Vec::<RerankCandidate>::with_capacity(approximate.len());
+    let mut vector_scratch = vec![0.0f32; tree.config.dimensions as usize];
+    let mut directory_session = directory.read(&tree.directory).await?;
     for candidate in approximate {
         if let Some(stopped) = stop_reason(control) {
             completion = stopped;
@@ -948,47 +948,47 @@ where
             completion = SearchCompletion::BudgetExhausted;
             break;
         }
-        let bytes = directory
-            .get(&tree.directory, &candidate.key)
-            .await?
-            .ok_or_else(|| Error::InvalidProximityObject {
+        let Some(handle) = directory_session.get_handle(&candidate.key).await? else {
+            return Err(Error::InvalidProximityObject {
                 kind: "product quantizer",
                 reason: "PQ code key is absent from authoritative directory".to_owned(),
-            })?;
+            });
+        };
+        let bytes = handle.value()?.len();
         if request
             .budget
             .max_committed_bytes
-            .is_some_and(|limit| stats.committed_bytes.saturating_add(bytes.len()) > limit)
+            .is_some_and(|limit| stats.committed_bytes.saturating_add(bytes) > limit)
         {
             completion = SearchCompletion::BudgetExhausted;
             break;
         }
-        let record = StoredRecord::decode(&bytes, tree.config.dimensions)?;
+        let record = crate::prolly::proximity::storage::StoredRecordRef::decode(
+            handle.value()?,
+            tree.config.dimensions,
+        )?;
+        crate::prolly::proximity::ProximityVectorRef::from_encoded(record.vector)
+            .copy_to_slice(&mut vector_scratch)?;
+        let distance = query_score(request.kernel, index.metric, &query, &vector_scratch);
         stats.nodes_read += 1;
-        stats.bytes_read += bytes.len();
-        stats.committed_bytes += bytes.len();
+        stats.bytes_read += bytes;
+        stats.committed_bytes += bytes;
         stats.distance_evaluations += 1;
-        reranked.push((
-            candidate.key,
-            record.value,
-            query_score(request.kernel, index.metric, &query, &record.vector),
-        ));
+        reranked.push(RerankCandidate::new(handle, &candidate.key, distance)?);
     }
     stats.reranked_candidates = reranked.len();
+    stats.candidate_handles_peak = reranked.len();
+    stats.candidate_retained_bytes_peak = retained_candidate_bytes(&reranked);
     reranked.sort_by(|left, right| {
-        left.2
-            .total_cmp(&right.2)
-            .then_with(|| left.0.cmp(&right.0))
+        left.distance
+            .total_cmp(&right.distance)
+            .then_with(|| left.key().cmp(right.key()))
     });
     let neighbors = reranked
         .into_iter()
         .take(request.k)
-        .map(|(key, value, distance)| Neighbor {
-            key,
-            value,
-            distance,
-        })
-        .collect();
+        .map(|candidate| candidate.into_neighbor(tree.config.dimensions))
+        .collect::<Result<Vec<_>, Error>>()?;
     Ok(SearchResult {
         neighbors,
         stats,
@@ -1173,9 +1173,30 @@ where
     add_async_stats(&mut stats, &base_result.stats);
     let mut completion = base_result.completion;
     let query = prepare_vector(tree.config.metric, request.query, tree.config.dimensions)?;
-    let mut merged = BTreeMap::<Vec<u8>, Neighbor>::new();
+    enum CompositeValue {
+        Owned { value: Vec<u8>, distance: f64 },
+        Retained(RerankCandidate),
+    }
+    impl CompositeValue {
+        fn distance(&self) -> f64 {
+            match self {
+                Self::Owned { distance, .. } => *distance,
+                Self::Retained(candidate) => candidate.distance,
+            }
+        }
+    }
+    let mut merged = BTreeMap::<Vec<u8>, CompositeValue>::new();
     for neighbor in base_result.neighbors.drain(..) {
-        if merged.insert(neighbor.key.clone(), neighbor).is_some() {
+        if merged
+            .insert(
+                neighbor.key,
+                CompositeValue::Owned {
+                    value: neighbor.value,
+                    distance: neighbor.distance,
+                },
+            )
+            .is_some()
+        {
             return Err(Error::InvalidProximityObject {
                 kind: "composite base",
                 reason: "base executor returned a duplicate key".to_owned(),
@@ -1186,6 +1207,10 @@ where
     let mut delta_range = delta_manager
         .range(&composite.delta_tree, &[], None)
         .await?;
+    let mut directory_session = directory.read(&tree.directory).await?;
+    let mut vector_scratch = vec![0.0f32; tree.config.dimensions as usize];
+    let mut retained_backings = HashSet::new();
+    let mut retained_bytes = 0usize;
     while let Some(entry) = delta_range.next().await {
         if let Some(stopped) = stop_reason(control) {
             completion = stopped;
@@ -1205,7 +1230,15 @@ where
             completion = SearchCompletion::BudgetExhausted;
             break;
         }
-        let record = StoredRecord::decode(&bytes, tree.config.dimensions)?;
+        let distance = {
+            let record = crate::prolly::proximity::storage::StoredRecordRef::decode(
+                &bytes,
+                tree.config.dimensions,
+            )?;
+            crate::prolly::proximity::ProximityVectorRef::from_encoded(record.vector)
+                .copy_to_slice(&mut vector_scratch)?;
+            query_score(request.kernel, tree.config.metric, &query, &vector_scratch)
+        };
         stats.nodes_read += 1;
         stats.bytes_read += bytes.len();
         stats.committed_bytes += bytes.len();
@@ -1230,49 +1263,56 @@ where
             completion = SearchCompletion::BudgetExhausted;
             break;
         }
-        let authoritative_bytes = directory.get(&tree.directory, &key).await?.ok_or_else(|| {
-            Error::InvalidProximityObject {
+        let Some(handle) = directory_session.get_handle(&key).await? else {
+            return Err(Error::InvalidProximityObject {
                 kind: "composite delta",
                 reason: "delta key is absent from current source".to_owned(),
-            }
-        })?;
-        if request.budget.max_committed_bytes.is_some_and(|limit| {
-            stats
-                .committed_bytes
-                .saturating_add(authoritative_bytes.len())
-                > limit
-        }) {
+            });
+        };
+        let authoritative_bytes = handle.value()?.len();
+        if request
+            .budget
+            .max_committed_bytes
+            .is_some_and(|limit| stats.committed_bytes.saturating_add(authoritative_bytes) > limit)
+        {
             completion = SearchCompletion::BudgetExhausted;
             break;
         }
-        let authoritative = StoredRecord::decode(&authoritative_bytes, tree.config.dimensions)?;
-        if record.vector != authoritative.vector {
+        let authoritative = crate::prolly::proximity::storage::StoredRecordRef::decode(
+            handle.value()?,
+            tree.config.dimensions,
+        )?;
+        let delta = crate::prolly::proximity::storage::StoredRecordRef::decode(
+            &bytes,
+            tree.config.dimensions,
+        )?;
+        if !super::super::map::encoded_vectors_equal(authoritative.vector, delta.vector) {
             return Err(Error::InvalidProximityObject {
                 kind: "composite delta",
                 reason: "delta vector disagrees with current source".to_owned(),
             });
         }
         stats.nodes_read += 1;
-        stats.bytes_read += authoritative_bytes.len();
-        stats.committed_bytes += authoritative_bytes.len();
+        stats.bytes_read += authoritative_bytes;
+        stats.committed_bytes += authoritative_bytes;
         stats.distance_evaluations += 1;
         stats.reranked_candidates += 1;
-        let neighbor = Neighbor {
-            key: key.clone(),
-            value: authoritative.value,
-            distance: query_score(
-                request.kernel,
-                tree.config.metric,
-                &query,
-                &authoritative.vector,
-            ),
-        };
-        if merged.insert(key, neighbor).is_some() {
+        let candidate = RerankCandidate::new(handle, &key, distance)?;
+        if retained_backings.insert(candidate.backing_id()) {
+            retained_bytes = retained_bytes.saturating_add(candidate.retained_bytes());
+        }
+        if merged
+            .insert(key, CompositeValue::Retained(candidate))
+            .is_some()
+        {
             return Err(Error::InvalidProximityObject {
                 kind: "composite accelerator",
                 reason: "delta key was not shadowed from base".to_owned(),
             });
         }
+        stats.candidate_handles_peak = stats.candidate_handles_peak.max(retained_backings.len());
+        stats.candidate_retained_bytes_peak =
+            stats.candidate_retained_bytes_peak.max(retained_bytes);
     }
     if completion != SearchCompletion::BudgetExhausted
         && completion != SearchCompletion::Cancelled
@@ -1284,13 +1324,31 @@ where
             reason: "delta cardinality disagrees with manifest".to_owned(),
         });
     }
-    let mut neighbors = merged.into_values().collect::<Vec<_>>();
-    neighbors.sort_by(|left, right| {
-        left.distance
-            .total_cmp(&right.distance)
-            .then_with(|| left.key.cmp(&right.key))
+    let mut candidates = merged.into_iter().collect::<Vec<_>>();
+    candidates.sort_by(|(left_key, left), (right_key, right)| {
+        left.distance()
+            .total_cmp(&right.distance())
+            .then_with(|| left_key.cmp(right_key))
     });
-    neighbors.truncate((*merge_target).min(request.k));
+    candidates.truncate((*merge_target).min(request.k));
+    let neighbors = candidates
+        .into_iter()
+        .map(|(key, candidate)| match candidate {
+            CompositeValue::Owned { value, distance } => Ok(Neighbor {
+                key,
+                value,
+                distance,
+            }),
+            CompositeValue::Retained(candidate) => {
+                let record = candidate.record(tree.config.dimensions)?;
+                Ok(Neighbor {
+                    key,
+                    value: record.value.to_vec(),
+                    distance: candidate.distance,
+                })
+            }
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
     Ok(SearchResult {
         neighbors,
         stats,
@@ -1334,6 +1392,12 @@ fn add_async_stats(total: &mut ProximitySearchStats, added: &ProximitySearchStat
         .reranked_candidates
         .saturating_add(added.reranked_candidates);
     total.frontier_peak = total.frontier_peak.max(added.frontier_peak);
+    total.candidate_handles_peak = total
+        .candidate_handles_peak
+        .max(added.candidate_handles_peak);
+    total.candidate_retained_bytes_peak = total
+        .candidate_retained_bytes_peak
+        .max(added.candidate_retained_bytes_peak);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1496,11 +1560,10 @@ where
     }
     let mut candidates = eligible.into_vec();
     candidates.sort();
-    let mut neighbors = Vec::with_capacity(request.k.min(candidates.len()));
+    let mut reranked = Vec::<RerankCandidate>::with_capacity(candidates.len());
+    let mut vector_scratch = vec![0.0f32; tree.config.dimensions as usize];
+    let mut directory_session = directory.read(&tree.directory).await?;
     for candidate in candidates {
-        if neighbors.len() == request.k {
-            break;
-        }
         if let Some(stopped) = stop_reason(control) {
             state.completion = stopped;
             break;
@@ -1509,41 +1572,49 @@ where
             state.completion = SearchCompletion::BudgetExhausted;
             break;
         }
-        let bytes = directory
-            .get(&tree.directory, &candidate.key)
-            .await?
-            .ok_or_else(|| Error::InvalidProximityObject {
+        let Some(handle) = directory_session.get_handle(&candidate.key).await? else {
+            return Err(Error::InvalidProximityObject {
                 kind: "HNSW",
                 reason: "result key is absent from authoritative directory".to_owned(),
-            })?;
+            });
+        };
+        let bytes = handle.value()?.len();
         if request
             .budget
             .max_committed_bytes
-            .is_some_and(|limit| state.stats.committed_bytes.saturating_add(bytes.len()) > limit)
+            .is_some_and(|limit| state.stats.committed_bytes.saturating_add(bytes) > limit)
         {
             state.completion = SearchCompletion::BudgetExhausted;
             break;
         }
-        let record = StoredRecord::decode(&bytes, tree.config.dimensions)?;
-        state.stats.nodes_read += 1;
-        state.stats.bytes_read += bytes.len();
-        state.stats.committed_bytes += bytes.len();
-        let Some(distance) = state.distance(&query, &record.vector) else {
+        let record = crate::prolly::proximity::storage::StoredRecordRef::decode(
+            handle.value()?,
+            tree.config.dimensions,
+        )?;
+        crate::prolly::proximity::ProximityVectorRef::from_encoded(record.vector)
+            .copy_to_slice(&mut vector_scratch)?;
+        let Some(distance) = state.distance(&query, &vector_scratch) else {
+            state.completion = SearchCompletion::BudgetExhausted;
             break;
         };
+        state.stats.nodes_read += 1;
+        state.stats.bytes_read += bytes;
+        state.stats.committed_bytes += bytes;
         state.stats.reranked_candidates += 1;
-        neighbors.push(Neighbor {
-            key: candidate.key,
-            value: record.value,
-            distance,
-        });
+        reranked.push(RerankCandidate::new(handle, &candidate.key, distance)?);
     }
-    neighbors.sort_by(|left, right| {
+    state.stats.candidate_handles_peak = reranked.len();
+    state.stats.candidate_retained_bytes_peak = retained_candidate_bytes(&reranked);
+    reranked.sort_by(|left, right| {
         left.distance
             .total_cmp(&right.distance)
-            .then_with(|| left.key.cmp(&right.key))
+            .then_with(|| left.key().cmp(right.key()))
     });
-    neighbors.truncate(request.k);
+    let neighbors = reranked
+        .into_iter()
+        .take(request.k)
+        .map(|candidate| candidate.into_neighbor(tree.config.dimensions))
+        .collect::<Result<Vec<_>, Error>>()?;
     Ok(SearchResult {
         neighbors,
         stats: state.stats,

--- a/src/prolly/proximity/search/engine.rs
+++ b/src/prolly/proximity/search/engine.rs
@@ -1,5 +1,11 @@
 use crate::prolly::cid::Cid;
+use crate::prolly::error::Error;
+use crate::prolly::proximity::storage::StoredRecordRef;
+use crate::prolly::proximity::storage::{ProximityEntry, ProximityNode};
+use crate::prolly::proximity::Neighbor;
+use crate::prolly::read::ReadValueHandle;
 use std::cmp::Ordering;
+use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub(crate) struct FrontierEntry {
@@ -38,9 +44,108 @@ impl Ord for FrontierEntry {
 
 #[derive(Clone, Debug)]
 pub(crate) struct SearchCandidate {
-    pub(crate) key: Vec<u8>,
-    pub(crate) vector: Vec<f32>,
+    node: Arc<ProximityNode>,
+    entry_index: usize,
     pub(crate) score: f64,
+}
+
+/// An authoritatively scored candidate that retains its packed directory leaf.
+///
+/// The application value stays borrowed until the final top-k result boundary.
+/// This also prevents cache eviction from invalidating the record while sorting
+/// the exact shortlist.
+#[derive(Clone, Debug)]
+pub(crate) struct RerankCandidate {
+    record: ReadValueHandle,
+    pub(crate) distance: f64,
+}
+
+impl RerankCandidate {
+    pub(crate) fn new(
+        record: ReadValueHandle,
+        expected_key: &[u8],
+        distance: f64,
+    ) -> Result<Self, Error> {
+        // Callers decode and score this exact handle immediately before
+        // construction. Re-decoding here would scan every vector twice.
+        if record.key()? != expected_key {
+            return Err(Error::InvalidProximityObject {
+                kind: "candidate",
+                reason: "retained directory key disagrees with candidate key".to_owned(),
+            });
+        }
+        Ok(Self { record, distance })
+    }
+
+    #[inline]
+    pub(crate) fn key(&self) -> &[u8] {
+        self.record
+            .key()
+            .expect("rerank candidate was validated at construction")
+    }
+
+    #[inline]
+    pub(crate) fn record(&self, dimensions: u32) -> Result<StoredRecordRef<'_>, Error> {
+        StoredRecordRef::decode(self.record.value()?, dimensions)
+    }
+
+    #[inline]
+    pub(crate) fn retained_bytes(&self) -> usize {
+        self.record.retained_bytes()
+    }
+
+    #[inline]
+    pub(crate) fn backing_id(&self) -> usize {
+        self.record.backing_id()
+    }
+
+    pub(crate) fn into_neighbor(self, dimensions: u32) -> Result<Neighbor, Error> {
+        let key = self.key().to_vec();
+        let value = self.record(dimensions)?.value.to_vec();
+        Ok(Neighbor {
+            key,
+            value,
+            distance: self.distance,
+        })
+    }
+}
+
+impl SearchCandidate {
+    pub(crate) fn new(node: Arc<ProximityNode>, entry_index: usize, score: f64) -> Self {
+        Self {
+            node,
+            entry_index,
+            score,
+        }
+    }
+
+    pub(crate) fn entry(&self) -> Result<&ProximityEntry, Error> {
+        self.node
+            .entries
+            .get(self.entry_index)
+            .ok_or_else(|| Error::InvalidProximityObject {
+                kind: "candidate",
+                reason: "retained entry index is outside its node".to_owned(),
+            })
+    }
+
+    pub(crate) fn key(&self) -> Result<&[u8], Error> {
+        Ok(&self.entry()?.key)
+    }
+
+    pub(crate) fn vector(&self) -> Result<&[f32], Error> {
+        self.entry()?.vector.inline()
+    }
+
+    #[inline]
+    pub(crate) fn retained_bytes(&self) -> usize {
+        self.node.retained_bytes()
+    }
+
+    #[inline]
+    pub(crate) fn backing_id(&self) -> usize {
+        Arc::as_ptr(&self.node) as usize
+    }
 }
 
 pub(crate) fn insert_top_k(
@@ -48,11 +153,145 @@ pub(crate) fn insert_top_k(
     candidate: SearchCandidate,
     k: usize,
 ) {
-    candidates.push(candidate);
-    candidates.sort_by(|left, right| {
-        left.score
-            .total_cmp(&right.score)
-            .then_with(|| left.key.cmp(&right.key))
+    let position = candidates.partition_point(|current| {
+        current
+            .score
+            .total_cmp(&candidate.score)
+            .then_with(|| {
+                current
+                    .key()
+                    .expect("candidate handle was validated at construction")
+                    .cmp(
+                        candidate
+                            .key()
+                            .expect("candidate handle was validated at construction"),
+                    )
+            })
+            .is_le()
     });
-    candidates.truncate(k);
+    if position < k {
+        candidates.insert(position, candidate);
+        candidates.truncate(k);
+    }
+}
+
+pub(crate) fn insert_reranked_top_k(
+    candidates: &mut Vec<RerankCandidate>,
+    candidate: RerankCandidate,
+    k: usize,
+) {
+    let position = candidates.partition_point(|current| {
+        current
+            .distance
+            .total_cmp(&candidate.distance)
+            .then_with(|| current.key().cmp(candidate.key()))
+            .is_le()
+    });
+    if position < k {
+        candidates.insert(position, candidate);
+        candidates.truncate(k);
+    }
+}
+
+pub(crate) fn retained_candidate_bytes(candidates: &[RerankCandidate]) -> usize {
+    let mut unique = std::collections::HashSet::with_capacity(candidates.len());
+    candidates
+        .iter()
+        .filter(|candidate| unique.insert(candidate.backing_id()))
+        .map(RerankCandidate::retained_bytes)
+        .sum()
+}
+
+pub(crate) fn retained_search_candidate_bytes(candidates: &[SearchCandidate]) -> usize {
+    let mut unique = std::collections::HashSet::with_capacity(candidates.len());
+    candidates
+        .iter()
+        .filter(|candidate| unique.insert(candidate.backing_id()))
+        .map(SearchCandidate::retained_bytes)
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prolly::proximity::storage::{PhysicalNodeKind, ProximityEntry, StoredRecord};
+    use crate::prolly::{Config, Prolly};
+    use crate::{DistanceMetric, MemStore};
+
+    fn node(keys: &[&[u8]]) -> Arc<ProximityNode> {
+        Arc::new(ProximityNode {
+            kind: PhysicalNodeKind::Leaf,
+            level: 0,
+            subtree_count: keys.len() as u64,
+            quantizer: None,
+            entries: keys
+                .iter()
+                .map(|key| ProximityEntry::inline_leaf(key.to_vec(), vec![1.0, 2.0]))
+                .collect(),
+        })
+    }
+
+    #[test]
+    fn retained_candidates_are_ordered_bounded_and_keep_their_node_alive() {
+        let node = node(&[b"c", b"a", b"b"]);
+        let mut candidates = Vec::new();
+        insert_top_k(
+            &mut candidates,
+            SearchCandidate::new(node.clone(), 0, 2.0),
+            2,
+        );
+        insert_top_k(
+            &mut candidates,
+            SearchCandidate::new(node.clone(), 1, 1.0),
+            2,
+        );
+        insert_top_k(
+            &mut candidates,
+            SearchCandidate::new(node.clone(), 2, 1.0),
+            2,
+        );
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].key().unwrap(), b"a");
+        assert_eq!(candidates[1].key().unwrap(), b"b");
+        assert_eq!(Arc::strong_count(&node), 3);
+        drop(node);
+        assert_eq!(candidates[0].vector().unwrap(), &[1.0, 2.0]);
+    }
+
+    #[test]
+    fn retained_candidate_rejects_an_invalid_entry_index() {
+        let candidate = SearchCandidate::new(node(&[b"a"]), 1, 0.0);
+        assert!(matches!(
+            candidate.entry(),
+            Err(Error::InvalidProximityObject { .. })
+        ));
+    }
+
+    #[test]
+    fn authoritative_candidate_survives_cache_clear_and_copies_only_final_value() {
+        let prolly = Prolly::new(MemStore::new(), Config::default());
+        let record = StoredRecord::new(
+            &[1.0, 2.0],
+            b"application-value".to_vec(),
+            DistanceMetric::L2Squared,
+            2,
+        )
+        .unwrap();
+        let tree = prolly
+            .put(&prolly.create(), b"key".to_vec(), record.encode())
+            .unwrap();
+        let mut session = prolly.read(&tree).unwrap();
+        let handle = session.get_handle(b"key").unwrap().unwrap();
+        StoredRecordRef::decode(handle.value().unwrap(), 2).unwrap();
+        let candidate = RerankCandidate::new(handle, b"key", 3.5).unwrap();
+        assert!(candidate.retained_bytes() > 0);
+
+        prolly.clear_cache();
+        drop(session);
+        let neighbor = candidate.into_neighbor(2).unwrap();
+        assert_eq!(neighbor.key, b"key");
+        assert_eq!(neighbor.value, b"application-value");
+        assert_eq!(neighbor.distance, 3.5);
+    }
 }

--- a/src/prolly/proximity/search/mod.rs
+++ b/src/prolly/proximity/search/mod.rs
@@ -11,7 +11,10 @@ use super::{QueryKernel, SearchBackend, SearchBudget, SearchPolicy};
 use crate::prolly::error::Error;
 use crate::prolly::tree::Tree;
 
-pub(crate) use engine::{insert_top_k, FrontierEntry, SearchCandidate};
+pub(crate) use engine::{
+    insert_reranked_top_k, insert_top_k, retained_candidate_bytes, retained_search_candidate_bytes,
+    FrontierEntry, RerankCandidate, SearchCandidate,
+};
 pub use filter::EligibilityCardinality;
 pub(crate) use filter::PreparedEligibility as PreparedFilter;
 pub(crate) use planner::plan_search;

--- a/src/prolly/proximity/search/runtime.rs
+++ b/src/prolly/proximity/search/runtime.rs
@@ -147,13 +147,30 @@ impl<S: Store + Clone> Store for SearchIo<S> {
         match self.runtime.load(self, self.kind, &cid, 2, |bytes| {
             validate_cached_object(bytes, self.dimensions)
         }) {
-            Ok(loaded) => Ok(Some((*loaded.bytes).clone())),
+            Ok(loaded) => Ok(Some(loaded.bytes.as_ref().to_vec())),
             Err(Error::NotFound(_)) => Ok(None),
             Err(Error::Store(error)) => match error.downcast::<S::Error>() {
                 Ok(error) => Err(*error),
                 Err(_) => self.store.get(key),
             },
             Err(_) => self.store.get(key),
+        }
+    }
+
+    fn get_shared(&self, key: &[u8]) -> Result<Option<Arc<[u8]>>, Self::Error> {
+        let Ok(cid) = <[u8; 32]>::try_from(key).map(Cid) else {
+            return self.store.get_shared(key);
+        };
+        match self.runtime.load(self, self.kind, &cid, 2, |bytes| {
+            validate_cached_object(bytes, self.dimensions)
+        }) {
+            Ok(loaded) => Ok(Some(loaded.bytes)),
+            Err(Error::NotFound(_)) => Ok(None),
+            Err(Error::Store(error)) => match error.downcast::<S::Error>() {
+                Ok(error) => Err(*error),
+                Err(_) => self.store.get_shared(key),
+            },
+            Err(_) => self.store.get_shared(key),
         }
     }
 
@@ -180,7 +197,7 @@ impl<S: Store + Clone> Store for SearchIo<S> {
         match self.runtime.load_batch(self, &cids, self.kind, 2) {
             Ok(values) => Ok(values
                 .into_iter()
-                .map(|value| value.map(|bytes| (*bytes).clone()))
+                .map(|value| value.map(|bytes| bytes.as_ref().to_vec()))
                 .collect()),
             Err(Error::Store(error)) => match error.downcast::<S::Error>() {
                 Ok(error) => Err(*error),
@@ -195,6 +212,31 @@ impl<S: Store + Clone> Store for SearchIo<S> {
         keys: &[&[u8]],
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
         self.batch_get_ordered(keys)
+    }
+
+    fn batch_get_shared_ordered_unique(
+        &self,
+        keys: &[&[u8]],
+    ) -> Result<Vec<Option<Arc<[u8]>>>, Self::Error> {
+        let cids = keys
+            .iter()
+            .map(|key| <[u8; 32]>::try_from(*key).map(Cid))
+            .collect::<Result<Vec<_>, _>>();
+        let Ok(cids) = cids else {
+            return self.store.batch_get_shared_ordered_unique(keys);
+        };
+        match self.runtime.load_batch(self, &cids, self.kind, 2) {
+            Ok(values) => Ok(values),
+            Err(Error::Store(error)) => match error.downcast::<S::Error>() {
+                Ok(error) => Err(*error),
+                Err(_) => self.store.batch_get_shared_ordered_unique(keys),
+            },
+            Err(_) => self.store.batch_get_shared_ordered_unique(keys),
+        }
+    }
+
+    fn has_native_shared_reads(&self) -> bool {
+        true
     }
 
     fn prefers_batch_reads(&self) -> bool {
@@ -232,13 +274,34 @@ where
             })
             .await
         {
-            Ok(loaded) => Ok(Some((*loaded.bytes).clone())),
+            Ok(loaded) => Ok(Some(loaded.bytes.as_ref().to_vec())),
             Err(Error::NotFound(_)) => Ok(None),
             Err(Error::Store(error)) => match error.downcast::<S::Error>() {
                 Ok(error) => Err(*error),
                 Err(_) => self.store.get(key).await,
             },
             Err(_) => self.store.get(key).await,
+        }
+    }
+
+    async fn get_shared(&self, key: &[u8]) -> Result<Option<Arc<[u8]>>, Self::Error> {
+        let Ok(cid) = <[u8; 32]>::try_from(key).map(Cid) else {
+            return self.store.get_shared(key).await;
+        };
+        match self
+            .runtime
+            .load_async(self, self.kind, &cid, 2, |bytes| {
+                validate_cached_object(bytes, self.dimensions)
+            })
+            .await
+        {
+            Ok(loaded) => Ok(Some(loaded.bytes)),
+            Err(Error::NotFound(_)) => Ok(None),
+            Err(Error::Store(error)) => match error.downcast::<S::Error>() {
+                Ok(error) => Err(*error),
+                Err(_) => self.store.get_shared(key).await,
+            },
+            Err(_) => self.store.get_shared(key).await,
         }
     }
 
@@ -252,6 +315,21 @@ where
 
     async fn batch(&self, ops: &[BatchOp<'_>]) -> Result<(), Self::Error> {
         self.store.batch(ops).await
+    }
+
+    async fn batch_get_shared_ordered_unique(
+        &self,
+        keys: &[&[u8]],
+    ) -> Result<Vec<Option<Arc<[u8]>>>, Self::Error> {
+        let mut values = Vec::with_capacity(keys.len());
+        for key in keys {
+            values.push(self.get_shared(key).await?);
+        }
+        Ok(values)
+    }
+
+    fn has_native_shared_reads(&self) -> bool {
+        true
     }
 
     fn prefers_batch_reads(&self) -> bool {
@@ -279,7 +357,7 @@ struct CacheKey {
 }
 
 struct CacheEntry {
-    bytes: Arc<Vec<u8>>,
+    bytes: Arc<[u8]>,
     partition: Partition,
     generation: u64,
 }
@@ -405,7 +483,7 @@ impl SearchRuntime {
             .unwrap_or_else(|poison| poison.into_inner());
         state.in_flight.remove(&key);
         let result = loaded.map(|bytes| {
-            let bytes = Arc::new(bytes);
+            let bytes = Arc::<[u8]>::from(bytes.into_boxed_slice());
             self.insert(&mut state, key.clone(), bytes.clone());
             RuntimeLoad { bytes }
         });
@@ -425,7 +503,7 @@ impl SearchRuntime {
         cids: &[Cid],
         kind: ContentObjectKind,
         decoder_version: u8,
-    ) -> Result<Vec<Option<Arc<Vec<u8>>>>, Error> {
+    ) -> Result<Vec<Option<Arc<[u8]>>>, Error> {
         let keys = cids
             .iter()
             .cloned()
@@ -511,7 +589,7 @@ impl SearchRuntime {
                     validate_cached_object(&bytes, io.dimensions)?;
                     io.physical_bytes_read
                         .fetch_add(bytes.len(), Ordering::Relaxed);
-                    let bytes = Arc::new(bytes);
+                    let bytes = Arc::<[u8]>::from(bytes.into_boxed_slice());
                     self.insert(&mut state, key.clone(), bytes.clone());
                     results[index] = Some(bytes);
                 }
@@ -613,7 +691,7 @@ impl SearchRuntime {
         state.in_flight.remove(&key);
         in_flight_guard.armed = false;
         let result = loaded.map(|bytes| {
-            let bytes = Arc::new(bytes);
+            let bytes = Arc::<[u8]>::from(bytes.into_boxed_slice());
             self.insert(&mut state, key.clone(), bytes.clone());
             RuntimeLoad { bytes }
         });
@@ -626,7 +704,7 @@ impl SearchRuntime {
         result
     }
 
-    fn insert(&self, state: &mut RuntimeState, key: CacheKey, bytes: Arc<Vec<u8>>) {
+    fn insert(&self, state: &mut RuntimeState, key: CacheKey, bytes: Arc<[u8]>) {
         let partition = partition(key.kind);
         let partition_limit = self.partition_limit(partition);
         if bytes.len() > self.policy.max_bytes || bytes.len() > partition_limit {
@@ -708,7 +786,7 @@ impl Drop for AsyncInFlightGuard<'_> {
 }
 
 pub(crate) struct RuntimeLoad {
-    pub bytes: Arc<Vec<u8>>,
+    pub bytes: Arc<[u8]>,
 }
 
 fn partition(kind: ContentObjectKind) -> Partition {
@@ -809,20 +887,20 @@ mod tests {
         let second_key = key(b"second", ContentObjectKind::OrderedNode);
         let third_key = key(b"third", ContentObjectKind::OrderedNode);
         let oversized_key = key(b"oversized", ContentObjectKind::OrderedNode);
-        let first = Arc::new(vec![1; 8]);
+        let first = Arc::<[u8]>::from(vec![1; 8]);
         let pinned = first.clone();
         let mut state = runtime.state.lock().unwrap();
         runtime.insert(&mut state, first_key.clone(), first);
-        runtime.insert(&mut state, second_key.clone(), Arc::new(vec![2; 8]));
-        runtime.insert(&mut state, third_key.clone(), Arc::new(vec![3; 8]));
+        runtime.insert(&mut state, second_key.clone(), Arc::from(vec![2; 8]));
+        runtime.insert(&mut state, third_key.clone(), Arc::from(vec![3; 8]));
         assert!(!state.entries.contains_key(&first_key));
         assert!(state.entries.contains_key(&second_key));
         assert!(state.entries.contains_key(&third_key));
         assert_eq!(state.bytes, 16);
-        runtime.insert(&mut state, oversized_key.clone(), Arc::new(vec![4; 17]));
+        runtime.insert(&mut state, oversized_key.clone(), Arc::from(vec![4; 17]));
         assert!(!state.entries.contains_key(&oversized_key));
         assert_eq!(state.bytes, 16);
         drop(state);
-        assert_eq!(pinned.as_slice(), &[1; 8]);
+        assert_eq!(pinned.as_ref(), &[1; 8]);
     }
 }

--- a/src/prolly/proximity/storage/codec.rs
+++ b/src/prolly/proximity/storage/codec.rs
@@ -136,9 +136,12 @@ impl<'a> Reader<'a> {
             }
             value |= u64::from(byte & 0x7f) << shift;
             if byte & 0x80 == 0 {
-                let mut canonical = Vec::new();
-                put_varint(value, &mut canonical);
-                if canonical.as_slice() != &self.bytes[start..self.offset] {
+                let canonical_len = if value == 0 {
+                    1
+                } else {
+                    ((64 - value.leading_zeros()) as usize).div_ceil(7)
+                };
+                if self.offset - start != canonical_len {
                     return Err(self.invalid("non-canonical varint"));
                 }
                 return Ok(value);

--- a/src/prolly/proximity/storage/mod.rs
+++ b/src/prolly/proximity/storage/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod vector;
 
 pub(crate) use descriptor::Descriptor;
 pub(crate) use node::{PhysicalNodeKind, ProximityEntry, ProximityNode, VectorRef};
-pub(crate) use record::StoredRecord;
+pub(crate) use record::{EncodedVectorRef, StoredRecord, StoredRecordRef};
 
 #[allow(dead_code)] // Consumed by the typed graph walker and replication slices.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/prolly/proximity/storage/node.rs
+++ b/src/prolly/proximity/storage/node.rs
@@ -100,6 +100,28 @@ pub(crate) struct ProximityNode {
 }
 
 impl ProximityNode {
+    pub(crate) fn retained_bytes(&self) -> usize {
+        std::mem::size_of::<Self>()
+            .saturating_add(
+                self.entries
+                    .capacity()
+                    .saturating_mul(std::mem::size_of::<ProximityEntry>()),
+            )
+            .saturating_add(self.entries.iter().fold(0usize, |total, entry| {
+                let vector = match &entry.vector {
+                    VectorRef::Inline(vector) => {
+                        vector.capacity().saturating_mul(std::mem::size_of::<f32>())
+                    }
+                    VectorRef::External(_) => 0,
+                };
+                total
+                    .saturating_add(entry.key.capacity())
+                    .saturating_add(entry.min_key.capacity())
+                    .saturating_add(entry.max_key.capacity())
+                    .saturating_add(vector)
+            }))
+    }
+
     pub(crate) fn encode(&self) -> Result<Vec<u8>, Error> {
         self.validate(None)?;
         let mut bytes = Vec::new();

--- a/src/prolly/proximity/storage/record.rs
+++ b/src/prolly/proximity/storage/record.rs
@@ -6,6 +6,55 @@ use crate::prolly::proximity::DistanceMetric;
 
 const MAGIC: &[u8; 4] = b"PRVR";
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct EncodedVectorRef<'a> {
+    pub(crate) bytes: &'a [u8],
+    pub(crate) dimensions: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct StoredRecordRef<'a> {
+    pub(crate) vector: EncodedVectorRef<'a>,
+    pub(crate) value: &'a [u8],
+}
+
+impl<'a> StoredRecordRef<'a> {
+    pub(crate) fn decode(bytes: &'a [u8], dimensions: u32) -> Result<Self, Error> {
+        let mut reader = Reader::new(bytes, "record");
+        reader.exact(MAGIC)?;
+        reader.version()?;
+        if reader.u8()? != VECTOR_ENCODING_F32_LE {
+            return Err(reader.invalid("unsupported vector encoding"));
+        }
+        if reader.varint()? != u64::from(dimensions) {
+            return Err(reader.invalid("dimension mismatch"));
+        }
+        let vector_bytes = usize::try_from(dimensions)
+            .ok()
+            .and_then(|value| value.checked_mul(4))
+            .ok_or_else(|| reader.invalid("vector length overflow"))?;
+        let vector = reader.take(vector_bytes)?;
+        for component in vector.chunks_exact(4) {
+            let value = f32::from_bits(u32::from_le_bytes(
+                component.try_into().expect("four-byte vector component"),
+            ));
+            if !value.is_finite() || value.to_bits() == 0x8000_0000 {
+                return Err(reader.invalid("non-canonical f32"));
+            }
+        }
+        let value_len = reader.bounded_usize(reader.remaining())?;
+        let value = reader.take(value_len)?;
+        reader.finish()?;
+        Ok(Self {
+            vector: EncodedVectorRef {
+                bytes: vector,
+                dimensions,
+            },
+            value,
+        })
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct StoredRecord {
     pub(crate) vector: Vec<f32>,
@@ -37,23 +86,11 @@ impl StoredRecord {
     }
 
     pub(crate) fn decode(bytes: &[u8], dimensions: u32) -> Result<Self, Error> {
-        let mut reader = Reader::new(bytes, "record");
-        reader.exact(MAGIC)?;
-        reader.version()?;
-        if reader.u8()? != VECTOR_ENCODING_F32_LE {
-            return Err(reader.invalid("unsupported vector encoding"));
-        }
-        if reader.varint()? != u64::from(dimensions) {
-            return Err(reader.invalid("dimension mismatch"));
-        }
-        let vector_bytes = usize::try_from(dimensions)
-            .ok()
-            .and_then(|value| value.checked_mul(4))
-            .ok_or_else(|| reader.invalid("vector length overflow"))?;
-        let vector = decode_components(reader.take(vector_bytes)?, dimensions)?;
-        let value = reader.bytes(reader.remaining())?;
-        reader.finish()?;
-        Ok(Self { vector, value })
+        let record = StoredRecordRef::decode(bytes, dimensions)?;
+        Ok(Self {
+            vector: decode_components(record.vector.bytes, dimensions)?,
+            value: record.value.to_vec(),
+        })
     }
 }
 

--- a/src/prolly/range.rs
+++ b/src/prolly/range.rs
@@ -77,9 +77,8 @@
 //! The iterator is lazy and only loads nodes as needed, making it memory-efficient
 //! for large trees.
 
-use super::cid::Cid;
 use super::error::Error;
-use super::node::Node;
+use super::node::ReadNode;
 #[cfg(feature = "async-store")]
 use super::read::EntryRef;
 use super::store::Store;
@@ -237,7 +236,7 @@ pub fn create_range_iter<'a, S: Store>(
     }
 
     // Find path to start key
-    let path = prolly.find_path_arcs(tree, start)?;
+    let path = prolly.find_read_path_arcs(tree, start)?;
     Ok(RangeIter::new(prolly, path, start, end))
 }
 
@@ -252,7 +251,7 @@ pub fn create_range_after_iter<'a, S: Store>(
         return Ok(RangeIter::new_after(prolly, Vec::new(), after_key, end));
     }
 
-    let path = prolly.find_path_arcs(tree, after_key)?;
+    let path = prolly.find_read_path_arcs(tree, after_key)?;
     Ok(RangeIter::new_after(prolly, path, after_key, end))
 }
 
@@ -272,7 +271,7 @@ where
         return Ok(AsyncRangeIter::new(prolly, Vec::new(), start, end));
     }
 
-    let path = prolly.find_path_arcs(tree, start).await?;
+    let path = prolly.find_read_path_arcs(tree, start).await?;
     Ok(AsyncRangeIter::new(prolly, path, start, end))
 }
 
@@ -297,7 +296,7 @@ where
         ));
     }
 
-    let path = prolly.find_path_arcs(tree, after_key).await?;
+    let path = prolly.find_read_path_arcs(tree, after_key).await?;
     Ok(AsyncRangeIter::new_after(prolly, path, after_key, end))
 }
 
@@ -312,7 +311,7 @@ pub struct RangeIter<'a, S: Store> {
     /// Reference to the Prolly tree manager
     prolly: &'a Prolly<S>,
     /// Stack of (node, index) pairs representing the traversal path
-    stack: Vec<(Arc<Node>, usize)>,
+    stack: Vec<(Arc<ReadNode>, usize)>,
     /// Optional end bound (exclusive)
     end: Option<Vec<u8>>,
     /// Whether we've started iteration (for positioning at start key)
@@ -323,7 +322,7 @@ pub struct RangeIter<'a, S: Store> {
     skip_start_key: bool,
     /// Last retained leaf location yielded by this iterator. The key is copied
     /// only if a resumable cursor is requested.
-    last_location: Option<(Arc<Node>, usize)>,
+    last_location: Option<(Arc<ReadNode>, usize)>,
 }
 
 impl<'a, S: Store> RangeIter<'a, S> {
@@ -336,7 +335,7 @@ impl<'a, S: Store> RangeIter<'a, S> {
     /// * `end` - Optional ending key (exclusive)
     pub(crate) fn new(
         prolly: &'a Prolly<S>,
-        stack: Vec<(Arc<Node>, usize)>,
+        stack: Vec<(Arc<ReadNode>, usize)>,
         start: &[u8],
         end: Option<&[u8]>,
     ) -> Self {
@@ -353,7 +352,7 @@ impl<'a, S: Store> RangeIter<'a, S> {
 
     pub(crate) fn new_after(
         prolly: &'a Prolly<S>,
-        stack: Vec<(Arc<Node>, usize)>,
+        stack: Vec<(Arc<ReadNode>, usize)>,
         after_key: &[u8],
         end: Option<&[u8]>,
     ) -> Self {
@@ -375,8 +374,8 @@ impl<'a, S: Store> RangeIter<'a, S> {
     pub fn resume_cursor(&self) -> RangeCursor {
         self.last_location
             .as_ref()
-            .and_then(|(node, index)| node.keys.get(*index))
-            .cloned()
+            .and_then(|(node, index)| node.key(*index))
+            .map(<[u8]>::to_vec)
             .map(RangeCursor::after_key)
             .unwrap_or_else(RangeCursor::start)
     }
@@ -397,7 +396,7 @@ impl<'a, S: Store> RangeIter<'a, S> {
         let (node, idx) = self.stack.last_mut()?;
 
         // If we're at a leaf, find the correct starting position
-        if node.leaf {
+        if node.is_leaf() {
             // Find first key >= start_key
             let start_idx = match node.search(&self.start_key) {
                 Ok(i) if self.skip_start_key => i.saturating_add(1),
@@ -437,7 +436,7 @@ impl<'a, S: Store> RangeIter<'a, S> {
         loop {
             let (node, idx) = self.stack.last()?;
 
-            if node.leaf {
+            if node.is_leaf() {
                 // We're at a leaf, return the current entry
                 if *idx >= node.len() {
                     return self.advance_to_next_leaf();
@@ -505,23 +504,16 @@ impl<'a, S: Store> RangeIter<'a, S> {
                     // Descend to the next child
                     return self.descend_to_leaf();
                 }
-                if parent.keys.len() != parent.vals.len() {
-                    return Some(Err(Error::InvalidNode));
-                }
                 // Otherwise, continue popping
             }
         }
     }
 
-    fn load_child_for_descent(&self, node: &Node, idx: usize) -> Result<Arc<Node>, Error> {
-        let child_cid = child_cid_at(node, idx)?;
+    fn load_child_for_descent(&self, node: &ReadNode, idx: usize) -> Result<Arc<ReadNode>, Error> {
+        let child_cid = node.child_cid(idx)?;
 
         if !self.prolly.store().prefers_batch_reads() {
-            return self.prolly.load_arc(&child_cid);
-        }
-
-        if let Some(child) = self.prolly.cached_node_arc(&child_cid) {
-            return Ok(child);
+            return self.prolly.load_read_arc(&child_cid);
         }
 
         let max_child_idx = node
@@ -537,19 +529,17 @@ impl<'a, S: Store> RangeIter<'a, S> {
                 Err(_) => break,
             }
 
-            match child_cid_at(node, child_idx) {
+            match node.child_cid(child_idx) {
                 Ok(cid) => child_cids.push(cid),
                 Err(_) => break,
             }
         }
 
         if child_cids.len() == 1 {
-            return self.prolly.load_arc(&child_cids[0]);
+            return self.prolly.load_read_arc(&child_cids[0]);
         }
 
-        let children = self
-            .prolly
-            .load_many_ordered_with_parallelism(&child_cids, RANGE_CHILD_PREFETCH_PARALLELISM)?;
+        let children = self.prolly.load_many_read_ordered(&child_cids)?;
         children.into_iter().next().ok_or(Error::InvalidNode)
     }
 }
@@ -570,17 +560,13 @@ impl<'a, S: Store> Iterator for RangeIter<'a, S> {
         loop {
             let (node, idx) = self.stack.last_mut()?;
 
-            if !node.leaf && node.keys.len() != node.vals.len() {
-                return Some(Err(Error::InvalidNode));
-            }
-
             // If we've exhausted this node, advance to next
             if *idx >= node.len() {
                 return self.advance_to_next_leaf();
             }
 
             // If we're at a leaf, yield the current entry
-            if node.leaf {
+            if node.is_leaf() {
                 match leaf_entry_before_end(node, *idx, self.end.as_deref()) {
                     Ok(Some(entry)) => {
                         let location = (node.clone(), *idx);
@@ -623,12 +609,12 @@ impl<'a, S: Store> Iterator for RangeIter<'a, S> {
 #[cfg(feature = "async-store")]
 pub struct AsyncRangeIter<'a, S: AsyncStore> {
     prolly: &'a AsyncProlly<S>,
-    stack: Vec<(Arc<Node>, usize)>,
+    stack: Vec<(Arc<ReadNode>, usize)>,
     end: Option<Vec<u8>>,
     started: bool,
     start_key: Vec<u8>,
     skip_start_key: bool,
-    last_location: Option<(Arc<Node>, usize)>,
+    last_location: Option<(Arc<ReadNode>, usize)>,
 }
 
 #[cfg(feature = "async-store")]
@@ -639,7 +625,7 @@ where
 {
     pub(crate) fn new(
         prolly: &'a AsyncProlly<S>,
-        stack: Vec<(Arc<Node>, usize)>,
+        stack: Vec<(Arc<ReadNode>, usize)>,
         start: &[u8],
         end: Option<&[u8]>,
     ) -> Self {
@@ -656,7 +642,7 @@ where
 
     pub(crate) fn new_after(
         prolly: &'a AsyncProlly<S>,
-        stack: Vec<(Arc<Node>, usize)>,
+        stack: Vec<(Arc<ReadNode>, usize)>,
         after_key: &[u8],
         end: Option<&[u8]>,
     ) -> Self {
@@ -691,10 +677,6 @@ where
         loop {
             let (node, idx) = self.stack.last_mut()?;
 
-            if !node.leaf && node.keys.len() != node.vals.len() {
-                return Some(Err(Error::InvalidNode));
-            }
-
             if *idx >= node.len() {
                 match self.advance_to_next_sibling() {
                     Ok(true) => continue,
@@ -703,19 +685,16 @@ where
                 }
             }
 
-            if node.leaf {
-                if node.keys.len() != node.vals.len() {
-                    return Some(Err(Error::InvalidNode));
-                }
+            if node.is_leaf() {
                 let index = *idx;
-                let key = match node.keys.get(index) {
+                let key = match node.key(index) {
                     Some(key) => key,
                     None => return Some(Err(Error::InvalidNode)),
                 };
-                if self.end.as_deref().is_some_and(|end| key.as_slice() >= end) {
+                if self.end.as_deref().is_some_and(|end| key >= end) {
                     return None;
                 }
-                let value = match node.vals.get(index) {
+                let value = match node.value(index) {
                     Some(value) => value,
                     None => return Some(Err(Error::InvalidNode)),
                 };
@@ -762,8 +741,8 @@ where
     pub fn resume_cursor(&self) -> RangeCursor {
         self.last_location
             .as_ref()
-            .and_then(|(node, index)| node.keys.get(*index))
-            .cloned()
+            .and_then(|(node, index)| node.key(*index))
+            .map(<[u8]>::to_vec)
             .map(RangeCursor::after_key)
             .unwrap_or_else(RangeCursor::start)
     }
@@ -785,7 +764,7 @@ where
             return;
         };
 
-        if node.leaf {
+        if node.is_leaf() {
             *idx = match node.search(&self.start_key) {
                 Ok(i) if self.skip_start_key => i.saturating_add(1),
                 Ok(i) | Err(i) => i,
@@ -808,22 +787,18 @@ where
                 }
                 return Ok(true);
             }
-
-            if parent.keys.len() != parent.vals.len() {
-                return Err(Error::InvalidNode);
-            }
         }
     }
 
-    async fn load_child_for_descent(&self, node: &Node, idx: usize) -> Result<Arc<Node>, Error> {
-        let child_cid = child_cid_at(node, idx)?;
+    async fn load_child_for_descent(
+        &self,
+        node: &ReadNode,
+        idx: usize,
+    ) -> Result<Arc<ReadNode>, Error> {
+        let child_cid = node.child_cid(idx)?;
 
         if !self.prolly.store().prefers_batch_reads() {
-            return self.prolly.load_arc(&child_cid).await;
-        }
-
-        if let Some(child) = self.prolly.cached_node_arc(&child_cid) {
-            return Ok(child);
+            return self.prolly.load_read_arc(&child_cid).await;
         }
 
         let max_child_idx = node
@@ -837,50 +812,42 @@ where
                 break;
             }
 
-            match child_cid_at(node, child_idx) {
+            match node.child_cid(child_idx) {
                 Ok(cid) => child_cids.push(cid),
                 Err(_) => break,
             }
         }
 
         if child_cids.len() == 1 {
-            return self.prolly.load_arc(&child_cids[0]).await;
+            return self.prolly.load_read_arc(&child_cids[0]).await;
         }
 
-        let children = self.prolly.load_child_frontier_ordered(&child_cids).await?;
+        let children = self.prolly.load_many_read_ordered(&child_cids).await?;
         children.into_iter().next().ok_or(Error::InvalidNode)
     }
 }
 
-fn leaf_entry_before_end(node: &Node, idx: usize, end: Option<&[u8]>) -> OptionalLeafEntry {
-    let key = node.keys.get(idx).ok_or(Error::InvalidNode)?;
+fn leaf_entry_before_end(node: &ReadNode, idx: usize, end: Option<&[u8]>) -> OptionalLeafEntry {
+    let key = node.key(idx).ok_or(Error::InvalidNode)?;
     if let Some(end) = end {
-        if key.as_slice() >= end {
+        if key >= end {
             return Ok(None);
         }
     }
 
-    let val = node.vals.get(idx).ok_or(Error::InvalidNode)?;
-    Ok(Some((key.clone(), val.clone())))
+    let val = node.value(idx).ok_or(Error::InvalidNode)?;
+    Ok(Some((key.to_vec(), val.to_vec())))
 }
 
 fn child_starts_at_or_after_end(
     end: Option<&[u8]>,
-    node: &Node,
+    node: &ReadNode,
     child_index: usize,
 ) -> Result<bool, Error> {
     let Some(end) = end else {
         return Ok(false);
     };
 
-    let first_key = node.keys.get(child_index).ok_or(Error::InvalidNode)?;
-    Ok(first_key.as_slice() >= end)
-}
-
-fn child_cid_at(node: &Node, idx: usize) -> Result<Cid, Error> {
-    let child = node.vals.get(idx).ok_or(Error::InvalidNode)?;
-    Ok(Cid(child
-        .as_slice()
-        .try_into()
-        .map_err(|_| Error::InvalidNode)?))
+    let first_key = node.key(child_index).ok_or(Error::InvalidNode)?;
+    Ok(first_key >= end)
 }

--- a/src/prolly/range.rs
+++ b/src/prolly/range.rs
@@ -80,6 +80,8 @@
 use super::cid::Cid;
 use super::error::Error;
 use super::node::Node;
+#[cfg(feature = "async-store")]
+use super::read::EntryRef;
 use super::store::Store;
 use super::tree::Tree;
 
@@ -319,8 +321,9 @@ pub struct RangeIter<'a, S: Store> {
     start_key: Vec<u8>,
     /// Whether to skip an entry equal to the start key.
     skip_start_key: bool,
-    /// Last key yielded by this iterator.
-    last_key: Option<Vec<u8>>,
+    /// Last retained leaf location yielded by this iterator. The key is copied
+    /// only if a resumable cursor is requested.
+    last_location: Option<(Arc<Node>, usize)>,
 }
 
 impl<'a, S: Store> RangeIter<'a, S> {
@@ -344,7 +347,7 @@ impl<'a, S: Store> RangeIter<'a, S> {
             started: false,
             start_key: start.to_vec(),
             skip_start_key: false,
-            last_key: None,
+            last_location: None,
         }
     }
 
@@ -361,7 +364,7 @@ impl<'a, S: Store> RangeIter<'a, S> {
             started: false,
             start_key: after_key.to_vec(),
             skip_start_key: true,
-            last_key: None,
+            last_location: None,
         }
     }
 
@@ -370,8 +373,10 @@ impl<'a, S: Store> RangeIter<'a, S> {
     /// If the iterator has not yielded an item yet, this returns
     /// [`RangeCursor::start`].
     pub fn resume_cursor(&self) -> RangeCursor {
-        self.last_key
-            .clone()
+        self.last_location
+            .as_ref()
+            .and_then(|(node, index)| node.keys.get(*index))
+            .cloned()
             .map(RangeCursor::after_key)
             .unwrap_or_else(RangeCursor::start)
     }
@@ -410,8 +415,9 @@ impl<'a, S: Store> RangeIter<'a, S> {
 
             match leaf_entry_before_end(node, *idx, self.end.as_deref()) {
                 Ok(Some(entry)) => {
+                    let location = (node.clone(), *idx);
                     *idx += 1;
-                    self.last_key = Some(entry.0.clone());
+                    self.last_location = Some(location);
                     return Some(Ok(entry));
                 }
                 Ok(None) => return None,
@@ -439,10 +445,11 @@ impl<'a, S: Store> RangeIter<'a, S> {
 
                 match leaf_entry_before_end(node, *idx, self.end.as_deref()) {
                     Ok(Some(entry)) => {
+                        let location = (node.clone(), *idx);
                         if let Some((_, idx)) = self.stack.last_mut() {
                             *idx += 1;
                         }
-                        self.last_key = Some(entry.0.clone());
+                        self.last_location = Some(location);
                         return Some(Ok(entry));
                     }
                     Ok(None) => return None,
@@ -576,8 +583,9 @@ impl<'a, S: Store> Iterator for RangeIter<'a, S> {
             if node.leaf {
                 match leaf_entry_before_end(node, *idx, self.end.as_deref()) {
                     Ok(Some(entry)) => {
+                        let location = (node.clone(), *idx);
                         *idx += 1;
-                        self.last_key = Some(entry.0.clone());
+                        self.last_location = Some(location);
                         return Some(Ok(entry));
                     }
                     Ok(None) => return None,
@@ -620,7 +628,7 @@ pub struct AsyncRangeIter<'a, S: AsyncStore> {
     started: bool,
     start_key: Vec<u8>,
     skip_start_key: bool,
-    last_key: Option<Vec<u8>>,
+    last_location: Option<(Arc<Node>, usize)>,
 }
 
 #[cfg(feature = "async-store")]
@@ -642,7 +650,7 @@ where
             started: false,
             start_key: start.to_vec(),
             skip_start_key: false,
-            last_key: None,
+            last_location: None,
         }
     }
 
@@ -659,13 +667,26 @@ where
             started: false,
             start_key: after_key.to_vec(),
             skip_start_key: true,
-            last_key: None,
+            last_location: None,
         }
     }
 
     /// Return the next key-value pair in lexicographic order.
     pub async fn next(&mut self) -> Option<RangeItem> {
+        self.next_with(|entry| entry.to_owned()).await
+    }
+
+    /// Visit the next entry without copying its key or value.
+    ///
+    /// The callback is synchronous and runs after any required child load has
+    /// completed, so its borrowed entry cannot cross an `.await` boundary.
+    pub async fn next_with<R>(
+        &mut self,
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Option<Result<R, Error>> {
         self.position_at_start();
+
+        let mut read = Some(read);
 
         loop {
             let (node, idx) = self.stack.last_mut()?;
@@ -683,15 +704,28 @@ where
             }
 
             if node.leaf {
-                match leaf_entry_before_end(node, *idx, self.end.as_deref()) {
-                    Ok(Some(entry)) => {
-                        *idx += 1;
-                        self.last_key = Some(entry.0.clone());
-                        return Some(Ok(entry));
-                    }
-                    Ok(None) => return None,
-                    Err(e) => return Some(Err(e)),
+                if node.keys.len() != node.vals.len() {
+                    return Some(Err(Error::InvalidNode));
                 }
+                let index = *idx;
+                let key = match node.keys.get(index) {
+                    Some(key) => key,
+                    None => return Some(Err(Error::InvalidNode)),
+                };
+                if self.end.as_deref().is_some_and(|end| key.as_slice() >= end) {
+                    return None;
+                }
+                let value = match node.vals.get(index) {
+                    Some(value) => value,
+                    None => return Some(Err(Error::InvalidNode)),
+                };
+                *idx += 1;
+                self.last_location = Some((node.clone(), index));
+                return Some(Ok(read
+                    .take()
+                    .expect("async range callback is invoked at most once")(
+                    EntryRef::new(key, value),
+                )));
             }
 
             match child_starts_at_or_after_end(self.end.as_deref(), node, *idx) {
@@ -726,8 +760,10 @@ where
     /// If the iterator has not yielded an item yet, this returns
     /// [`RangeCursor::start`].
     pub fn resume_cursor(&self) -> RangeCursor {
-        self.last_key
-            .clone()
+        self.last_location
+            .as_ref()
+            .and_then(|(node, index)| node.keys.get(*index))
+            .cloned()
             .map(RangeCursor::after_key)
             .unwrap_or_else(RangeCursor::start)
     }

--- a/src/prolly/read.rs
+++ b/src/prolly/read.rs
@@ -1,0 +1,1711 @@
+//! Borrowed, callback-scoped read APIs.
+//!
+//! This module implements the core substrate specified by
+//! `docs/superpowers/specs/2026-07-15-prolly-zero-copy-read-architecture-design.md`.
+//! Values are borrowed from immutable retained nodes only for the duration of a
+//! synchronous callback. Existing owned APIs remain compatibility wrappers.
+
+use std::ops::ControlFlow;
+use std::sync::{Arc, Weak};
+
+use super::blob;
+use super::cid::Cid;
+use super::error::{Conflict, Diff, Error};
+use super::key;
+use super::node::Node;
+#[cfg(feature = "async-store")]
+use super::store::AsyncStore;
+use super::store::Store;
+use super::tree::Tree;
+#[cfg(feature = "async-store")]
+use super::AsyncProlly;
+use super::{
+    child_cid_at, route_key_positions_to_children, sorted_key_positions, InlinePositions, KeyValue,
+    Prolly, GET_MANY_PREFETCH_PARALLELISM,
+};
+
+/// A callback-scoped borrowed key/value entry.
+///
+/// The fields are private so the backing representation can evolve without
+/// changing callers. An `EntryRef` cannot outlive the callback that receives it.
+#[derive(Clone, Copy, Debug)]
+pub struct EntryRef<'a> {
+    key: &'a [u8],
+    value: &'a [u8],
+}
+
+impl<'a> EntryRef<'a> {
+    pub(crate) fn new(key: &'a [u8], value: &'a [u8]) -> Self {
+        Self { key, value }
+    }
+
+    /// Borrow the entry key.
+    #[inline]
+    pub fn key(&self) -> &'a [u8] {
+        self.key
+    }
+
+    /// Borrow the entry value.
+    #[inline]
+    pub fn value(&self) -> &'a [u8] {
+        self.value
+    }
+
+    /// Explicitly copy this borrowed entry into the legacy owned representation.
+    pub fn to_owned(self) -> KeyValue {
+        (self.key.to_vec(), self.value.to_vec())
+    }
+}
+
+/// The result of a callback traversal that supports early termination.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScanOutcome<B> {
+    /// Number of entries delivered to the callback, including the entry that
+    /// returned `ControlFlow::Break`.
+    pub visited: u64,
+    /// The callback's break value, or `None` when traversal reached its bound.
+    pub break_value: Option<B>,
+}
+
+impl<B> ScanOutcome<B> {
+    pub(crate) fn complete(visited: u64) -> Self {
+        Self {
+            visited,
+            break_value: None,
+        }
+    }
+
+    pub(crate) fn stopped(visited: u64, break_value: B) -> Self {
+        Self {
+            visited,
+            break_value: Some(break_value),
+        }
+    }
+}
+
+/// Borrowed view of a stored large-value envelope.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ValueRefView<'a> {
+    /// Inline application bytes.
+    Inline(&'a [u8]),
+    /// Validated content-addressed blob reference.
+    Blob { cid: Cid, len: u64 },
+}
+
+impl ValueRefView<'_> {
+    /// Explicitly copy this view into the legacy owned value-reference type.
+    pub fn to_owned(self) -> blob::ValueRef {
+        match self {
+            Self::Inline(value) => blob::ValueRef::Inline(value.to_vec()),
+            Self::Blob { cid, len } => blob::ValueRef::Blob(blob::BlobRef { cid, len }),
+        }
+    }
+}
+
+/// A callback-scoped borrowed difference between two trees.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiffRef<'a> {
+    Added {
+        key: &'a [u8],
+        value: &'a [u8],
+    },
+    Removed {
+        key: &'a [u8],
+        value: &'a [u8],
+    },
+    Changed {
+        key: &'a [u8],
+        old: &'a [u8],
+        new: &'a [u8],
+    },
+}
+
+impl DiffRef<'_> {
+    /// Borrow the affected key.
+    pub fn key(&self) -> &[u8] {
+        match self {
+            Self::Added { key, .. } | Self::Removed { key, .. } | Self::Changed { key, .. } => key,
+        }
+    }
+
+    /// Explicitly copy this event into the legacy owned diff representation.
+    pub fn to_owned(self) -> Diff {
+        match self {
+            Self::Added { key, value } => Diff::Added {
+                key: key.to_vec(),
+                val: value.to_vec(),
+            },
+            Self::Removed { key, value } => Diff::Removed {
+                key: key.to_vec(),
+                val: value.to_vec(),
+            },
+            Self::Changed { key, old, new } => Diff::Changed {
+                key: key.to_vec(),
+                old: old.to_vec(),
+                new: new.to_vec(),
+            },
+        }
+    }
+}
+
+/// Callback-scoped values for one genuine three-way merge conflict.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ConflictRef<'a> {
+    pub key: &'a [u8],
+    pub base: Option<&'a [u8]>,
+    pub left: Option<&'a [u8]>,
+    pub right: Option<&'a [u8]>,
+}
+
+impl ConflictRef<'_> {
+    /// Explicitly copy this view into the legacy owned conflict type.
+    pub fn to_owned(self) -> Conflict {
+        Conflict {
+            key: self.key.to_vec(),
+            base: self.base.map(<[u8]>::to_vec),
+            left: self.left.map(<[u8]>::to_vec),
+            right: self.right.map(<[u8]>::to_vec),
+        }
+    }
+}
+
+/// A borrowed merge resolver's selection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MergeDecision {
+    UseBase,
+    UseLeft,
+    UseRight,
+    Value(Vec<u8>),
+    Delete,
+    Unresolved,
+}
+
+/// Resolver that inspects borrowed conflict values and can select an existing
+/// branch without first copying it.
+pub trait BorrowedMergeResolver: Send + Sync {
+    fn resolve(&self, conflict: ConflictRef<'_>) -> MergeDecision;
+}
+
+struct PathFrame {
+    node: Arc<Node>,
+    index: usize,
+}
+
+// A fixed-size, direct-mapped table keeps hot route nodes out of the shared
+// cache lock without becoming a second unbounded cache. Weak references mean
+// a session never prevents normal cache eviction.
+const SESSION_NODE_SLOTS: usize = 1024;
+const SESSION_NODE_WAYS: usize = 4;
+const SESSION_NODE_SETS: usize = SESSION_NODE_SLOTS / SESSION_NODE_WAYS;
+type SessionNodeSlot = Option<(Cid, Weak<Node>)>;
+
+struct SessionNodeTable {
+    slots: Box<[SessionNodeSlot]>,
+    next_way: Box<[u8]>,
+}
+
+impl SessionNodeTable {
+    fn new() -> Self {
+        Self {
+            slots: std::iter::repeat_with(|| None)
+                .take(SESSION_NODE_SLOTS)
+                .collect(),
+            next_way: vec![0; SESSION_NODE_SETS].into_boxed_slice(),
+        }
+    }
+
+    #[inline]
+    fn set(cid: &Cid) -> usize {
+        let prefix = u64::from_ne_bytes(
+            cid.as_bytes()[..8]
+                .try_into()
+                .expect("CID has a fixed 32-byte representation"),
+        );
+        prefix as usize & (SESSION_NODE_SETS - 1)
+    }
+
+    #[inline]
+    fn get(&self, cid: &Cid) -> Option<Arc<Node>> {
+        let start = Self::set(cid) * SESSION_NODE_WAYS;
+        self.slots[start..start + SESSION_NODE_WAYS]
+            .iter()
+            .flatten()
+            .find(|(cached, _)| cached == cid)
+            .and_then(|(_, node)| node.upgrade())
+    }
+
+    #[inline]
+    fn insert(&mut self, cid: Cid, node: &Arc<Node>) {
+        let set = Self::set(&cid);
+        let start = set * SESSION_NODE_WAYS;
+        let ways = &mut self.slots[start..start + SESSION_NODE_WAYS];
+        let slot = ways
+            .iter()
+            .position(|entry| entry.as_ref().is_some_and(|(cached, _)| cached == &cid))
+            .or_else(|| ways.iter().position(Option::is_none))
+            .unwrap_or_else(|| {
+                let way = usize::from(self.next_way[set]);
+                self.next_way[set] = ((way + 1) % SESSION_NODE_WAYS) as u8;
+                way
+            });
+        ways[slot] = Some((cid, Arc::downgrade(node)));
+    }
+}
+
+/// A reusable root-bound read context for one immutable tree.
+///
+/// The session retains the decoded root and a session-local recent leaf. It is
+/// intended to be reused by one worker; methods that update traversal state
+/// require `&mut self`.
+pub struct ReadSession<'manager, 'tree, S: Store> {
+    manager: &'manager Prolly<S>,
+    tree: &'tree Tree,
+    root: Option<Arc<Node>>,
+    recent_leaf: Option<Arc<Node>>,
+    local_nodes: SessionNodeTable,
+}
+
+/// Reusable root-bound read context for an asynchronous store.
+///
+/// All visitors are synchronous. A node is fully loaded before a visitor sees
+/// a borrowed slice, and the visitor returns before traversal can await again.
+#[cfg(feature = "async-store")]
+pub struct AsyncReadSession<'manager, 'tree, S: AsyncStore> {
+    manager: &'manager AsyncProlly<S>,
+    tree: &'tree Tree,
+    root: Option<Arc<Node>>,
+    recent_leaf: Option<Arc<Node>>,
+    local_nodes: SessionNodeTable,
+}
+
+impl<S: Store> Prolly<S> {
+    /// Open a reusable borrowed read session over an immutable tree.
+    pub fn read<'manager, 'tree>(
+        &'manager self,
+        tree: &'tree Tree,
+    ) -> Result<ReadSession<'manager, 'tree, S>, Error> {
+        if tree.config.format != self.config.format {
+            return Err(Error::FormatMismatch {
+                expected: self.config.format.digest()?,
+                actual: tree.config.format.digest()?,
+            });
+        }
+
+        let root = tree
+            .root
+            .as_ref()
+            .map(|cid| self.load_arc(cid))
+            .transpose()?;
+        if let Some(root) = root.as_ref() {
+            if root.format != tree.config.format {
+                return Err(Error::FormatMismatch {
+                    expected: tree.config.format.digest()?,
+                    actual: root.format.digest()?,
+                });
+            }
+        }
+
+        let recent_leaf_enabled = self
+            .node_cache
+            .read()
+            .is_ok_and(|cache| !cache.is_disabled());
+        let recent_leaf = recent_leaf_enabled
+            .then_some(tree.root.as_ref())
+            .flatten()
+            .and_then(|root_cid| {
+                self.recent_leaf.read().ok().and_then(|recent| {
+                    recent
+                        .as_ref()
+                        .filter(|entry| &entry.root == root_cid)
+                        .map(|entry| entry.node.clone())
+                })
+            });
+
+        Ok(ReadSession {
+            manager: self,
+            tree,
+            root,
+            recent_leaf,
+            local_nodes: SessionNodeTable::new(),
+        })
+    }
+
+    /// Read a value without allocating an owned result unless the callback does.
+    pub fn get_with<R>(
+        &self,
+        tree: &Tree,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error> {
+        if tree.config.format != self.config.format {
+            return Err(Error::FormatMismatch {
+                expected: self.config.format.digest()?,
+                actual: tree.config.format.digest()?,
+            });
+        }
+        let Some(root) = tree.root.as_ref() else {
+            return Ok(None);
+        };
+        let recent_leaf_enabled = self
+            .node_cache
+            .read()
+            .is_ok_and(|cache| !cache.is_disabled());
+        let recent_leaf = recent_leaf_enabled
+            .then(|| self.recent_leaf.read().ok())
+            .flatten()
+            .and_then(|recent| {
+                recent
+                    .as_ref()
+                    .filter(|entry| &entry.root == root)
+                    .map(|entry| entry.node.clone())
+            });
+        if let Some(leaf) = recent_leaf {
+            ReadSession::<S>::validate_leaf(&leaf)?;
+            if leaf
+                .keys
+                .first()
+                .zip(leaf.keys.last())
+                .is_some_and(|(first, last)| key >= first.as_slice() && key <= last.as_slice())
+            {
+                self.metrics.add_cache_hits(1);
+                return match leaf.search(key) {
+                    Ok(index) => Ok(Some(read(leaf.vals.get(index).ok_or(Error::InvalidNode)?))),
+                    Err(_) => Ok(None),
+                };
+            }
+        }
+        let mut session = self.read(tree)?;
+        let result = session.get_with(key, read);
+        if result.is_ok() {
+            if let (Some(root), Some(leaf)) = (tree.root.as_ref(), session.recent_leaf) {
+                self.maybe_cache_recent_leaf(root, leaf);
+            }
+        }
+        result
+    }
+
+    /// Check key membership without copying its value.
+    pub fn contains_key(&self, tree: &Tree, key: &[u8]) -> Result<bool, Error> {
+        Ok(self.get_with(tree, key, |_| ())?.is_some())
+    }
+
+    /// Inspect a stored large-value reference without copying inline bytes.
+    pub fn get_value_ref_with<R>(
+        &self,
+        tree: &Tree,
+        key: &[u8],
+        read: impl for<'value> FnOnce(ValueRefView<'value>) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.get_with(tree, key, |bytes| {
+            blob::value_ref_view_from_stored_bytes(bytes).map(read)
+        })?
+        .transpose()
+    }
+
+    /// Visit point-read results in caller order without owning hit values.
+    pub fn get_many_with<K, F>(&self, tree: &Tree, keys: &[K], visit: F) -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+        F: for<'value> FnMut(usize, &[u8], Option<&'value [u8]>),
+    {
+        self.read(tree)?.get_many_with(keys, visit)
+    }
+
+    /// Visit the entry at a zero-based ordinal without copying it.
+    pub fn select_with<R>(
+        &self,
+        tree: &Tree,
+        ordinal: u64,
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.read(tree)?.select_with(ordinal, read)
+    }
+
+    /// Visit the first entry without copying it.
+    pub fn first_entry_with<R>(
+        &self,
+        tree: &Tree,
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.read(tree)?.first_entry_with(read)
+    }
+
+    /// Visit the last entry without copying it.
+    pub fn last_entry_with<R>(
+        &self,
+        tree: &Tree,
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.read(tree)?.last_entry_with(read)
+    }
+
+    /// Visit the first entry with key greater than or equal to `key`.
+    pub fn lower_bound_with<R>(
+        &self,
+        tree: &Tree,
+        key: &[u8],
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.read(tree)?.lower_bound_with(key, read)
+    }
+
+    /// Visit the first entry with key strictly greater than `key`.
+    pub fn upper_bound_with<R>(
+        &self,
+        tree: &Tree,
+        key: &[u8],
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.read(tree)?.upper_bound_with(key, read)
+    }
+
+    /// Visit a half-open range in ascending key order.
+    pub fn scan_range(
+        &self,
+        tree: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        self.read(tree)?.scan_range(start, end, visit)
+    }
+
+    /// Visit a half-open range in ascending order with early termination.
+    pub fn scan_range_until<B>(
+        &self,
+        tree: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.read(tree)?.scan_range_until(start, end, visit)
+    }
+
+    /// Visit every entry under `prefix` in ascending key order.
+    pub fn scan_prefix(
+        &self,
+        tree: &Tree,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        self.read(tree)?.scan_prefix(prefix, visit)
+    }
+
+    /// Visit every entry under `prefix` with early termination.
+    pub fn scan_prefix_until<B>(
+        &self,
+        tree: &Tree,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.read(tree)?.scan_prefix_until(prefix, visit)
+    }
+
+    /// Visit a half-open range in descending key order.
+    pub fn scan_range_reverse(
+        &self,
+        tree: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        self.read(tree)?.scan_range_reverse(start, end, visit)
+    }
+
+    /// Visit a half-open descending range with early termination.
+    pub fn scan_range_reverse_until<B>(
+        &self,
+        tree: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.read(tree)?.scan_range_reverse_until(start, end, visit)
+    }
+
+    /// Visit a prefix in descending key order.
+    pub fn scan_prefix_reverse(
+        &self,
+        tree: &Tree,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        self.read(tree)?.scan_prefix_reverse(prefix, visit)
+    }
+
+    /// Visit a descending prefix with early termination.
+    pub fn scan_prefix_reverse_until<B>(
+        &self,
+        tree: &Tree,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.read(tree)?.scan_prefix_reverse_until(prefix, visit)
+    }
+}
+
+impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
+    /// The immutable tree bound to this session.
+    pub fn tree(&self) -> &Tree {
+        self.tree
+    }
+
+    /// Return the number of logical entries using the retained root.
+    pub fn len(&self) -> Result<u64, Error> {
+        let Some(root) = self.root.as_ref() else {
+            return Ok(0);
+        };
+        if root.leaf {
+            return Ok(root.len() as u64);
+        }
+        if root.child_counts.len() == root.len() && !root.child_counts.contains(&0) {
+            return Ok(root.child_counts.iter().copied().sum());
+        }
+        self.manager.subtree_count(
+            self.tree
+                .root
+                .as_ref()
+                .expect("a retained root has a tree root CID"),
+        )
+    }
+
+    /// Return whether the bound tree contains no entries.
+    pub fn is_empty(&self) -> Result<bool, Error> {
+        Ok(self.len()? == 0)
+    }
+
+    /// Return the number of keys strictly less than `key`.
+    pub fn rank(&mut self, key: &[u8]) -> Result<u64, Error> {
+        let Some(mut node) = self.root.clone() else {
+            return Ok(0);
+        };
+        let mut rank = 0u64;
+        loop {
+            if node.leaf {
+                Self::validate_leaf(&node)?;
+                return Ok(rank.saturating_add(
+                    node.keys
+                        .partition_point(|candidate| candidate.as_slice() < key)
+                        as u64,
+                ));
+            }
+            Self::validate_internal(&node)?;
+            let insertion = node
+                .keys
+                .partition_point(|candidate| candidate.as_slice() <= key);
+            if insertion == 0 {
+                return Ok(rank);
+            }
+            let child_index = insertion - 1;
+            for index in 0..child_index {
+                rank = rank.saturating_add(self.child_count(&node, index)?);
+            }
+            node = self.manager.load_arc(&child_cid_at(&node, child_index)?)?;
+        }
+    }
+
+    /// Read a value without copying it.
+    pub fn get_with<R>(
+        &mut self,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error> {
+        if let Some(leaf) = self.recent_leaf.as_ref() {
+            Self::validate_leaf(leaf)?;
+            if leaf
+                .keys
+                .first()
+                .zip(leaf.keys.last())
+                .is_some_and(|(first, last)| key >= first.as_slice() && key <= last.as_slice())
+            {
+                return match leaf.search(key) {
+                    Ok(index) => Ok(Some(read(leaf.vals.get(index).ok_or(Error::InvalidNode)?))),
+                    Err(_) => Ok(None),
+                };
+            }
+        }
+
+        let Some(mut node) = self.root.clone() else {
+            return Ok(None);
+        };
+        loop {
+            let index = Self::route_index(&node, key)?;
+            if node.leaf {
+                self.recent_leaf = Some(node.clone());
+                return if node.keys.get(index).map(Vec::as_slice) == Some(key) {
+                    Ok(Some(read(node.vals.get(index).ok_or(Error::InvalidNode)?)))
+                } else {
+                    Ok(None)
+                };
+            }
+            let cid = child_cid_at(&node, index)?;
+            node = match self.local_nodes.get(&cid) {
+                Some(node) => node,
+                None => {
+                    let node = self.manager.load_arc(&cid)?;
+                    self.local_nodes.insert(cid, &node);
+                    node
+                }
+            };
+        }
+    }
+
+    /// Inspect a stored large-value envelope without copying inline bytes.
+    pub fn get_value_ref_with<R>(
+        &mut self,
+        key: &[u8],
+        read: impl for<'value> FnOnce(ValueRefView<'value>) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.get_with(key, |bytes| {
+            blob::value_ref_view_from_stored_bytes(bytes).map(read)
+        })?
+        .transpose()
+    }
+
+    /// Check membership without copying the value.
+    pub fn contains_key(&mut self, key: &[u8]) -> Result<bool, Error> {
+        Ok(self.get_with(key, |_| ())?.is_some())
+    }
+
+    /// Visit point-read results exactly once per input position and in order.
+    pub fn get_many_with<K, F>(&mut self, keys: &[K], mut visit: F) -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+        F: for<'value> FnMut(usize, &[u8], Option<&'value [u8]>),
+    {
+        if keys.is_empty() {
+            return Ok(());
+        }
+        let Some(root) = self.root.clone() else {
+            for (position, key) in keys.iter().enumerate() {
+                visit(position, key.as_ref(), None);
+            }
+            return Ok(());
+        };
+
+        let positions = InlinePositions::from_vec(sorted_key_positions(keys))
+            .expect("keys are non-empty after early return");
+        let mut frames = vec![(root, positions)];
+        let mut locations: Vec<Option<(Arc<Node>, usize)>> = vec![None; keys.len()];
+
+        while !frames.is_empty() {
+            let mut children = Vec::new();
+            for (node, positions) in frames {
+                if node.leaf {
+                    Self::fill_leaf_locations(node, positions, keys, &mut locations)?;
+                } else {
+                    children.extend(route_key_positions_to_children(&node, positions, keys)?);
+                }
+            }
+            if children.is_empty() {
+                break;
+            }
+            let cids = children
+                .iter()
+                .map(|frame| frame.cid.clone())
+                .collect::<Vec<_>>();
+            let nodes = if self.manager.store.prefers_batch_reads() {
+                self.manager
+                    .load_many_ordered_with_parallelism(&cids, GET_MANY_PREFETCH_PARALLELISM)?
+            } else {
+                self.manager.load_many_ordered(&cids)?
+            };
+            frames = children
+                .into_iter()
+                .zip(nodes)
+                .map(|(frame, node)| (node, frame.positions))
+                .collect();
+        }
+
+        for (position, key) in keys.iter().enumerate() {
+            let value = match locations[position].as_ref() {
+                Some((node, index)) => {
+                    Some(node.vals.get(*index).ok_or(Error::InvalidNode)?.as_slice())
+                }
+                None => None,
+            };
+            visit(position, key.as_ref(), value);
+        }
+        Ok(())
+    }
+
+    /// Visit the zero-based entry at `ordinal` without copying it.
+    pub fn select_with<R>(
+        &mut self,
+        mut ordinal: u64,
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error> {
+        let Some(mut node) = self.root.clone() else {
+            return Ok(None);
+        };
+        loop {
+            if node.leaf {
+                Self::validate_leaf(&node)?;
+                let index = usize::try_from(ordinal).map_err(|_| Error::InvalidNode)?;
+                let Some(key) = node.keys.get(index) else {
+                    return Ok(None);
+                };
+                let value = node.vals.get(index).ok_or(Error::InvalidNode)?;
+                return Ok(Some(read(EntryRef::new(key, value))));
+            }
+            Self::validate_internal(&node)?;
+            let mut selected = None;
+            for index in 0..node.len() {
+                let count = self.child_count(&node, index)?;
+                if ordinal < count {
+                    selected = Some(index);
+                    break;
+                }
+                ordinal -= count;
+            }
+            let Some(index) = selected else {
+                return Ok(None);
+            };
+            node = self.manager.load_arc(&child_cid_at(&node, index)?)?;
+        }
+    }
+
+    /// Visit the first entry in key order.
+    pub fn first_entry_with<R>(
+        &mut self,
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.lower_bound_with(&[], read)
+    }
+
+    /// Visit the last entry in key order.
+    pub fn last_entry_with<R>(
+        &mut self,
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error> {
+        let mut read = Some(read);
+        let outcome = self.scan_range_reverse_until(&[], None, |entry| {
+            ControlFlow::Break(read.take().expect("single-entry callback")(entry))
+        })?;
+        Ok(outcome.break_value)
+    }
+
+    /// Visit the first entry whose key is at least `key`.
+    pub fn lower_bound_with<R>(
+        &mut self,
+        key: &[u8],
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error> {
+        let mut read = Some(read);
+        let outcome = self.scan_forward_until(key, None, false, |entry| {
+            ControlFlow::Break(read.take().expect("single-entry callback")(entry))
+        })?;
+        Ok(outcome.break_value)
+    }
+
+    /// Visit the first entry whose key is strictly greater than `key`.
+    pub fn upper_bound_with<R>(
+        &mut self,
+        key: &[u8],
+        read: impl for<'entry> FnOnce(EntryRef<'entry>) -> R,
+    ) -> Result<Option<R>, Error> {
+        let mut read = Some(read);
+        let outcome = self.scan_forward_until(key, None, true, |entry| {
+            ControlFlow::Break(read.take().expect("single-entry callback")(entry))
+        })?;
+        Ok(outcome.break_value)
+    }
+
+    /// Visit a half-open range in ascending order.
+    pub fn scan_range(
+        &mut self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        mut visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_range_until(start, end, |entry| {
+                visit(entry);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    /// Visit a half-open range in ascending order with early termination.
+    pub fn scan_range_until<B>(
+        &mut self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.scan_forward_until(start, end, false, visit)
+    }
+
+    /// Visit all entries under `prefix` in ascending order.
+    pub fn scan_prefix(
+        &mut self,
+        prefix: &[u8],
+        mut visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_prefix_until(prefix, |entry| {
+                visit(entry);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    /// Visit all entries under `prefix` with early termination.
+    pub fn scan_prefix_until<B>(
+        &mut self,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        let (start, end) = key::prefix_range(prefix);
+        self.scan_range_until(&start, end.as_deref(), visit)
+    }
+
+    /// Visit a half-open range in descending order.
+    pub fn scan_range_reverse(
+        &mut self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        mut visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_range_reverse_until(start, end, |entry| {
+                visit(entry);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    /// Visit a half-open range in descending order with early termination.
+    pub fn scan_range_reverse_until<B>(
+        &mut self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        mut visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        if end.is_some_and(|end| end <= start) {
+            return Ok(ScanOutcome::complete(0));
+        }
+        let mut stack = self.seek_reverse(end)?;
+        let mut visited = 0u64;
+
+        loop {
+            let Some(frame) = stack.last_mut() else {
+                return Ok(ScanOutcome::complete(visited));
+            };
+            if !frame.node.leaf {
+                return Err(Error::InvalidNode);
+            }
+            Self::validate_leaf(&frame.node)?;
+            let key = frame.node.keys.get(frame.index).ok_or(Error::InvalidNode)?;
+            if key.as_slice() < start {
+                return Ok(ScanOutcome::complete(visited));
+            }
+            let value = frame.node.vals.get(frame.index).ok_or(Error::InvalidNode)?;
+            visited = visited.saturating_add(1);
+            if let ControlFlow::Break(value) = visit(EntryRef::new(key, value)) {
+                return Ok(ScanOutcome::stopped(visited, value));
+            }
+            if frame.index > 0 {
+                frame.index -= 1;
+            } else if !Self::advance_reverse(self.manager, &mut stack)? {
+                return Ok(ScanOutcome::complete(visited));
+            }
+        }
+    }
+
+    /// Visit a prefix in descending order.
+    pub fn scan_prefix_reverse(
+        &mut self,
+        prefix: &[u8],
+        mut visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_prefix_reverse_until(prefix, |entry| {
+                visit(entry);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    /// Visit a prefix in descending order with early termination.
+    pub fn scan_prefix_reverse_until<B>(
+        &mut self,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        let (start, end) = key::prefix_range(prefix);
+        self.scan_range_reverse_until(&start, end.as_deref(), visit)
+    }
+
+    fn scan_forward_until<B>(
+        &mut self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        strict_start: bool,
+        mut visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        if end.is_some_and(|end| end <= start) {
+            return Ok(ScanOutcome::complete(0));
+        }
+        let mut stack = self.seek_forward(start, strict_start)?;
+        let mut visited = 0u64;
+
+        loop {
+            let Some(frame) = stack.last_mut() else {
+                return Ok(ScanOutcome::complete(visited));
+            };
+            if !frame.node.leaf {
+                return Err(Error::InvalidNode);
+            }
+            Self::validate_leaf(&frame.node)?;
+            if frame.index >= frame.node.len() {
+                if !Self::advance_forward(self.manager, &mut stack)? {
+                    return Ok(ScanOutcome::complete(visited));
+                }
+                continue;
+            }
+            let key = frame.node.keys.get(frame.index).ok_or(Error::InvalidNode)?;
+            if end.is_some_and(|end| key.as_slice() >= end) {
+                return Ok(ScanOutcome::complete(visited));
+            }
+            let value = frame.node.vals.get(frame.index).ok_or(Error::InvalidNode)?;
+            frame.index += 1;
+            visited = visited.saturating_add(1);
+            if let ControlFlow::Break(value) = visit(EntryRef::new(key, value)) {
+                return Ok(ScanOutcome::stopped(visited, value));
+            }
+        }
+    }
+
+    fn seek_forward(&self, key: &[u8], strict: bool) -> Result<Vec<PathFrame>, Error> {
+        let Some(mut node) = self.root.clone() else {
+            return Ok(Vec::new());
+        };
+        let mut stack = Vec::new();
+        loop {
+            if node.leaf {
+                Self::validate_leaf(&node)?;
+                let index = if strict {
+                    node.keys
+                        .partition_point(|candidate| candidate.as_slice() <= key)
+                } else {
+                    node.keys
+                        .partition_point(|candidate| candidate.as_slice() < key)
+                };
+                stack.push(PathFrame { node, index });
+                return Ok(stack);
+            }
+            Self::validate_internal(&node)?;
+            let index = node
+                .keys
+                .partition_point(|candidate| candidate.as_slice() <= key)
+                .saturating_sub(1);
+            let cid = child_cid_at(&node, index)?;
+            stack.push(PathFrame { node, index });
+            node = self.manager.load_arc(&cid)?;
+        }
+    }
+
+    fn seek_reverse(&self, end: Option<&[u8]>) -> Result<Vec<PathFrame>, Error> {
+        let Some(mut node) = self.root.clone() else {
+            return Ok(Vec::new());
+        };
+        let mut stack = Vec::new();
+        loop {
+            if node.leaf {
+                Self::validate_leaf(&node)?;
+                let exclusive = match end {
+                    Some(end) => node
+                        .keys
+                        .partition_point(|candidate| candidate.as_slice() < end),
+                    None => node.len(),
+                };
+                if exclusive == 0 {
+                    return Ok(Vec::new());
+                }
+                stack.push(PathFrame {
+                    node,
+                    index: exclusive - 1,
+                });
+                return Ok(stack);
+            }
+            Self::validate_internal(&node)?;
+            let exclusive = match end {
+                Some(end) => node
+                    .keys
+                    .partition_point(|candidate| candidate.as_slice() < end),
+                None => node.len(),
+            };
+            if exclusive == 0 {
+                return Ok(Vec::new());
+            }
+            let index = exclusive - 1;
+            let cid = child_cid_at(&node, index)?;
+            stack.push(PathFrame { node, index });
+            node = self.manager.load_arc(&cid)?;
+        }
+    }
+
+    fn advance_forward(manager: &Prolly<S>, stack: &mut Vec<PathFrame>) -> Result<bool, Error> {
+        stack.pop();
+        while let Some(parent) = stack.last_mut() {
+            Self::validate_internal(&parent.node)?;
+            parent.index += 1;
+            if parent.index >= parent.node.len() {
+                stack.pop();
+                continue;
+            }
+            let cid = child_cid_at(&parent.node, parent.index)?;
+            let mut node = manager.load_arc(&cid)?;
+            loop {
+                if node.leaf {
+                    Self::validate_leaf(&node)?;
+                    stack.push(PathFrame { node, index: 0 });
+                    return Ok(true);
+                }
+                Self::validate_internal(&node)?;
+                let cid = child_cid_at(&node, 0)?;
+                stack.push(PathFrame { node, index: 0 });
+                node = manager.load_arc(&cid)?;
+            }
+        }
+        Ok(false)
+    }
+
+    fn advance_reverse(manager: &Prolly<S>, stack: &mut Vec<PathFrame>) -> Result<bool, Error> {
+        stack.pop();
+        while let Some(parent) = stack.last_mut() {
+            Self::validate_internal(&parent.node)?;
+            if parent.index == 0 {
+                stack.pop();
+                continue;
+            }
+            parent.index -= 1;
+            let cid = child_cid_at(&parent.node, parent.index)?;
+            let mut node = manager.load_arc(&cid)?;
+            loop {
+                if node.leaf {
+                    Self::validate_leaf(&node)?;
+                    let index = node.len().checked_sub(1).ok_or(Error::InvalidNode)?;
+                    stack.push(PathFrame { node, index });
+                    return Ok(true);
+                }
+                Self::validate_internal(&node)?;
+                let index = node.len().checked_sub(1).ok_or(Error::InvalidNode)?;
+                let cid = child_cid_at(&node, index)?;
+                stack.push(PathFrame { node, index });
+                node = manager.load_arc(&cid)?;
+            }
+        }
+        Ok(false)
+    }
+
+    fn route_index(node: &Node, key: &[u8]) -> Result<usize, Error> {
+        if node.leaf {
+            Self::validate_leaf(node)?;
+        } else {
+            Self::validate_internal(node)?;
+        }
+        Ok(match node.search(key) {
+            Ok(index) => index,
+            Err(index) => index.saturating_sub(1),
+        })
+    }
+
+    fn validate_leaf(node: &Node) -> Result<(), Error> {
+        if !node.leaf || node.keys.len() != node.vals.len() {
+            return Err(Error::InvalidNode);
+        }
+        Ok(())
+    }
+
+    fn validate_internal(node: &Node) -> Result<(), Error> {
+        if node.leaf || node.keys.is_empty() || node.keys.len() != node.vals.len() {
+            return Err(Error::InvalidNode);
+        }
+        Ok(())
+    }
+
+    fn child_count(&self, node: &Node, index: usize) -> Result<u64, Error> {
+        match node.child_counts.get(index).copied() {
+            Some(count) if count > 0 => Ok(count),
+            _ => self.manager.subtree_count(&child_cid_at(node, index)?),
+        }
+    }
+
+    fn fill_leaf_locations<K: AsRef<[u8]>>(
+        node: Arc<Node>,
+        positions: InlinePositions,
+        keys: &[K],
+        locations: &mut [Option<(Arc<Node>, usize)>],
+    ) -> Result<(), Error> {
+        Self::validate_leaf(&node)?;
+        let mut leaf_index = 0usize;
+        let mut positions = positions.into_iter().peekable();
+        while let Some(position) = positions.next() {
+            let key = keys[position].as_ref();
+            while leaf_index < node.len() && node.keys[leaf_index].as_slice() < key {
+                leaf_index += 1;
+            }
+            let found = (leaf_index < node.len() && node.keys[leaf_index].as_slice() == key)
+                .then_some(leaf_index);
+            if let Some(index) = found {
+                locations[position] = Some((node.clone(), index));
+            }
+            while let Some(duplicate) =
+                positions.next_if(|candidate| keys[*candidate].as_ref() == key)
+            {
+                if let Some(index) = found {
+                    locations[duplicate] = Some((node.clone(), index));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "async-store")]
+impl<S> AsyncProlly<S>
+where
+    S: AsyncStore,
+    S::Error: Send + Sync,
+{
+    /// Open a reusable borrowed async read session over an immutable tree.
+    pub async fn read<'manager, 'tree>(
+        &'manager self,
+        tree: &'tree Tree,
+    ) -> Result<AsyncReadSession<'manager, 'tree, S>, Error> {
+        if tree.config.format != self.config().format {
+            return Err(Error::FormatMismatch {
+                expected: self.config().format.digest()?,
+                actual: tree.config.format.digest()?,
+            });
+        }
+        let root = tree.root.as_ref().map(|cid| self.load_arc(cid));
+        let root = match root {
+            Some(load) => Some(load.await?),
+            None => None,
+        };
+        if let Some(root) = root.as_ref() {
+            if root.format != tree.config.format {
+                return Err(Error::FormatMismatch {
+                    expected: tree.config.format.digest()?,
+                    actual: root.format.digest()?,
+                });
+            }
+        }
+        Ok(AsyncReadSession {
+            manager: self,
+            tree,
+            root,
+            recent_leaf: None,
+            local_nodes: SessionNodeTable::new(),
+        })
+    }
+
+    /// Read one async-store value without allocating an owned result.
+    pub async fn get_with<R>(
+        &self,
+        tree: &Tree,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.read(tree).await?.get_with(key, read).await
+    }
+
+    /// Inspect a stored large-value envelope without copying inline bytes.
+    pub async fn get_value_ref_with<R>(
+        &self,
+        tree: &Tree,
+        key: &[u8],
+        read: impl for<'value> FnOnce(ValueRefView<'value>) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.read(tree).await?.get_value_ref_with(key, read).await
+    }
+
+    /// Visit async point-read results exactly once per input position.
+    pub async fn get_many_with<K, F>(&self, tree: &Tree, keys: &[K], visit: F) -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+        F: for<'value> FnMut(usize, &[u8], Option<&'value [u8]>),
+    {
+        self.read(tree).await?.get_many_with(keys, visit).await
+    }
+
+    /// Visit an async half-open range without allocating entries.
+    pub async fn scan_range(
+        &self,
+        tree: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        self.read(tree).await?.scan_range(start, end, visit).await
+    }
+
+    pub async fn scan_range_until<B>(
+        &self,
+        tree: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.read(tree)
+            .await?
+            .scan_range_until(start, end, visit)
+            .await
+    }
+
+    /// Visit an async prefix without allocating entries.
+    pub async fn scan_prefix(
+        &self,
+        tree: &Tree,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        self.read(tree).await?.scan_prefix(prefix, visit).await
+    }
+
+    pub async fn scan_prefix_until<B>(
+        &self,
+        tree: &Tree,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.read(tree)
+            .await?
+            .scan_prefix_until(prefix, visit)
+            .await
+    }
+
+    pub async fn scan_range_reverse(
+        &self,
+        tree: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        self.read(tree)
+            .await?
+            .scan_range_reverse(start, end, visit)
+            .await
+    }
+
+    pub async fn scan_range_reverse_until<B>(
+        &self,
+        tree: &Tree,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.read(tree)
+            .await?
+            .scan_range_reverse_until(start, end, visit)
+            .await
+    }
+
+    pub async fn scan_prefix_reverse(
+        &self,
+        tree: &Tree,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        self.read(tree)
+            .await?
+            .scan_prefix_reverse(prefix, visit)
+            .await
+    }
+
+    pub async fn scan_prefix_reverse_until<B>(
+        &self,
+        tree: &Tree,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.read(tree)
+            .await?
+            .scan_prefix_reverse_until(prefix, visit)
+            .await
+    }
+}
+
+#[cfg(feature = "async-store")]
+impl<'manager, 'tree, S> AsyncReadSession<'manager, 'tree, S>
+where
+    S: AsyncStore,
+    S::Error: Send + Sync,
+{
+    /// Return the immutable tree bound to this session.
+    pub fn tree(&self) -> &Tree {
+        self.tree
+    }
+
+    /// Read a value after all required I/O and before any subsequent await.
+    pub async fn get_with<R>(
+        &mut self,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error> {
+        if let Some(leaf) = self.recent_leaf.as_ref() {
+            ReadSession::<super::store::MemStore>::validate_leaf(leaf)?;
+            if leaf
+                .keys
+                .first()
+                .zip(leaf.keys.last())
+                .is_some_and(|(first, last)| key >= first.as_slice() && key <= last.as_slice())
+            {
+                return match leaf.search(key) {
+                    Ok(index) => Ok(Some(read(leaf.vals.get(index).ok_or(Error::InvalidNode)?))),
+                    Err(_) => Ok(None),
+                };
+            }
+        }
+
+        let Some(mut node) = self.root.clone() else {
+            return Ok(None);
+        };
+        loop {
+            let index = async_route_index(&node, key)?;
+            if node.leaf {
+                self.recent_leaf = Some(node.clone());
+                return if node.keys.get(index).map(Vec::as_slice) == Some(key) {
+                    Ok(Some(read(node.vals.get(index).ok_or(Error::InvalidNode)?)))
+                } else {
+                    Ok(None)
+                };
+            }
+            let cid = child_cid_at(&node, index)?;
+            node = match self.local_nodes.get(&cid) {
+                Some(node) => node,
+                None => {
+                    let node = self.manager.load_arc(&cid).await?;
+                    self.local_nodes.insert(cid, &node);
+                    node
+                }
+            };
+        }
+    }
+
+    /// Inspect an async-store large-value envelope without copying inline data.
+    pub async fn get_value_ref_with<R>(
+        &mut self,
+        key: &[u8],
+        read: impl for<'value> FnOnce(ValueRefView<'value>) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.get_with(key, |bytes| {
+            blob::value_ref_view_from_stored_bytes(bytes).map(read)
+        })
+        .await?
+        .transpose()
+    }
+
+    /// Visit async multi-get results in input order without owning hit values.
+    pub async fn get_many_with<K, F>(&mut self, keys: &[K], mut visit: F) -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+        F: for<'value> FnMut(usize, &[u8], Option<&'value [u8]>),
+    {
+        if keys.is_empty() {
+            return Ok(());
+        }
+        let Some(root) = self.root.clone() else {
+            for (position, key) in keys.iter().enumerate() {
+                visit(position, key.as_ref(), None);
+            }
+            return Ok(());
+        };
+
+        let positions = InlinePositions::from_vec(sorted_key_positions(keys))
+            .expect("keys are non-empty after early return");
+        let mut frames = vec![(root, positions)];
+        let mut locations: Vec<Option<(Arc<Node>, usize)>> = vec![None; keys.len()];
+
+        while !frames.is_empty() {
+            let mut children = Vec::new();
+            for (node, positions) in frames {
+                if node.leaf {
+                    fill_async_leaf_locations(node, positions, keys, &mut locations)?;
+                } else {
+                    children.extend(route_key_positions_to_children(&node, positions, keys)?);
+                }
+            }
+            if children.is_empty() {
+                break;
+            }
+            let cids = children
+                .iter()
+                .map(|frame| frame.cid.clone())
+                .collect::<Vec<_>>();
+            let nodes = self.manager.load_child_frontier_ordered(&cids).await?;
+            frames = children
+                .into_iter()
+                .zip(nodes)
+                .map(|(frame, node)| (node, frame.positions))
+                .collect();
+        }
+
+        for (position, key) in keys.iter().enumerate() {
+            let value = locations[position]
+                .as_ref()
+                .map(|(node, index)| node.vals.get(*index).ok_or(Error::InvalidNode))
+                .transpose()?
+                .map(Vec::as_slice);
+            visit(position, key.as_ref(), value);
+        }
+        Ok(())
+    }
+
+    /// Visit a half-open range, never holding a borrowed entry across await.
+    pub async fn scan_range(
+        &mut self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        mut visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_range_until(start, end, |entry| {
+                visit(entry);
+                ControlFlow::<()>::Continue(())
+            })
+            .await?
+            .visited)
+    }
+
+    pub async fn scan_range_until<B>(
+        &mut self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        mut visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        let mut range = self.manager.range(self.tree, start, end).await?;
+        let mut visited = 0u64;
+        while let Some(result) = range.next_with(&mut visit).await {
+            visited = visited.saturating_add(1);
+            if let ControlFlow::Break(value) = result? {
+                return Ok(ScanOutcome::stopped(visited, value));
+            }
+        }
+        Ok(ScanOutcome::complete(visited))
+    }
+
+    /// Visit every key under a prefix without allocating entries.
+    pub async fn scan_prefix(
+        &mut self,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        let (start, end) = key::prefix_range(prefix);
+        self.scan_range(&start, end.as_deref(), visit).await
+    }
+
+    pub async fn scan_prefix_until<B>(
+        &mut self,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        let (start, end) = key::prefix_range(prefix);
+        self.scan_range_until(&start, end.as_deref(), visit).await
+    }
+
+    pub async fn scan_range_reverse(
+        &mut self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        mut visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_range_reverse_until(start, end, |entry| {
+                visit(entry);
+                ControlFlow::<()>::Continue(())
+            })
+            .await?
+            .visited)
+    }
+
+    pub async fn scan_range_reverse_until<B>(
+        &mut self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        mut visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        if end.is_some_and(|end| end <= start) {
+            return Ok(ScanOutcome::complete(0));
+        }
+        let mut stack = self.seek_reverse(end).await?;
+        let mut visited = 0u64;
+        loop {
+            let Some(frame) = stack.last_mut() else {
+                return Ok(ScanOutcome::complete(visited));
+            };
+            if !frame.node.leaf || frame.node.keys.len() != frame.node.vals.len() {
+                return Err(Error::InvalidNode);
+            }
+            let key = frame.node.keys.get(frame.index).ok_or(Error::InvalidNode)?;
+            if key.as_slice() < start {
+                return Ok(ScanOutcome::complete(visited));
+            }
+            let value = frame.node.vals.get(frame.index).ok_or(Error::InvalidNode)?;
+            visited = visited.saturating_add(1);
+            if let ControlFlow::Break(value) = visit(EntryRef::new(key, value)) {
+                return Ok(ScanOutcome::stopped(visited, value));
+            }
+            if frame.index > 0 {
+                frame.index -= 1;
+            } else if !self.advance_reverse(&mut stack).await? {
+                return Ok(ScanOutcome::complete(visited));
+            }
+        }
+    }
+
+    pub async fn scan_prefix_reverse(
+        &mut self,
+        prefix: &[u8],
+        mut visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_prefix_reverse_until(prefix, |entry| {
+                visit(entry);
+                ControlFlow::<()>::Continue(())
+            })
+            .await?
+            .visited)
+    }
+
+    pub async fn scan_prefix_reverse_until<B>(
+        &mut self,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        let (start, end) = key::prefix_range(prefix);
+        self.scan_range_reverse_until(&start, end.as_deref(), visit)
+            .await
+    }
+
+    async fn seek_reverse(&self, end: Option<&[u8]>) -> Result<Vec<PathFrame>, Error> {
+        let Some(mut node) = self.root.clone() else {
+            return Ok(Vec::new());
+        };
+        let mut stack = Vec::new();
+        loop {
+            if node.leaf {
+                if node.keys.len() != node.vals.len() {
+                    return Err(Error::InvalidNode);
+                }
+                let exclusive = match end {
+                    Some(end) => node
+                        .keys
+                        .partition_point(|candidate| candidate.as_slice() < end),
+                    None => node.len(),
+                };
+                if exclusive == 0 {
+                    return Ok(Vec::new());
+                }
+                stack.push(PathFrame {
+                    node,
+                    index: exclusive - 1,
+                });
+                return Ok(stack);
+            }
+            if node.keys.is_empty() || node.keys.len() != node.vals.len() {
+                return Err(Error::InvalidNode);
+            }
+            let exclusive = match end {
+                Some(end) => node
+                    .keys
+                    .partition_point(|candidate| candidate.as_slice() < end),
+                None => node.len(),
+            };
+            if exclusive == 0 {
+                return Ok(Vec::new());
+            }
+            let index = exclusive - 1;
+            let cid = child_cid_at(&node, index)?;
+            stack.push(PathFrame { node, index });
+            node = self.manager.load_arc(&cid).await?;
+        }
+    }
+
+    async fn advance_reverse(&self, stack: &mut Vec<PathFrame>) -> Result<bool, Error> {
+        stack.pop();
+        while let Some(parent) = stack.last_mut() {
+            if parent.node.leaf
+                || parent.node.keys.is_empty()
+                || parent.node.keys.len() != parent.node.vals.len()
+            {
+                return Err(Error::InvalidNode);
+            }
+            if parent.index == 0 {
+                stack.pop();
+                continue;
+            }
+            parent.index -= 1;
+            let cid = child_cid_at(&parent.node, parent.index)?;
+            let mut node = self.manager.load_arc(&cid).await?;
+            loop {
+                if node.leaf {
+                    if node.keys.len() != node.vals.len() {
+                        return Err(Error::InvalidNode);
+                    }
+                    let index = node.len().checked_sub(1).ok_or(Error::InvalidNode)?;
+                    stack.push(PathFrame { node, index });
+                    return Ok(true);
+                }
+                if node.keys.is_empty() || node.keys.len() != node.vals.len() {
+                    return Err(Error::InvalidNode);
+                }
+                let index = node.len() - 1;
+                let cid = child_cid_at(&node, index)?;
+                stack.push(PathFrame { node, index });
+                node = self.manager.load_arc(&cid).await?;
+            }
+        }
+        Ok(false)
+    }
+}
+
+#[cfg(feature = "async-store")]
+fn async_route_index(node: &Node, key: &[u8]) -> Result<usize, Error> {
+    if node.leaf {
+        if node.keys.len() != node.vals.len() {
+            return Err(Error::InvalidNode);
+        }
+    } else if node.keys.is_empty() || node.keys.len() != node.vals.len() {
+        return Err(Error::InvalidNode);
+    }
+    Ok(match node.search(key) {
+        Ok(index) => index,
+        Err(index) => index.saturating_sub(1),
+    })
+}
+
+#[cfg(feature = "async-store")]
+fn fill_async_leaf_locations<K: AsRef<[u8]>>(
+    node: Arc<Node>,
+    positions: InlinePositions,
+    keys: &[K],
+    locations: &mut [Option<(Arc<Node>, usize)>],
+) -> Result<(), Error> {
+    if !node.leaf || node.keys.len() != node.vals.len() {
+        return Err(Error::InvalidNode);
+    }
+    let mut leaf_index = 0usize;
+    let mut positions = positions.into_iter().peekable();
+    while let Some(position) = positions.next() {
+        let key = keys[position].as_ref();
+        while leaf_index < node.len() && node.keys[leaf_index].as_slice() < key {
+            leaf_index += 1;
+        }
+        let found = (leaf_index < node.len() && node.keys[leaf_index].as_slice() == key)
+            .then_some(leaf_index);
+        if let Some(index) = found {
+            locations[position] = Some((node.clone(), index));
+        }
+        while let Some(duplicate) = positions.next_if(|candidate| keys[*candidate].as_ref() == key)
+        {
+            if let Some(index) = found {
+                locations[duplicate] = Some((node.clone(), index));
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/prolly/read.rs
+++ b/src/prolly/read.rs
@@ -6,23 +6,20 @@
 //! synchronous callback. Existing owned APIs remain compatibility wrappers.
 
 use std::ops::ControlFlow;
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
 use super::blob;
 use super::cid::Cid;
 use super::error::{Conflict, Diff, Error};
 use super::key;
-use super::node::Node;
+use super::node::ReadNode;
 #[cfg(feature = "async-store")]
 use super::store::AsyncStore;
 use super::store::Store;
 use super::tree::Tree;
 #[cfg(feature = "async-store")]
 use super::AsyncProlly;
-use super::{
-    child_cid_at, route_key_positions_to_children, sorted_key_positions, InlinePositions, KeyValue,
-    Prolly, GET_MANY_PREFETCH_PARALLELISM,
-};
+use super::{sorted_key_positions, InlinePositions, KeyLookupFrame, KeyValue, Prolly};
 
 /// A callback-scoped borrowed key/value entry.
 ///
@@ -187,17 +184,52 @@ pub trait BorrowedMergeResolver: Send + Sync {
 }
 
 struct PathFrame {
-    node: Arc<Node>,
+    node: Arc<ReadNode>,
     index: usize,
 }
 
+/// Retained location of one value in an immutable packed leaf.
+///
+/// This is crate-private so higher-level engines such as proximity reranking
+/// can keep a bounded shortlist without copying application values. The value
+/// borrow is tied to `&self`; eviction of the shared cache cannot invalidate it.
+#[derive(Clone, Debug)]
+pub(crate) struct ReadValueHandle {
+    node: Arc<ReadNode>,
+    index: usize,
+}
+
+impl ReadValueHandle {
+    #[inline]
+    pub(crate) fn key(&self) -> Result<&[u8], Error> {
+        self.node.key(self.index).ok_or(Error::InvalidNode)
+    }
+
+    #[inline]
+    pub(crate) fn value(&self) -> Result<&[u8], Error> {
+        self.node.value(self.index).ok_or(Error::InvalidNode)
+    }
+
+    #[inline]
+    pub(crate) fn retained_bytes(&self) -> usize {
+        self.node.retained_bytes()
+    }
+
+    #[inline]
+    pub(crate) fn backing_id(&self) -> usize {
+        Arc::as_ptr(&self.node) as usize
+    }
+}
+
 // A fixed-size, direct-mapped table keeps hot route nodes out of the shared
-// cache lock without becoming a second unbounded cache. Weak references mean
-// a session never prevents normal cache eviction.
-const SESSION_NODE_SLOTS: usize = 1024;
+// cache lock without becoming a second unbounded cache. Strong handles avoid
+// a weak-count compare/exchange on every routed node while the fixed slot count
+// keeps session retention strictly bounded.
+const SESSION_NODE_SLOTS: usize = 4096;
 const SESSION_NODE_WAYS: usize = 4;
+const RECENT_LEAF_DISABLE_AFTER_MISSES: u8 = 8;
 const SESSION_NODE_SETS: usize = SESSION_NODE_SLOTS / SESSION_NODE_WAYS;
-type SessionNodeSlot = Option<(Cid, Weak<Node>)>;
+type SessionNodeSlot = Option<(Cid, Arc<ReadNode>)>;
 
 struct SessionNodeTable {
     slots: Box<[SessionNodeSlot]>,
@@ -205,6 +237,15 @@ struct SessionNodeTable {
 }
 
 impl SessionNodeTable {
+    #[inline]
+    fn prefix(cid: &Cid) -> u64 {
+        u64::from_ne_bytes(
+            cid.as_bytes()[..8]
+                .try_into()
+                .expect("CID has a fixed 32-byte representation"),
+        )
+    }
+
     fn new() -> Self {
         Self {
             slots: std::iter::repeat_with(|| None)
@@ -216,26 +257,22 @@ impl SessionNodeTable {
 
     #[inline]
     fn set(cid: &Cid) -> usize {
-        let prefix = u64::from_ne_bytes(
-            cid.as_bytes()[..8]
-                .try_into()
-                .expect("CID has a fixed 32-byte representation"),
-        );
-        prefix as usize & (SESSION_NODE_SETS - 1)
+        Self::prefix(cid) as usize & (SESSION_NODE_SETS - 1)
     }
 
     #[inline]
-    fn get(&self, cid: &Cid) -> Option<Arc<Node>> {
+    fn get(&self, cid: &Cid) -> Option<Arc<ReadNode>> {
         let start = Self::set(cid) * SESSION_NODE_WAYS;
+        let prefix = Self::prefix(cid);
         self.slots[start..start + SESSION_NODE_WAYS]
             .iter()
             .flatten()
-            .find(|(cached, _)| cached == cid)
-            .and_then(|(_, node)| node.upgrade())
+            .find(|(cached, _)| Self::prefix(cached) == prefix && cached == cid)
+            .map(|(_, node)| node.clone())
     }
 
     #[inline]
-    fn insert(&mut self, cid: Cid, node: &Arc<Node>) {
+    fn insert(&mut self, cid: Cid, node: &Arc<ReadNode>) {
         let set = Self::set(&cid);
         let start = set * SESSION_NODE_WAYS;
         let ways = &mut self.slots[start..start + SESSION_NODE_WAYS];
@@ -248,7 +285,7 @@ impl SessionNodeTable {
                 self.next_way[set] = ((way + 1) % SESSION_NODE_WAYS) as u8;
                 way
             });
-        ways[slot] = Some((cid, Arc::downgrade(node)));
+        ways[slot] = Some((cid, node.clone()));
     }
 }
 
@@ -260,8 +297,10 @@ impl SessionNodeTable {
 pub struct ReadSession<'manager, 'tree, S: Store> {
     manager: &'manager Prolly<S>,
     tree: &'tree Tree,
-    root: Option<Arc<Node>>,
-    recent_leaf: Option<Arc<Node>>,
+    root: Option<Arc<ReadNode>>,
+    recent_leaf: Option<Arc<ReadNode>>,
+    recent_leaf_misses: u8,
+    recent_leaf_disabled: bool,
     local_nodes: SessionNodeTable,
 }
 
@@ -273,8 +312,10 @@ pub struct ReadSession<'manager, 'tree, S: Store> {
 pub struct AsyncReadSession<'manager, 'tree, S: AsyncStore> {
     manager: &'manager AsyncProlly<S>,
     tree: &'tree Tree,
-    root: Option<Arc<Node>>,
-    recent_leaf: Option<Arc<Node>>,
+    root: Option<Arc<ReadNode>>,
+    recent_leaf: Option<Arc<ReadNode>>,
+    recent_leaf_misses: u8,
+    recent_leaf_disabled: bool,
     local_nodes: SessionNodeTable,
 }
 
@@ -294,13 +335,13 @@ impl<S: Store> Prolly<S> {
         let root = tree
             .root
             .as_ref()
-            .map(|cid| self.load_arc(cid))
+            .map(|cid| self.load_read_arc(cid))
             .transpose()?;
         if let Some(root) = root.as_ref() {
-            if root.format != tree.config.format {
+            if root.format() != &tree.config.format {
                 return Err(Error::FormatMismatch {
                     expected: tree.config.format.digest()?,
-                    actual: root.format.digest()?,
+                    actual: root.format().digest()?,
                 });
             }
         }
@@ -326,6 +367,8 @@ impl<S: Store> Prolly<S> {
             tree,
             root,
             recent_leaf,
+            recent_leaf_misses: 0,
+            recent_leaf_disabled: false,
             local_nodes: SessionNodeTable::new(),
         })
     }
@@ -362,14 +405,13 @@ impl<S: Store> Prolly<S> {
         if let Some(leaf) = recent_leaf {
             ReadSession::<S>::validate_leaf(&leaf)?;
             if leaf
-                .keys
-                .first()
-                .zip(leaf.keys.last())
-                .is_some_and(|(first, last)| key >= first.as_slice() && key <= last.as_slice())
+                .key(0)
+                .zip(leaf.key(leaf.len().saturating_sub(1)))
+                .is_some_and(|(first, last)| key >= first && key <= last)
             {
                 self.metrics.add_cache_hits(1);
                 return match leaf.search(key) {
-                    Ok(index) => Ok(Some(read(leaf.vals.get(index).ok_or(Error::InvalidNode)?))),
+                    Ok(index) => Ok(Some(read(leaf.value(index).ok_or(Error::InvalidNode)?))),
                     Err(_) => Ok(None),
                 };
             }
@@ -555,11 +597,13 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
         let Some(root) = self.root.as_ref() else {
             return Ok(0);
         };
-        if root.leaf {
+        if root.is_leaf() {
             return Ok(root.len() as u64);
         }
-        if root.child_counts.len() == root.len() && !root.child_counts.contains(&0) {
-            return Ok(root.child_counts.iter().copied().sum());
+        if (0..root.len()).all(|index| root.child_count(index).is_some_and(|count| count > 0)) {
+            return Ok((0..root.len())
+                .map(|index| root.child_count(index).expect("checked child count"))
+                .sum());
         }
         self.manager.subtree_count(
             self.tree
@@ -581,18 +625,13 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
         };
         let mut rank = 0u64;
         loop {
-            if node.leaf {
+            if node.is_leaf() {
                 Self::validate_leaf(&node)?;
-                return Ok(rank.saturating_add(
-                    node.keys
-                        .partition_point(|candidate| candidate.as_slice() < key)
-                        as u64,
-                ));
+                let insertion = packed_partition_point(&node, |candidate| candidate < key);
+                return Ok(rank.saturating_add(insertion as u64));
             }
             Self::validate_internal(&node)?;
-            let insertion = node
-                .keys
-                .partition_point(|candidate| candidate.as_slice() <= key);
+            let insertion = packed_partition_point(&node, |candidate| candidate <= key);
             if insertion == 0 {
                 return Ok(rank);
             }
@@ -600,7 +639,7 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
             for index in 0..child_index {
                 rank = rank.saturating_add(self.child_count(&node, index)?);
             }
-            node = self.manager.load_arc(&child_cid_at(&node, child_index)?)?;
+            node = self.manager.load_read_arc(&node.child_cid(child_index)?)?;
         }
     }
 
@@ -610,18 +649,28 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
         key: &[u8],
         read: impl FnOnce(&[u8]) -> R,
     ) -> Result<Option<R>, Error> {
-        if let Some(leaf) = self.recent_leaf.as_ref() {
+        if let Some(leaf) = self
+            .recent_leaf
+            .as_ref()
+            .filter(|_| !self.recent_leaf_disabled)
+        {
             Self::validate_leaf(leaf)?;
             if leaf
-                .keys
-                .first()
-                .zip(leaf.keys.last())
-                .is_some_and(|(first, last)| key >= first.as_slice() && key <= last.as_slice())
+                .key(0)
+                .zip(leaf.key(leaf.len().saturating_sub(1)))
+                .is_some_and(|(first, last)| key >= first && key <= last)
             {
+                self.recent_leaf_misses = 0;
                 return match leaf.search(key) {
-                    Ok(index) => Ok(Some(read(leaf.vals.get(index).ok_or(Error::InvalidNode)?))),
+                    Ok(index) => Ok(Some(read(leaf.value(index).ok_or(Error::InvalidNode)?))),
                     Err(_) => Ok(None),
                 };
+            }
+            self.recent_leaf_misses = self.recent_leaf_misses.saturating_add(1);
+            if self.recent_leaf_misses >= RECENT_LEAF_DISABLE_AFTER_MISSES {
+                self.recent_leaf = None;
+                self.recent_leaf_misses = 0;
+                self.recent_leaf_disabled = true;
             }
         }
 
@@ -629,21 +678,84 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
             return Ok(None);
         };
         loop {
-            let index = Self::route_index(&node, key)?;
-            if node.leaf {
-                self.recent_leaf = Some(node.clone());
-                return if node.keys.get(index).map(Vec::as_slice) == Some(key) {
-                    Ok(Some(read(node.vals.get(index).ok_or(Error::InvalidNode)?)))
-                } else {
-                    Ok(None)
+            if node.is_leaf() {
+                Self::validate_leaf(&node)?;
+                if !self.recent_leaf_disabled {
+                    self.recent_leaf = Some(node.clone());
+                }
+                return match node.search(key) {
+                    Ok(index) => Ok(Some(read(node.value(index).ok_or(Error::InvalidNode)?))),
+                    Err(_) => Ok(None),
                 };
             }
-            let cid = child_cid_at(&node, index)?;
+            let index = Self::route_index(&node, key)?;
+            let cid = node.child_cid(index)?;
             node = match self.local_nodes.get(&cid) {
                 Some(node) => node,
                 None => {
-                    let node = self.manager.load_arc(&cid)?;
-                    self.local_nodes.insert(cid, &node);
+                    let node = self.manager.load_read_arc(&cid)?;
+                    if !node.is_leaf() {
+                        self.local_nodes.insert(cid, &node);
+                    }
+                    node
+                }
+            };
+        }
+    }
+
+    /// Retain the packed leaf location for a bounded internal consumer.
+    ///
+    /// Public callers use `get_with`; this handle exists for algorithms that
+    /// must rank several records before deciding which final values to own.
+    pub(crate) fn get_handle(&mut self, key: &[u8]) -> Result<Option<ReadValueHandle>, Error> {
+        if let Some(leaf) = self
+            .recent_leaf
+            .as_ref()
+            .filter(|_| !self.recent_leaf_disabled)
+        {
+            Self::validate_leaf(leaf)?;
+            if leaf
+                .key(0)
+                .zip(leaf.key(leaf.len().saturating_sub(1)))
+                .is_some_and(|(first, last)| key >= first && key <= last)
+            {
+                self.recent_leaf_misses = 0;
+                return Ok(leaf.search(key).ok().map(|index| ReadValueHandle {
+                    node: leaf.clone(),
+                    index,
+                }));
+            }
+            self.recent_leaf_misses = self.recent_leaf_misses.saturating_add(1);
+            if self.recent_leaf_misses >= RECENT_LEAF_DISABLE_AFTER_MISSES {
+                self.recent_leaf = None;
+                self.recent_leaf_misses = 0;
+                self.recent_leaf_disabled = true;
+            }
+        }
+
+        let Some(mut node) = self.root.clone() else {
+            return Ok(None);
+        };
+        loop {
+            if node.is_leaf() {
+                Self::validate_leaf(&node)?;
+                if !self.recent_leaf_disabled {
+                    self.recent_leaf = Some(node.clone());
+                }
+                return Ok(match node.search(key) {
+                    Ok(index) => Some(ReadValueHandle { node, index }),
+                    Err(_) => None,
+                });
+            }
+            let index = Self::route_index(&node, key)?;
+            let cid = node.child_cid(index)?;
+            node = match self.local_nodes.get(&cid) {
+                Some(node) => node,
+                None => {
+                    let node = self.manager.load_read_arc(&cid)?;
+                    if !node.is_leaf() {
+                        self.local_nodes.insert(cid, &node);
+                    }
                     node
                 }
             };
@@ -682,19 +794,17 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
             }
             return Ok(());
         };
-
-        let positions = InlinePositions::from_vec(sorted_key_positions(keys))
-            .expect("keys are non-empty after early return");
+        let positions =
+            InlinePositions::from_vec(sorted_key_positions(keys)).expect("non-empty key positions");
         let mut frames = vec![(root, positions)];
-        let mut locations: Vec<Option<(Arc<Node>, usize)>> = vec![None; keys.len()];
-
+        let mut locations: Vec<Option<(Arc<ReadNode>, usize)>> = vec![None; keys.len()];
         while !frames.is_empty() {
             let mut children = Vec::new();
             for (node, positions) in frames {
-                if node.leaf {
-                    Self::fill_leaf_locations(node, positions, keys, &mut locations)?;
+                if node.is_leaf() {
+                    fill_packed_leaf_locations(node, positions, keys, &mut locations)?;
                 } else {
-                    children.extend(route_key_positions_to_children(&node, positions, keys)?);
+                    children.extend(route_packed_positions(&node, positions, keys)?);
                 }
             }
             if children.is_empty() {
@@ -704,26 +814,18 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
                 .iter()
                 .map(|frame| frame.cid.clone())
                 .collect::<Vec<_>>();
-            let nodes = if self.manager.store.prefers_batch_reads() {
-                self.manager
-                    .load_many_ordered_with_parallelism(&cids, GET_MANY_PREFETCH_PARALLELISM)?
-            } else {
-                self.manager.load_many_ordered(&cids)?
-            };
+            let nodes = self.manager.load_many_read_ordered(&cids)?;
             frames = children
                 .into_iter()
                 .zip(nodes)
                 .map(|(frame, node)| (node, frame.positions))
                 .collect();
         }
-
         for (position, key) in keys.iter().enumerate() {
-            let value = match locations[position].as_ref() {
-                Some((node, index)) => {
-                    Some(node.vals.get(*index).ok_or(Error::InvalidNode)?.as_slice())
-                }
-                None => None,
-            };
+            let value = locations[position]
+                .as_ref()
+                .map(|(node, index)| node.value(*index).ok_or(Error::InvalidNode))
+                .transpose()?;
             visit(position, key.as_ref(), value);
         }
         Ok(())
@@ -739,13 +841,13 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
             return Ok(None);
         };
         loop {
-            if node.leaf {
+            if node.is_leaf() {
                 Self::validate_leaf(&node)?;
                 let index = usize::try_from(ordinal).map_err(|_| Error::InvalidNode)?;
-                let Some(key) = node.keys.get(index) else {
+                let Some(key) = node.key(index) else {
                     return Ok(None);
                 };
-                let value = node.vals.get(index).ok_or(Error::InvalidNode)?;
+                let value = node.value(index).ok_or(Error::InvalidNode)?;
                 return Ok(Some(read(EntryRef::new(key, value))));
             }
             Self::validate_internal(&node)?;
@@ -761,7 +863,7 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
             let Some(index) = selected else {
                 return Ok(None);
             };
-            node = self.manager.load_arc(&child_cid_at(&node, index)?)?;
+            node = self.manager.load_read_arc(&node.child_cid(index)?)?;
         }
     }
 
@@ -892,15 +994,15 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
             let Some(frame) = stack.last_mut() else {
                 return Ok(ScanOutcome::complete(visited));
             };
-            if !frame.node.leaf {
+            if !frame.node.is_leaf() {
                 return Err(Error::InvalidNode);
             }
             Self::validate_leaf(&frame.node)?;
-            let key = frame.node.keys.get(frame.index).ok_or(Error::InvalidNode)?;
-            if key.as_slice() < start {
+            let key = frame.node.key(frame.index).ok_or(Error::InvalidNode)?;
+            if key < start {
                 return Ok(ScanOutcome::complete(visited));
             }
-            let value = frame.node.vals.get(frame.index).ok_or(Error::InvalidNode)?;
+            let value = frame.node.value(frame.index).ok_or(Error::InvalidNode)?;
             visited = visited.saturating_add(1);
             if let ControlFlow::Break(value) = visit(EntryRef::new(key, value)) {
                 return Ok(ScanOutcome::stopped(visited, value));
@@ -954,7 +1056,7 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
             let Some(frame) = stack.last_mut() else {
                 return Ok(ScanOutcome::complete(visited));
             };
-            if !frame.node.leaf {
+            if !frame.node.is_leaf() {
                 return Err(Error::InvalidNode);
             }
             Self::validate_leaf(&frame.node)?;
@@ -964,11 +1066,11 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
                 }
                 continue;
             }
-            let key = frame.node.keys.get(frame.index).ok_or(Error::InvalidNode)?;
-            if end.is_some_and(|end| key.as_slice() >= end) {
+            let key = frame.node.key(frame.index).ok_or(Error::InvalidNode)?;
+            if end.is_some_and(|end| key >= end) {
                 return Ok(ScanOutcome::complete(visited));
             }
-            let value = frame.node.vals.get(frame.index).ok_or(Error::InvalidNode)?;
+            let value = frame.node.value(frame.index).ok_or(Error::InvalidNode)?;
             frame.index += 1;
             visited = visited.saturating_add(1);
             if let ControlFlow::Break(value) = visit(EntryRef::new(key, value)) {
@@ -983,26 +1085,22 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
         };
         let mut stack = Vec::new();
         loop {
-            if node.leaf {
+            if node.is_leaf() {
                 Self::validate_leaf(&node)?;
                 let index = if strict {
-                    node.keys
-                        .partition_point(|candidate| candidate.as_slice() <= key)
+                    packed_partition_point(&node, |candidate| candidate <= key)
                 } else {
-                    node.keys
-                        .partition_point(|candidate| candidate.as_slice() < key)
+                    packed_partition_point(&node, |candidate| candidate < key)
                 };
                 stack.push(PathFrame { node, index });
                 return Ok(stack);
             }
             Self::validate_internal(&node)?;
-            let index = node
-                .keys
-                .partition_point(|candidate| candidate.as_slice() <= key)
-                .saturating_sub(1);
-            let cid = child_cid_at(&node, index)?;
+            let index =
+                packed_partition_point(&node, |candidate| candidate <= key).saturating_sub(1);
+            let cid = node.child_cid(index)?;
             stack.push(PathFrame { node, index });
-            node = self.manager.load_arc(&cid)?;
+            node = self.manager.load_read_arc(&cid)?;
         }
     }
 
@@ -1012,12 +1110,10 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
         };
         let mut stack = Vec::new();
         loop {
-            if node.leaf {
+            if node.is_leaf() {
                 Self::validate_leaf(&node)?;
                 let exclusive = match end {
-                    Some(end) => node
-                        .keys
-                        .partition_point(|candidate| candidate.as_slice() < end),
+                    Some(end) => packed_partition_point(&node, |candidate| candidate < end),
                     None => node.len(),
                 };
                 if exclusive == 0 {
@@ -1031,18 +1127,16 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
             }
             Self::validate_internal(&node)?;
             let exclusive = match end {
-                Some(end) => node
-                    .keys
-                    .partition_point(|candidate| candidate.as_slice() < end),
+                Some(end) => packed_partition_point(&node, |candidate| candidate < end),
                 None => node.len(),
             };
             if exclusive == 0 {
                 return Ok(Vec::new());
             }
             let index = exclusive - 1;
-            let cid = child_cid_at(&node, index)?;
+            let cid = node.child_cid(index)?;
             stack.push(PathFrame { node, index });
-            node = self.manager.load_arc(&cid)?;
+            node = self.manager.load_read_arc(&cid)?;
         }
     }
 
@@ -1055,18 +1149,18 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
                 stack.pop();
                 continue;
             }
-            let cid = child_cid_at(&parent.node, parent.index)?;
-            let mut node = manager.load_arc(&cid)?;
+            let cid = parent.node.child_cid(parent.index)?;
+            let mut node = manager.load_read_arc(&cid)?;
             loop {
-                if node.leaf {
+                if node.is_leaf() {
                     Self::validate_leaf(&node)?;
                     stack.push(PathFrame { node, index: 0 });
                     return Ok(true);
                 }
                 Self::validate_internal(&node)?;
-                let cid = child_cid_at(&node, 0)?;
+                let cid = node.child_cid(0)?;
                 stack.push(PathFrame { node, index: 0 });
-                node = manager.load_arc(&cid)?;
+                node = manager.load_read_arc(&cid)?;
             }
         }
         Ok(false)
@@ -1081,10 +1175,10 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
                 continue;
             }
             parent.index -= 1;
-            let cid = child_cid_at(&parent.node, parent.index)?;
-            let mut node = manager.load_arc(&cid)?;
+            let cid = parent.node.child_cid(parent.index)?;
+            let mut node = manager.load_read_arc(&cid)?;
             loop {
-                if node.leaf {
+                if node.is_leaf() {
                     Self::validate_leaf(&node)?;
                     let index = node.len().checked_sub(1).ok_or(Error::InvalidNode)?;
                     stack.push(PathFrame { node, index });
@@ -1092,16 +1186,16 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
                 }
                 Self::validate_internal(&node)?;
                 let index = node.len().checked_sub(1).ok_or(Error::InvalidNode)?;
-                let cid = child_cid_at(&node, index)?;
+                let cid = node.child_cid(index)?;
                 stack.push(PathFrame { node, index });
-                node = manager.load_arc(&cid)?;
+                node = manager.load_read_arc(&cid)?;
             }
         }
         Ok(false)
     }
 
-    fn route_index(node: &Node, key: &[u8]) -> Result<usize, Error> {
-        if node.leaf {
+    fn route_index(node: &ReadNode, key: &[u8]) -> Result<usize, Error> {
+        if node.is_leaf() {
             Self::validate_leaf(node)?;
         } else {
             Self::validate_internal(node)?;
@@ -1112,56 +1206,110 @@ impl<'manager, 'tree, S: Store> ReadSession<'manager, 'tree, S> {
         })
     }
 
-    fn validate_leaf(node: &Node) -> Result<(), Error> {
-        if !node.leaf || node.keys.len() != node.vals.len() {
+    fn validate_leaf(node: &ReadNode) -> Result<(), Error> {
+        if !node.is_leaf() {
             return Err(Error::InvalidNode);
         }
         Ok(())
     }
 
-    fn validate_internal(node: &Node) -> Result<(), Error> {
-        if node.leaf || node.keys.is_empty() || node.keys.len() != node.vals.len() {
+    fn validate_internal(node: &ReadNode) -> Result<(), Error> {
+        if node.is_leaf() || node.is_empty() {
             return Err(Error::InvalidNode);
         }
         Ok(())
     }
 
-    fn child_count(&self, node: &Node, index: usize) -> Result<u64, Error> {
-        match node.child_counts.get(index).copied() {
+    fn child_count(&self, node: &ReadNode, index: usize) -> Result<u64, Error> {
+        match node.child_count(index) {
             Some(count) if count > 0 => Ok(count),
-            _ => self.manager.subtree_count(&child_cid_at(node, index)?),
+            _ => self.manager.subtree_count(&node.child_cid(index)?),
         }
     }
+}
 
-    fn fill_leaf_locations<K: AsRef<[u8]>>(
-        node: Arc<Node>,
-        positions: InlinePositions,
-        keys: &[K],
-        locations: &mut [Option<(Arc<Node>, usize)>],
-    ) -> Result<(), Error> {
-        Self::validate_leaf(&node)?;
-        let mut leaf_index = 0usize;
-        let mut positions = positions.into_iter().peekable();
-        while let Some(position) = positions.next() {
-            let key = keys[position].as_ref();
-            while leaf_index < node.len() && node.keys[leaf_index].as_slice() < key {
-                leaf_index += 1;
-            }
-            let found = (leaf_index < node.len() && node.keys[leaf_index].as_slice() == key)
-                .then_some(leaf_index);
+#[inline]
+fn packed_partition_point(node: &ReadNode, mut predicate: impl FnMut(&[u8]) -> bool) -> usize {
+    let mut left = 0usize;
+    let mut right = node.len();
+    while left < right {
+        let mid = left + (right - left) / 2;
+        if predicate(node.key(mid).expect("validated read node metadata")) {
+            left = mid + 1;
+        } else {
+            right = mid;
+        }
+    }
+    left
+}
+
+fn route_packed_positions<K: AsRef<[u8]>>(
+    node: &ReadNode,
+    positions: InlinePositions,
+    keys: &[K],
+) -> Result<Vec<KeyLookupFrame>, Error> {
+    if node.is_leaf() || node.is_empty() {
+        return Err(Error::InvalidNode);
+    }
+    let mut frames = Vec::<KeyLookupFrame>::with_capacity(node.len().min(positions.len()));
+    let mut child_index = match node.search(keys[positions.first].as_ref()) {
+        Ok(index) => index,
+        Err(index) => index.saturating_sub(1),
+    };
+    let mut last_child = None;
+    for position in positions {
+        let key = keys[position].as_ref();
+        while child_index + 1 < node.len()
+            && key >= node.key(child_index + 1).ok_or(Error::InvalidNode)?
+        {
+            child_index += 1;
+        }
+        if last_child == Some(child_index) {
+            frames
+                .last_mut()
+                .ok_or(Error::InvalidNode)?
+                .positions
+                .push(position);
+        } else {
+            frames.push(KeyLookupFrame {
+                cid: node.child_cid(child_index)?,
+                positions: InlinePositions::new(position),
+            });
+            last_child = Some(child_index);
+        }
+    }
+    Ok(frames)
+}
+
+fn fill_packed_leaf_locations<K: AsRef<[u8]>>(
+    node: Arc<ReadNode>,
+    positions: InlinePositions,
+    keys: &[K],
+    locations: &mut [Option<(Arc<ReadNode>, usize)>],
+) -> Result<(), Error> {
+    if !node.is_leaf() {
+        return Err(Error::InvalidNode);
+    }
+    let mut leaf_index = 0usize;
+    let mut positions = positions.into_iter().peekable();
+    while let Some(position) = positions.next() {
+        let key = keys[position].as_ref();
+        while leaf_index < node.len() && node.key(leaf_index).ok_or(Error::InvalidNode)? < key {
+            leaf_index += 1;
+        }
+        let found =
+            (leaf_index < node.len() && node.key(leaf_index) == Some(key)).then_some(leaf_index);
+        if let Some(index) = found {
+            locations[position] = Some((node.clone(), index));
+        }
+        while let Some(duplicate) = positions.next_if(|candidate| keys[*candidate].as_ref() == key)
+        {
             if let Some(index) = found {
-                locations[position] = Some((node.clone(), index));
-            }
-            while let Some(duplicate) =
-                positions.next_if(|candidate| keys[*candidate].as_ref() == key)
-            {
-                if let Some(index) = found {
-                    locations[duplicate] = Some((node.clone(), index));
-                }
+                locations[duplicate] = Some((node.clone(), index));
             }
         }
-        Ok(())
     }
+    Ok(())
 }
 
 #[cfg(feature = "async-store")]
@@ -1181,16 +1329,16 @@ where
                 actual: tree.config.format.digest()?,
             });
         }
-        let root = tree.root.as_ref().map(|cid| self.load_arc(cid));
+        let root = tree.root.as_ref().map(|cid| self.load_read_arc(cid));
         let root = match root {
             Some(load) => Some(load.await?),
             None => None,
         };
         if let Some(root) = root.as_ref() {
-            if root.format != tree.config.format {
+            if root.format() != &tree.config.format {
                 return Err(Error::FormatMismatch {
                     expected: tree.config.format.digest()?,
-                    actual: root.format.digest()?,
+                    actual: root.format().digest()?,
                 });
             }
         }
@@ -1199,6 +1347,8 @@ where
             tree,
             root,
             recent_leaf: None,
+            recent_leaf_misses: 0,
+            recent_leaf_disabled: false,
             local_nodes: SessionNodeTable::new(),
         })
     }
@@ -1346,18 +1496,28 @@ where
         key: &[u8],
         read: impl FnOnce(&[u8]) -> R,
     ) -> Result<Option<R>, Error> {
-        if let Some(leaf) = self.recent_leaf.as_ref() {
+        if let Some(leaf) = self
+            .recent_leaf
+            .as_ref()
+            .filter(|_| !self.recent_leaf_disabled)
+        {
             ReadSession::<super::store::MemStore>::validate_leaf(leaf)?;
             if leaf
-                .keys
-                .first()
-                .zip(leaf.keys.last())
-                .is_some_and(|(first, last)| key >= first.as_slice() && key <= last.as_slice())
+                .key(0)
+                .zip(leaf.key(leaf.len().saturating_sub(1)))
+                .is_some_and(|(first, last)| key >= first && key <= last)
             {
+                self.recent_leaf_misses = 0;
                 return match leaf.search(key) {
-                    Ok(index) => Ok(Some(read(leaf.vals.get(index).ok_or(Error::InvalidNode)?))),
+                    Ok(index) => Ok(Some(read(leaf.value(index).ok_or(Error::InvalidNode)?))),
                     Err(_) => Ok(None),
                 };
+            }
+            self.recent_leaf_misses = self.recent_leaf_misses.saturating_add(1);
+            if self.recent_leaf_misses >= RECENT_LEAF_DISABLE_AFTER_MISSES {
+                self.recent_leaf = None;
+                self.recent_leaf_misses = 0;
+                self.recent_leaf_disabled = true;
             }
         }
 
@@ -1365,21 +1525,84 @@ where
             return Ok(None);
         };
         loop {
-            let index = async_route_index(&node, key)?;
-            if node.leaf {
-                self.recent_leaf = Some(node.clone());
-                return if node.keys.get(index).map(Vec::as_slice) == Some(key) {
-                    Ok(Some(read(node.vals.get(index).ok_or(Error::InvalidNode)?)))
-                } else {
-                    Ok(None)
+            if node.is_leaf() {
+                ReadSession::<super::store::MemStore>::validate_leaf(&node)?;
+                if !self.recent_leaf_disabled {
+                    self.recent_leaf = Some(node.clone());
+                }
+                return match node.search(key) {
+                    Ok(index) => Ok(Some(read(node.value(index).ok_or(Error::InvalidNode)?))),
+                    Err(_) => Ok(None),
                 };
             }
-            let cid = child_cid_at(&node, index)?;
+            let index = async_route_index(&node, key)?;
+            let cid = node.child_cid(index)?;
             node = match self.local_nodes.get(&cid) {
                 Some(node) => node,
                 None => {
-                    let node = self.manager.load_arc(&cid).await?;
-                    self.local_nodes.insert(cid, &node);
+                    let node = self.manager.load_read_arc(&cid).await?;
+                    if !node.is_leaf() {
+                        self.local_nodes.insert(cid, &node);
+                    }
+                    node
+                }
+            };
+        }
+    }
+
+    /// Retain one packed async leaf location after all required I/O completes.
+    pub(crate) async fn get_handle(
+        &mut self,
+        key: &[u8],
+    ) -> Result<Option<ReadValueHandle>, Error> {
+        if let Some(leaf) = self
+            .recent_leaf
+            .as_ref()
+            .filter(|_| !self.recent_leaf_disabled)
+        {
+            ReadSession::<super::store::MemStore>::validate_leaf(leaf)?;
+            if leaf
+                .key(0)
+                .zip(leaf.key(leaf.len().saturating_sub(1)))
+                .is_some_and(|(first, last)| key >= first && key <= last)
+            {
+                self.recent_leaf_misses = 0;
+                return Ok(leaf.search(key).ok().map(|index| ReadValueHandle {
+                    node: leaf.clone(),
+                    index,
+                }));
+            }
+            self.recent_leaf_misses = self.recent_leaf_misses.saturating_add(1);
+            if self.recent_leaf_misses >= RECENT_LEAF_DISABLE_AFTER_MISSES {
+                self.recent_leaf = None;
+                self.recent_leaf_misses = 0;
+                self.recent_leaf_disabled = true;
+            }
+        }
+
+        let Some(mut node) = self.root.clone() else {
+            return Ok(None);
+        };
+        loop {
+            if node.is_leaf() {
+                ReadSession::<super::store::MemStore>::validate_leaf(&node)?;
+                if !self.recent_leaf_disabled {
+                    self.recent_leaf = Some(node.clone());
+                }
+                return Ok(match node.search(key) {
+                    Ok(index) => Some(ReadValueHandle { node, index }),
+                    Err(_) => None,
+                });
+            }
+            let index = async_route_index(&node, key)?;
+            let cid = node.child_cid(index)?;
+            node = match self.local_nodes.get(&cid) {
+                Some(node) => node,
+                None => {
+                    let node = self.manager.load_read_arc(&cid).await?;
+                    if !node.is_leaf() {
+                        self.local_nodes.insert(cid, &node);
+                    }
                     node
                 }
             };
@@ -1414,19 +1637,17 @@ where
             }
             return Ok(());
         };
-
-        let positions = InlinePositions::from_vec(sorted_key_positions(keys))
-            .expect("keys are non-empty after early return");
+        let positions =
+            InlinePositions::from_vec(sorted_key_positions(keys)).expect("non-empty key positions");
         let mut frames = vec![(root, positions)];
-        let mut locations: Vec<Option<(Arc<Node>, usize)>> = vec![None; keys.len()];
-
+        let mut locations: Vec<Option<(Arc<ReadNode>, usize)>> = vec![None; keys.len()];
         while !frames.is_empty() {
             let mut children = Vec::new();
             for (node, positions) in frames {
-                if node.leaf {
-                    fill_async_leaf_locations(node, positions, keys, &mut locations)?;
+                if node.is_leaf() {
+                    fill_packed_leaf_locations(node, positions, keys, &mut locations)?;
                 } else {
-                    children.extend(route_key_positions_to_children(&node, positions, keys)?);
+                    children.extend(route_packed_positions(&node, positions, keys)?);
                 }
             }
             if children.is_empty() {
@@ -1436,20 +1657,18 @@ where
                 .iter()
                 .map(|frame| frame.cid.clone())
                 .collect::<Vec<_>>();
-            let nodes = self.manager.load_child_frontier_ordered(&cids).await?;
+            let nodes = self.manager.load_many_read_ordered(&cids).await?;
             frames = children
                 .into_iter()
                 .zip(nodes)
                 .map(|(frame, node)| (node, frame.positions))
                 .collect();
         }
-
         for (position, key) in keys.iter().enumerate() {
             let value = locations[position]
                 .as_ref()
-                .map(|(node, index)| node.vals.get(*index).ok_or(Error::InvalidNode))
-                .transpose()?
-                .map(Vec::as_slice);
+                .map(|(node, index)| node.value(*index).ok_or(Error::InvalidNode))
+                .transpose()?;
             visit(position, key.as_ref(), value);
         }
         Ok(())
@@ -1477,15 +1696,35 @@ where
         end: Option<&[u8]>,
         mut visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
     ) -> Result<ScanOutcome<B>, Error> {
-        let mut range = self.manager.range(self.tree, start, end).await?;
+        if end.is_some_and(|end| end <= start) {
+            return Ok(ScanOutcome::complete(0));
+        }
+        let mut stack = self.seek_forward(start).await?;
         let mut visited = 0u64;
-        while let Some(result) = range.next_with(&mut visit).await {
+        loop {
+            let Some(frame) = stack.last_mut() else {
+                return Ok(ScanOutcome::complete(visited));
+            };
+            if !frame.node.is_leaf() {
+                return Err(Error::InvalidNode);
+            }
+            if frame.index >= frame.node.len() {
+                if !self.advance_forward(&mut stack).await? {
+                    return Ok(ScanOutcome::complete(visited));
+                }
+                continue;
+            }
+            let key = frame.node.key(frame.index).ok_or(Error::InvalidNode)?;
+            if end.is_some_and(|end| key >= end) {
+                return Ok(ScanOutcome::complete(visited));
+            }
+            let value = frame.node.value(frame.index).ok_or(Error::InvalidNode)?;
+            frame.index += 1;
             visited = visited.saturating_add(1);
-            if let ControlFlow::Break(value) = result? {
+            if let ControlFlow::Break(value) = visit(EntryRef::new(key, value)) {
                 return Ok(ScanOutcome::stopped(visited, value));
             }
         }
-        Ok(ScanOutcome::complete(visited))
     }
 
     /// Visit every key under a prefix without allocating entries.
@@ -1537,14 +1776,14 @@ where
             let Some(frame) = stack.last_mut() else {
                 return Ok(ScanOutcome::complete(visited));
             };
-            if !frame.node.leaf || frame.node.keys.len() != frame.node.vals.len() {
+            if !frame.node.is_leaf() {
                 return Err(Error::InvalidNode);
             }
-            let key = frame.node.keys.get(frame.index).ok_or(Error::InvalidNode)?;
-            if key.as_slice() < start {
+            let key = frame.node.key(frame.index).ok_or(Error::InvalidNode)?;
+            if key < start {
                 return Ok(ScanOutcome::complete(visited));
             }
-            let value = frame.node.vals.get(frame.index).ok_or(Error::InvalidNode)?;
+            let value = frame.node.value(frame.index).ok_or(Error::InvalidNode)?;
             visited = visited.saturating_add(1);
             if let ControlFlow::Break(value) = visit(EntryRef::new(key, value)) {
                 return Ok(ScanOutcome::stopped(visited, value));
@@ -1587,14 +1826,9 @@ where
         };
         let mut stack = Vec::new();
         loop {
-            if node.leaf {
-                if node.keys.len() != node.vals.len() {
-                    return Err(Error::InvalidNode);
-                }
+            if node.is_leaf() {
                 let exclusive = match end {
-                    Some(end) => node
-                        .keys
-                        .partition_point(|candidate| candidate.as_slice() < end),
+                    Some(end) => packed_partition_point(&node, |candidate| candidate < end),
                     None => node.len(),
                 };
                 if exclusive == 0 {
@@ -1606,32 +1840,78 @@ where
                 });
                 return Ok(stack);
             }
-            if node.keys.is_empty() || node.keys.len() != node.vals.len() {
+            if node.is_empty() {
                 return Err(Error::InvalidNode);
             }
             let exclusive = match end {
-                Some(end) => node
-                    .keys
-                    .partition_point(|candidate| candidate.as_slice() < end),
+                Some(end) => packed_partition_point(&node, |candidate| candidate < end),
                 None => node.len(),
             };
             if exclusive == 0 {
                 return Ok(Vec::new());
             }
             let index = exclusive - 1;
-            let cid = child_cid_at(&node, index)?;
+            let cid = node.child_cid(index)?;
             stack.push(PathFrame { node, index });
-            node = self.manager.load_arc(&cid).await?;
+            node = self.manager.load_read_arc(&cid).await?;
         }
+    }
+
+    async fn seek_forward(&self, start: &[u8]) -> Result<Vec<PathFrame>, Error> {
+        let Some(mut node) = self.root.clone() else {
+            return Ok(Vec::new());
+        };
+        let mut stack = Vec::new();
+        loop {
+            if node.is_leaf() {
+                let index = packed_partition_point(&node, |candidate| candidate < start);
+                stack.push(PathFrame { node, index });
+                return Ok(stack);
+            }
+            if node.is_empty() {
+                return Err(Error::InvalidNode);
+            }
+            let index =
+                packed_partition_point(&node, |candidate| candidate <= start).saturating_sub(1);
+            let cid = node.child_cid(index)?;
+            stack.push(PathFrame { node, index });
+            node = self.manager.load_read_arc(&cid).await?;
+        }
+    }
+
+    async fn advance_forward(&self, stack: &mut Vec<PathFrame>) -> Result<bool, Error> {
+        stack.pop();
+        while let Some(parent) = stack.last_mut() {
+            if parent.node.is_leaf() || parent.node.is_empty() {
+                return Err(Error::InvalidNode);
+            }
+            parent.index += 1;
+            if parent.index >= parent.node.len() {
+                stack.pop();
+                continue;
+            }
+            let cid = parent.node.child_cid(parent.index)?;
+            let mut node = self.manager.load_read_arc(&cid).await?;
+            loop {
+                if node.is_leaf() {
+                    stack.push(PathFrame { node, index: 0 });
+                    return Ok(true);
+                }
+                if node.is_empty() {
+                    return Err(Error::InvalidNode);
+                }
+                let cid = node.child_cid(0)?;
+                stack.push(PathFrame { node, index: 0 });
+                node = self.manager.load_read_arc(&cid).await?;
+            }
+        }
+        Ok(false)
     }
 
     async fn advance_reverse(&self, stack: &mut Vec<PathFrame>) -> Result<bool, Error> {
         stack.pop();
         while let Some(parent) = stack.last_mut() {
-            if parent.node.leaf
-                || parent.node.keys.is_empty()
-                || parent.node.keys.len() != parent.node.vals.len()
-            {
+            if parent.node.is_leaf() || parent.node.is_empty() {
                 return Err(Error::InvalidNode);
             }
             if parent.index == 0 {
@@ -1639,24 +1919,21 @@ where
                 continue;
             }
             parent.index -= 1;
-            let cid = child_cid_at(&parent.node, parent.index)?;
-            let mut node = self.manager.load_arc(&cid).await?;
+            let cid = parent.node.child_cid(parent.index)?;
+            let mut node = self.manager.load_read_arc(&cid).await?;
             loop {
-                if node.leaf {
-                    if node.keys.len() != node.vals.len() {
-                        return Err(Error::InvalidNode);
-                    }
+                if node.is_leaf() {
                     let index = node.len().checked_sub(1).ok_or(Error::InvalidNode)?;
                     stack.push(PathFrame { node, index });
                     return Ok(true);
                 }
-                if node.keys.is_empty() || node.keys.len() != node.vals.len() {
+                if node.is_empty() {
                     return Err(Error::InvalidNode);
                 }
                 let index = node.len() - 1;
-                let cid = child_cid_at(&node, index)?;
+                let cid = node.child_cid(index)?;
                 stack.push(PathFrame { node, index });
-                node = self.manager.load_arc(&cid).await?;
+                node = self.manager.load_read_arc(&cid).await?;
             }
         }
         Ok(false)
@@ -1664,48 +1941,12 @@ where
 }
 
 #[cfg(feature = "async-store")]
-fn async_route_index(node: &Node, key: &[u8]) -> Result<usize, Error> {
-    if node.leaf {
-        if node.keys.len() != node.vals.len() {
-            return Err(Error::InvalidNode);
-        }
-    } else if node.keys.is_empty() || node.keys.len() != node.vals.len() {
+fn async_route_index(node: &ReadNode, key: &[u8]) -> Result<usize, Error> {
+    if !node.is_leaf() && node.is_empty() {
         return Err(Error::InvalidNode);
     }
     Ok(match node.search(key) {
         Ok(index) => index,
         Err(index) => index.saturating_sub(1),
     })
-}
-
-#[cfg(feature = "async-store")]
-fn fill_async_leaf_locations<K: AsRef<[u8]>>(
-    node: Arc<Node>,
-    positions: InlinePositions,
-    keys: &[K],
-    locations: &mut [Option<(Arc<Node>, usize)>],
-) -> Result<(), Error> {
-    if !node.leaf || node.keys.len() != node.vals.len() {
-        return Err(Error::InvalidNode);
-    }
-    let mut leaf_index = 0usize;
-    let mut positions = positions.into_iter().peekable();
-    while let Some(position) = positions.next() {
-        let key = keys[position].as_ref();
-        while leaf_index < node.len() && node.keys[leaf_index].as_slice() < key {
-            leaf_index += 1;
-        }
-        let found = (leaf_index < node.len() && node.keys[leaf_index].as_slice() == key)
-            .then_some(leaf_index);
-        if let Some(index) = found {
-            locations[position] = Some((node.clone(), index));
-        }
-        while let Some(duplicate) = positions.next_if(|candidate| keys[*candidate].as_ref() == key)
-        {
-            if let Some(index) = found {
-                locations[duplicate] = Some((node.clone(), index));
-            }
-        }
-    }
-    Ok(())
 }

--- a/src/prolly/secondary_index/coordinator.rs
+++ b/src/prolly/secondary_index/coordinator.rs
@@ -318,6 +318,15 @@ where
         self.source().get(key)
     }
 
+    /// Read one source value without allocating an intermediate owned value.
+    pub fn get_with<R>(
+        &self,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.source().get_with(key, read)
+    }
+
     /// Re-run bounded structural startup validation and return exact health state.
     pub fn health(&self) -> Result<IndexedMapHealth, Error> {
         self.validate_state()

--- a/src/prolly/secondary_index/definition.rs
+++ b/src/prolly/secondary_index/definition.rs
@@ -26,6 +26,23 @@ pub struct SecondaryIndexEntry {
     pub projection: Option<Vec<u8>>,
 }
 
+/// Callback-scoped index emission used by allocation-reusing extractors.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SecondaryIndexEntryRef<'a> {
+    pub term: &'a [u8],
+    pub projection: Option<&'a [u8]>,
+}
+
+/// Extractor that emits borrowed terms/projections into a synchronous sink.
+pub trait StreamingSecondaryIndexExtractor: Send + Sync {
+    fn extract(
+        &self,
+        primary_key: &[u8],
+        source_value: &[u8],
+        emit: &mut dyn FnMut(SecondaryIndexEntryRef<'_>) -> Result<(), SecondaryIndexError>,
+    ) -> Result<(), SecondaryIndexError>;
+}
+
 impl SecondaryIndexEntry {
     /// Emit a term without application projection bytes.
     pub fn term(term: impl AsRef<[u8]>) -> Self {

--- a/src/prolly/secondary_index/mod.rs
+++ b/src/prolly/secondary_index/mod.rs
@@ -20,19 +20,21 @@ pub use coordinator::{
 };
 pub use definition::{
     IndexProjection, SecondaryIndex, SecondaryIndexBuilder, SecondaryIndexEntry,
-    SecondaryIndexError, SecondaryIndexExtractor, SecondaryIndexLimits, SecondaryIndexRegistry,
+    SecondaryIndexEntryRef, SecondaryIndexError, SecondaryIndexExtractor, SecondaryIndexLimits,
+    SecondaryIndexRegistry, StreamingSecondaryIndexExtractor,
 };
 pub use snapshot::{
-    IndexedSnapshot, IndexedSnapshotId, IndexedSourceRecord, ProjectedIndexEntry,
-    SecondaryIndexCursor, SecondaryIndexDirection, SecondaryIndexMatch, SecondaryIndexPage,
-    SecondaryIndexSnapshot,
+    IndexedSnapshot, IndexedSnapshotId, IndexedSourceRecord, IndexedSourceRecordRef,
+    ProjectedIndexEntry, SecondaryIndexCursor, SecondaryIndexDirection, SecondaryIndexMatch,
+    SecondaryIndexMatchRef, SecondaryIndexPage, SecondaryIndexSnapshot,
 };
 pub use storage::{
     catalog_checkpoint_key, catalog_checkpoints_prefix, catalog_current_key,
     catalog_descriptor_key, catalog_format_key, catalog_map_id, catalog_retired_key,
-    control_record_key, control_root_name, decode_physical_index_key, descriptor_fingerprint,
-    index_map_id, physical_index_key, term_bounds_exact, term_bounds_prefix, term_bounds_range,
-    ActiveIndexControl, DecodedPhysicalIndexKey, IndexCheckpoint, IndexControl, IndexValue,
-    IndexedHeadRecord, SecondaryIndexDescriptor, TermBounds, INDEX_PHYSICAL_LAYOUT_VERSION,
-    SECONDARY_INDEX_FORMAT_VERSION,
+    control_record_key, control_root_name, decode_physical_index_key,
+    decode_physical_index_key_ref, descriptor_fingerprint, index_map_id, physical_index_key,
+    term_bounds_exact, term_bounds_prefix, term_bounds_range, ActiveIndexControl,
+    DecodedPhysicalIndexKey, DecodedPhysicalIndexKeyRef, IndexCheckpoint, IndexControl, IndexValue,
+    IndexValueRef, IndexedHeadRecord, SecondaryIndexDescriptor, TermBounds,
+    INDEX_PHYSICAL_LAYOUT_VERSION, SECONDARY_INDEX_FORMAT_VERSION,
 };

--- a/src/prolly/secondary_index/snapshot.rs
+++ b/src/prolly/secondary_index/snapshot.rs
@@ -2,6 +2,7 @@ use super::super::cid::Cid;
 use super::super::error::Error;
 use super::super::manifest::ManifestStore;
 use super::super::range::ReverseCursor;
+use super::super::read::{EntryRef, ScanOutcome};
 use super::super::store::Store;
 use super::super::transaction::TransactionalStore;
 use super::super::tree::Tree;
@@ -11,14 +12,23 @@ use super::coordinator::{validate_catalog_format, IndexedMap};
 use super::definition::IndexProjection;
 use super::storage::{
     catalog_checkpoint_key, catalog_current_key, catalog_descriptor_key, catalog_map_id,
-    decode_physical_index_key, term_bounds_exact, term_bounds_prefix, term_bounds_range,
-    IndexCheckpoint, IndexValue, IndexedHeadRecord, SecondaryIndexDescriptor, TermBounds,
+    decode_physical_index_key, decode_physical_index_key_ref, term_bounds_exact,
+    term_bounds_prefix, term_bounds_range, IndexCheckpoint, IndexValue, IndexValueRef,
+    IndexedHeadRecord, SecondaryIndexDescriptor, TermBounds,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::ops::ControlFlow;
 
 const CURSOR_MAGIC: &[u8; 8] = b"PSICUR01";
 const CURSOR_VERSION: u32 = 1;
+const SOURCE_JOIN_BATCH_SIZE: usize = 256;
+
+struct SourceJoinMatch {
+    term: Vec<u8>,
+    primary_key: Vec<u8>,
+    projection: Option<Vec<u8>>,
+}
 
 /// Reproducible identity of one catalog-selected indexed snapshot.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -33,6 +43,39 @@ pub struct SecondaryIndexMatch {
     pub term: Vec<u8>,
     pub primary_key: Vec<u8>,
     pub projection: Option<Vec<u8>>,
+}
+
+/// Callback-scoped decoded secondary-index match.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SecondaryIndexMatchRef<'a> {
+    pub term: &'a [u8],
+    pub primary_key: &'a [u8],
+    pub projection: Option<&'a [u8]>,
+}
+
+impl SecondaryIndexMatchRef<'_> {
+    pub fn to_owned(self) -> SecondaryIndexMatch {
+        SecondaryIndexMatch {
+            term: self.term.to_vec(),
+            primary_key: self.primary_key.to_vec(),
+            projection: self.projection.map(<[u8]>::to_vec),
+        }
+    }
+}
+
+/// Callback-scoped index match joined to its pinned source record.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct IndexedSourceRecordRef<'a> {
+    pub term: &'a [u8],
+    pub primary_key: &'a [u8],
+    pub projection: Option<&'a [u8]>,
+    pub source_value: &'a [u8],
+}
+
+impl IndexedSourceRecordRef<'_> {
+    pub fn to_owned(self) -> IndexedSourceRecord {
+        (self.primary_key.to_vec(), self.source_value.to_vec())
+    }
 }
 
 /// One primary key and its optional projected bytes.
@@ -233,11 +276,15 @@ impl<'a, S: Store> SecondaryIndexSnapshot<'a, S> {
     }
 
     pub fn exact(&self, term: &[u8]) -> Result<Vec<SecondaryIndexMatch>, Error> {
-        self.collect(LogicalBounds::Exact(term.to_vec()))
+        let mut matches = Vec::new();
+        self.scan_exact(term, |matched| matches.push(matched.to_owned()))?;
+        Ok(matches)
     }
 
     pub fn prefix(&self, prefix: &[u8]) -> Result<Vec<SecondaryIndexMatch>, Error> {
-        self.collect(LogicalBounds::Prefix(prefix.to_vec()))
+        let mut matches = Vec::new();
+        self.scan_prefix(prefix, |matched| matches.push(matched.to_owned()))?;
+        Ok(matches)
     }
 
     pub fn range(
@@ -245,10 +292,165 @@ impl<'a, S: Store> SecondaryIndexSnapshot<'a, S> {
         start_term: &[u8],
         end_term: Option<&[u8]>,
     ) -> Result<Vec<SecondaryIndexMatch>, Error> {
-        self.collect(LogicalBounds::Range(
-            start_term.to_vec(),
-            end_term.map(ToOwned::to_owned),
-        ))
+        let mut matches = Vec::new();
+        self.scan_range(start_term, end_term, |matched| {
+            matches.push(matched.to_owned())
+        })?;
+        Ok(matches)
+    }
+
+    pub fn scan_exact(
+        &self,
+        term: &[u8],
+        mut visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_exact_until(term, |row| {
+                visit(row);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    pub fn scan_exact_until<B>(
+        &self,
+        term: &[u8],
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.scan_matches_until(
+            LogicalBounds::Exact(term.to_vec()),
+            SecondaryIndexDirection::Forward,
+            visit,
+        )
+    }
+
+    pub fn scan_prefix(
+        &self,
+        prefix: &[u8],
+        mut visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_prefix_until(prefix, |row| {
+                visit(row);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    pub fn scan_prefix_until<B>(
+        &self,
+        prefix: &[u8],
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.scan_matches_until(
+            LogicalBounds::Prefix(prefix.to_vec()),
+            SecondaryIndexDirection::Forward,
+            visit,
+        )
+    }
+
+    pub fn scan_range(
+        &self,
+        start_term: &[u8],
+        end_term: Option<&[u8]>,
+        mut visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_range_until(start_term, end_term, |row| {
+                visit(row);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    pub fn scan_range_until<B>(
+        &self,
+        start_term: &[u8],
+        end_term: Option<&[u8]>,
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.scan_matches_until(
+            LogicalBounds::Range(start_term.to_vec(), end_term.map(ToOwned::to_owned)),
+            SecondaryIndexDirection::Forward,
+            visit,
+        )
+    }
+
+    pub fn scan_exact_reverse(
+        &self,
+        term: &[u8],
+        mut visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_exact_reverse_until(term, |row| {
+                visit(row);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    pub fn scan_exact_reverse_until<B>(
+        &self,
+        term: &[u8],
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.scan_matches_until(
+            LogicalBounds::Exact(term.to_vec()),
+            SecondaryIndexDirection::Reverse,
+            visit,
+        )
+    }
+
+    pub fn scan_prefix_reverse(
+        &self,
+        prefix: &[u8],
+        mut visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_prefix_reverse_until(prefix, |row| {
+                visit(row);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    pub fn scan_prefix_reverse_until<B>(
+        &self,
+        prefix: &[u8],
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.scan_matches_until(
+            LogicalBounds::Prefix(prefix.to_vec()),
+            SecondaryIndexDirection::Reverse,
+            visit,
+        )
+    }
+
+    pub fn scan_range_reverse(
+        &self,
+        start_term: &[u8],
+        end_term: Option<&[u8]>,
+        mut visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_range_reverse_until(start_term, end_term, |row| {
+                visit(row);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    pub fn scan_range_reverse_until<B>(
+        &self,
+        start_term: &[u8],
+        end_term: Option<&[u8]>,
+        visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        self.scan_matches_until(
+            LogicalBounds::Range(start_term.to_vec(), end_term.map(ToOwned::to_owned)),
+            SecondaryIndexDirection::Reverse,
+            visit,
+        )
     }
 
     pub fn primary_keys(&self, term: &[u8]) -> Result<Vec<Vec<u8>>, Error> {
@@ -269,27 +471,108 @@ impl<'a, S: Store> SecondaryIndexSnapshot<'a, S> {
 
     /// Resolve matching primary keys with one ordered batched source read.
     pub fn records(&self, term: &[u8]) -> Result<Vec<IndexedSourceRecord>, Error> {
-        let matches = self.exact(term)?;
-        let keys: Vec<&[u8]> = matches
+        let mut records = Vec::new();
+        self.scan_records(term, |record| records.push(record.to_owned()))?;
+        Ok(records)
+    }
+
+    pub fn scan_records(
+        &self,
+        term: &[u8],
+        mut visit: impl for<'row> FnMut(IndexedSourceRecordRef<'row>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_records_until(term, |row| {
+                visit(row);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    pub fn scan_records_until<B>(
+        &self,
+        term: &[u8],
+        mut visit: impl for<'row> FnMut(IndexedSourceRecordRef<'row>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        let mut source = self.prolly.read(&self.source_tree)?;
+        let mut chunk = Vec::with_capacity(SOURCE_JOIN_BATCH_SIZE);
+        let mut delivered = 0u64;
+        let mut terminal = None;
+        self.scan_exact_until(term, |matched| {
+            chunk.push(SourceJoinMatch {
+                term: matched.term.to_vec(),
+                primary_key: matched.primary_key.to_vec(),
+                projection: matched.projection.map(<[u8]>::to_vec),
+            });
+            if chunk.len() < SOURCE_JOIN_BATCH_SIZE {
+                return ControlFlow::Continue(());
+            }
+            match self.flush_source_join_chunk(&mut source, &mut chunk, &mut delivered, &mut visit)
+            {
+                Ok(Some(value)) => {
+                    terminal = Some(Ok(value));
+                    ControlFlow::Break(())
+                }
+                Ok(None) => ControlFlow::Continue(()),
+                Err(error) => {
+                    terminal = Some(Err(error));
+                    ControlFlow::Break(())
+                }
+            }
+        })?;
+
+        if terminal.is_none() && !chunk.is_empty() {
+            terminal = self
+                .flush_source_join_chunk(&mut source, &mut chunk, &mut delivered, &mut visit)
+                .transpose();
+        }
+        match terminal {
+            Some(Ok(value)) => Ok(ScanOutcome::stopped(delivered, value)),
+            Some(Err(error)) => Err(error),
+            None => Ok(ScanOutcome::complete(delivered)),
+        }
+    }
+
+    fn flush_source_join_chunk<B>(
+        &self,
+        source: &mut super::super::read::ReadSession<'_, '_, S>,
+        chunk: &mut Vec<SourceJoinMatch>,
+        delivered: &mut u64,
+        visit: &mut impl for<'row> FnMut(IndexedSourceRecordRef<'row>) -> ControlFlow<B>,
+    ) -> Result<Option<B>, Error> {
+        let keys = chunk
             .iter()
             .map(|matched| matched.primary_key.as_slice())
-            .collect();
-        let values = self.prolly.get_many(&self.source_tree, &keys)?;
-        matches
-            .into_iter()
-            .zip(values)
-            .map(|(matched, value)| match value {
-                Some(value) => Ok((matched.primary_key, value)),
-                None => Err(Error::IndexCheckpointMismatch {
+            .collect::<Vec<_>>();
+        let mut terminal = None;
+        source.get_many_with(&keys, |position, _, source_value| {
+            if terminal.is_some() {
+                return;
+            }
+            let matched = &chunk[position];
+            let Some(source_value) = source_value else {
+                terminal = Some(Err(Error::IndexCheckpointMismatch {
                     name: self.descriptor.name.clone(),
                     source_version: self.snapshot_id.source_version.clone(),
                     reason: format!(
                         "index references missing source primary key {:?}",
                         matched.primary_key
                     ),
-                }),
-            })
-            .collect()
+                }));
+                return;
+            };
+            *delivered = delivered.saturating_add(1);
+            if let ControlFlow::Break(value) = visit(IndexedSourceRecordRef {
+                term: &matched.term,
+                primary_key: &matched.primary_key,
+                projection: matched.projection.as_deref(),
+                source_value,
+            }) {
+                terminal = Some(Ok(value));
+            }
+        })?;
+        chunk.clear();
+        terminal.transpose()
     }
 
     pub fn exact_page(
@@ -378,15 +661,49 @@ impl<'a, S: Store> SecondaryIndexSnapshot<'a, S> {
         )
     }
 
-    fn collect(&self, logical: LogicalBounds) -> Result<Vec<SecondaryIndexMatch>, Error> {
+    fn scan_matches_until<B>(
+        &self,
+        logical: LogicalBounds,
+        direction: SecondaryIndexDirection,
+        mut visit: impl for<'row> FnMut(SecondaryIndexMatchRef<'row>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
         let bounds = physical_bounds(&logical)?;
-        self.prolly
-            .range(self.index.tree(), &bounds.start, bounds.end.as_deref())?
-            .map(|entry| {
-                let (key, value) = entry?;
-                self.decode_match(&key, &value)
-            })
-            .collect()
+        let mut term_scratch = Vec::new();
+        let mut primary_key_scratch = Vec::new();
+        let mut handle = |entry: EntryRef<'_>| {
+            let matched = match self.decode_match_ref(
+                entry.key(),
+                entry.value(),
+                &mut term_scratch,
+                &mut primary_key_scratch,
+            ) {
+                Ok(matched) => matched,
+                Err(error) => return ControlFlow::Break(Err(error)),
+            };
+            match visit(matched) {
+                ControlFlow::Continue(()) => ControlFlow::Continue(()),
+                ControlFlow::Break(value) => ControlFlow::Break(Ok(value)),
+            }
+        };
+        let outcome = match direction {
+            SecondaryIndexDirection::Forward => self.prolly.scan_range_until(
+                self.index.tree(),
+                &bounds.start,
+                bounds.end.as_deref(),
+                &mut handle,
+            )?,
+            SecondaryIndexDirection::Reverse => self.prolly.scan_range_reverse_until(
+                self.index.tree(),
+                &bounds.start,
+                bounds.end.as_deref(),
+                &mut handle,
+            )?,
+        };
+        match outcome.break_value {
+            Some(Ok(value)) => Ok(ScanOutcome::stopped(outcome.visited, value)),
+            Some(Err(error)) => Err(error),
+            None => Ok(ScanOutcome::complete(outcome.visited)),
+        }
     }
 
     fn page(
@@ -531,6 +848,34 @@ impl<'a, S: Store> SecondaryIndexSnapshot<'a, S> {
             }
         };
         Ok(SecondaryIndexMatch {
+            term: decoded.term,
+            primary_key: decoded.primary_key,
+            projection,
+        })
+    }
+
+    fn decode_match_ref<'row>(
+        &self,
+        key: &'row [u8],
+        value: &'row [u8],
+        term_scratch: &'row mut Vec<u8>,
+        primary_key_scratch: &'row mut Vec<u8>,
+    ) -> Result<SecondaryIndexMatchRef<'row>, Error> {
+        let decoded = decode_physical_index_key_ref(key, term_scratch, primary_key_scratch)?;
+        let stored = IndexValueRef::decode(value, self.max_projection_bytes)?;
+        let projection = match (self.descriptor.projection, stored) {
+            (IndexProjection::KeysOnly, IndexValueRef::KeysOnly) => None,
+            (IndexProjection::Include, IndexValueRef::Included(bytes))
+            | (IndexProjection::All, IndexValueRef::FullSource(bytes)) => Some(bytes),
+            _ => {
+                return Err(Error::IndexCheckpointMismatch {
+                    name: self.descriptor.name.clone(),
+                    source_version: self.snapshot_id.source_version.clone(),
+                    reason: "stored projection value does not match its descriptor".to_string(),
+                })
+            }
+        };
+        Ok(SecondaryIndexMatchRef {
             term: decoded.term,
             primary_key: decoded.primary_key,
             projection,

--- a/src/prolly/secondary_index/storage.rs
+++ b/src/prolly/secondary_index/storage.rs
@@ -536,29 +536,16 @@ pub enum IndexValue {
     FullSource(Vec<u8>),
 }
 
-impl IndexValue {
-    pub fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-        let (tag, payload) = match self {
-            Self::KeysOnly => return Ok(Vec::new()),
-            Self::Included(payload) => (1, payload),
-            Self::FullSource(payload) => (2, payload),
-        };
-        let payload_len =
-            u32::try_from(payload.len()).map_err(|_| Error::IndexResourceLimitExceeded {
-                resource: "projection_bytes",
-                limit: u32::MAX as usize,
-                actual: payload.len(),
-            })?;
-        let mut bytes = Vec::with_capacity(13usize.saturating_add(payload.len()));
-        bytes.extend_from_slice(INDEX_VALUE_MAGIC);
-        bytes.extend_from_slice(&SECONDARY_INDEX_FORMAT_VERSION.to_be_bytes());
-        bytes.push(tag);
-        bytes.extend_from_slice(&payload_len.to_be_bytes());
-        bytes.extend_from_slice(payload);
-        Ok(bytes)
-    }
+/// Strict borrowed view of a persisted secondary-index value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IndexValueRef<'a> {
+    KeysOnly,
+    Included(&'a [u8]),
+    FullSource(&'a [u8]),
+}
 
-    pub fn from_bytes(bytes: &[u8], max_payload_bytes: usize) -> Result<Self, Error> {
+impl<'a> IndexValueRef<'a> {
+    pub fn decode(bytes: &'a [u8], max_payload_bytes: usize) -> Result<Self, Error> {
         if bytes.is_empty() {
             return Ok(Self::KeysOnly);
         }
@@ -588,7 +575,7 @@ impl IndexValue {
                 "secondary-index value length mismatch or trailing bytes".to_string(),
             ));
         }
-        let payload = bytes[13..].to_vec();
+        let payload = &bytes[13..];
         match bytes[8] {
             1 => Ok(Self::Included(payload)),
             2 => Ok(Self::FullSource(payload)),
@@ -596,6 +583,41 @@ impl IndexValue {
                 "unknown secondary-index value tag {tag}"
             ))),
         }
+    }
+
+    pub fn to_owned(self) -> IndexValue {
+        match self {
+            Self::KeysOnly => IndexValue::KeysOnly,
+            Self::Included(value) => IndexValue::Included(value.to_vec()),
+            Self::FullSource(value) => IndexValue::FullSource(value.to_vec()),
+        }
+    }
+}
+
+impl IndexValue {
+    pub fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        let (tag, payload) = match self {
+            Self::KeysOnly => return Ok(Vec::new()),
+            Self::Included(payload) => (1, payload),
+            Self::FullSource(payload) => (2, payload),
+        };
+        let payload_len =
+            u32::try_from(payload.len()).map_err(|_| Error::IndexResourceLimitExceeded {
+                resource: "projection_bytes",
+                limit: u32::MAX as usize,
+                actual: payload.len(),
+            })?;
+        let mut bytes = Vec::with_capacity(13usize.saturating_add(payload.len()));
+        bytes.extend_from_slice(INDEX_VALUE_MAGIC);
+        bytes.extend_from_slice(&SECONDARY_INDEX_FORMAT_VERSION.to_be_bytes());
+        bytes.push(tag);
+        bytes.extend_from_slice(&payload_len.to_be_bytes());
+        bytes.extend_from_slice(payload);
+        Ok(bytes)
+    }
+
+    pub fn from_bytes(bytes: &[u8], max_payload_bytes: usize) -> Result<Self, Error> {
+        Ok(IndexValueRef::decode(bytes, max_payload_bytes)?.to_owned())
     }
 }
 
@@ -646,6 +668,83 @@ fn append_hex(output: &mut Vec<u8>, bytes: &[u8]) {
 pub struct DecodedPhysicalIndexKey {
     pub term: Vec<u8>,
     pub primary_key: Vec<u8>,
+}
+
+/// Borrowed logical components of one physical secondary-index key.
+///
+/// Unescaped components point directly into `key`; escaped components use the
+/// caller-owned scratch buffers, which are reusable across rows.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DecodedPhysicalIndexKeyRef<'a> {
+    pub term: &'a [u8],
+    pub primary_key: &'a [u8],
+}
+
+pub fn decode_physical_index_key_ref<'a>(
+    key: &'a [u8],
+    term_scratch: &'a mut Vec<u8>,
+    primary_key_scratch: &'a mut Vec<u8>,
+) -> Result<DecodedPhysicalIndexKeyRef<'a>, Error> {
+    let mut offset = 0usize;
+    let term = decode_physical_segment_ref(key, &mut offset, term_scratch)?;
+    let primary_key = decode_physical_segment_ref(key, &mut offset, primary_key_scratch)?;
+    if offset != key.len() {
+        return Err(Error::Deserialize(
+            "physical secondary-index key must contain exactly two segments".to_string(),
+        ));
+    }
+    Ok(DecodedPhysicalIndexKeyRef { term, primary_key })
+}
+
+fn decode_physical_segment_ref<'a>(
+    key: &'a [u8],
+    offset: &mut usize,
+    scratch: &'a mut Vec<u8>,
+) -> Result<&'a [u8], Error> {
+    let start = *offset;
+    let mut cursor = start;
+    let mut escaped = false;
+    loop {
+        let byte = *key.get(cursor).ok_or_else(|| {
+            Error::Deserialize("unterminated physical secondary-index segment".to_string())
+        })?;
+        if byte != 0 {
+            cursor += 1;
+            continue;
+        }
+        let marker = *key.get(cursor + 1).ok_or_else(|| {
+            Error::Deserialize("truncated physical secondary-index escape".to_string())
+        })?;
+        match marker {
+            0 => {
+                *offset = cursor + 2;
+                if !escaped {
+                    return Ok(&key[start..cursor]);
+                }
+                scratch.clear();
+                let mut decode = start;
+                while decode < cursor {
+                    if key[decode] == 0 {
+                        scratch.push(0);
+                        decode += 2;
+                    } else {
+                        scratch.push(key[decode]);
+                        decode += 1;
+                    }
+                }
+                return Ok(scratch.as_slice());
+            }
+            0xff => {
+                escaped = true;
+                cursor += 2;
+            }
+            marker => {
+                return Err(Error::Deserialize(format!(
+                    "invalid physical secondary-index escape marker {marker}"
+                )))
+            }
+        }
+    }
 }
 
 pub fn physical_index_key(term: &[u8], primary_key: &[u8]) -> Result<Vec<u8>, Error> {
@@ -769,6 +868,23 @@ mod tests {
     }
 
     #[test]
+    fn borrowed_physical_keys_reuse_scratch_and_match_owned_decoding() {
+        let mut term_scratch = Vec::with_capacity(16);
+        let mut key_scratch = Vec::with_capacity(16);
+        let encoded = physical_index_key(&[0, b'a'], &[b'u', 0, 0xff]).unwrap();
+        let decoded =
+            decode_physical_index_key_ref(&encoded, &mut term_scratch, &mut key_scratch).unwrap();
+        assert_eq!(decoded.term, &[0, b'a']);
+        assert_eq!(decoded.primary_key, &[b'u', 0, 0xff]);
+
+        let direct = physical_index_key(b"plain", b"key").unwrap();
+        let decoded =
+            decode_physical_index_key_ref(&direct, &mut term_scratch, &mut key_scratch).unwrap();
+        assert_eq!(decoded.term.as_ptr(), direct.as_ptr());
+        assert_eq!(decoded.primary_key, b"key");
+    }
+
+    #[test]
     fn projection_values_are_versioned_and_canonical() {
         assert_eq!(IndexValue::KeysOnly.to_bytes().unwrap(), Vec::<u8>::new());
         let encoded = IndexValue::Included(b"Ada".to_vec()).to_bytes().unwrap();
@@ -776,6 +892,10 @@ mod tests {
         assert_eq!(
             IndexValue::from_bytes(&encoded, 1024).unwrap(),
             IndexValue::Included(b"Ada".to_vec())
+        );
+        assert_eq!(
+            IndexValueRef::decode(&encoded, 1024).unwrap(),
+            IndexValueRef::Included(b"Ada")
         );
         assert!(IndexValue::from_bytes(&[encoded, vec![0]].concat(), 1024).is_err());
         assert!(

--- a/src/prolly/store/memory.rs
+++ b/src/prolly/store/memory.rs
@@ -1,7 +1,7 @@
 //! In-memory storage backend implementation
 
 use std::collections::{BTreeMap, HashMap};
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 use super::super::error::Error;
 use super::super::manifest::{
@@ -17,7 +17,7 @@ use super::{cid_from_store_key, sort_cids, BatchOp, NodeStoreScan, OrderedBatchR
 /// In-memory store for testing and simple use cases
 #[derive(Debug, Default)]
 pub struct MemStore {
-    data: RwLock<BTreeMap<Vec<u8>, Vec<u8>>>,
+    data: RwLock<BTreeMap<Vec<u8>, Arc<[u8]>>>,
     roots: RwLock<BTreeMap<Vec<u8>, RootManifest>>,
 }
 
@@ -51,6 +51,14 @@ impl Store for MemStore {
             .data
             .read()
             .map_err(|e| MemStoreError(format!("lock poisoned: {}", e)))?;
+        Ok(data.get(key).map(|value| value.as_ref().to_vec()))
+    }
+
+    fn get_shared(&self, key: &[u8]) -> Result<Option<Arc<[u8]>>, Self::Error> {
+        let data = self
+            .data
+            .read()
+            .map_err(|e| MemStoreError(format!("lock poisoned: {}", e)))?;
         Ok(data.get(key).cloned())
     }
 
@@ -59,7 +67,7 @@ impl Store for MemStore {
             .data
             .write()
             .map_err(|e| MemStoreError(format!("lock poisoned: {}", e)))?;
-        data.insert(key.to_vec(), value.to_vec());
+        data.insert(key.to_vec(), Arc::from(value));
         Ok(())
     }
 
@@ -81,7 +89,7 @@ impl Store for MemStore {
         for op in ops {
             match op {
                 BatchOp::Upsert { key, value } => {
-                    data.insert(key.to_vec(), value.to_vec());
+                    data.insert(key.to_vec(), Arc::from(*value));
                 }
                 BatchOp::Delete { key } => {
                     data.remove(*key);
@@ -103,7 +111,7 @@ impl Store for MemStore {
         let mut results = HashMap::with_capacity(plan.unique_keys().len());
         for key in plan.unique_keys() {
             if let Some(value) = data.get(*key) {
-                results.insert(key.to_vec(), value.clone());
+                results.insert(key.to_vec(), value.as_ref().to_vec());
             }
         }
         Ok(results)
@@ -120,7 +128,7 @@ impl Store for MemStore {
         let unique_values = plan
             .unique_keys()
             .iter()
-            .map(|key| data.get(*key).cloned())
+            .map(|key| data.get(*key).map(|value| value.as_ref().to_vec()))
             .collect::<Vec<_>>();
         Ok(plan.expand_owned(unique_values))
     }
@@ -134,7 +142,25 @@ impl Store for MemStore {
             .read()
             .map_err(|e| MemStoreError(format!("lock poisoned: {}", e)))?;
 
+        Ok(keys
+            .iter()
+            .map(|key| data.get(*key).map(|value| value.as_ref().to_vec()))
+            .collect())
+    }
+
+    fn batch_get_shared_ordered_unique(
+        &self,
+        keys: &[&[u8]],
+    ) -> Result<Vec<Option<Arc<[u8]>>>, Self::Error> {
+        let data = self
+            .data
+            .read()
+            .map_err(|e| MemStoreError(format!("lock poisoned: {}", e)))?;
         Ok(keys.iter().map(|key| data.get(*key).cloned()).collect())
+    }
+
+    fn has_native_shared_reads(&self) -> bool {
+        true
     }
 
     fn prefers_batch_reads(&self) -> bool {
@@ -149,7 +175,7 @@ impl Store for MemStore {
             .map_err(|e| MemStoreError(format!("lock poisoned: {}", e)))?;
 
         for (key, value) in entries {
-            data.insert(key.to_vec(), value.to_vec());
+            data.insert(key.to_vec(), Arc::from(*value));
         }
         Ok(())
     }
@@ -279,7 +305,7 @@ impl TransactionalStore for MemStore {
         for write in node_writes {
             match write {
                 TransactionNodeWrite::Upsert { key, value } => {
-                    data.insert(key.clone(), value.clone());
+                    data.insert(key.clone(), Arc::from(value.as_slice()));
                 }
                 TransactionNodeWrite::Delete { key } => {
                     data.remove(key);
@@ -326,6 +352,18 @@ mod tests {
         let store = MemStore::new();
         let result = store.get(b"nonexistent").unwrap();
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn shared_reads_retain_the_same_immutable_allocation() {
+        let store = MemStore::new();
+        store.put(b"key", b"value").unwrap();
+
+        let first = store.get_shared(b"key").unwrap().unwrap();
+        let second = store.get_shared(b"key").unwrap().unwrap();
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(first.as_ref(), b"value");
     }
 
     #[test]

--- a/src/prolly/store/mod.rs
+++ b/src/prolly/store/mod.rs
@@ -99,6 +99,9 @@ pub enum BatchOp<'a> {
     Delete { key: &'a [u8] },
 }
 
+/// Ordered results from a retained immutable-byte batch read.
+pub type SharedReadBatch = Vec<Option<Arc<[u8]>>>;
+
 /// Storage backend trait for Prolly Trees
 ///
 /// Keys are CID bytes, values are serialized nodes.
@@ -112,6 +115,32 @@ pub trait Store: Send + Sync {
     /// Returns `Ok(Some(value))` if key exists, `Ok(None)` if not found,
     /// or `Err` on storage failure.
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Get immutable shared bytes without requiring the engine to copy an
+    /// already-retained cache value. Stores that cannot retain values may use
+    /// the default owned-read adapter.
+    fn get_shared(&self, key: &[u8]) -> Result<Option<Arc<[u8]>>, Self::Error> {
+        self.get(key)
+            .map(|value| value.map(|bytes| Arc::from(bytes.into_boxed_slice())))
+    }
+
+    /// Retrieve unique keys in order as retained immutable byte buffers.
+    fn batch_get_shared_ordered_unique(
+        &self,
+        keys: &[&[u8]],
+    ) -> Result<SharedReadBatch, Self::Error> {
+        self.batch_get_ordered_unique(keys).map(|values| {
+            values
+                .into_iter()
+                .map(|value| value.map(|bytes| Arc::from(bytes.into_boxed_slice())))
+                .collect()
+        })
+    }
+
+    /// Whether shared reads return an already-retained immutable allocation.
+    fn has_native_shared_reads(&self) -> bool {
+        false
+    }
 
     /// Store key-value pair
     ///
@@ -317,6 +346,31 @@ pub trait AsyncStore {
 
     /// Get value by key.
     async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Async immutable shared-byte read.
+    async fn get_shared(&self, key: &[u8]) -> Result<Option<Arc<[u8]>>, Self::Error> {
+        self.get(key)
+            .await
+            .map(|value| value.map(|bytes| Arc::from(bytes.into_boxed_slice())))
+    }
+
+    /// Async ordered retained-byte batch read for unique keys.
+    async fn batch_get_shared_ordered_unique(
+        &self,
+        keys: &[&[u8]],
+    ) -> Result<SharedReadBatch, Self::Error> {
+        self.batch_get_ordered_unique(keys).await.map(|values| {
+            values
+                .into_iter()
+                .map(|value| value.map(|bytes| Arc::from(bytes.into_boxed_slice())))
+                .collect()
+        })
+    }
+
+    /// Whether async shared reads retain backend-owned immutable allocations.
+    fn has_native_shared_reads(&self) -> bool {
+        false
+    }
 
     /// Store key-value pair.
     async fn put(&self, key: &[u8], value: &[u8]) -> Result<(), Self::Error>;
@@ -951,6 +1005,21 @@ impl<T: Store> Store for std::sync::Arc<T> {
         (**self).get(key)
     }
 
+    fn get_shared(&self, key: &[u8]) -> Result<Option<Arc<[u8]>>, Self::Error> {
+        (**self).get_shared(key)
+    }
+
+    fn batch_get_shared_ordered_unique(
+        &self,
+        keys: &[&[u8]],
+    ) -> Result<SharedReadBatch, Self::Error> {
+        (**self).batch_get_shared_ordered_unique(keys)
+    }
+
+    fn has_native_shared_reads(&self) -> bool {
+        (**self).has_native_shared_reads()
+    }
+
     fn put(&self, key: &[u8], value: &[u8]) -> Result<(), Self::Error> {
         (**self).put(key, value)
     }
@@ -1021,6 +1090,21 @@ impl<T: Store + ?Sized> Store for &T {
         (**self).get(key)
     }
 
+    fn get_shared(&self, key: &[u8]) -> Result<Option<Arc<[u8]>>, Self::Error> {
+        (**self).get_shared(key)
+    }
+
+    fn batch_get_shared_ordered_unique(
+        &self,
+        keys: &[&[u8]],
+    ) -> Result<SharedReadBatch, Self::Error> {
+        (**self).batch_get_shared_ordered_unique(keys)
+    }
+
+    fn has_native_shared_reads(&self) -> bool {
+        (**self).has_native_shared_reads()
+    }
+
     fn put(&self, key: &[u8], value: &[u8]) -> Result<(), Self::Error> {
         (**self).put(key, value)
     }
@@ -1085,6 +1169,21 @@ impl<T: AsyncStore> AsyncStore for std::sync::Arc<T> {
 
     async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         (**self).get(key).await
+    }
+
+    async fn get_shared(&self, key: &[u8]) -> Result<Option<Arc<[u8]>>, Self::Error> {
+        (**self).get_shared(key).await
+    }
+
+    async fn batch_get_shared_ordered_unique(
+        &self,
+        keys: &[&[u8]],
+    ) -> Result<SharedReadBatch, Self::Error> {
+        (**self).batch_get_shared_ordered_unique(keys).await
+    }
+
+    fn has_native_shared_reads(&self) -> bool {
+        (**self).has_native_shared_reads()
     }
 
     async fn put(&self, key: &[u8], value: &[u8]) -> Result<(), Self::Error> {

--- a/src/prolly/versioned_map.rs
+++ b/src/prolly/versioned_map.rs
@@ -18,6 +18,7 @@ use super::error::{Diff, Error, Mutation};
 use super::key::decode_segments;
 use super::manifest::{ManifestStore, ManifestStoreScan, NamedRootRetention, RootManifest};
 use super::range::{CursorWindow, RangeCursor, RangeIter, RangePage, ReverseCursor, ReversePage};
+use super::read::{EntryRef, ReadSession, ValueRefView};
 use super::secondary_index::{control_record_key, control_root_name, IndexControl};
 use super::stats::TreeStats;
 use super::store::Store;
@@ -801,6 +802,57 @@ impl<'a, S: Store> MapSnapshot<'a, S> {
         &self.version.tree
     }
 
+    /// Open a reusable zero-copy read session pinned to this snapshot.
+    pub fn read<'snapshot>(&'snapshot self) -> Result<ReadSession<'a, 'snapshot, S>, Error> {
+        self.prolly.read(self.tree())
+    }
+
+    /// Read one key through a callback-scoped borrowed value.
+    pub fn get_with<R>(
+        &self,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.prolly.get_with(self.tree(), key, read)
+    }
+
+    /// Inspect an inline/blob envelope without copying inline payload bytes.
+    pub fn get_value_ref_with<R>(
+        &self,
+        key: &[u8],
+        read: impl for<'value> FnOnce(ValueRefView<'value>) -> R,
+    ) -> Result<Option<R>, Error> {
+        self.prolly.get_value_ref_with(self.tree(), key, read)
+    }
+
+    /// Visit ordered point-read results without owning hit values.
+    pub fn get_many_with<K, F>(&self, keys: &[K], visit: F) -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+        F: for<'value> FnMut(usize, &[u8], Option<&'value [u8]>),
+    {
+        self.prolly.get_many_with(self.tree(), keys, visit)
+    }
+
+    /// Visit a snapshot-pinned half-open range without per-row allocation.
+    pub fn scan_range(
+        &self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        self.prolly.scan_range(self.tree(), start, end, visit)
+    }
+
+    /// Visit a snapshot-pinned prefix without per-row allocation.
+    pub fn scan_prefix(
+        &self,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        self.prolly.scan_prefix(self.tree(), prefix, visit)
+    }
+
     /// Read one key.
     pub fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
         self.prolly.get(self.tree(), key)
@@ -1315,8 +1367,7 @@ where
     pub fn get(&self, key: &K) -> Result<Option<V>, Error> {
         let key = self.key_codec.encode_key(key)?;
         self.inner
-            .get(&key)?
-            .map(|bytes| self.value_codec.decode(&bytes))
+            .get_with(&key, |bytes| self.value_codec.decode(bytes))?
             .transpose()
     }
 
@@ -1324,8 +1375,7 @@ where
     pub fn get_at(&self, id: &MapVersionId, key: &K) -> Result<Option<V>, Error> {
         let key = self.key_codec.encode_key(key)?;
         self.inner
-            .get_at(id, &key)?
-            .map(|bytes| self.value_codec.decode(&bytes))
+            .get_at_with(id, &key, |bytes| self.value_codec.decode(bytes))?
             .transpose()
     }
 
@@ -1880,6 +1930,30 @@ where
         }
     }
 
+    /// Read a key from the current version through a borrowed callback.
+    pub fn get_with<R>(
+        &self,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error> {
+        match self.head()? {
+            Some(version) => self.prolly.get_with(&version.tree, key, read),
+            None => Ok(None),
+        }
+    }
+
+    /// Inspect a current inline/blob envelope without copying inline bytes.
+    pub fn get_value_ref_with<R>(
+        &self,
+        key: &[u8],
+        read: impl for<'value> FnOnce(ValueRefView<'value>) -> R,
+    ) -> Result<Option<R>, Error> {
+        match self.head()? {
+            Some(version) => self.prolly.get_value_ref_with(&version.tree, key, read),
+            None => Ok(None),
+        }
+    }
+
     /// Read one value from head and resolve offloaded blob content.
     pub fn get_large_value<B: super::blob::BlobStore>(
         &self,
@@ -1931,6 +2005,33 @@ where
             .map(|version| version.tree)
             .unwrap_or_else(|| self.prolly.create());
         self.prolly.prefix(&tree, prefix)
+    }
+
+    /// Visit a current-snapshot range without owning rows.
+    pub fn scan_range(
+        &self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        let tree = self
+            .head()?
+            .map(|version| version.tree)
+            .unwrap_or_else(|| self.prolly.create());
+        self.prolly.scan_range(&tree, start, end, visit)
+    }
+
+    /// Visit a current-snapshot prefix without owning rows.
+    pub fn scan_prefix(
+        &self,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        let tree = self
+            .head()?
+            .map(|version| version.tree)
+            .unwrap_or_else(|| self.prolly.create());
+        self.prolly.scan_prefix(&tree, prefix, visit)
     }
 
     /// Read a cursor page from the current version.
@@ -2000,6 +2101,32 @@ where
         self.prolly.get(&version.tree, key)
     }
 
+    /// Read one key from a specific version through a borrowed callback.
+    pub fn get_at_with<R>(
+        &self,
+        id: &MapVersionId,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error> {
+        let version = self
+            .version(id)?
+            .ok_or_else(|| Error::InvalidVersionedMap(format!("unknown map version {id}")))?;
+        self.prolly.get_with(&version.tree, key, read)
+    }
+
+    /// Inspect an inline/blob envelope at a specific immutable version.
+    pub fn get_value_ref_at_with<R>(
+        &self,
+        id: &MapVersionId,
+        key: &[u8],
+        read: impl for<'value> FnOnce(ValueRefView<'value>) -> R,
+    ) -> Result<Option<R>, Error> {
+        let version = self
+            .version(id)?
+            .ok_or_else(|| Error::InvalidVersionedMap(format!("unknown map version {id}")))?;
+        self.prolly.get_value_ref_with(&version.tree, key, read)
+    }
+
     /// Read several keys from a specific immutable version.
     pub fn get_many_at<K: AsRef<[u8]>>(
         &self,
@@ -2035,6 +2162,33 @@ where
             .version(id)?
             .ok_or_else(|| Error::InvalidVersionedMap(format!("unknown map version {id}")))?;
         self.prolly.prefix(&version.tree, prefix)
+    }
+
+    /// Visit a range at a specific immutable version without owning rows.
+    pub fn scan_range_at(
+        &self,
+        id: &MapVersionId,
+        start: &[u8],
+        end: Option<&[u8]>,
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        let version = self
+            .version(id)?
+            .ok_or_else(|| Error::InvalidVersionedMap(format!("unknown map version {id}")))?;
+        self.prolly.scan_range(&version.tree, start, end, visit)
+    }
+
+    /// Visit a prefix at a specific immutable version without owning rows.
+    pub fn scan_prefix_at(
+        &self,
+        id: &MapVersionId,
+        prefix: &[u8],
+        visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        let version = self
+            .version(id)?
+            .ok_or_else(|| Error::InvalidVersionedMap(format!("unknown map version {id}")))?;
+        self.prolly.scan_prefix(&version.tree, prefix, visit)
     }
 
     /// Read a cursor page from a specific immutable version.

--- a/src/prolly/write_session.rs
+++ b/src/prolly/write_session.rs
@@ -1,8 +1,10 @@
 //! Bounded read-through mutation sessions.
 
 use std::collections::BTreeMap;
+use std::ops::{Bound, ControlFlow};
 
 use super::error::{Error, Mutation};
+use super::read::{EntryRef, ScanOutcome};
 use super::store::Store;
 use super::{KeyValue, Prolly, Tree};
 
@@ -65,34 +67,121 @@ impl<'a, S: Store> WriteSession<'a, S> {
     }
 
     pub fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+        self.get_with(key, <[u8]>::to_vec)
+    }
+
+    /// Read through the overlay without cloning a staged or base value.
+    pub fn get_with<R>(
+        &self,
+        key: &[u8],
+        read: impl FnOnce(&[u8]) -> R,
+    ) -> Result<Option<R>, Error> {
         match self.overlay.get(key) {
-            Some(PendingValue::Value(value)) => Ok(Some(value.clone())),
+            Some(PendingValue::Value(value)) => Ok(Some(read(value))),
             Some(PendingValue::Deleted) => Ok(None),
-            None => self.manager.get(&self.base, key),
+            None => self.manager.get_with(&self.base, key, read),
         }
     }
 
     /// Materialize one bounded merged range from the base cursor and overlay.
     pub fn range(&self, start: &[u8], end: Option<&[u8]>) -> Result<Vec<KeyValue>, Error> {
-        let mut merged = BTreeMap::new();
-        for entry in self.manager.range(&self.base, start, end)? {
-            let (key, value) = entry?;
-            merged.insert(key, value);
-        }
-        for (key, pending) in self.overlay.range(start.to_vec()..) {
-            if end.map(|bound| key.as_slice() >= bound).unwrap_or(false) {
-                break;
-            }
-            match pending {
-                PendingValue::Value(value) => {
-                    merged.insert(key.clone(), value.clone());
+        let mut entries = Vec::new();
+        self.scan_range(start, end, |entry| entries.push(entry.to_owned()))?;
+        Ok(entries)
+    }
+
+    /// Visit the ordered overlay/base merge without materializing a map.
+    pub fn scan_range(
+        &self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        mut visit: impl for<'entry> FnMut(EntryRef<'entry>),
+    ) -> Result<u64, Error> {
+        Ok(self
+            .scan_range_until(start, end, |entry| {
+                visit(entry);
+                ControlFlow::<()>::Continue(())
+            })?
+            .visited)
+    }
+
+    /// Visit the ordered overlay/base merge with early termination.
+    pub fn scan_range_until<B>(
+        &self,
+        start: &[u8],
+        end: Option<&[u8]>,
+        mut visit: impl for<'entry> FnMut(EntryRef<'entry>) -> ControlFlow<B>,
+    ) -> Result<ScanOutcome<B>, Error> {
+        let mut overlay = self
+            .overlay
+            .range::<[u8], _>((Bound::Included(start), Bound::Unbounded))
+            .take_while(|(key, _)| end.map_or(true, |end| key.as_slice() < end))
+            .peekable();
+        let mut visited = 0u64;
+        let mut stopped = None;
+
+        let base_outcome = self
+            .manager
+            .scan_range_until(&self.base, start, end, |base_entry| {
+                while overlay
+                    .peek()
+                    .is_some_and(|(key, _)| key.as_slice() < base_entry.key())
+                {
+                    let (key, pending) = overlay.next().expect("peeked overlay entry");
+                    if let PendingValue::Value(value) = pending {
+                        visited = visited.saturating_add(1);
+                        if let ControlFlow::Break(value) =
+                            visit(EntryRef::new(key.as_slice(), value.as_slice()))
+                        {
+                            stopped = Some(value);
+                            return ControlFlow::Break(());
+                        }
+                    }
                 }
-                PendingValue::Deleted => {
-                    merged.remove(key);
+
+                if overlay
+                    .peek()
+                    .is_some_and(|(key, _)| key.as_slice() == base_entry.key())
+                {
+                    let (key, pending) = overlay.next().expect("peeked overlay entry");
+                    if let PendingValue::Value(value) = pending {
+                        visited = visited.saturating_add(1);
+                        if let ControlFlow::Break(value) =
+                            visit(EntryRef::new(key.as_slice(), value.as_slice()))
+                        {
+                            stopped = Some(value);
+                            return ControlFlow::Break(());
+                        }
+                    }
+                    return ControlFlow::Continue(());
+                }
+
+                visited = visited.saturating_add(1);
+                if let ControlFlow::Break(value) = visit(base_entry) {
+                    stopped = Some(value);
+                    ControlFlow::Break(())
+                } else {
+                    ControlFlow::Continue(())
+                }
+            })?;
+
+        if base_outcome.break_value.is_some() {
+            return Ok(ScanOutcome {
+                visited,
+                break_value: stopped,
+            });
+        }
+        for (key, pending) in overlay {
+            if let PendingValue::Value(value) = pending {
+                visited = visited.saturating_add(1);
+                if let ControlFlow::Break(value) =
+                    visit(EntryRef::new(key.as_slice(), value.as_slice()))
+                {
+                    return Ok(ScanOutcome::stopped(visited, value));
                 }
             }
         }
-        Ok(merged.into_iter().collect())
+        Ok(ScanOutcome::complete(visited))
     }
 
     pub fn savepoint(&self) -> Savepoint {

--- a/tests/proximity_async.rs
+++ b/tests/proximity_async.rs
@@ -206,6 +206,14 @@ fn async_scalar_quantized_routing_matches_sync_order_and_reranking() {
             actual.stats.reranked_candidates,
             expected.stats.reranked_candidates
         );
+        assert_eq!(
+            actual.stats.candidate_handles_peak,
+            expected.stats.candidate_handles_peak
+        );
+        assert_eq!(
+            actual.stats.candidate_retained_bytes_peak,
+            expected.stats.candidate_retained_bytes_peak
+        );
         assert_eq!(actual.stats.committed_bytes, expected.stats.committed_bytes);
     });
 }
@@ -319,6 +327,14 @@ fn async_only_hnsw_and_pq_use_the_sync_plan_and_logical_execution() {
             assert_eq!(
                 actual.stats.quantized_distance_evaluations,
                 expected.stats.quantized_distance_evaluations
+            );
+            assert_eq!(
+                actual.stats.candidate_handles_peak,
+                expected.stats.candidate_handles_peak
+            );
+            assert_eq!(
+                actual.stats.candidate_retained_bytes_peak,
+                expected.stats.candidate_retained_bytes_peak
             );
             assert_eq!(actual.stats.committed_bytes, expected.stats.committed_bytes);
         }

--- a/tests/proximity_hnsw.rs
+++ b/tests/proximity_hnsw.rs
@@ -112,6 +112,12 @@ fn hnsw_has_fixed_seed_recall_enforces_filters_and_resolves_authoritative_values
     let second = index.search(&map, request).unwrap();
     assert_eq!(first.neighbors, second.neighbors);
     assert_eq!(first.stats, second.stats);
+    assert!(first.stats.reranked_candidates > first.neighbors.len());
+    assert_eq!(
+        first.stats.candidate_handles_peak,
+        first.stats.reranked_candidates
+    );
+    assert!(first.stats.candidate_retained_bytes_peak > 0);
     let exact_keys: HashSet<_> = exact.neighbors.iter().map(|hit| hit.key.clone()).collect();
     let overlap = first
         .neighbors

--- a/tests/proximity_map.rs
+++ b/tests/proximity_map.rs
@@ -2,6 +2,7 @@ use prolly::{
     DistanceMetric, Error, MemStore, ProximityConfig, ProximityFilter, ProximityMap,
     ProximityRecord, SearchBackend, SearchBudget, SearchCompletion, SearchPolicy, SearchRequest,
 };
+use std::ops::ControlFlow;
 use std::sync::Arc;
 
 fn config(dimensions: u32) -> ProximityConfig {
@@ -81,6 +82,30 @@ fn proximity_build_supports_exact_present_and_absent_key_lookup() {
     assert_eq!(value, b"payload".to_vec());
     assert_eq!(map.get(b"absent").unwrap(), None);
     assert!(!map.contains_key(b"absent").unwrap());
+
+    let borrowed = map
+        .get_with(b"document-1", |record| {
+            assert_eq!(record.vector.dimensions(), 2);
+            assert_eq!(record.vector.component(0), Some(1.0));
+            assert_eq!(record.vector.component(1), Some(0.0));
+            assert_eq!(record.vector.component(2), None);
+            let mut output = [0.0; 2];
+            record.vector.copy_to_slice(&mut output).unwrap();
+            (output, record.value.to_vec())
+        })
+        .unwrap();
+    assert_eq!(borrowed, Some(([1.0, 0.0], b"payload".to_vec())));
+
+    let mut session = map.read().unwrap();
+    assert!(session.contains_key(b"document-1").unwrap());
+    let stopped = session
+        .scan_records_until(|key, record| {
+            assert_eq!(record.to_owned(), (vec![1.0, 0.0], b"payload".to_vec()));
+            ControlFlow::Break(key.to_vec())
+        })
+        .unwrap();
+    assert_eq!(stopped.visited, 1);
+    assert_eq!(stopped.break_value, Some(b"document-1".to_vec()));
 }
 
 #[test]

--- a/tests/proximity_quantization.rs
+++ b/tests/proximity_quantization.rs
@@ -147,6 +147,11 @@ fn product_quantization_is_thread_identical_source_bound_and_full_precision_rera
     let result = loaded.search(&map, request).unwrap();
     assert!(result.stats.quantized_distance_evaluations > 0);
     assert_eq!(result.stats.reranked_candidates, 100);
+    assert_eq!(
+        result.stats.candidate_handles_peak,
+        result.stats.reranked_candidates
+    );
+    assert!(result.stats.candidate_retained_bytes_peak > 0);
     assert_eq!(result.neighbors.len(), exact.neighbors.len());
     for (expected, actual) in exact.neighbors.iter().zip(&result.neighbors) {
         assert_eq!(expected.key, actual.key);

--- a/tests/secondary_index.rs
+++ b/tests/secondary_index.rs
@@ -3,6 +3,7 @@ use prolly::{
     Config, Error, IndexControl, IndexProjection, MemStore, Mutation, ParallelConfig, Prolly,
     SecondaryIndex, SecondaryIndexEntry, SecondaryIndexError, SecondaryIndexRegistry,
 };
+use std::ops::ControlFlow;
 use std::sync::Arc;
 
 #[test]
@@ -691,6 +692,29 @@ fn indexed_snapshot_queries_are_exact_projected_paged_and_historical() {
             (b"user-2".to_vec(), b"active|Grace".to_vec()),
         ]
     );
+    let mut borrowed = Vec::new();
+    assert_eq!(
+        by_status
+            .scan_exact(b"active", |matched| borrowed.push(matched.to_owned()))
+            .unwrap(),
+        2
+    );
+    assert_eq!(borrowed, by_status.exact(b"active").unwrap());
+    let mut borrowed_records = Vec::new();
+    by_status
+        .scan_records(b"active", |record| borrowed_records.push(record.to_owned()))
+        .unwrap();
+    assert_eq!(borrowed_records, by_status.records(b"active").unwrap());
+    let mut reverse_keys = Vec::new();
+    let stopped = by_status
+        .scan_exact_reverse_until(b"active", |matched| {
+            reverse_keys.push(matched.primary_key.to_vec());
+            ControlFlow::Break(matched.primary_key.to_vec())
+        })
+        .unwrap();
+    assert_eq!(stopped.visited, 1);
+    assert_eq!(reverse_keys, vec![b"user-2".to_vec()]);
+    assert_eq!(stopped.break_value, Some(b"user-2".to_vec()));
     assert_eq!(
         historical
             .index(b"by-status-name")

--- a/tests/write_session.rs
+++ b/tests/write_session.rs
@@ -1,4 +1,5 @@
 use prolly::{Config, Error, MemStore, Mutation, Prolly};
+use std::ops::ControlFlow;
 use std::sync::Arc;
 
 fn base() -> (Prolly<Arc<MemStore>>, prolly::Tree) {
@@ -32,12 +33,30 @@ fn overlay_reads_ranges_and_flush_match_direct_batch() {
     assert_eq!(session.get(b"a").unwrap(), None);
     assert_eq!(session.get(b"b").unwrap(), Some(b"2".to_vec()));
     assert_eq!(
+        session.get_with(b"b", |value| value[0]).unwrap(),
+        Some(b'2')
+    );
+    assert_eq!(
         session.range(b"a", Some(b"d")).unwrap(),
         vec![
             (b"b".to_vec(), b"2".to_vec()),
             (b"c".to_vec(), b"changed".to_vec()),
         ]
     );
+    let mut borrowed = Vec::new();
+    let outcome = session
+        .scan_range_until(b"a", Some(b"d"), |entry| {
+            borrowed.push(entry.to_owned());
+            if borrowed.len() == 2 {
+                ControlFlow::Break(entry.key().to_vec())
+            } else {
+                ControlFlow::Continue(())
+            }
+        })
+        .unwrap();
+    assert_eq!(outcome.visited, 2);
+    assert_eq!(outcome.break_value, Some(b"c".to_vec()));
+    assert_eq!(borrowed, session.range(b"a", Some(b"d")).unwrap());
 
     let direct = manager
         .batch(

--- a/tests/zero_copy_reads.rs
+++ b/tests/zero_copy_reads.rs
@@ -1,0 +1,747 @@
+use std::ops::ControlFlow;
+use std::sync::Arc;
+#[cfg(feature = "async-store")]
+use std::{
+    future::Future,
+    task::{Context, Poll},
+};
+
+#[cfg(feature = "async-store")]
+use prolly::{AsyncProlly, SyncStoreAsAsync};
+use prolly::{
+    BlobRef, BorrowedMergeResolver, Config, ConflictRef, Error, MemStore, MergeDecision, Mutation,
+    NodeLayoutSpec, Prolly, ValueRef, ValueRefView,
+};
+
+struct Select(MergeDecision);
+
+impl BorrowedMergeResolver for Select {
+    fn resolve(&self, _conflict: ConflictRef<'_>) -> MergeDecision {
+        self.0.clone()
+    }
+}
+
+#[cfg(feature = "async-store")]
+fn block_on<F: Future>(future: F) -> F::Output {
+    let waker = futures_util::task::noop_waker();
+    let mut context = Context::from_waker(&waker);
+    let mut future = Box::pin(future);
+    loop {
+        match future.as_mut().poll(&mut context) {
+            Poll::Ready(value) => return value,
+            Poll::Pending => std::thread::yield_now(),
+        }
+    }
+}
+
+fn fixture(layout: NodeLayoutSpec, count: usize) -> (Prolly<Arc<MemStore>>, prolly::Tree) {
+    let config = Config::builder().node_layout(layout).build();
+    let prolly = Prolly::new(Arc::new(MemStore::new()), config);
+    let entries = (0..count)
+        .map(|index| {
+            (
+                format!("key/{index:06}").into_bytes(),
+                format!("value/{index:06}").into_bytes(),
+            )
+        })
+        .collect();
+    let tree = prolly.build_from_sorted_entries(entries).unwrap();
+    (prolly, tree)
+}
+
+fn layouts() -> [NodeLayoutSpec; 3] {
+    [
+        NodeLayoutSpec::Plain,
+        NodeLayoutSpec::PrefixCompressed,
+        NodeLayoutSpec::OffsetTable,
+    ]
+}
+
+#[test]
+fn borrowed_point_reads_match_owned_reads_for_every_layout() {
+    for layout in layouts() {
+        let (prolly, tree) = fixture(layout, 1_024);
+        let mut session = prolly.read(&tree).unwrap();
+
+        for index in [0, 1, 127, 511, 1_023] {
+            let key = format!("key/{index:06}");
+            let expected = format!("value/{index:06}").into_bytes();
+            assert_eq!(
+                session
+                    .get_with(key.as_bytes(), |value| value.to_vec())
+                    .unwrap(),
+                Some(expected.clone())
+            );
+            assert_eq!(prolly.get(&tree, key.as_bytes()).unwrap(), Some(expected));
+            assert!(session.contains_key(key.as_bytes()).unwrap());
+        }
+
+        let mut called = false;
+        assert_eq!(
+            session
+                .get_with(b"key/missing", |_| {
+                    called = true;
+                })
+                .unwrap(),
+            None
+        );
+        assert!(!called);
+        assert!(!session.contains_key(b"key/missing").unwrap());
+    }
+}
+
+#[test]
+fn borrowed_ranges_match_owned_forward_reverse_prefix_and_bounds() {
+    for layout in layouts() {
+        let (prolly, tree) = fixture(layout, 2_000);
+        let start = b"key/000317";
+        let end = Some(b"key/001743".as_slice());
+        let expected = prolly
+            .range(&tree, start, end)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        let mut session = prolly.read(&tree).unwrap();
+        let mut forward = Vec::new();
+        assert_eq!(
+            session
+                .scan_range(start, end, |entry| forward.push(entry.to_owned()))
+                .unwrap(),
+            expected.len() as u64
+        );
+        assert_eq!(forward, expected);
+
+        let mut reverse = Vec::new();
+        assert_eq!(
+            session
+                .scan_range_reverse(start, end, |entry| reverse.push(entry.to_owned()))
+                .unwrap(),
+            expected.len() as u64
+        );
+        let mut expected_reverse = expected.clone();
+        expected_reverse.reverse();
+        assert_eq!(reverse, expected_reverse);
+
+        let mut prefix = Vec::new();
+        session
+            .scan_prefix(b"key/0003", |entry| prefix.push(entry.to_owned()))
+            .unwrap();
+        assert!(prefix.iter().all(|(key, _)| key.starts_with(b"key/0003")));
+        assert_eq!(prefix.len(), 100);
+
+        assert_eq!(
+            session
+                .lower_bound_with(b"key/000317", |entry| entry.to_owned())
+                .unwrap(),
+            expected.first().cloned()
+        );
+        assert_eq!(
+            session
+                .upper_bound_with(b"key/000317", |entry| entry.to_owned())
+                .unwrap()
+                .unwrap()
+                .0,
+            b"key/000318"
+        );
+        assert_eq!(
+            session
+                .select_with(1_337, |entry| entry.to_owned())
+                .unwrap()
+                .unwrap()
+                .0,
+            b"key/001337"
+        );
+        assert_eq!(session.rank(b"key/001337").unwrap(), 1_337);
+        assert_eq!(session.len().unwrap(), 2_000);
+    }
+}
+
+#[test]
+fn early_stop_counts_the_break_entry_and_preserves_order() {
+    let (prolly, tree) = fixture(NodeLayoutSpec::PrefixCompressed, 1_000);
+    let mut session = prolly.read(&tree).unwrap();
+    let mut keys = Vec::new();
+    let outcome = session
+        .scan_range_until(b"key/000100", Some(b"key/000900"), |entry| {
+            keys.push(entry.key().to_vec());
+            if keys.len() == 37 {
+                ControlFlow::Break(entry.value().to_vec())
+            } else {
+                ControlFlow::Continue(())
+            }
+        })
+        .unwrap();
+    assert_eq!(outcome.visited, 37);
+    assert_eq!(outcome.break_value, Some(b"value/000136".to_vec()));
+    assert_eq!(keys.first().unwrap(), b"key/000100");
+    assert_eq!(keys.last().unwrap(), b"key/000136");
+
+    let mut reverse_keys = Vec::new();
+    let outcome = session
+        .scan_range_reverse_until(b"key/000100", Some(b"key/000900"), |entry| {
+            reverse_keys.push(entry.key().to_vec());
+            if reverse_keys.len() == 23 {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        })
+        .unwrap();
+    assert_eq!(outcome.visited, 23);
+    assert_eq!(reverse_keys.first().unwrap(), b"key/000899");
+    assert_eq!(reverse_keys.last().unwrap(), b"key/000877");
+}
+
+#[test]
+fn borrowed_multi_get_preserves_positions_duplicates_and_misses() {
+    let (prolly, tree) = fixture(NodeLayoutSpec::OffsetTable, 512);
+    let keys = [
+        b"key/000400".as_slice(),
+        b"missing".as_slice(),
+        b"key/000002".as_slice(),
+        b"key/000400".as_slice(),
+    ];
+    let mut actual = Vec::new();
+    let mut session = prolly.read(&tree).unwrap();
+    session
+        .get_many_with(&keys, |position, key, value| {
+            actual.push((position, key.to_vec(), value.map(<[u8]>::to_vec)));
+        })
+        .unwrap();
+
+    assert_eq!(actual.len(), keys.len());
+    assert_eq!(actual[0].2, Some(b"value/000400".to_vec()));
+    assert_eq!(actual[1].2, None);
+    assert_eq!(actual[2].2, Some(b"value/000002".to_vec()));
+    assert_eq!(actual[3].2, Some(b"value/000400".to_vec()));
+    assert_eq!(
+        actual.iter().map(|entry| entry.0).collect::<Vec<_>>(),
+        vec![0, 1, 2, 3]
+    );
+}
+
+#[test]
+fn borrowed_large_value_views_match_owned_decoding() {
+    let prolly = Prolly::new(MemStore::new(), Config::default());
+    let mut tree = prolly.create();
+    tree = prolly
+        .put(&tree, b"raw".to_vec(), b"raw-value".to_vec())
+        .unwrap();
+    tree = prolly
+        .put(
+            &tree,
+            b"escaped".to_vec(),
+            ValueRef::Inline(b"PLVB-inline".to_vec()).to_bytes(),
+        )
+        .unwrap();
+    let blob = BlobRef::from_bytes(b"external-value");
+    tree = prolly
+        .put(
+            &tree,
+            b"blob".to_vec(),
+            ValueRef::Blob(blob.clone()).to_bytes(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        prolly
+            .get_value_ref_with(&tree, b"raw", |view| view.to_owned())
+            .unwrap(),
+        Some(ValueRef::Inline(b"raw-value".to_vec()))
+    );
+    assert_eq!(
+        prolly
+            .get_value_ref_with(&tree, b"escaped", |view| match view {
+                ValueRefView::Inline(value) => value.to_vec(),
+                ValueRefView::Blob { .. } => unreachable!(),
+            })
+            .unwrap(),
+        Some(b"PLVB-inline".to_vec())
+    );
+    assert_eq!(
+        prolly
+            .get_value_ref_with(&tree, b"blob", |view| view.to_owned())
+            .unwrap(),
+        Some(ValueRef::Blob(blob))
+    );
+}
+
+#[test]
+fn read_session_rejects_persisted_format_mismatch_even_for_empty_tree() {
+    let source = Prolly::new(
+        MemStore::new(),
+        Config::builder().node_layout(NodeLayoutSpec::Plain).build(),
+    );
+    let tree = source.create();
+    let other = Prolly::new(
+        MemStore::new(),
+        Config::builder()
+            .node_layout(NodeLayoutSpec::OffsetTable)
+            .build(),
+    );
+    assert!(matches!(
+        other.read(&tree),
+        Err(Error::FormatMismatch { .. })
+    ));
+}
+
+#[test]
+fn callbacks_can_reenter_manager_reads_without_cache_lock_deadlock() {
+    let (prolly, tree) = fixture(NodeLayoutSpec::Plain, 128);
+    let mut checked = 0usize;
+    prolly
+        .scan_range(&tree, b"key/000010", Some(b"key/000020"), |entry| {
+            let owned = prolly.get(&tree, entry.key()).unwrap().unwrap();
+            assert_eq!(owned, entry.value());
+            checked += 1;
+        })
+        .unwrap();
+    assert_eq!(checked, 10);
+}
+
+#[test]
+fn borrowed_structural_diff_matches_owned_diff_and_range_filtering() {
+    for layout in layouts() {
+        let (prolly, base) = fixture(layout, 2_000);
+        let mut other = base.clone();
+        for index in (100..1_900).step_by(137) {
+            other = prolly
+                .put(
+                    &other,
+                    format!("key/{index:06}").into_bytes(),
+                    format!("changed/{index:06}").into_bytes(),
+                )
+                .unwrap();
+        }
+        for index in (150..1_700).step_by(211) {
+            other = prolly
+                .delete(&other, format!("key/{index:06}").as_bytes())
+                .unwrap();
+        }
+        for index in 2_000..2_075 {
+            other = prolly
+                .put(
+                    &other,
+                    format!("key/{index:06}").into_bytes(),
+                    format!("added/{index:06}").into_bytes(),
+                )
+                .unwrap();
+        }
+
+        let expected = prolly.diff(&base, &other).unwrap();
+        let mut actual = Vec::new();
+        assert_eq!(
+            prolly
+                .scan_diff(&base, &other, |diff| actual.push(diff.to_owned()))
+                .unwrap(),
+            expected.len() as u64
+        );
+        assert_eq!(actual, expected);
+
+        let start = b"key/000500";
+        let end = Some(b"key/001500".as_slice());
+        let expected_range = expected
+            .iter()
+            .filter(|diff| diff.key() >= start && end.map_or(true, |end| diff.key() < end))
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut actual_range = Vec::new();
+        prolly
+            .scan_range_diff(&base, &other, start, end, |diff| {
+                actual_range.push(diff.to_owned())
+            })
+            .unwrap();
+        assert_eq!(actual_range, expected_range);
+
+        let stopped = prolly
+            .scan_diff_until(&base, &other, |_| ControlFlow::Break("done"))
+            .unwrap();
+        assert_eq!(stopped.visited, u64::from(!expected.is_empty()));
+        assert_eq!(
+            stopped.break_value,
+            (!expected.is_empty()).then_some("done")
+        );
+        assert_eq!(prolly.scan_diff(&base, &base, |_| {}).unwrap(), 0);
+    }
+}
+
+#[test]
+fn borrowed_conflict_scan_matches_legacy_conflict_stream() {
+    let prolly = Prolly::new(MemStore::new(), Config::default());
+    let mut base = prolly.create();
+    for (key, value) in [(b"a", b"base-a"), (b"b", b"base-b"), (b"c", b"base-c")] {
+        base = prolly.put(&base, key.to_vec(), value.to_vec()).unwrap();
+    }
+    let mut left = prolly
+        .put(&base, b"a".to_vec(), b"left-a".to_vec())
+        .unwrap();
+    left = prolly.delete(&left, b"b").unwrap();
+    left = prolly
+        .put(&left, b"d".to_vec(), b"left-d".to_vec())
+        .unwrap();
+
+    let mut right = prolly
+        .put(&base, b"a".to_vec(), b"right-a".to_vec())
+        .unwrap();
+    right = prolly
+        .put(&right, b"b".to_vec(), b"right-b".to_vec())
+        .unwrap();
+    right = prolly
+        .put(&right, b"c".to_vec(), b"right-c".to_vec())
+        .unwrap();
+    right = prolly
+        .put(&right, b"d".to_vec(), b"right-d".to_vec())
+        .unwrap();
+
+    let legacy = prolly
+        .stream_conflicts(&base, &left, &right)
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .into_iter()
+        .map(|conflict| (conflict.key, conflict.base, conflict.left, conflict.right))
+        .collect::<Vec<_>>();
+    let mut borrowed = Vec::new();
+    assert_eq!(
+        prolly
+            .scan_conflicts(&base, &left, &right, |conflict| {
+                let conflict = conflict.to_owned();
+                borrowed.push((conflict.key, conflict.base, conflict.left, conflict.right));
+            })
+            .unwrap(),
+        legacy.len() as u64
+    );
+    assert_eq!(borrowed, legacy);
+    assert_eq!(
+        borrowed
+            .iter()
+            .map(|conflict| conflict.0.as_slice())
+            .collect::<Vec<_>>(),
+        vec![b"a".as_slice(), b"b".as_slice(), b"d".as_slice()]
+    );
+
+    let stopped = prolly
+        .scan_conflicts_until(&base, &left, &right, |conflict| {
+            ControlFlow::Break(conflict.key.to_vec())
+        })
+        .unwrap();
+    assert_eq!(stopped.visited, 1);
+    assert_eq!(stopped.break_value, Some(b"a".to_vec()));
+}
+
+#[test]
+fn borrowed_merge_matches_legacy_and_supports_symbolic_decisions() {
+    for layout in layouts() {
+        let (prolly, base) = fixture(layout, 1_000);
+        let mut left = base.clone();
+        let mut right = base.clone();
+
+        for index in (50..850).step_by(79) {
+            left = prolly
+                .put(
+                    &left,
+                    format!("key/{index:06}").into_bytes(),
+                    format!("left/{index:06}").into_bytes(),
+                )
+                .unwrap();
+            right = prolly
+                .put(
+                    &right,
+                    format!("key/{index:06}").into_bytes(),
+                    format!("right/{index:06}").into_bytes(),
+                )
+                .unwrap();
+        }
+        left = prolly
+            .put(&left, b"left-only".to_vec(), b"left".to_vec())
+            .unwrap();
+        right = prolly
+            .put(&right, b"right-only".to_vec(), b"right".to_vec())
+            .unwrap();
+
+        let legacy = prolly
+            .merge(
+                &base,
+                &left,
+                &right,
+                Some(Box::new(|conflict| {
+                    conflict
+                        .left
+                        .clone()
+                        .map_or_else(prolly::Resolution::delete, prolly::Resolution::value)
+                })),
+            )
+            .unwrap();
+        let borrowed = prolly
+            .merge_with(&base, &left, &right, Some(&Select(MergeDecision::UseLeft)))
+            .unwrap();
+        assert_eq!(borrowed.root, legacy.root);
+
+        let prefer_right = prolly
+            .merge_with(&base, &left, &right, Some(&Select(MergeDecision::UseRight)))
+            .unwrap();
+        for index in (50..850).step_by(79) {
+            assert_eq!(
+                prolly
+                    .get(&prefer_right, format!("key/{index:06}").as_bytes())
+                    .unwrap(),
+                Some(format!("right/{index:06}").into_bytes())
+            );
+        }
+
+        let prefer_base = prolly
+            .merge_with(&base, &left, &right, Some(&Select(MergeDecision::UseBase)))
+            .unwrap();
+        for index in (50..850).step_by(79) {
+            assert_eq!(
+                prolly
+                    .get(&prefer_base, format!("key/{index:06}").as_bytes())
+                    .unwrap(),
+                Some(format!("value/{index:06}").into_bytes())
+            );
+        }
+
+        assert!(matches!(
+            prolly.merge_with(
+                &base,
+                &left,
+                &right,
+                Some(&Select(MergeDecision::Unresolved)),
+            ),
+            Err(Error::Conflict(_))
+        ));
+    }
+}
+
+#[test]
+fn borrowed_merge_batches_large_fallbacks_without_changing_the_canonical_root() {
+    let (prolly, base) = fixture(NodeLayoutSpec::OffsetTable, 10_000);
+    let left = prolly
+        .put(&base, b"key/left-only".to_vec(), b"left".to_vec())
+        .unwrap();
+    let right_mutations = (0..9_000)
+        .step_by(2)
+        .map(|index| Mutation::Upsert {
+            key: format!("key/{index:06}").into_bytes(),
+            val: format!("right/{index:06}").into_bytes(),
+        })
+        .collect::<Vec<_>>();
+    assert!(right_mutations.len() > 4_096);
+    let right = prolly.batch(&base, right_mutations.clone()).unwrap();
+
+    let expected = prolly.batch(&left, right_mutations).unwrap();
+    let merged = prolly.merge_with(&base, &left, &right, None).unwrap();
+    assert_eq!(merged.root, expected.root);
+}
+
+#[test]
+fn borrowed_range_and_prefix_merge_do_not_modify_outside_selection() {
+    let (prolly, base) = fixture(NodeLayoutSpec::PrefixCompressed, 200);
+    let left = prolly
+        .put(&base, b"key/000150".to_vec(), b"left-150".to_vec())
+        .unwrap();
+    let mut right = prolly
+        .put(&base, b"key/000050".to_vec(), b"right-050".to_vec())
+        .unwrap();
+    right = prolly
+        .put(&right, b"key/000150".to_vec(), b"right-150".to_vec())
+        .unwrap();
+
+    let ranged = prolly
+        .merge_range_with(
+            &base,
+            &left,
+            &right,
+            b"key/000000",
+            Some(b"key/000100"),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        prolly.get(&ranged, b"key/000050").unwrap(),
+        Some(b"right-050".to_vec())
+    );
+    assert_eq!(
+        prolly.get(&ranged, b"key/000150").unwrap(),
+        Some(b"left-150".to_vec())
+    );
+
+    let prefixed = prolly
+        .merge_prefix_with(&base, &left, &right, b"key/0000", None)
+        .unwrap();
+    assert_eq!(
+        prolly.get(&prefixed, b"key/000050").unwrap(),
+        Some(b"right-050".to_vec())
+    );
+    assert_eq!(
+        prolly.get(&prefixed, b"key/000150").unwrap(),
+        Some(b"left-150".to_vec())
+    );
+}
+
+#[cfg(feature = "async-store")]
+#[test]
+fn async_borrowed_reads_match_sync_results_without_owned_iterator_entries() {
+    block_on(async {
+        let store = Arc::new(MemStore::new());
+        let config = Config::builder()
+            .node_layout(NodeLayoutSpec::OffsetTable)
+            .build();
+        let sync = Prolly::new(store.clone(), config.clone());
+        let entries = (0..512)
+            .map(|index| {
+                (
+                    format!("key/{index:06}").into_bytes(),
+                    format!("value/{index:06}").into_bytes(),
+                )
+            })
+            .collect();
+        let tree = sync.build_from_sorted_entries(entries).unwrap();
+        let async_prolly = AsyncProlly::new(SyncStoreAsAsync::new(store), config);
+        let mut session = async_prolly.read(&tree).await.unwrap();
+
+        assert_eq!(
+            session
+                .get_with(b"key/000123", |value| value.to_vec())
+                .await
+                .unwrap(),
+            Some(b"value/000123".to_vec())
+        );
+        assert_eq!(
+            session
+                .get_with(b"missing", |_| unreachable!())
+                .await
+                .unwrap(),
+            None
+        );
+
+        let keys = [
+            b"key/000400".as_slice(),
+            b"missing".as_slice(),
+            b"key/000002".as_slice(),
+            b"key/000400".as_slice(),
+        ];
+        let mut values = Vec::new();
+        session
+            .get_many_with(&keys, |position, _, value| {
+                values.push((position, value.map(<[u8]>::to_vec)));
+            })
+            .await
+            .unwrap();
+        assert_eq!(values[0].1, Some(b"value/000400".to_vec()));
+        assert_eq!(values[1].1, None);
+        assert_eq!(values[3].1, values[0].1);
+
+        let mut scanned = Vec::new();
+        assert_eq!(
+            session
+                .scan_range(b"key/000100", Some(b"key/000125"), |entry| {
+                    scanned.push(entry.to_owned())
+                })
+                .await
+                .unwrap(),
+            25
+        );
+        assert_eq!(scanned.first().unwrap().0, b"key/000100");
+        assert_eq!(scanned.last().unwrap().0, b"key/000124");
+
+        let mut reverse = Vec::new();
+        let stopped = session
+            .scan_range_reverse_until(b"key/000100", Some(b"key/000125"), |entry| {
+                reverse.push(entry.key().to_vec());
+                if reverse.len() == 7 {
+                    ControlFlow::Break(entry.value().to_vec())
+                } else {
+                    ControlFlow::Continue(())
+                }
+            })
+            .await
+            .unwrap();
+        assert_eq!(stopped.visited, 7);
+        assert_eq!(reverse.first().unwrap(), b"key/000124");
+        assert_eq!(reverse.last().unwrap(), b"key/000118");
+        assert_eq!(stopped.break_value, Some(b"value/000118".to_vec()));
+
+        let mut iterator = async_prolly
+            .range(&tree, b"key/000200", Some(b"key/000202"))
+            .await
+            .unwrap();
+        let first = iterator
+            .next_with(|entry| (entry.key().to_vec(), entry.value().to_vec()))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.0, b"key/000200");
+        assert_eq!(
+            iterator.resume_cursor().after(),
+            Some(b"key/000200".as_slice())
+        );
+
+        let mut other = async_prolly
+            .put(&tree, b"key/000123".to_vec(), b"changed".to_vec())
+            .await
+            .unwrap();
+        other = async_prolly.delete(&other, b"key/000321").await.unwrap();
+        other = async_prolly
+            .put(&other, b"key/000999".to_vec(), b"added".to_vec())
+            .await
+            .unwrap();
+        let expected = sync.diff(&tree, &other).unwrap();
+        let mut actual = Vec::new();
+        assert_eq!(
+            async_prolly
+                .scan_diff(&tree, &other, |diff| actual.push(diff.to_owned()))
+                .await
+                .unwrap(),
+            expected.len() as u64
+        );
+        assert_eq!(actual, expected);
+        let stopped = async_prolly
+            .scan_diff_until(&tree, &other, |diff| {
+                ControlFlow::Break(diff.key().to_vec())
+            })
+            .await
+            .unwrap();
+        assert_eq!(stopped.visited, 1);
+        assert_eq!(stopped.break_value, Some(expected[0].key().to_vec()));
+
+        let left = async_prolly
+            .put(&tree, b"key/000123".to_vec(), b"left".to_vec())
+            .await
+            .unwrap();
+        let mut right = async_prolly
+            .put(&tree, b"key/000123".to_vec(), b"right".to_vec())
+            .await
+            .unwrap();
+        right = async_prolly
+            .put(&right, b"key/000999".to_vec(), b"right-only".to_vec())
+            .await
+            .unwrap();
+        let mut conflicts = Vec::new();
+        assert_eq!(
+            async_prolly
+                .scan_conflicts(&tree, &left, &right, |conflict| {
+                    conflicts.push(conflict.to_owned())
+                })
+                .await
+                .unwrap(),
+            1
+        );
+        assert_eq!(conflicts[0].key, b"key/000123");
+
+        let resolver = Select(MergeDecision::UseRight);
+        let merged = async_prolly
+            .merge_with(&tree, &left, &right, Some(&resolver))
+            .await
+            .unwrap();
+        assert_eq!(
+            async_prolly.get(&merged, b"key/000123").await.unwrap(),
+            Some(b"right".to_vec())
+        );
+        assert_eq!(
+            async_prolly.get(&merged, b"key/000999").await.unwrap(),
+            Some(b"right-only".to_vec())
+        );
+    });
+}


### PR DESCRIPTION
## Summary

- make packed ReadNode and retained Arc byte storage the canonical read substrate
- migrate point, range, diff, async, and owned boundary adapters to packed traversal
- retain authoritative proximity candidates through exact, eligible, PQ, HNSW, and composite reranking, copying only final neighbor values
- add candidate memory accounting, packed search acceleration, and the comprehensive architecture design

## Performance

Three-run medians against the frozen Dolt Go comparator on deterministic fresh/random in-memory workloads:

| Records | Point-read speedup | Range-scan speedup |
| ---: | ---: | ---: |
| 1M | 2.86x | 4.98x |
| 5M | 1.84x | 6.89x |
| 10M | 1.61x | 6.27x |

All compared workload digests and result counts matched. Proximity measurements in the design are reported as absolute results because no honest pre-change proximity baseline was retained.

## Verification

- 479 library tests
- complete integration suite
- 97 documentation tests
- cargo clippy --all-features --lib --tests -- -D warnings
- git diff --check

## Review focus

- packed-node validation and common-prefix/order-word search correctness
- borrowed lifetimes and no-borrow-across-await guarantees
- diff boundary-drift localization and batch hydration
- authoritative candidate lifetime, HNSW/PQ shortlist reranking, and final-only value ownership
- shared-store ownership and cache accounting