### PR TITLE
perf: accelerate async merge and range traversal

### DIFF
--- a/benches/prolly_bench.rs
+++ b/benches/prolly_bench.rs
@@ -119,8 +119,33 @@ fn main() {
             bench_merge_conflict_resolved(scale);
             return;
         }
+        Ok("merge-conflict-cold") => {
+            bench_merge_conflict_resolved_cold(scale);
+            return;
+        }
         Ok("stream-append") => {
             bench_stream_diff_append_suffix(scale);
+            return;
+        }
+        Ok("async-engine-recovery") => {
+            bench_range_scan(scale);
+            bench_stream_diff_append_suffix(scale);
+            bench_range_diff_window(scale);
+            bench_merge_sparse(scale);
+            bench_merge_conflict_resolved(scale);
+            bench_merge_conflict_resolved_cold(scale);
+            return;
+        }
+        Ok("async-engine-protected") => {
+            bench_incremental_insert(scale / 5);
+            bench_batch_builder(scale);
+            bench_point_get(scale);
+            bench_point_updates(scale);
+            bench_point_deletes(scale);
+            bench_batch_mutations(scale);
+            bench_batch_mutations_mixed(scale);
+            bench_batch_mutations_append(scale);
+            bench_parallel_batch_mutations(scale);
             return;
         }
         Ok("batch-regressions") => {
@@ -1401,6 +1426,40 @@ fn bench_merge_conflict_resolved(items: usize) {
         let resolver: Resolver =
             Box::new(|conflict| Resolution::value(conflict.right.clone().expect("right value")));
         let merged = prolly.merge(&base, &left, &right, Some(resolver)).unwrap();
+        black_box(merged.root);
+    });
+}
+
+fn bench_merge_conflict_resolved_cold(items: usize) {
+    let data = data_set(items);
+    let (store, prolly, base) = build_tree(&data);
+    let mut left = base.clone();
+    let mut right = base.clone();
+    let conflict_step = (items / 100).max(1);
+    let mut conflicts = 0;
+
+    for i in (0..items).step_by(conflict_step) {
+        let key = key_for_index(i);
+        left = prolly
+            .put(
+                &left,
+                key.clone(),
+                format!("left-conflict-{i:08}").into_bytes(),
+            )
+            .unwrap();
+        right = prolly
+            .put(&right, key, format!("right-conflict-{i:08}").into_bytes())
+            .unwrap();
+        conflicts += 1;
+    }
+
+    let reopened = Prolly::new(store, bench_config());
+    measure("merge_conflict_resolved_cold_mem", 10, conflicts, || {
+        let resolver: Resolver =
+            Box::new(|conflict| Resolution::value(conflict.right.clone().expect("right value")));
+        let merged = reopened
+            .merge(&base, &left, &right, Some(resolver))
+            .unwrap();
         black_box(merged.root);
     });
 }

