### PR TITLE
perf: preserve batch performance with async lineage

### DIFF
--- a/benches/prolly_bench.rs
+++ b/benches/prolly_bench.rs
@@ -140,6 +140,21 @@ fn main() {
             bench_stream_diff_append_suffix(scale);
             return;
         }
+        Ok("diff-sparse") => {
+            bench_diff_sparse(scale);
+            bench_stream_diff_sparse(scale);
+            return;
+        }
+        Ok("diff-append") => {
+            bench_diff_append_suffix(scale);
+            bench_stream_diff_append_suffix(scale);
+            return;
+        }
+        Ok("diff-full") => {
+            bench_diff_empty_to_full(scale);
+            bench_diff_full_rewrite(scale);
+            return;
+        }
         Ok("append-chain") => {
             bench_append_batch_direct(scale);
             bench_append_batch_chain(scale);

--- a/benches/prolly_bench.rs
+++ b/benches/prolly_bench.rs
@@ -109,6 +109,37 @@ fn main() {
             bench_batch_builder(scale);
             return;
         }
+        Ok("incremental-insert") => {
+            bench_incremental_insert(scale / 5);
+            return;
+        }
+        Ok("point-reads") => {
+            bench_point_get(scale);
+            return;
+        }
+        Ok("point-updates") => {
+            bench_point_updates(scale);
+            return;
+        }
+        Ok("point-deletes") => {
+            bench_point_deletes(scale);
+            return;
+        }
+        Ok("range-scans") => {
+            bench_range_scan(scale);
+            bench_range_scan_window(scale);
+            return;
+        }
+        Ok("diff-suite") => {
+            bench_diff_identical(scale);
+            bench_diff_sparse(scale);
+            bench_diff_append_suffix(scale);
+            bench_diff_empty_to_full(scale);
+            bench_diff_full_rewrite(scale);
+            bench_stream_diff_sparse(scale);
+            bench_stream_diff_append_suffix(scale);
+            return;
+        }
         Ok("append-chain") => {
             bench_append_batch_direct(scale);
             bench_append_batch_chain(scale);
@@ -920,6 +951,11 @@ fn bench_chunking_cutover(items: usize) {
 }
 
 fn bench_incremental_insert(items: usize) {
+    let items = std::env::var("PROLLY_BENCH_INCREMENTAL_ITEMS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(items);
     let data = data_set(items);
     let config = bench_config();
 
@@ -954,7 +990,11 @@ fn bench_batch_builder(items: usize) {
 fn bench_point_get(items: usize) {
     let data = data_set(items);
     let (_, prolly, tree) = build_tree(&data);
-    let gets = items * 20;
+    let gets = std::env::var("PROLLY_BENCH_GETS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(items * 20);
 
     if std::env::var_os("PROLLY_BENCH_DIAG").is_some() {
         println!(
@@ -1710,12 +1750,22 @@ fn point_delete_keys(items: usize, count: usize) -> Vec<Vec<u8>> {
 }
 
 fn mutation_count(items: usize) -> usize {
-    (items / 10).max(100)
+    std::env::var("PROLLY_BENCH_MUTATIONS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or_else(|| (items / 10).max(100))
+        .min(items)
 }
 
 fn window_bounds(items: usize) -> (usize, usize) {
     let start = items / 3;
-    let len = (items / 10).max(100).min(items - start);
+    let len = std::env::var("PROLLY_BENCH_WINDOW_ITEMS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or_else(|| (items / 10).max(100))
+        .min(items - start);
     (start, start + len)
 }
 

--- a/src/prolly/mod.rs
+++ b/src/prolly/mod.rs
@@ -1242,6 +1242,18 @@ fn branch_lineage_from_mutations(mutations: &[Mutation]) -> Option<BranchLineage
     })
 }
 
+fn automatic_branch_lineage(
+    origin: PublicationOrigin,
+    mutations: &[Mutation],
+) -> Option<BranchLineage> {
+    matches!(
+        origin,
+        PublicationOrigin::PointUpsert | PublicationOrigin::PointDelete | PublicationOrigin::Merge
+    )
+    .then(|| branch_lineage_from_mutations(mutations))
+    .flatten()
+}
+
 #[cfg(test)]
 struct RecentLeafRead {
     root: Cid,
@@ -1726,7 +1738,7 @@ impl<S: Store> Prolly<S> {
         mutations: Vec<Mutation>,
         origin: PublicationOrigin,
     ) -> Result<Tree, Error> {
-        let lineage = branch_lineage_from_mutations(&mutations);
+        let lineage = automatic_branch_lineage(origin, &mutations);
         let branch = self
             .engine
             .canonical_batch_tree_ready(tree, mutations, origin)?;
@@ -4631,7 +4643,7 @@ where
         mutations: Vec<Mutation>,
         origin: PublicationOrigin,
     ) -> Result<Tree, Error> {
-        let lineage = branch_lineage_from_mutations(&mutations);
+        let lineage = automatic_branch_lineage(origin, &mutations);
         let branch = self.canonical_batch(tree, mutations, origin).await?.0;
         if let Some(lineage) = lineage {
             self.record_branch_lineage(tree, &branch, lineage);


### PR DESCRIPTION
## Summary

Follow-up to #28 after running the async engine API matrix on 10,000,000-record trees.

- restrict automatic branch-lineage admission to point and merge publications
- keep ordinary batch and append APIs on the canonical path without lineage bookkeeping
- preserve explicit batch ancestry through `batch_with_lineage`
- add focused benchmark modes and workload-size controls for reproducible 10M regression checks

## Root cause

The 10M matrix found a reproducible 6–10% regression in chained 200-mutation append batches. Those batches fell below the automatic 256-mutation lineage cap, so every round recorded ancestry that the append API did not consume. Direct 10K append batches were not admitted and did not regress.

Limiting automatic admission to point and merge publications removes that overhead while retaining the warm sparse/conflict merge acceleration from #28.

## 10M verification

The matrix used full 10M trees/builds/scans, fixed 10K mutation and range windows, adjacent current/candidate runs, reversed run order, and 7–31 samples for suspect rows. Gates were median ratio <=1.03 and p95 ratio <=1.05.

After the fix, no reproducible regression remains across the APIs represented by the root performance harness. Representative results:

| Workload | Current | Candidate |
| --- | ---: | ---: |
| Incremental insert | 28.9 us | 27.6 us |
| Owned / borrowed point get | 170 / 104 ns | 169 / 100 ns |
| Point update | 37.29 us | 37.31 us |
| Point delete | 10.24 ms | 8.35 ms |
| Batch update / mixed / parallel | 1.005 / 5.112 / 5.162 us | 0.984 / 5.058 / 5.104 us |
| Direct / warm / cold append | 128 / 340 / 420 ns | 126 / 338 / 429 ns |
| Owned / borrowed full scan | 150 / 57 ns | 146 / 57 ns |
| Eager / streaming append diff | 56 / 63 ns | 57 / 61 ns |
| Full rewrite diff | 373 ns | 369 ns |
| Range diff | 176 ns/item | 66 ns/item |
| Warm conflict merge | ~697 ms | ~0.079 ms |

The default 10%-of-scale mutation rule was also attempted. At 10M it generated one million point deletes per pass and did not complete that row after 82 minutes. It remained CPU-bound, used no swap, and peaked at 17.6 GB RSS. The focused matrix therefore keeps the 10M tree while using the repository's established 10K mutation window.

## Validation

- `cargo test --release --lib` — 498 passed
- targeted release integration suites — 27 passed
- `cargo clippy --release --lib --tests -- -D warnings`
- `cargo clippy --release --bench prolly_bench -- -D warnings`
- focused 10M API matrix with reversed-order reruns
- `git diff --check`

Release verification ran from isolated root-package copies because the parent workspace currently has an unrelated `prolly-store-turso` / `prolly-map` version-resolution mismatch.
