### PR TITLE
release: publish Rust store adapters 0.2.0

### DIFF
--- a/stores/prolly-store-cosmosdb/Cargo.toml
+++ b/stores/prolly-store-cosmosdb/Cargo.toml
@@ -3,7 +3,7 @@ name = "prolly-store-cosmosdb"
 description = "Cosmos DB store adapter for prolly-map."
 edition = "2021"
 rust-version = "1.81"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crabbuild/prolly"
 homepage = "https://github.com/crabbuild/prolly"
@@ -22,7 +22,7 @@ hex = "0.4"
 hmac = "0.12.1"
 httpdate = "1.0.3"
 percent-encoding = "2.3.2"
-prolly = { package = "prolly-map", path = "../..", version = "0.3.0", features = ["async-store"] }
+prolly = { package = "prolly-map", path = "../..", version = "0.4.0", features = ["async-store"] }
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/stores/prolly-store-dynamodb/Cargo.toml
+++ b/stores/prolly-store-dynamodb/Cargo.toml
@@ -3,7 +3,7 @@ name = "prolly-store-dynamodb"
 description = "DynamoDB store adapter for prolly-map."
 edition = "2021"
 rust-version = "1.81"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crabbuild/prolly"
 homepage = "https://github.com/crabbuild/prolly"
@@ -31,7 +31,7 @@ aws-smithy-runtime-api-macros = "=1.0.0"
 aws-smithy-schema = "=0.1.0"
 aws-smithy-types = "=1.5.0"
 aws-types = "=1.3.16"
-prolly = { package = "prolly-map", path = "../..", version = "0.3.0", features = ["async-store"] }
+prolly = { package = "prolly-map", path = "../..", version = "0.4.0", features = ["async-store"] }
 
 [dev-dependencies]
 aws-config = { version = "=1.5.18", features = ["behavior-version-latest"] }

--- a/stores/prolly-store-mysql/Cargo.toml
+++ b/stores/prolly-store-mysql/Cargo.toml
@@ -3,7 +3,7 @@ name = "prolly-store-mysql"
 description = "MySQL store adapter for prolly-map."
 edition = "2021"
 rust-version = "1.81"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crabbuild/prolly"
 homepage = "https://github.com/crabbuild/prolly"
@@ -17,7 +17,7 @@ name = "prolly_store_mysql"
 path = "src/lib.rs"
 
 [dependencies]
-prolly = { package = "prolly-map", path = "../..", version = "0.3.0", features = ["async-store"] }
+prolly = { package = "prolly-map", path = "../..", version = "0.4.0", features = ["async-store"] }
 sqlx = { version = "0.8", default-features = false, features = ["mysql", "runtime-tokio"] }
 
 [dev-dependencies]

--- a/stores/prolly-store-pglite/Cargo.toml
+++ b/stores/prolly-store-pglite/Cargo.toml
@@ -3,7 +3,7 @@ name = "prolly-store-pglite"
 description = "PGlite sidecar store adapter for prolly-map."
 edition = "2021"
 rust-version = "1.81"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crabbuild/prolly"
 homepage = "https://github.com/crabbuild/prolly"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 hex = "0.4"
-prolly = { package = "prolly-map", path = "../..", version = "0.3.0" }
+prolly = { package = "prolly-map", path = "../..", version = "0.4.0" }
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/stores/prolly-store-pglite/README.md
+++ b/stores/prolly-store-pglite/README.md
@@ -6,6 +6,6 @@ Node.js sidecar with `@electric-sql/pglite` available in its working directory.
 
 ```toml
 [dependencies]
-prolly-map = "0.2"
-prolly-store-pglite = "0.1"
+prolly-map = "0.4"
+prolly-store-pglite = "0.2"
 ```

--- a/stores/prolly-store-postgres/Cargo.toml
+++ b/stores/prolly-store-postgres/Cargo.toml
@@ -3,7 +3,7 @@ name = "prolly-store-postgres"
 description = "PostgreSQL store adapter for prolly-map."
 edition = "2021"
 rust-version = "1.81"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crabbuild/prolly"
 homepage = "https://github.com/crabbuild/prolly"
@@ -17,7 +17,7 @@ name = "prolly_store_postgres"
 path = "src/lib.rs"
 
 [dependencies]
-prolly = { package = "prolly-map", path = "../..", version = "0.3.0", features = ["async-store"] }
+prolly = { package = "prolly-map", path = "../..", version = "0.4.0", features = ["async-store"] }
 sqlx = { version = "0.8", default-features = false, features = ["postgres", "runtime-tokio"] }
 
 [dev-dependencies]

--- a/stores/prolly-store-redis/Cargo.toml
+++ b/stores/prolly-store-redis/Cargo.toml
@@ -3,7 +3,7 @@ name = "prolly-store-redis"
 description = "Redis store adapter for prolly-map."
 edition = "2021"
 rust-version = "1.81"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crabbuild/prolly"
 homepage = "https://github.com/crabbuild/prolly"
@@ -17,7 +17,7 @@ name = "prolly_store_redis"
 path = "src/lib.rs"
 
 [dependencies]