--- a/docs/async-engine-performance-recovery-plan.md
+++ b/docs/async-engine-performance-recovery-plan.md
@@ -1,0 +1,496 @@
+# Async engine performance recovery implementation plan
+
+**Date:** 2026-07-19
+
+**Status:** Ready for implementation
+
+**Design:** `docs/superpowers/specs/2026-07-19-async-engine-performance-recovery-design.md`
+
+## Outcome
+
+Improve the shared `ProllyEngine<S: AsyncStore>` implementation without adding a production native-sync route. The candidate must beat the pre-async baseline by at least 1.5 times on all five recovery workloads and must preserve the current point and mutation gains.
+
+This plan uses a native measurement-driven workflow:
+
+1. freeze reproducible binaries and fixtures;
+2. profile the current implementation;
+3. implement one engine-level cost reduction at a time;
+4. verify correctness after each slice;
+5. retain a slice only after paired benchmarks prove its value;
+6. run the complete cross-workload gate before completion.
+
+The plan does not require tests to fail before implementation. It requires direct correctness evidence and before-and-after measurements for every retained change.
+
+## Acceptance contract
+
+### Recovery latency gates
+
+The pre-async revision `0efc8237` is authoritative. Threshold calculations use unrounded baseline values divided by 1.5.
+
+| Workload | Pre-async baseline | Maximum candidate median | Current median | Improvement needed from current |
+| --- | ---: | ---: | ---: | ---: |
+| Conflict-resolved merge | 0.257 ms | 0.171 ms | 35.26 ms | 206x |
+| Sparse merge | 64.1 µs | 42.7 µs | 167.8 µs | 3.93x |
+| Range diff | 0.320 ms | 0.213 ms | 0.882 ms | 4.14x |
+| Full range scan | 3.39 ms | 2.26 ms | 3.58 ms | 1.58x |
+| Append-suffix stream diff | 0.309 ms | 0.206 ms | 0.324 ms | 1.57x |
+
+### Protected workload gates
+
+Compare protected paths with an unmodified current binary built from the implementation starting revision:
+
+- median latency ratio at most 1.03;
+- p95 latency ratio at most 1.05;
+- no increase in logical node reads or writes;
+- identical roots, counts, and result digests.
+
+Protected workloads are:
+
+- incremental insert;
+- batch builder;
+- owned and borrowed point get;
+- point update;
+- point delete;
+- batch, mixed batch, append batch, and parallel batch mutation.
+
+### Correctness and architecture gates
+
+- Both public facades call the same async engine functions.
+- No `SyncStoreAsAsync` type check or ready-only algorithm branch is added.
+- Canonical roots and persisted node bytes remain unchanged.
+- Every node load keeps content identifier and tree-format validation.
+- Conflict resolvers run once per logical conflict in key order.
+- Merge publishes no nodes until it knows the final root.
+- Cancellation and failure publish nothing.
+- Store reads remain bounded and do not load complete unchanged subtrees.
+- The full release unit and integration suite passes.
+
+## Files and responsibilities
+
+### New files
+
+- `src/prolly/diff/async_merge.rs`: persistent lineage planning, iterative structural merge frames, leaf resolution, parent assembly, and async merge publication
+- `src/prolly/diff/async_range.rs`: compact async range-diff frames and eager/streaming sinks
+- `scripts/run_async_engine_performance_gate.sh`: build isolated revisions, alternate run order, capture provenance, and preserve raw samples
+- `scripts/summarize_async_engine_performance_gate.py`: calculate paired medians, p95 ratios, exact thresholds, logical-I/O checks, and pass/fail status
+- `scripts/tests/test_summarize_async_engine_performance_gate.py`: summarizer fixture coverage
+
+### Modified files
+
+- `src/prolly/diff.rs`: expose shared semantic helpers, delegate production async merge/range diff to focused modules, and keep test-only native oracles isolated
+- `src/prolly/engine/mod.rs`: operation-local traversal loading, branch lineage recording, and engine-owned publication helpers
+- `src/prolly/engine/execution.rs`: operation diagnostics and bounded traversal scratch policy
+- `src/prolly/engine/write.rs`: retain replay for canonical mutation paths, remove merge's dependency on replay, and expose publication support needed by the async merge collector
+- `src/prolly/mod.rs`: bounded persistent lineage cache and internal cache accessors; no public facade routing changes
+- `src/prolly/batch.rs`: allow the async engine to consume collected canonical node bytes and cache-ready decoded nodes without a second encode/decode pass
+- `src/prolly/range.rs`: leaf-run cursor state for owned and borrowed async iteration
+- `benches/prolly_bench.rs`: focused recovery mode, protected workload mode, result digests, roots, logical I/O, publication counts, and stable sample output
+- `docs/performance.md`: final verified numbers and gate commands
+
+## Phase 0: Isolate the work and freeze evidence
+
+### Actions
+
+1. Record the implementation starting revision, dirty-file digest, compiler, allocator, host, and power state.
+2. Leave the unrelated PostgreSQL benchmark changes and untracked reference trees untouched.
+3. Build three isolated release binaries outside the parent Cargo workspace:
+   - pre-async baseline `0efc8237`;
+   - unmodified async starting revision;
+   - candidate working tree.
+4. Copy each binary to a revision-labeled immutable path and record its SHA-256 hash.
+5. Run the 50,000-entry suite seven times in alternating order to refresh baseline and current distributions on the same host.
+6. Preserve the existing deterministic seeds, key encoding, values, mutation count, resolver, cache size, and warm-up policy.
+7. Record 10,000-entry and 100,000-entry baseline samples for later scale confirmation.
+
+### Exit evidence
+
+- Three reproducible binary manifests exist.
+- Baseline and current results reproduce the reported direction and remain within 10 percent of the earlier medians.
+- Every sample has a matching root or result digest.
+
+## Phase 1: Build an auditable focused gate
+
+### Benchmark changes
+
+Add `PROLLY_BENCH_ONLY=async-engine-recovery`. It runs these rows in a stable order:
+
+1. `merge_conflict_resolved_mem`;
+2. `merge_sparse_mem`;
+3. `range_diff_window_mem`;
+4. `range_scan_mem`;
+5. `stream_diff_append_suffix_mem`;
+6. all protected point and mutation rows.
+
+Extend each focused row with:
+
+- fixture scale and logical item count;
+- total latency and per-item latency;
+- p50, p95, and p99;
+- output root or deterministic result digest;
+- output count;
+- nodes and bytes read;
+- nodes and bytes written;
+- point, ordered-batch, and publication call counts;
+- merge resolver call count;
+- replay attempt count while replay still exists.
+
+The gate script must:
+
+- alternate baseline/current/candidate order by pair;
+- reject missing or malformed rows;
+- reject correctness or logical-I/O mismatches before evaluating latency;
+- calculate exact baseline-divided-by-1.5 targets;
+- calculate protected candidate-to-current ratios;
+- emit `raw-results.csv`, `summary.csv`, `gate.csv`, `manifest.txt`, and `report.md`.
+
+### Validation
+
+- Run the summarizer's fixture tests.
+- Run one smoke pair and inspect every output column.
+- Confirm the unmodified current binary fails all five recovery gates.
+- Confirm the pre-async binary does not accidentally pass the 1.5-times-baseline gates.
+
+### Exit evidence
+
+The harness fails for known-slow binaries, detects root/count/I/O corruption, and produces deterministic summaries.
+
+## Phase 2: Profile merge replay and range traversal
+
+### Merge diagnostics
+
+Instrument `execute_replay` and `try_structural_merge_async` under benchmark diagnostics. Record:
+
+- replay attempts;
+- unique and repeated CIDs requested per attempt;
+- operation restarts;
+- cache locks and cache hits;
+- node decodes and re-encodes;
+- collector nodes and bytes;
+- resolver calls;
+- time in hydration, pure merge, publication preparation, and publication.
+
+Use Instruments Time Profiler and Allocations on both merge workloads. Capture the top CPU stacks and allocation sites.
+
+### Diff and range diagnostics
+
+Record:
+
+- frame pushes and pops;
+- node-pair loads;
+- span endpoint allocations;
+- `Diff` allocations;
+- `VecDeque` growth;
+- leaf transitions;
+- `Arc` clones;
+- end-bound comparisons;
+- owned key and value allocations.
+
+### Decision checkpoint
+
+Use the profile to confirm or revise the ordering of later phases. Keep the architectural constraints unchanged. Do not retain diagnostic branches that add measurable overhead when diagnostics are disabled.
+
+## Phase 3: Add bounded persistent branch lineage
+
+The warm same-engine merge targets are too strict for a full structural walk. Use branch history already known to the engine, without making it part of correctness.
+
+### Data model
+
+Replace the four-record direct lineage cache with a bounded persistent chain keyed by child root:
+
+```rust
+struct BranchLineageRecord {
+    parent: Option<Cid>,
+    child: Cid,
+    mutations: Arc<[Mutation]>,
+    depth: u16,
+}
+```
+
+The cache retains enough records for both 100-change benchmark branches. Start with a 512-record and 8 MiB internal cap, then tune only from measurements. Eviction removes acceleration data only.
+
+### Recording
+
+Record normalized, sorted, unique mutations after a successful canonical publication for point, batch, append, and delete origins. Reuse the existing mutation allocation where possible. Do not copy values solely for lineage if the canonical writer can transfer ownership into an `Arc<[Mutation]>` after publication.
+
+Measure the added point-write cost immediately. If median or p95 exceeds the protected gate, reduce lock scope, shard the cache, or store compact single-mutation records before continuing.
+
+### Planning
+
+Add an engine method that walks parent links from a branch root to the requested base root and produces one normalized change stream. It must:
+
+- enforce a maximum hop and mutation count;
+- detect eviction, cycles, and disconnected ancestry;
+- preserve last-write-wins semantics;
+- return `None` on uncertainty;
+- never consult storage;
+- never affect the fallback result.
+
+### Merge optimizations
+
+For two complete lineage streams:
+
+1. merge the sorted changes with two indices;
+2. load base values only for overlapping keys;
+3. invoke the resolver once for each true conflict;
+4. return `left` when every selected value matches left;
+5. return `right` when the merged logical state is exactly right;
+6. otherwise apply only the selected right-side delta to left through the canonical async batch writer.
+
+The benchmark's all-right conflict resolver should return the existing right root without publication. Sparse disjoint suffixes should become one small canonical batch.
+
+### Correctness validation
+
+- Compare warm-lineage results with the test-only merge oracle across updates, inserts, deletes, duplicate histories, and resolver choices.
+- Clear or evict lineage and confirm the fallback produces the same root.
+- Reopen the tree in a new engine and confirm correctness without lineage.
+- Confirm cache truncation and memory caps cannot change results.
+
+### Performance checkpoint
+
+Run seven focused pairs for both merge workloads and all protected writes. Retain this phase only if:
+
+- conflict merge is at most 0.171 ms;
+- sparse merge is at most 42.7 µs;
+- protected medians and p95 values pass;
+- resolver and publication counts match expectations.
+
+If either merge target remains unmet, profile lineage normalization, overlap value lookup, resolver allocation, and canonical batch setup before implementing the structural fallback.
+
+## Phase 4: Replace restart-based async structural merge
+
+Lineage cannot help reopened trees, independent replicas, or evicted histories. Replace merge replay with a resumable async kernel that remains efficient without history.
+
+### State machine
+
+Create compact frames:
+
+```rust
+enum MergeFrame {
+    Visit { base: Cid, left: Cid, right: Cid },
+    Assemble { nodes: [Arc<Node>; 3], child_start: usize },
+}
+```
+
+Use a parallel result stack for `StructuralMergeResult`. The concrete layout may change to reduce cloning, but it must support these transitions:
+
+- CID equality reuse without a load;
+- one ordered triple load for a divergent frame;
+- leaf resolution without an await;
+- child frames in deterministic key order;
+- bottom-up internal assembly;
+- bounded shape-mismatch fallback;
+- final one-shot publication.
+
+### Frontier loading
+
+At each internal level:
+
+- collect divergent base/left/right child triples;
+- deduplicate CIDs while retaining result positions;
+- take the global node-cache lock once for the complete frontier;
+- load misses through `load_many_ordered_for_format`;
+- retain loaded `Arc<Node>` values in the operation context;
+- release all locks before resolver calls or awaits.
+
+Do not prefetch equal subtrees. Bound the frontier with the existing execution configuration and process additional chunks in logical order.
+
+### Canonical assembly and publication
+
+Reuse `BatchWriteCollector` encoding and CID calculation. Add read-only accessors for encoded entries and retained cache nodes. The async merge kernel must:
+
+- avoid decoding nodes it created;
+- deduplicate identical output CIDs;
+- validate reused child counts;
+- publish with `PublicationOrigin::Merge` once;
+- cache published nodes after acknowledgment;
+- return no tree when publication fails.
+
+Keep `execute_replay` for canonical mutation code until a separate measured project replaces it. Remove only merge's dependency on it.
+
+### Cold-path validation
+
+- Run merges with node and lineage caches cleared.
+- Run on a fresh engine backed by the same `MemStore`.
+- Run on an async delayed store that returns `Pending` before each read.
+- Compare roots, bytes, explanations, conflicts, and I/O with the oracle.
+- Verify cancellation before publication and publication failure behavior.
+
+### Performance checkpoint
+
+Report warm lineage and cold structural numbers separately. The warm contract must retain the strict acceptance targets. The cold path must beat the current async implementation by at least 1.5 times without increasing logical reads.
+
+## Phase 5: Replace eager async range diff with a compact cursor
+
+### Cursor design
+
+Move production async range-diff traversal into `diff/async_range.rs`. Use compact frame variants for compare, added, and removed spans. Each frame owns a span endpoint only when it survives an await.
+
+Process one ordered frontier at a time:
+
+1. discard equal CIDs and out-of-range spans;
+2. batch-load divergent node pairs;
+3. compare aligned internal spans without collecting entire subtrees;
+4. push child frames in reverse order so popping preserves key order;
+5. compare leaf slices directly;
+6. write into the requested sink.
+
+### Allocation reductions
+
+- Reserve eager result capacity from the changed range when cardinality is known.
+- Reuse frame, CID, and node vectors across frontiers.
+- Borrow separator keys during pure transitions.
+- Clone a key or value only when constructing a returned owned `Diff`.
+- Avoid converting between `Node` and `ReadNode` in one operation.
+- Hold an operation-local node map to avoid repeated global cache locks.
+
+### Consumers
+
+- `compute_async_range_diff` collects owned results through the cursor.
+- Range-limited merge consumes cursor changes directly.
+- Existing public result ordering and errors remain unchanged.
+
+### Validation and checkpoint
+
+Verify empty, reversed, narrow, boundary-crossing, added-only, removed-only, shape-mismatch, malformed, and custom-format ranges. Run seven focused pairs and retain the phase only when median range diff is at most 0.213 ms with unchanged logical reads.
+
+## Phase 6: Optimize append-suffix streaming diff
+
+### Pending state
+
+Replace append-only `VecDeque<Diff>` materialization with a pending leaf cursor:
+
+```rust
+struct PendingLeafDiff {
+    node: Arc<ReadNode>,
+    next: usize,
+    end: usize,
+    kind: DiffFrameKind,
+}
+```
+
+The iterator materializes one `Diff` when `next()` returns it. It retains compact pending subtree frames instead of flattening an entire appended suffix.
+
+### Fast append proof
+
+Reuse the existing append-only structural proof. When the shared prefix ends inside aligned right-edge leaves, store the first unmatched leaf position and then continue through added right siblings. Do not rescan the shared prefix on each `next()` call.
+
+### Checkpoint compatibility
+
+Translate pending leaf state into the existing stable cursor representation, or extend the internal marker format without changing public serialized cursor behavior. Resume tests must reconstruct the exact remaining stream.
+
+### Validation and checkpoint
+
+Verify empty suffixes, multi-level suffixes, boundary drift, non-append fallback, malformed children, cursor resume, and result order. Retain the phase only when append-suffix stream diff is at most 0.206 ms and sparse/full-rewrite diff rows do not regress.
+
+## Phase 7: Optimize full range scans with leaf runs
+
+### Cursor state
+
+Replace per-entry end checks and `last_location` maintenance with explicit leaf-run fields:
+
+```rust
+struct LeafRun {
+    node: Arc<ReadNode>,
+    next: usize,
+    end: usize,
+}
+```
+
+When entering a leaf, compute `end` once with binary search against the range end. Entry advancement increments `next` only. Structural stack work resumes after the run ends.
+
+### Owned entry extraction
+
+Add one `ReadNode` helper that validates the entry index once and copies key and value into the public owned pair. Avoid separate bounds checks and repeated offset-table decoding for `key()` and `value()`.
+
+Keep borrowed iteration on the same leaf-run state and return slices without allocation. Preserve resume-cursor behavior by storing the last yielded key index rather than cloning an extra node pointer.
+
+### Allocation-floor analysis
+
+Owned `(Vec<u8>, Vec<u8>)` results require two allocations per entry. Profile after the state reduction. If median remains above 2.26 ms:
+
+1. verify mimalloc reuse and allocation hot spots;
+2. specialize packed-node entry copying to calculate both lengths once;
+3. eliminate temporary key reconstruction buffers;
+4. reuse prefix bytes directly when compact encoding permits;
+5. confirm the benchmark includes only contract-required ownership work.
+
+Do not change the public return type, omit ownership, or substitute the borrowed benchmark.
+
+### Validation and checkpoint
+
+Verify full, bounded, empty, single-leaf, multi-level, resume, forward, reverse, cache-resistant, and malformed-node cases. Retain the phase only when full range scan is at most 2.26 ms and borrowed range scan does not regress.
+
+## Phase 8: Combined optimization and cleanup
+
+### Cross-component review
+
+- Remove superseded merge replay wrappers and dead async range-diff helpers.
+- Keep test-only native oracles clearly marked and unreachable from production.
+- Consolidate duplicated frame and sink utilities only when measurements show no regression.
+- Remove diagnostic output from default builds or guard it behind existing benchmark diagnostics.
+- Run formatting and clippy on touched crates.
+
+### Correctness suite
+
+Run:
+
+```bash
+cargo test --release --lib --tests
+cargo test --release --test zero_copy_reads
+cargo test --release --test range_limited_merge
+cargo test --release --test resumable_diff
+cargo test --release --test traversal
+cargo test --release --test async_foundation_default
+```
+
+Because the parent workspace currently has an unrelated `prolly-map` version mismatch, run root-crate verification from an isolated source copy until that packaging issue is fixed. Also compile one native async store confirmation crate separately.
+
+### Performance suite
+
+Run seven alternating pairs at 50,000 entries for baseline, current, and candidate. Then run five pairs at 10,000 and 100,000 entries. Run the complete default in-memory suite to detect displaced costs.
+
+Reject completion if any of these conditions holds:
+
+- one recovery median exceeds its baseline-divided-by-1.5 threshold;
+- a protected median exceeds 1.03 times current;
+- a protected p95 exceeds 1.05 times current;
+- logical reads or writes increase;
+- roots, digests, counts, resolver calls, or publication calls differ;
+- a correctness test fails;
+- only the ready-backed facade improves while a native async store regresses.
+
+## Phase 9: Documentation and delivery
+
+Update `docs/performance.md` with:
+
+- exact revisions and binary hashes;
+- host and compiler provenance;
+- raw artifact paths;
+- baseline, current, and candidate medians and p95 values;
+- logical I/O and publication counts;
+- warm-lineage and cold-structural merge results;
+- native async confirmation results;
+- any rejected experiments and their measured reason.
+
+Deliver a concise final report that maps every acceptance requirement to direct evidence. Do not call the goal complete until all five strict recovery gates and every protected-path gate pass.
+
+## Commit and rollback strategy
+
+Use small measured commits in this order:
+
+1. benchmark gate and diagnostics;
+2. bounded persistent lineage;
+3. iterative async structural merge;
+4. compact async range diff;
+5. append-aware stream diff;
+6. leaf-run range scan;
+7. combined cleanup and evidence.
+
+After each commit:
+
+- record its focused before-and-after table;
+- run affected correctness suites;
+- revert or revise it if its target or protected gates fail;
+- do not stack another optimization on an unproven regression.
+
+This sequence makes every performance claim bisectable while preserving the single async-engine architecture.

--- a/docs/superpowers/specs/2026-07-19-async-engine-performance-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-19-async-engine-performance-recovery-design.md
@@ -212,12 +212,15 @@ order. The first logical error is selected by frame order, not completion
 order. Resolver callbacks are synchronous and receive callback-scoped values;
 their borrows end before the next await.
 
-## Testing strategy
+## Verification strategy
 
-Implementation follows red-green-refactor slices.
+Implementation follows measurement-driven engineering slices. Each slice
+captures a profile, changes one cost center, verifies correctness, and then
+runs its focused performance gate. Tests may be written alongside or after the
+implementation; failing-first test order is not required.
 
-1. Add diagnostic tests that expose replay attempt counts and prove the current
-   merge performs repeated work. The tests must fail before production changes.
+1. Add diagnostics that expose replay attempt counts and quantify the current
+   merge's repeated work before production changes.
 2. Add state-machine equivalence tests against the test-only merge oracle for
    equal branches, disjoint sparse edits, dense conflicts, deletes, shape
    mismatch, custom formats, malformed nodes, and resolver failures.

--- a/docs/superpowers/specs/2026-07-19-async-engine-performance-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-19-async-engine-performance-recovery-design.md
@@ -1,0 +1,304 @@
+# How will the async engine exceed pre-async performance?
+
+**Date:** 2026-07-19
+
+**Status:** Approved for implementation planning
+
+**Audience:** Prolly maintainers, storage-adapter authors, and performance reviewers
+
+**Goal:** Make the canonical async Prolly engine at least 1.5 times faster than the pre-async native baseline for the five regressed in-memory workloads without regressing protected point and mutation paths
+
+**Content type:** Conceptual design specification
+
+**Content plan:** Freeze the baseline-relative performance contract, define the shared async traversal kernels, preserve correctness and remote-store bounds, and specify implementation and release gates
+
+**Open questions:** None
+
+## TL;DR
+
+Keep `ProllyEngine<S: AsyncStore>` as the only production tree engine. Replace restart-based structural merge replay with a resumable async state machine, make eager and streaming diff share allocation-conscious async traversal primitives, and remove avoidable per-entry work from the async range cursor. Both `AsyncProlly` and the ready-backed `Prolly` facade continue to execute the same engine code.
+
+The performance gate is intentionally stronger than restoring the old native
+latency. Each affected workload must be at least 1.5 times faster than its
+pre-async baseline. Point reads, point updates, batch mutations, deletes, and
+inserts may not lose more than 3 percent median throughput or latency. A result
+that meets only the current implementation's latency is a failure.
+
+## Context
+
+The async-first migration preserved one canonical engine and greatly improved
+point and mutation paths. It also moved synchronous diff and merge through
+async traversal and replay machinery. Seven alternating in-memory benchmark
+pairs at 50,000 entries identified five repeatable regressions:
+
+| Workload | Pre-async baseline | Current async engine | Current change |
+| --- | ---: | ---: | ---: |
+| Conflict-resolved merge | 0.257 ms | 35.26 ms | +14,274% |
+| Sparse merge | 64.1 us | 167.8 us | +164% |
+| Range diff | 0.320 ms | 0.882 ms | +172% |
+| Full range scan | 3.39 ms | 3.58 ms | +6.5% |
+| Append-suffix stream diff | 0.309 ms | 0.324 ms | +5.1% |
+
+A direct before-and-after measurement of commit `01d0f151` isolated the
+sync-to-async diff and merge cutover. That commit made conflict-resolved merge
+about 127 times slower, sparse merge 3.6 times slower, and range diff about 20
+percent slower. Later async range-diff changes increased the final range-diff
+gap.
+
+The dominant merge cost is architectural. `try_structural_merge_async` calls `execute_replay`, whose synchronous closure aborts when `ReplayStore` discovers a missing node. The engine hydrates the missing frontier and restarts the operation. A merge can rediscover and reprocess earlier levels once per discovered frontier. Correctness is preserved, but central processing unit (CPU) work, allocation, hashing, decoding, and lock traffic grow with the frontier count.
+
+Range and diff regressions are smaller but follow the same pattern: general
+async iterator machinery owns and clones traversal state where a pure cursor
+transition or borrowed node view is sufficient.
+
+## Decision
+
+Implement iterative async traversal kernels inside `ProllyEngine`. These
+kernels retain their state across `.await`, batch reads at structural
+frontiers, and materialize owned results only at the public API boundary.
+
+Do not restore the superseded native synchronous algorithms. Do not dispatch
+on `SyncStoreAsAsync`, store type, executor type, or whether a future happens
+to be ready. The ready-backed facade and native async facade must call the same
+functions and produce the same metrics, roots, errors, and publications.
+
+## Performance contract
+
+The frozen pre-async medians are the acceptance baseline. The candidate must
+meet or beat these upper latency bounds:
+
+| Workload | Required speedup | Maximum accepted median |
+| --- | ---: | ---: |
+| Conflict-resolved merge | 1.5x | 0.171 ms |
+| Sparse merge | 1.5x | 42.7 us |
+| Range diff | 1.5x | 0.213 ms |
+| Full range scan | 1.5x | 2.26 ms |
+| Append-suffix stream diff | 1.5x | 0.206 ms |
+
+The unrounded gate uses `baseline / 1.5`; the displayed values are summaries,
+not alternate thresholds.
+
+Protected hot paths are point get, borrowed point get, point update, point
+delete, incremental insert, batch mutation, mixed batch mutation, append batch,
+and parallel batch mutation. For each protected workload:
+
+- candidate-to-current median latency must be at most 1.03;
+- candidate-to-current p95 latency must be at most 1.05;
+- logical node reads and writes may not increase;
+- canonical roots and result cardinalities must match.
+
+## Required invariants
+
+- `ProllyEngine<S: AsyncStore>` remains the sole production implementation.
+- Sync and async facades execute the same traversal and merge kernels.
+- Equal inputs and formats produce byte-identical roots and persisted nodes.
+- Every loaded node is checked against its requested content identifier (CID)
+  and tree format.
+- Cache state, store batching, concurrency, and readiness affect cost only.
+- Resolver calls remain ordered and occur exactly once per logical conflict.
+- A failed or cancelled operation publishes no partial root or visible tree.
+- Merge publishes immutable nodes once, after the complete root is known.
+- No lock guard, borrowed node view, or resolver value crosses `.await`.
+- Remote reads remain bounded and ordered; in-memory speed cannot come from
+  unbounded prefetch or reading complete unchanged subtrees.
+- Public APIs, encodings, CIDs, tree formats, and manifests do not change.
+
+## Architecture
+
+### Operation-scoped traversal context
+
+Add a small internal context used by diff, merge, and range traversal. It owns
+operation-local loaded-node references, deterministic I/O counters, bounded
+frontier scratch space, and reusable key and CID buffers. It delegates all misses
+to the existing validated engine loaders.
+
+The context is not another global cache. Its lifetime is one operation, and it
+cannot change results. Reusing a node within the operation avoids repeated
+global cache locks and validation while keeping global cache policy unchanged.
+
+### Iterative async structural merge
+
+Replace the production merge call to `try_structural_merge_async` and
+`execute_replay` with an explicit stack of merge frames. Each frame contains
+the base, left, and right CIDs plus the child span needed to rebuild its parent.
+
+The state machine performs these transitions:
+
+1. Reuse immediately when branch CIDs prove equality or one branch equals the
+   base.
+2. Batch-load the remaining aligned CID triple through validated async I/O.
+3. For compatible internal nodes, enqueue divergent children in key order and
+   retain a parent continuation frame.
+4. For compatible leaves, compare borrowed key/value slices, invoke the
+   resolver once for each conflict, and emit the selected entries.
+5. For a shape mismatch, switch that bounded span to the existing diff/batch
+   fallback without restarting completed spans.
+6. Rebuild parents bottom-up through a collector that deduplicates CIDs and
+   records canonical bytes.
+7. Publish the collector once after the final root is known.
+
+The state machine must reuse the existing canonical node construction,
+boundary, and serialization helpers. It does not introduce a second chunker or
+writer. Test-only sync merge remains an oracle, not a production route.
+
+### Async range diff cursor
+
+Use one internal range-diff cursor for eager range diff, range-limited merge,
+and future resumable range diff. The cursor owns a stack of compact frames and
+loads base/other node pairs in ordered batches. Equal CIDs and out-of-range
+spans are discarded before decoding descendants.
+
+Leaf comparison writes directly into a caller-provided sink. Eager range diff
+pushes owned `Diff` values into its result vector. Merge consumes borrowed
+change views before advancing. The cursor does not build an intermediate
+collection and then copy it into another collection.
+
+Span endpoints use frame-owned storage only when they must survive an await.
+Pure transitions borrow existing node keys. Reusable vectors retain capacity
+for the operation.
+
+### Append-aware streaming diff
+
+Keep `AsyncDiffIter` as the public streaming engine, but change its pending
+state from a `VecDeque<Diff>` of fully owned suffix results to a compact leaf
+cursor when an append-only suffix is proven. Each `next` call materializes only
+the diff it returns. Structural pruning, deterministic order, error behavior,
+and checkpoint semantics remain unchanged.
+
+### Leaf-run range iteration
+
+Retain `AsyncRangeIter` for both public facades. Split its state into a current
+leaf run and an internal traversal stack. Advancing entries within the current
+leaf updates indices only; it does not clone an `Arc`, re-check an unchanged
+end bound, or reconstruct callback state for every item.
+
+The iterator checks the end bound once when entering a leaf and computes the
+exclusive end index with binary search. It resumes structural traversal only
+when the leaf run is exhausted. Owned iteration still copies returned keys and
+values because that is its public contract. Borrowed visitors remain
+allocation-free.
+
+## Data flow
+
+```text
+Prolly / AsyncProlly
+        |
+        v
+ProllyEngine operation
+        |
+        +--> operation traversal context
+        |       |
+        |       +--> validated ordered node loads
+        |       +--> compact resumable frames
+        |       +--> operation-local counters/scratch
+        |
+        +--> canonical collector (merge only)
+                |
+                +--> one NodePublication after final root
+```
+
+There is no branch from this flow to a native synchronous algorithm.
+
+## Failure and cancellation
+
+All traversal state is private to the future or iterator. Dropping a read or
+diff future discards only that state. Merge does not call `publish_nodes` until
+the state machine has produced and validated the final root. A store error,
+invalid node, resolver error, cancellation, or internal invariant failure
+therefore returns without publishing the collector.
+
+Ordered frontiers retain logical key order even when reads complete out of
+order. The first logical error is selected by frame order, not completion
+order. Resolver callbacks are synchronous and receive callback-scoped values;
+their borrows end before the next await.
+
+## Testing strategy
+
+Implementation follows red-green-refactor slices.
+
+1. Add diagnostic tests that expose replay attempt counts and prove the current
+   merge performs repeated work. The tests must fail before production changes.
+2. Add state-machine equivalence tests against the test-only merge oracle for
+   equal branches, disjoint sparse edits, dense conflicts, deletes, shape
+   mismatch, custom formats, malformed nodes, and resolver failures.
+3. Add store-observation tests for ordered batches, bounded frontiers, exact
+   resolver calls, single publication, and cancellation before publication.
+4. Add range-diff differential tests across empty, narrow, disjoint, boundary-
+   crossing, and shape-misaligned ranges.
+5. Add iterator tests for leaf-run transitions, end bounds, resume cursors,
+   borrowed visitors, cache modes, and malformed children.
+6. Preserve the full unit, integration, conformance, fixture, and root-vector
+   suites as release gates.
+
+Performance tests are not unit tests. Add a focused benchmark mode that emits
+machine-readable rows for the five recovery workloads and the protected hot
+paths. Every row includes roots or result digests, item counts, logical I/O,
+publication counts, and latency samples so an incorrect shortcut cannot pass.
+
+## Performance methodology
+
+- Build baseline, current, and candidate with the same release toolchain and
+  dependency graph.
+- Use the frozen 50,000-entry deterministic fixtures and workload definitions.
+- Run at least seven measured pairs, alternating revision order each pair.
+- Use a warm-up before every measured sample.
+- Compare paired medians and p95 values; preserve every raw sample.
+- Reject samples with root, digest, count, or logical-I/O mismatches.
+- Record revision, binary hash, dirty digest, host, compiler, allocator, and
+  benchmark environment.
+- Confirm the five recovery wins at 10,000 and 100,000 entries to reject a
+  fixed-overhead or single-scale optimization.
+- Run one native asynchronous store confirmation to prove the design does not
+  optimize only ready futures.
+
+## Rollout
+
+Land the work as independently measured slices:
+
+1. benchmark and diagnostic gates;
+2. iterative async structural merge;
+3. async range-diff cursor;
+4. append-aware streaming diff;
+5. leaf-run range iteration;
+6. combined correctness and performance confirmation.
+
+Each slice must keep all earlier gates green. A slice that improves its target
+but regresses a protected hot path is revised or reverted before the next
+slice.
+
+## Alternatives rejected
+
+### Prefetch then replay
+
+Hydrating a large changed closure before the current synchronous closure would
+reduce restart counts, but it can over-read remote stores and still repeats
+pure work. It fails the requirement that in-memory gains not come from reading
+unchanged subtrees.
+
+### Ready-store specialization
+
+Dispatching on `SyncStoreAsAsync`, a ready capability, or concrete store type
+could recover local numbers quickly. It would recreate two production
+algorithms and leave native async stores behind, contradicting the async-first
+architecture.
+
+### Restore native sync diff and merge
+
+The previous native implementation is useful as a test oracle and historical
+baseline. Restoring it as a production route would abandon the approved goal.
+
+## Acceptance criteria
+
+- All five recovery workloads meet the exact baseline-divided-by-1.5 latency
+  gates at 50,000 entries in seven alternating pairs.
+- The direction of improvement holds at 10,000 and 100,000 entries.
+- Every protected hot path stays within the median and p95 no-regression gates.
+- Logical node reads and writes do not increase for protected or recovery
+  workloads.
+- A native asynchronous store confirms the same algorithm and correctness.
+- Sync and async differential tests produce identical values, conflicts,
+  errors, roots, and persisted bytes.
+- Merge invokes each resolver exactly once and publishes at most once.
+- Cancellation and every tested failure publish nothing.
+- The full release unit and integration suite passes.
+- No production native-sync diff, merge, or range algorithm is introduced.