-prolly = { package = "prolly-map", path = "../..", version = "0.3.0", features = ["async-store"] }
+prolly = { package = "prolly-map", path = "../..", version = "0.4.0", features = ["async-store"] }
 redis-client = { package = "redis", version = "0.32.7", default-features = false, features = [
     "aio",
     "tokio-comp",

--- a/stores/prolly-store-rocksdb/Cargo.toml
+++ b/stores/prolly-store-rocksdb/Cargo.toml
@@ -3,7 +3,7 @@ name = "prolly-store-rocksdb"
 description = "RocksDB store adapter for prolly-map."
 edition = "2021"
 rust-version = "1.81"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crabbuild/prolly"
 homepage = "https://github.com/crabbuild/prolly"
@@ -17,7 +17,7 @@ name = "prolly_store_rocksdb"
 path = "src/lib.rs"
 
 [dependencies]
-prolly = { package = "prolly-map", path = "../..", version = "0.3.0" }
+prolly = { package = "prolly-map", path = "../..", version = "0.4.0" }
 rocksdb = "0.22"
 
 [dev-dependencies]

--- a/stores/prolly-store-rocksdb/README.md
+++ b/stores/prolly-store-rocksdb/README.md
@@ -4,8 +4,8 @@ RocksDB storage adapter for [`prolly-map`](https://crates.io/crates/prolly-map).
 
 ```toml
 [dependencies]
-prolly-map = "0.2"
-prolly-store-rocksdb = "0.1"
+prolly-map = "0.4"
+prolly-store-rocksdb = "0.2"
 ```
 
 ```rust

--- a/stores/prolly-store-slatedb/Cargo.toml
+++ b/stores/prolly-store-slatedb/Cargo.toml
@@ -3,7 +3,7 @@ name = "prolly-store-slatedb"
 description = "SlateDB store adapter for prolly-map."
 edition = "2021"
 rust-version = "1.81"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crabbuild/prolly"
 homepage = "https://github.com/crabbuild/prolly"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 futures-util = "0.3"
-prolly = { package = "prolly-map", path = "../..", version = "0.3.0" }
+prolly = { package = "prolly-map", path = "../..", version = "0.4.0" }
 slatedb = "0.14.0"
 tokio = { version = "1.45", features = ["rt-multi-thread", "time"] }
 

--- a/stores/prolly-store-slatedb/README.md
+++ b/stores/prolly-store-slatedb/README.md
@@ -6,6 +6,6 @@ store contract.
 
 ```toml
 [dependencies]
-prolly-map = "0.2"
-prolly-store-slatedb = "0.1"
+prolly-map = "0.4"
+prolly-store-slatedb = "0.2"
 ```

--- a/stores/prolly-store-spanner/Cargo.toml
+++ b/stores/prolly-store-spanner/Cargo.toml
@@ -3,7 +3,7 @@ name = "prolly-store-spanner"
 description = "Cloud Spanner store adapter for prolly-map."
 edition = "2021"
 rust-version = "1.81"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crabbuild/prolly"
 homepage = "https://github.com/crabbuild/prolly"
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 [dependencies]
 google-cloud-googleapis = { package = "gcloud-googleapis", version = "1.3.0", features = ["spanner"] }
 google-cloud-spanner = { package = "gcloud-spanner", version = "=1.8.1" }
-prolly = { package = "prolly-map", path = "../..", version = "0.3.0", features = ["async-store"] }
+prolly = { package = "prolly-map", path = "../..", version = "0.4.0", features = ["async-store"] }
 
 [dev-dependencies]
 tokio = { version = "1.45", features = ["rt-multi-thread", "time"] }

--- a/stores/prolly-store-sqlite/Cargo.toml
+++ b/stores/prolly-store-sqlite/Cargo.toml
@@ -3,7 +3,7 @@ name = "prolly-store-sqlite"
 description = "SQLite store adapter for prolly-map."
 edition = "2021"
 rust-version = "1.81"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crabbuild/prolly"
 homepage = "https://github.com/crabbuild/prolly"
@@ -17,7 +17,7 @@ name = "prolly_store_sqlite"
 path = "src/lib.rs"
 
 [dependencies]
-prolly = { package = "prolly-map", path = "../..", version = "0.3.0" }
+prolly = { package = "prolly-map", path = "../..", version = "0.4.0" }
 rusqlite = { version = "0.31", features = ["bundled"] }
 
 [dev-dependencies]

--- a/stores/prolly-store-sqlite/README.md
+++ b/stores/prolly-store-sqlite/README.md
@@ -4,8 +4,8 @@ SQLite storage adapter for [`prolly-map`](https://crates.io/crates/prolly-map).
 
 ```toml
 [dependencies]
-prolly-map = "0.2"
-prolly-store-sqlite = "0.1"
+prolly-map = "0.4"
+prolly-store-sqlite = "0.2"
 ```
 
 ```rust

--- a/stores/prolly-store-test/Cargo.toml
+++ b/stores/prolly-store-test/Cargo.toml
@@ -8,4 +8,4 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-prolly = { package = "prolly-map", path = "../..", version = "0.3.0" }
+prolly = { package = "prolly-map", path = "../..", version = "0.4.0" }


### PR DESCRIPTION
## Summary

- bump all ten published Rust store adapters from `0.1.0` to `0.2.0`
- move every adapter and the unpublished conformance helper to `prolly-map 0.4.0`
- update public Cargo dependency snippets to the coordinated `0.4`/`0.2` release lines

## Why

`prolly-map 0.4.0` crosses a breaking pre-1.0 API boundary. The adapters must update their core dependency requirement, and their own minor versions must advance to reflect that compatibility boundary.

## User impact

Consumers should use `prolly-map = "0.4"` and their selected Rust store adapter at `0.2`. Live-service integration tests remain opt-in through each adapter's environment configuration.

## Validation

- `cargo test --manifest-path stores/<adapter>/Cargo.toml` for all ten published adapters
- `cargo publish --dry-run --manifest-path stores/<adapter>/Cargo.toml` for all ten published adapters
- each packaged adapter verified against the crates.io copy of `prolly-map 0.4.0`
- published and independently downloaded all ten adapter crates at `0.2.0`