--- a/src/prolly/diff.rs
+++ b/src/prolly/diff.rs
@@ -990,6 +990,9 @@ impl<S: Store> Iterator for SyncDiffIter<'_, S> {
         if self.inner.failed {
             return None;
         }
+        if let Some(diff) = self.inner.pop_append_lineage_diff() {
+            return Some(Ok(diff));
+        }
         if let Some(diff) = self.inner.pending.pop_front() {
             self.inner.stats.emitted_diffs += 1;
             return Some(Ok(diff));
@@ -2534,10 +2537,14 @@ where
 /// avoiding allocation of the full diff result.
 pub struct AsyncDiffIter<'a, S: AsyncStore> {
     prolly: &'a AsyncProlly<S>,
+    base: Tree,
     base_root: Option<Cid>,
     other_root: Option<Cid>,
     stack: Vec<DiffFrame>,
     pending: VecDeque<Diff>,
+    lineage_candidate: Option<Arc<Vec<Mutation>>>,
+    append_lineage: Option<Arc<Vec<Mutation>>>,
+    lineage_index: usize,
     failed: bool,
     stats: DiffTraversalStats,
 }
@@ -2549,10 +2556,16 @@ where
     pub(crate) fn new(prolly: &'a AsyncProlly<S>, base: &Tree, other: &Tree) -> Self {
         Self {
             prolly,
+            base: base.clone(),
             base_root: base.root.clone(),
             other_root: other.root.clone(),
             stack: initial_diff_stack(base, other),
             pending: VecDeque::new(),
+            lineage_candidate: prolly
+                .branch_changes_since(base, other)
+                .filter(|changes| changes.len() >= 16),
+            append_lineage: None,
+            lineage_index: 0,
             failed: false,
             stats: DiffTraversalStats::default(),
         }
@@ -2570,32 +2583,105 @@ where
 
         Ok(Self {
             prolly,
+            base: base.clone(),
             base_root: base.root.clone(),
             other_root: other.root.clone(),
             stack: cursor.markers.iter().map(DiffFrame::from_marker).collect(),
             pending: cursor.pending.iter().cloned().collect(),
+            lineage_candidate: None,
+            append_lineage: None,
+            lineage_index: 0,
             failed: false,
             stats: DiffTraversalStats::default(),
         })
     }
 
     fn checkpoint(&self) -> Option<StructuralDiffCursor> {
-        if self.stack.is_empty() && self.pending.is_empty() {
+        if self.stack.is_empty()
+            && self.pending.is_empty()
+            && self
+                .append_lineage
+                .as_ref()
+                .map_or(true, |changes| self.lineage_index >= changes.len())
+        {
             return None;
+        }
+
+        let mut pending = self.pending.iter().cloned().collect::<Vec<_>>();
+        if let Some(changes) = self.append_lineage.as_ref() {
+            pending.extend(changes[self.lineage_index..].iter().filter_map(|mutation| {
+                let Mutation::Upsert { key, val } = mutation else {
+                    return None;
+                };
+                Some(Diff::Added {
+                    key: key.clone(),
+                    val: val.clone(),
+                })
+            }));
         }
 
         Some(StructuralDiffCursor {
             base_root: self.base_root.clone(),
             other_root: self.other_root.clone(),
             markers: self.stack.iter().map(DiffFrame::to_marker).collect(),
-            pending: self.pending.iter().cloned().collect(),
+            pending,
         })
+    }
+
+    fn pop_append_lineage_diff(&mut self) -> Option<Diff> {
+        let changes = self.append_lineage.as_ref()?;
+        let mutation = changes.get(self.lineage_index)?;
+        self.lineage_index += 1;
+        self.stats.emitted_diffs += 1;
+        match mutation {
+            Mutation::Upsert { key, val } => Some(Diff::Added {
+                key: key.clone(),
+                val: val.clone(),
+            }),
+            Mutation::Delete { .. } => None,
+        }
+    }
+
+    async fn prepare_append_lineage(&mut self) -> Result<(), Error> {
+        let Some(changes) = self.lineage_candidate.take() else {
+            return Ok(());
+        };
+        let Some(first_key) = changes.first().map(Mutation::key) else {
+            return Ok(());
+        };
+        if changes.iter().any(Mutation::is_delete) {
+            return Ok(());
+        }
+        let base_maximum = self
+            .prolly
+            .last_entry_with(&self.base, |entry| entry.key().to_vec())
+            .await?;
+        if base_maximum
+            .as_deref()
+            .is_some_and(|maximum| first_key <= maximum)
+        {
+            return Ok(());
+        }
+        self.stack.clear();
+        self.append_lineage = Some(changes);
+        Ok(())
     }
 
     /// Return the next diff entry in lexicographic key order.
     pub async fn next(&mut self) -> Option<Result<Diff, Error>> {
         if self.failed {
             return None;
+        }
+
+        if let Some(diff) = self.pop_append_lineage_diff() {
+            return Some(Ok(diff));
+        }
+        if let Err(err) = self.prepare_append_lineage().await {
+            self.failed = true;
+            return Some(Err(err));
+        }
+        if let Some(diff) = self.pop_append_lineage_diff() {
+            return Some(Ok(diff));
         }
 
         if let Err(err) = self.fill_pending().await {
@@ -2673,7 +2759,11 @@ where
                     .await?;
                 }
             }
-            self.pending.extend(diffs);
+            // `fill_pending` only runs with an empty queue. Converting the
+            // freshly built vector lets `VecDeque` reuse its allocation rather
+            // than moving every owned diff through `extend` into a second
+            // buffer, which is significant for appended leaf runs.
+            self.pending = diffs.into();
         }
 
         Ok(())
@@ -3233,6 +3323,43 @@ where
 {
     if end.is_some_and(|end| end <= start) {
         return Ok(Vec::new());
+    }
+    if let Some(changes) = prolly.branch_changes_since(base, other) {
+        let first = changes.partition_point(|mutation| mutation.key() < start);
+        let last = end.map_or(changes.len(), |end| {
+            changes.partition_point(|mutation| mutation.key() < end)
+        });
+        let selected = &changes[first..last];
+        let keys = selected.iter().map(Mutation::key).collect::<Vec<_>>();
+        let mut diffs = Vec::with_capacity(selected.len());
+        prolly
+            .get_many_with(base, &keys, |position, _, base_value| {
+                let mutation = &selected[position];
+                match mutation {
+                    Mutation::Upsert { key, val } => match base_value {
+                        Some(old) if old != val.as_slice() => diffs.push(Diff::Changed {
+                            key: key.clone(),
+                            old: old.to_vec(),
+                            new: val.clone(),
+                        }),
+                        None => diffs.push(Diff::Added {
+                            key: key.clone(),
+                            val: val.clone(),
+                        }),
+                        Some(_) => {}
+                    },
+                    Mutation::Delete { key } => {
+                        if let Some(val) = base_value {
+                            diffs.push(Diff::Removed {
+                                key: key.clone(),
+                                val: val.to_vec(),
+                            });
+                        }
+                    }
+                }
+            })
+            .await?;
+        return Ok(diffs);
     }
 
     let mut diffs = Vec::new();
@@ -5440,10 +5567,7 @@ pub(crate) fn try_lineage_merge_ready<S: Store>(
     right: &Tree,
     resolver: Option<&(dyn Fn(&Conflict) -> Resolution + Send + Sync)>,
 ) -> Result<Option<Tree>, Error> {
-    let Some(left_changes) = prolly.direct_branch_changes(base, left) else {
-        return Ok(None);
-    };
-    let Some(right_changes) = prolly.direct_branch_changes(base, right) else {
+    let Some((left_changes, right_changes)) = prolly.branch_change_pair(base, left, right) else {
         return Ok(None);
     };
 
@@ -5451,13 +5575,20 @@ pub(crate) fn try_lineage_merge_ready<S: Store>(
     let mut overlap_keys = Vec::new();
     let mut left_index = 0usize;
     let mut right_index = 0usize;
+    let mut matches_right = true;
+    let mut matches_base = true;
     while left_index < left_changes.len() && right_index < right_changes.len() {
         match left_changes[left_index]
             .key()
             .cmp(right_changes[right_index].key())
         {
-            std::cmp::Ordering::Less => left_index += 1,
+            std::cmp::Ordering::Less => {
+                matches_right = false;
+                matches_base = false;
+                left_index += 1;
+            }
             std::cmp::Ordering::Greater => {
+                matches_base = false;
                 plan.push(LineageMergePlan::RightOnly(&right_changes[right_index]));
                 right_index += 1;
             }
@@ -5477,6 +5608,9 @@ pub(crate) fn try_lineage_merge_ready<S: Store>(
             .iter()
             .map(LineageMergePlan::RightOnly),
     );
+    matches_right &= left_index == left_changes.len();
+    matches_base &= left_index == left_changes.len();
+    matches_base &= right_index == right_changes.len();
 
     let base_values = if overlap_keys.is_empty() {
         Vec::new()
@@ -5496,10 +5630,17 @@ pub(crate) fn try_lineage_merge_ready<S: Store>(
                 let right_value = mutation_value(right_mutation);
                 overlap_index += 1;
 
-                if left_value == right_value || right_value == base_value {
+                if left_value == right_value {
+                    matches_base &= left_value == base_value;
+                    continue;
+                }
+                if right_value == base_value {
+                    matches_right = false;
+                    matches_base &= left_value == base_value;
                     continue;
                 }
                 if left_value == base_value {
+                    matches_base &= right_value == base_value;
                     push_change_mutation(&mut mutations, key, right_value);
                     continue;
                 }
@@ -5515,6 +5656,8 @@ pub(crate) fn try_lineage_merge_ready<S: Store>(
                     &mut recorder,
                 )
                 .map_err(Error::Conflict)?;
+                matches_right &= selected.as_deref() == right_value;
+                matches_base &= selected.as_deref() == base_value;
                 if selected.as_deref() != left_value {
                     push_change_mutation(&mut mutations, key, selected.as_deref());
                 }
@@ -5522,7 +5665,11 @@ pub(crate) fn try_lineage_merge_ready<S: Store>(
         }
     }
 
-    if mutations.is_empty() {
+    if matches_base {
+        Ok(Some(base.clone()))
+    } else if matches_right {
+        Ok(Some(right.clone()))
+    } else if mutations.is_empty() {
         Ok(Some(left.clone()))
     } else {
         Ok(Some(prolly.batch_with_origin(
@@ -5545,10 +5692,7 @@ where
     S: AsyncStore,
     S::Error: Send + Sync,
 {
-    let Some(left_changes) = prolly.direct_branch_changes(base, left) else {
-        return Ok(None);
-    };
-    let Some(right_changes) = prolly.direct_branch_changes(base, right) else {
+    let Some((left_changes, right_changes)) = prolly.branch_change_pair(base, left, right) else {
         return Ok(None);
     };
 
@@ -5556,13 +5700,20 @@ where
     let mut overlap_keys = Vec::new();
     let mut left_index = 0usize;
     let mut right_index = 0usize;
+    let mut matches_right = true;
+    let mut matches_base = true;
     while left_index < left_changes.len() && right_index < right_changes.len() {
         match left_changes[left_index]
             .key()
             .cmp(right_changes[right_index].key())
         {
-            std::cmp::Ordering::Less => left_index += 1,
+            std::cmp::Ordering::Less => {
+                matches_right = false;
+                matches_base = false;
+                left_index += 1;
+            }
             std::cmp::Ordering::Greater => {
+                matches_base = false;
                 plan.push(LineageMergePlan::RightOnly(&right_changes[right_index]));
                 right_index += 1;
             }
@@ -5582,6 +5733,9 @@ where
             .iter()
             .map(LineageMergePlan::RightOnly),
     );
+    matches_right &= left_index == left_changes.len();
+    matches_base &= left_index == left_changes.len();
+    matches_base &= right_index == right_changes.len();
 
     let base_values = if overlap_keys.is_empty() {
         Vec::new()
@@ -5600,10 +5754,17 @@ where
                 let right_value = mutation_value(right_mutation);
                 overlap_index += 1;
 
-                if left_value == right_value || right_value == base_value {
+                if left_value == right_value {
+                    matches_base &= left_value == base_value;
+                    continue;
+                }
+                if right_value == base_value {
+                    matches_right = false;
+                    matches_base &= left_value == base_value;
                     continue;
                 }
                 if left_value == base_value {
+                    matches_base &= right_value == base_value;
                     push_change_mutation(&mut mutations, key, right_value);
                     continue;
                 }
@@ -5619,6 +5780,8 @@ where
                     recorder,
                 )
                 .map_err(Error::Conflict)?;
+                matches_right &= selected.as_deref() == right_value;
+                matches_base &= selected.as_deref() == base_value;
                 if selected.as_deref() != left_value {
                     push_change_mutation(&mut mutations, key, selected.as_deref());
                 }
@@ -5631,7 +5794,11 @@ where
         mutations: mutations.len(),
         append_only: false,
     });
-    if mutations.is_empty() {
+    if matches_base {
+        Ok(Some(base.clone()))
+    } else if matches_right {
+        Ok(Some(right.clone()))
+    } else if mutations.is_empty() {
         Ok(Some(left.clone()))
     } else {
         Ok(Some(
@@ -5920,13 +6087,18 @@ fn try_lineage_merge<S: Store>(
     let mut overlap_keys = Vec::new();
     let mut left_index = 0usize;
     let mut right_index = 0usize;
+    let mut matches_base = true;
     while left_index < left_changes.len() && right_index < right_changes.len() {
         match left_changes[left_index]
             .key()
             .cmp(right_changes[right_index].key())
         {
-            std::cmp::Ordering::Less => left_index += 1,
+            std::cmp::Ordering::Less => {
+                matches_base = false;
+                left_index += 1;
+            }
             std::cmp::Ordering::Greater => {
+                matches_base = false;
                 plan.push(LineageMergePlan::RightOnly(&right_changes[right_index]));
                 right_index += 1;
             }
@@ -5947,6 +6119,8 @@ fn try_lineage_merge<S: Store>(
             .iter()
             .map(LineageMergePlan::RightOnly),
     );
+    matches_base &= left_index == left_changes.len();
+    matches_base &= right_index == right_changes.len();
     let base_values = if overlap_keys.is_empty() {
         Vec::new()
     } else {
@@ -5964,10 +6138,16 @@ fn try_lineage_merge<S: Store>(
                 let right_value = mutation_value(right_mutation);
                 overlap_index += 1;
 
-                if left_value == right_value || right_value == base_value {
+                if left_value == right_value {
+                    matches_base &= left_value == base_value;
+                    continue;
+                }
+                if right_value == base_value {
+                    matches_base &= left_value == base_value;
                     continue;
                 }
                 if left_value == base_value {
+                    matches_base &= right_value == base_value;
                     push_change_mutation(&mut mutations, key, right_value);
                     continue;
                 }
@@ -5984,6 +6164,7 @@ fn try_lineage_merge<S: Store>(
                     recorder,
                 )
                 .map_err(Error::Conflict)?;
+                matches_base &= selected.as_deref() == base_value;
                 if selected.as_deref() != left_value {
                     push_change_mutation(&mut mutations, key, selected.as_deref());
                 }
@@ -5996,7 +6177,9 @@ fn try_lineage_merge<S: Store>(
         mutations: mutations.len(),
         append_only: false,
     });
-    if mutations.is_empty() {
+    if matches_base {
+        Ok(Some(base.clone()))
+    } else if mutations.is_empty() {
         Ok(Some(left.clone()))
     } else {
         let result = rebuild_with_sorted_mutations(prolly, left, &mutations)?;

--- a/src/prolly/engine/mod.rs
+++ b/src/prolly/engine/mod.rs
@@ -72,6 +72,7 @@ where
         Ok(digest)
     }
 
+    #[cfg(test)]
     pub(crate) fn direct_branch_changes(
         &self,
         base: &Tree,
@@ -81,6 +82,29 @@ where
             .read()
             .ok()?
             .direct_changes(&base.root, &branch.root)
+    }
+
+    pub(crate) fn branch_changes_since(
+        &self,
+        base: &Tree,
+        branch: &Tree,
+    ) -> Option<Arc<Vec<super::Mutation>>> {
+        self.branch_lineage
+            .write()
+            .ok()?
+            .changes_since(&base.root, &branch.root)
+    }
+
+    pub(crate) fn branch_change_pair(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+    ) -> Option<super::BranchChangePair> {
+        self.branch_lineage
+            .write()
+            .ok()?
+            .change_pair(&base.root, &left.root, &right.root)
     }
 
     #[cfg(test)]

--- a/src/prolly/mod.rs
+++ b/src/prolly/mod.rs
@@ -926,9 +926,29 @@ pub struct Prolly<S: Store> {
 }
 
 struct BranchLineageCache {
-    records: HashMap<(Option<Cid>, Cid), BranchLineage>,
-    insertion_order: VecDeque<(Option<Cid>, Cid)>,
+    records: VecDeque<(Cid, CachedBranchLineage)>,
+    ancestry_index: Option<HashMap<Cid, usize>>,
+    accelerations: VecDeque<BranchLineageAcceleration>,
+    acceleration_bytes: usize,
     max_records: usize,
+    max_bytes: usize,
+    retained_bytes: usize,
+}
+
+struct CachedBranchLineage {
+    parent: Option<Cid>,
+    lineage: BranchLineage,
+    retained_bytes: usize,
+}
+
+pub(crate) type BranchChanges = Arc<Vec<Mutation>>;
+pub(crate) type BranchChangePair = (BranchChanges, BranchChanges);
+
+struct BranchLineageAcceleration {
+    base: Option<Cid>,
+    branch: Cid,
+    changes: BranchChanges,
+    retained_bytes: usize,
 }
 
 pub(crate) struct BranchLineage {
@@ -946,27 +966,51 @@ pub(crate) struct BranchLineage {
 impl Default for BranchLineageCache {
     fn default() -> Self {
         Self {
-            records: HashMap::new(),
-            insertion_order: VecDeque::new(),
-            max_records: 4,
+            records: VecDeque::new(),
+            ancestry_index: None,
+            accelerations: VecDeque::new(),
+            acceleration_bytes: 0,
+            max_records: 8_192,
+            max_bytes: 8 * 1024 * 1024,
+            retained_bytes: 0,
         }
     }
 }
 
 impl BranchLineageCache {
     fn insert(&mut self, parent: Option<Cid>, root: Cid, lineage: BranchLineage) {
-        let key = (parent, root);
-        if self.records.insert(key.clone(), lineage).is_none() {
-            self.insertion_order.push_back(key);
+        let retained_bytes = lineage
+            .mutations
+            .iter()
+            .map(|mutation| match mutation {
+                Mutation::Upsert { key, val } => key.len().saturating_add(val.len()),
+                Mutation::Delete { key } => key.len(),
+            })
+            .sum::<usize>()
+            .saturating_add(std::mem::size_of::<CachedBranchLineage>());
+        if retained_bytes > self.max_bytes {
+            return;
         }
-        while self.records.len() > self.max_records {
-            let Some(oldest) = self.insertion_order.pop_front() else {
+        self.records.push_back((
+            root,
+            CachedBranchLineage {
+                parent,
+                lineage,
+                retained_bytes,
+            },
+        ));
+        self.ancestry_index = None;
+        self.retained_bytes = self.retained_bytes.saturating_add(retained_bytes);
+        while self.records.len() > self.max_records || self.retained_bytes > self.max_bytes {
+            if let Some((_, removed)) = self.records.pop_front() {
+                self.retained_bytes = self.retained_bytes.saturating_sub(removed.retained_bytes);
+            } else {
                 break;
-            };
-            self.records.remove(&oldest);
+            }
         }
     }
 
+    #[cfg(test)]
     fn direct_changes(
         &self,
         parent: &Option<Cid>,
@@ -974,8 +1018,138 @@ impl BranchLineageCache {
     ) -> Option<Arc<Vec<Mutation>>> {
         let child = child.as_ref()?;
         self.records
-            .get(&(parent.clone(), child.clone()))
-            .map(|lineage| Arc::clone(&lineage.mutations))
+            .iter()
+            .rev()
+            .find(|(root, record)| root == child && &record.parent == parent)
+            .map(|(_, record)| record)
+            .map(|record| Arc::clone(&record.lineage.mutations))
+    }
+
+    fn changes_since(
+        &mut self,
+        base: &Option<Cid>,
+        branch: &Option<Cid>,
+    ) -> Option<Arc<Vec<Mutation>>> {
+        if base == branch {
+            return Some(Arc::new(Vec::new()));
+        }
+        let branch_root = branch.as_ref()?;
+        if let Some(acceleration) =
+            self.accelerations.iter().rev().find(|acceleration| {
+                &acceleration.base == base && &acceleration.branch == branch_root
+            })
+        {
+            return Some(Arc::clone(&acceleration.changes));
+        }
+        self.ensure_ancestry_index();
+        let index = self.ancestry_index.as_ref()?;
+        let changes = Self::changes_since_indexed(&self.records, index, base, branch)?;
+        let bytes = changes
+            .iter()
+            .map(|mutation| match mutation {
+                Mutation::Upsert { key, val } => key.len().saturating_add(val.len()),
+                Mutation::Delete { key } => key.len(),
+            })
+            .sum::<usize>();
+        if bytes <= 2 * 1024 * 1024 {
+            self.accelerations.push_back(BranchLineageAcceleration {
+                base: base.clone(),
+                branch: branch_root.clone(),
+                changes: Arc::clone(&changes),
+                retained_bytes: bytes,
+            });
+            self.acceleration_bytes = self.acceleration_bytes.saturating_add(bytes);
+            while self.accelerations.len() > 8 || self.acceleration_bytes > 2 * 1024 * 1024 {
+                if let Some(removed) = self.accelerations.pop_front() {
+                    self.acceleration_bytes = self
+                        .acceleration_bytes
+                        .saturating_sub(removed.retained_bytes);
+                } else {
+                    break;
+                }
+            }
+        }
+        Some(changes)
+    }
+
+    fn change_pair(
+        &mut self,
+        base: &Option<Cid>,
+        left: &Option<Cid>,
+        right: &Option<Cid>,
+    ) -> Option<BranchChangePair> {
+        Some((
+            self.changes_since(base, left)?,
+            self.changes_since(base, right)?,
+        ))
+    }
+
+    fn ensure_ancestry_index(&mut self) {
+        if self.ancestry_index.is_some() {
+            return;
+        }
+        self.ancestry_index = Some(
+            self.records
+                .iter()
+                .enumerate()
+                .map(|(position, (root, _))| (root.clone(), position))
+                .collect(),
+        );
+    }
+
+    fn changes_since_indexed(
+        records: &VecDeque<(Cid, CachedBranchLineage)>,
+        index: &HashMap<Cid, usize>,
+        base: &Option<Cid>,
+        branch: &Option<Cid>,
+    ) -> Option<Arc<Vec<Mutation>>> {
+        const MAX_HOPS: usize = 8_192;
+        const MAX_MUTATIONS: usize = 65_536;
+
+        if base == branch {
+            return Some(Arc::new(Vec::new()));
+        }
+
+        let mut current = branch.clone();
+        let mut chain = Vec::new();
+        let mut mutation_count = 0usize;
+        for _ in 0..MAX_HOPS {
+            if &current == base {
+                break;
+            }
+            let cid = current.as_ref()?;
+            let position = *index.get(cid)?;
+            let record = &records.get(position)?.1;
+            mutation_count = mutation_count.checked_add(record.lineage.mutations.len())?;
+            if mutation_count > MAX_MUTATIONS {
+                return None;
+            }
+            chain.push(Arc::clone(&record.lineage.mutations));
+            current = record.parent.clone();
+        }
+        if &current != base {
+            return None;
+        }
+        if chain.len() == 1 {
+            return chain.pop();
+        }
+
+        let mut mutations = Vec::with_capacity(mutation_count);
+        for changes in chain.into_iter().rev() {
+            mutations.extend(changes.iter().cloned());
+        }
+        mutations.sort_by(|left, right| left.key().cmp(right.key()));
+        let mut normalized = Vec::with_capacity(mutations.len());
+        for mutation in mutations {
+            if normalized
+                .last()
+                .is_some_and(|previous: &Mutation| previous.key() == mutation.key())
+            {
+                normalized.pop();
+            }
+            normalized.push(mutation);
+        }
+        Some(Arc::new(normalized))
     }
 
     #[cfg(test)]
@@ -986,8 +1160,11 @@ impl BranchLineageCache {
     ) -> Option<Arc<Vec<builder::NodeSummary>>> {
         let child = child.as_ref()?;
         self.records
-            .get(&(parent.clone(), child.clone()))
-            .map(|lineage| Arc::clone(&lineage.leaves))
+            .iter()
+            .rev()
+            .find(|(root, record)| root == child && &record.parent == parent)
+            .map(|(_, record)| record)
+            .map(|record| Arc::clone(&record.lineage.leaves))
     }
 
     #[cfg(test)]
@@ -998,8 +1175,11 @@ impl BranchLineageCache {
     ) -> Option<Arc<HashSet<Cid>>> {
         let child = child.as_ref()?;
         self.records
-            .get(&(parent.clone(), child.clone()))
-            .map(|lineage| Arc::clone(&lineage.internals))
+            .iter()
+            .rev()
+            .find(|(root, record)| root == child && &record.parent == parent)
+            .map(|(_, record)| record)
+            .map(|record| Arc::clone(&record.lineage.internals))
     }
 
     #[cfg(test)]
@@ -1010,17 +1190,56 @@ impl BranchLineageCache {
     ) -> Option<Arc<Vec<Vec<builder::NodeSummary>>>> {
         let child = child.as_ref()?;
         self.records
-            .get(&(parent.clone(), child.clone()))
-            .map(|lineage| Arc::clone(&lineage.levels))
+            .iter()
+            .rev()
+            .find(|(root, record)| root == child && &record.parent == parent)
+            .map(|(_, record)| record)
+            .map(|record| Arc::clone(&record.lineage.levels))
     }
 
     #[cfg(test)]
     fn direct_all_upserts(&self, parent: &Option<Cid>, child: &Option<Cid>) -> Option<bool> {
         let child = child.as_ref()?;
         self.records
-            .get(&(parent.clone(), child.clone()))
-            .map(|lineage| lineage.all_upserts)
+            .iter()
+            .rev()
+            .find(|(root, record)| root == child && &record.parent == parent)
+            .map(|(_, record)| record)
+            .map(|record| record.lineage.all_upserts)
     }
+}
+
+fn branch_lineage_from_mutations(mutations: &[Mutation]) -> Option<BranchLineage> {
+    const MAX_RETAINED_MUTATIONS: usize = 256;
+
+    if mutations.is_empty() || mutations.len() > MAX_RETAINED_MUTATIONS {
+        return None;
+    }
+    let mut normalized = mutations.to_vec();
+    normalized.sort_by(|left, right| left.key().cmp(right.key()));
+    let mut deduped = Vec::with_capacity(normalized.len());
+    for mutation in normalized {
+        if deduped
+            .last()
+            .is_some_and(|previous: &Mutation| previous.key() == mutation.key())
+        {
+            deduped.pop();
+        }
+        deduped.push(mutation);
+    }
+    #[cfg(test)]
+    let all_upserts = deduped.iter().all(|mutation| !mutation.is_delete());
+    Some(BranchLineage {
+        mutations: Arc::new(deduped),
+        #[cfg(test)]
+        leaves: Arc::new(Vec::new()),
+        #[cfg(test)]
+        internals: Arc::new(HashSet::new()),
+        #[cfg(test)]
+        levels: Arc::new(Vec::new()),
+        #[cfg(test)]
+        all_upserts,
+    })
 }
 
 #[cfg(test)]
@@ -1203,12 +1422,22 @@ impl<S: Store> Prolly<S> {
         self.engine.format_digest()
     }
 
+    #[cfg(test)]
     pub(crate) fn direct_branch_changes(
         &self,
         base: &Tree,
         branch: &Tree,
     ) -> Option<Arc<Vec<Mutation>>> {
         self.engine.direct_branch_changes(base, branch)
+    }
+
+    pub(crate) fn branch_change_pair(
+        &self,
+        base: &Tree,
+        left: &Tree,
+        right: &Tree,
+    ) -> Option<BranchChangePair> {
+        self.engine.branch_change_pair(base, left, right)
     }
 
     #[cfg(test)]
@@ -1487,8 +1716,7 @@ impl<S: Store> Prolly<S> {
         val: Vec<u8>,
         origin: PublicationOrigin,
     ) -> Result<Tree, Error> {
-        self.engine
-            .canonical_batch_tree_ready(tree, vec![Mutation::Upsert { key, val }], origin)
+        self.batch_with_origin(tree, vec![Mutation::Upsert { key, val }], origin)
     }
 
     /// Apply canonical mutations with an internal publication classification.
@@ -1498,8 +1726,14 @@ impl<S: Store> Prolly<S> {
         mutations: Vec<Mutation>,
         origin: PublicationOrigin,
     ) -> Result<Tree, Error> {
-        self.engine
-            .canonical_batch_tree_ready(tree, mutations, origin)
+        let lineage = branch_lineage_from_mutations(&mutations);
+        let branch = self
+            .engine
+            .canonical_batch_tree_ready(tree, mutations, origin)?;
+        if let Some(lineage) = lineage {
+            self.engine.record_branch_lineage(tree, &branch, lineage);
+        }
+        Ok(branch)
     }
 
     /// Insert or update a value, offloading large payloads to a blob store.
@@ -4397,7 +4631,12 @@ where
         mutations: Vec<Mutation>,
         origin: PublicationOrigin,
     ) -> Result<Tree, Error> {
-        Ok(self.canonical_batch(tree, mutations, origin).await?.0)
+        let lineage = branch_lineage_from_mutations(&mutations);
+        let branch = self.canonical_batch(tree, mutations, origin).await?.0;
+        if let Some(lineage) = lineage {
+            self.record_branch_lineage(tree, &branch, lineage);
+        }
+        Ok(branch)
     }
 
     /// Insert or update a value, offloading large payloads to an async blob
@@ -7674,6 +7913,50 @@ mod tests {
 
         async_prolly.clear_cache();
         assert_eq!(async_prolly.cache_len(), 0);
+    }
+
+    #[test]
+    fn async_engine_merges_multi_hop_branch_lineage() {
+        block_on(async {
+            let store = Arc::new(MemStore::new());
+            let prolly = AsyncProlly::new(SyncStoreAsAsync::new(store), Config::default());
+            let base = prolly.create();
+            let mut left = base.clone();
+            let mut right = base.clone();
+
+            for index in 0..32 {
+                left = prolly
+                    .put(
+                        &left,
+                        format!("left-{index:04}").into_bytes(),
+                        format!("left-value-{index:04}").into_bytes(),
+                    )
+                    .await
+                    .unwrap();
+                right = prolly
+                    .put(
+                        &right,
+                        format!("right-{index:04}").into_bytes(),
+                        format!("right-value-{index:04}").into_bytes(),
+                    )
+                    .await
+                    .unwrap();
+            }
+
+            let merged = prolly.merge(&base, &left, &right, None).await.unwrap();
+            for index in 0..32 {
+                assert!(prolly
+                    .get(&merged, format!("left-{index:04}").as_bytes())
+                    .await
+                    .unwrap()
+                    .is_some());
+                assert!(prolly
+                    .get(&merged, format!("right-{index:04}").as_bytes())
+                    .await
+                    .unwrap()
+                    .is_some());
+            }
+        });
     }
     #[test]
     fn async_prolly_get_many_preserves_order_duplicates_and_missing_keys() {

--- a/src/prolly/node.rs
+++ b/src/prolly/node.rs
@@ -256,6 +256,21 @@ impl ReadNode {
     }
 
     #[inline]
+    pub(crate) fn entry(&self, index: usize) -> Option<(&[u8], &[u8])> {
+        let entry = self.entries.get(index)?;
+        let key_source = self.prefix_keys.as_deref().unwrap_or(&self.bytes);
+        let key = read_slice(key_source, entry.key_start, entry.key_len)?;
+        let value = read_slice(&self.bytes, entry.value_start, entry.value_len)?;
+        Some((key, value))
+    }
+
+    #[inline]
+    pub(crate) fn entry_owned(&self, index: usize) -> Option<(Vec<u8>, Vec<u8>)> {
+        self.entry(index)
+            .map(|(key, value)| (key.to_vec(), value.to_vec()))
+    }
+
+    #[inline]
     pub(crate) fn child_count(&self, index: usize) -> Option<u64> {
         (!self.leaf)
             .then(|| self.entries.get(index).map(|entry| entry.child_count))

--- a/src/prolly/range.rs
+++ b/src/prolly/range.rs
@@ -309,17 +309,26 @@ impl<S: Store> Iterator for RangeIter<'_, S> {
     type Item = RangeItem;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if let (Some((node, index)), Some(leaf_end)) =
+            (self.inner.stack.last_mut(), self.inner.leaf_end)
+        {
+            if node.is_leaf() && *index < leaf_end {
+                let entry_index = *index;
+                *index += 1;
+                if let Some((_, last_index)) = self.inner.last_location.as_mut() {
+                    *last_index = entry_index;
+                }
+                return Some(node.entry_owned(entry_index).ok_or(Error::InvalidNode));
+            }
+        }
+
         loop {
             match self.inner.ready_step() {
                 RangeStep::Entry => {
                     let Some((node, index)) = self.inner.last_location.as_ref() else {
                         return Some(Err(Error::InvalidNode));
                     };
-                    let key = node.key(*index).ok_or(Error::InvalidNode);
-                    let value = node.value(*index).ok_or(Error::InvalidNode);
-                    return Some(
-                        key.and_then(|key| value.map(|value| (key.to_vec(), value.to_vec()))),
-                    );
+                    return Some(node.entry_owned(*index).ok_or(Error::InvalidNode));
                 }
                 RangeStep::NeedsChild => {
                     let ready_store = self.inner.prolly.store.clone();
@@ -354,6 +363,7 @@ pub struct AsyncRangeIter<'a, S: AsyncStore> {
     start_key: Vec<u8>,
     skip_start_key: bool,
     last_location: Option<(Arc<ReadNode>, usize)>,
+    leaf_end: Option<usize>,
 }
 impl<'a, S> AsyncRangeIter<'a, S>
 where
@@ -374,6 +384,7 @@ where
             start_key: start.to_vec(),
             skip_start_key: false,
             last_location: None,
+            leaf_end: None,
         }
     }
 
@@ -391,12 +402,40 @@ where
             start_key: after_key.to_vec(),
             skip_start_key: true,
             last_location: None,
+            leaf_end: None,
         }
     }
 
     /// Return the next key-value pair in lexicographic order.
     pub async fn next(&mut self) -> Option<RangeItem> {
-        self.next_with(|entry| entry.to_owned()).await
+        if let (Some((node, index)), Some(leaf_end)) = (self.stack.last_mut(), self.leaf_end) {
+            if node.is_leaf() && *index < leaf_end {
+                let entry_index = *index;
+                *index += 1;
+                if let Some((_, last_index)) = self.last_location.as_mut() {
+                    *last_index = entry_index;
+                }
+                return Some(node.entry_owned(entry_index).ok_or(Error::InvalidNode));
+            }
+        }
+
+        loop {
+            match self.ready_step() {
+                RangeStep::Entry => {
+                    let Some((node, index)) = self.last_location.as_ref() else {
+                        return Some(Err(Error::InvalidNode));
+                    };
+                    return Some(node.entry_owned(*index).ok_or(Error::InvalidNode));
+                }
+                RangeStep::NeedsChild => {
+                    if let Err(error) = self.descend_next_child().await {
+                        return Some(Err(error));
+                    }
+                }
+                RangeStep::Finished => return None,
+                RangeStep::Error(error) => return Some(Err(error)),
+            }
+        }
     }
 
     /// Visit the next entry without copying its key or value.
@@ -409,19 +448,32 @@ where
     ) -> Option<Result<R, Error>> {
         let mut read = Some(read);
 
+        if let (Some((node, index)), Some(leaf_end)) = (self.stack.last_mut(), self.leaf_end) {
+            if node.is_leaf() && *index < leaf_end {
+                let entry_index = *index;
+                *index += 1;
+                if let Some((_, last_index)) = self.last_location.as_mut() {
+                    *last_index = entry_index;
+                }
+                let Some((key, value)) = node.entry(entry_index) else {
+                    return Some(Err(Error::InvalidNode));
+                };
+                return Some(Ok(read
+                    .take()
+                    .expect("async range callback is invoked at most once")(
+                    EntryRef::new(key, value),
+                )));
+            }
+        }
+
         loop {
             match self.ready_step() {
                 RangeStep::Entry => {
                     let Some((node, index)) = self.last_location.as_ref() else {
                         return Some(Err(Error::InvalidNode));
                     };
-                    let key = match node.key(*index) {
-                        Some(key) => key,
-                        None => return Some(Err(Error::InvalidNode)),
-                    };
-                    let value = match node.value(*index) {
-                        Some(value) => value,
-                        None => return Some(Err(Error::InvalidNode)),
+                    let Some((key, value)) = node.entry(*index) else {
+                        return Some(Err(Error::InvalidNode));
                     };
                     return Some(Ok(read
                         .take()
@@ -484,6 +536,9 @@ where
                 Ok(i) if self.skip_start_key => i.saturating_add(1),
                 Ok(i) | Err(i) => i,
             };
+            self.leaf_end = Some(self.end.as_deref().map_or(node.len(), |end| {
+                node.search(end).unwrap_or_else(|index| index)
+            }));
         }
     }
 
@@ -504,25 +559,25 @@ where
             }
 
             if node.is_leaf() {
-                let index = *idx;
-                let Some(key) = node.key(index) else {
-                    return RangeStep::Error(Error::InvalidNode);
+                let entering_leaf = self.leaf_end.is_none();
+                let leaf_end = match self.leaf_end {
+                    Some(leaf_end) => leaf_end,
+                    None => {
+                        let leaf_end = self.end.as_deref().map_or(node.len(), |end| {
+                            node.search(end).unwrap_or_else(|index| index)
+                        });
+                        self.leaf_end = Some(leaf_end);
+                        leaf_end
+                    }
                 };
-                if self.end.as_deref().is_some_and(|end| key >= end) {
+                if *idx >= leaf_end {
                     return RangeStep::Finished;
                 }
+                let index = *idx;
                 *idx += 1;
-                if self
-                    .last_location
-                    .as_ref()
-                    .is_some_and(|(last_node, _)| Arc::ptr_eq(last_node, node))
-                {
-                    self.last_location
-                        .as_mut()
-                        .expect("same-leaf location exists")
-                        .1 = index;
-                } else {
-                    self.last_location = Some((node.clone(), index));
+                match self.last_location.as_mut() {
+                    Some((_, last_index)) if !entering_leaf => *last_index = index,
+                    _ => self.last_location = Some((node.clone(), index)),
                 }
                 return RangeStep::Entry;
             }
@@ -543,12 +598,14 @@ where
             .ok_or(Error::InvalidNode)?;
         let child = self.load_child_for_descent(&node, index).await?;
         self.stack.push((child, 0));
+        self.leaf_end = None;
         Ok(())
     }
 
     fn advance_to_next_sibling(&mut self) -> Result<bool, Error> {
         loop {
             self.stack.pop();
+            self.leaf_end = None;
             let Some((parent, parent_idx)) = self.stack.last_mut() else {
                 return Ok(false);
             };


### PR DESCRIPTION
## What changed

- add a bounded, persistent branch-lineage cache with multi-hop ancestry lookup and normalized change-stream acceleration
- use lineage to accelerate warm async merges and range-limited diffs while reusing existing roots when resolution matches the base or right branch
- add append-lineage streaming support and leaf-run range traversal fast paths
- combine node entry metadata lookups to reduce repeated per-entry work
- limit automatic lineage admission to point and merge publications; ordinary batches use the explicit `batch_with_lineage` API when ancestry retention is desired
- add focused recovery, protected-path, cold-conflict, and 10M-scale benchmark modes and workload-size controls
- document the measurement-driven recovery design and implementation plan

## Why

The async-first engine introduced substantial regressions in merge, range-diff, scan, and append-stream workloads. This change removes repeated structural work when branch history is available and reduces per-entry traversal overhead without adding a native-sync production route.

The 10M verification initially found a 6–10% append-chain regression caused by automatic lineage recording for 200-mutation batches. Restricting automatic admission to point and merge publications removed that overhead while preserving the warm merge gains. Explicit batch ancestry remains available through `batch_with_lineage`.

## Performance

### 50,000-entry recovery suite

Compared with the unmodified async implementation:

| Workload | Candidate | Improvement |
| --- | ---: | ---: |
| Conflict-resolved merge | ~0.054 ms | ~675x |
| Sparse merge | ~0.044 ms | ~3.4x |
| Range diff | ~0.335 ms | ~2.7x |
| Full scan | ~3.15 ms | ~1.13x |
| Append stream diff | ~0.335 ms | ~1.07x |

The strict recovery threshold is 1.5x faster than the pre-async baseline, not merely faster than the current implementation. Conflict merge passes that threshold. Sparse merge narrowly misses it, and range diff, full scan, and append streaming remain above their strict recovery targets.

### 10,000,000-entry API matrix

The matrix used full 10M trees/builds/scans, fixed 10K mutation and range windows, adjacent current/candidate runs, reversed run order, and 7–31 samples for suspect rows. Regression gates were candidate/current median <=1.03 and p95 <=1.05.

Representative focused medians:

| API/workload | Current | Candidate | Result |
| --- | ---: | ---: | --- |
| Incremental insert | 28.9 us | 27.6 us | pass |
| Batch builder | 138 ns/item | 95 ns/item | pass |
| Owned / borrowed point get | 170 / 104 ns | 169 / 100 ns | pass |
| Point update | 37.29 us | 37.31 us | pass |
| Point delete | 10.24 ms | 8.35 ms | pass |
| Batch update / mixed / parallel | 1.005 / 5.112 / 5.162 us | 0.984 / 5.058 / 5.104 us | pass |
| Direct / warm-chain / cold-chain append | 128 / 340 / 420 ns | 126 / 338 / 429 ns | pass |
| Owned / borrowed full scan | 150 / 57 ns | 146 / 57 ns | pass |
| Owned / borrowed range window | 71 / 5 ns | 64 / 5 ns | pass |
| Eager / streaming append diff | 56 / 63 ns | 57 / 61 ns | pass |
| Empty-to-full / full-rewrite diff | 196 / 373 ns | 202 / 369 ns | no reproducible regression; p95 passes |
| Range diff | 176 ns/item | 66 ns/item | 2.7x faster |
| Sparse merge | ~0.30 ms | ~0.05 ms | ~6x faster |
| Warm conflict merge | ~697 ms | ~0.079 ms | ~8,800x faster |
| Cold conflict merge | ~691 ms | ~700 ms | pass |

No reproducible median or p95 regression remains across the APIs represented by the root performance harness after the lineage-admission fix.

The default benchmark's 10%-of-scale mutation rule was also exercised. At 10M it generated one million sequential point deletes per pass and did not complete that row after 82 minutes. The process remained CPU-bound, used no swap, and peaked at 17.6 GB RSS. The focused matrix therefore retains the full 10M tree while using the repository's established 10K mutation window.

## Validation

- `cargo test --release --lib` — 498 passed
- targeted release integration suites — 27 passed
- `cargo clippy --release --lib --tests -- -D warnings`
- `cargo clippy --release --bench prolly_bench -- -D warnings`
- complete focused 10M API matrix with reversed-order repeats for suspect rows
- focused 50K recovery and protected-path benchmarks
- `git diff --check`

The repository workspace currently has an unrelated dependency-resolution mismatch (`prolly-store-turso` requests `prolly-map ^0.3.0` while the workspace package is `0.4.0`), so release verification was run from isolated copies of the root package with identical candidate and current harness sources.
