### PR TITLE
bench: add reproducible Rust-Go prolly evaluation

### DIFF
--- a/docs/prolly-performance-evaluation.md
+++ b/docs/prolly-performance-evaluation.md
@@ -1,0 +1,92 @@
+# Repeatable Rust/Go prolly performance evaluation
+
+Use `scripts/run_prolly_evaluation.sh` for the canonical Dolt Go versus Rust comparison. One invocation builds and pins both implementations, runs one native Go baseline, runs bounded and unbounded Rust cache profiles, validates logical identity, captures peak RSS, and produces one combined report.
+
+## Quick contract check
+
+```sh
+BENCH_PROFILE=smoke \
+BENCH_OUT=performance-results/prolly-evaluation-smoke \
+DOLT_REV=<full-dolt-commit-sha> \
+scripts/run_prolly_evaluation.sh
+```
+
+The smoke profile uses 10,000 records, one repetition, a 1% random version workload, and no lifecycle matrix. It still runs all fresh and mutation tree localities.
+
+## Canonical matrix
+
+```sh
+BENCH_PROFILE=canonical \
+BENCH_OUT=performance-results/prolly-evaluation-$(date -u +%Y%m%dT%H%M%SZ) \
+DOLT_REV=<full-dolt-commit-sha> \
+scripts/run_prolly_evaluation.sh
+```
+
+Canonical defaults are:
+
+- sizes: 10K, 50K, 1M, 5M, and 10M;
+- repetitions: three process-isolated samples;
+- tree phases: fresh build and 30% mutation;
+- localities: append, random, and clustered;
+- version densities: 0%, 1%, and 30%;
+- Rust cache profiles: bounded and unbounded;
+- one worker and in-memory storage;
+- Rust lifecycle measurements enabled.
+
+Always set `DOLT_REV` for a publishable rerun. If it is omitted, the driver resolves `origin/main` once and records the resulting commit, but a later invocation may resolve a newer revision.
+
+## Resume an interrupted run
+
+```sh
+BENCH_PROFILE=canonical \
+BENCH_OUT=performance-results/prolly-evaluation-20260720T200000Z \
+BENCH_RESUME=1 \
+scripts/run_prolly_evaluation.sh
+```
+
+Resume uses the immutable binaries captured under `bin/`; it does not fetch Dolt or rebuild by default. Every completed sample is revalidated against its durable state file before reuse. A changed configuration, source hash, framework hash, binary hash, revision, command, raw CSV, stderr, or timing/RSS artifact stops the run.
+
+Set `BENCH_REBUILD_ON_RESUME=1` only when intentionally verifying that a rebuild is byte-identical to the captured provenance. It cannot be used to continue a run after changing code or configuration.
+
+The output-directory lock prevents concurrent writers. A dead process lock is removed only during an explicit resume.
+
+## Useful configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `BENCH_PROFILE` | `canonical` | Select `smoke` or `canonical` defaults. |
+| `BENCH_OUT` | Timestamped result directory | Immutable artifact destination. |
+| `BENCH_RESUME` | `0` | Reuse validated completed samples when set to `1`. |
+| `BENCH_SIZES` | Profile-specific | Space-separated record counts. |
+| `BENCH_RUNS` | Profile-specific | Repetitions per process-isolated scenario. |
+| `BENCH_DENSITIES` | Profile-specific | Version change densities from `0 1 30`. |
+| `BENCH_LOCALITIES` | Profile-specific | Any ordered subset of `append random clustered`. |
+| `BENCH_RUST_CACHE_PROFILES` | `bounded unbounded` | Rust cache profiles; canonical publication should retain both. |
+| `BENCH_LIFECYCLE` | Profile-specific | Enable the separate Rust lifecycle matrix with `1`. |
+| `BENCH_SKIP_SMOKE` | `0` | Skip pre-matrix parity smoke only during framework debugging. |
+| `DOLT_REV` | Resolved `origin/main` | Exact Dolt commit to benchmark. |
+| `DOLT_CACHE` | `target/dolt-benchmark` | Reusable Dolt checkout. |
+
+## Artifacts
+
+Each result directory contains:
+
+- `manifest.txt`: immutable configuration fingerprint, source and binary hashes, revisions, matrix, and cache policies;
+- `machine.txt`: host, OS, CPU, memory, Rust, and Go details;
+- `bin/`: exact Rust and Go executables used by the run;
+- `tree/`, `version/`, and `lifecycle/`: raw CSV, stderr, process timing, durable sample state, normalized results, summaries, and cache-effect CSVs;
+- `report.md`: bounded and unbounded Rust results against the same Go samples;
+- `WARNINGS`: present when lifecycle result digests differ between Rust cache profiles;
+- `COMPLETE`: written only after strict matrix validation and report generation.
+
+`COMPLETE` can coexist with `WARNINGS`: it means the configured matrix is intact and fully processed, while `WARNINGS` identifies lifecycle rows that still require correctness review before publication. Starting a resume removes `COMPLETE` until every saved sample has been revalidated and the report has been regenerated.
+
+Raw filenames identify implementation, cache profile, scenario, and repetition. Go samples use the `native` cache profile. Rust samples use `bounded` or `unbounded`.
+
+## Interpretation rules
+
+The report labels a result `winner_flip` when winner direction changes across repetitions, `narrow` when medians differ by at most 5%, and `high_variance` when either implementation's coefficient of variation exceeds 25%. Do not advertise those rows as strong winner claims.
+
+Peak RSS covers the complete scenario process, including untimed fixture construction and validation. Unbounded Rust means the decoded-node cache has no node or byte cap; normal engine safety limits and the host's physical-memory limit still apply.
+
+The lifecycle workload contract compares deterministic logical inputs, operation counts, cardinalities, and validation flags across cache profiles. Version-ID-derived result digests are reported separately. A `DIVERGED` lifecycle result identity and the `WARNINGS` marker mean the logical workload completed but the profiles produced different version identifiers; treat those rows as a correctness investigation, not publishable performance evidence.

--- a/scripts/prolly_evaluation_runner.py
+++ b/scripts/prolly_evaluation_runner.py
@@ -1,0 +1,714 @@
+#!/usr/bin/env python3
+"""Run and validate the repeatable Dolt-Go/Rust prolly evaluation matrix."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+TREE_HEADER = (
+    "implementation,revision,contract_version,records,phase,workload,operation,"
+    "operations,elapsed_ns,ns_per_op,ops_per_sec,workload_digest,result_count,validated"
+)
+VERSION_HEADER = (
+    "implementation,revision,contract_version,records,density,locality,operation,"
+    "relationship,operations,elapsed_ns,ns_per_op,ops_per_sec,workload_digest,"
+    "result_digest,result_count,base_count,target_count,conflict_count,validated"
+)
+TREE_OPERATIONS = ("write", "point_read", "range_scan")
+VERSION_ZERO_OPERATIONS = (
+    "full_diff",
+    "range_diff",
+    "patch_generate",
+    "patch_apply",
+    "merge_noop",
+)
+VERSION_CHANGED_OPERATIONS = (
+    "full_diff",
+    "range_diff",
+    "patch_generate",
+    "patch_apply",
+    "merge_disjoint",
+    "merge_convergent",
+    "merge_conflict",
+)
+LIFECYCLE_OPERATIONS = {
+    "publish": ("version_publish",),
+    "read": (
+        "head_resolve",
+        "snapshot_resolve",
+        "historical_point_read",
+        "historical_range_scan",
+        "version_list",
+    ),
+    "rollback": ("rollback",),
+    "prune": ("retention_prune",),
+}
+TREE_INVARIANTS = (
+    "contract_version",
+    "records",
+    "phase",
+    "workload",
+    "operation",
+    "operations",
+    "workload_digest",
+    "result_count",
+    "validated",
+)
+VERSION_INVARIANTS = (
+    "contract_version",
+    "records",
+    "density",
+    "locality",
+    "operation",
+    "relationship",
+    "operations",
+    "workload_digest",
+    "result_digest",
+    "base_count",
+    "target_count",
+    "conflict_count",
+    "validated",
+)
+LIFECYCLE_INVARIANTS = (
+    "contract_version",
+    "records",
+    "density",
+    "locality",
+    "operation",
+    "relationship",
+    "operations",
+    "workload_digest",
+    "result_count",
+    "base_count",
+    "target_count",
+    "conflict_count",
+    "validated",
+)
+
+
+class EvaluationError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Participant:
+    implementation: str
+    profile: str
+    binary: Path
+    revision: str
+
+    @property
+    def runner_implementation(self) -> str:
+        return "rust" if self.implementation == "rust" else "dolt-go"
+
+
+@dataclass(frozen=True)
+class Sample:
+    domain: str
+    participant: Participant
+    repetition: int
+    arguments: tuple[str, ...]
+    identity: tuple[str, ...]
+    expected_operations: tuple[str, ...]
+
+    @property
+    def slug(self) -> str:
+        return "-".join((self.domain, self.participant.implementation, self.participant.profile, *self.identity, f"run{self.repetition}"))
+
+
+def parse_positive_list(raw: str, label: str) -> tuple[int, ...]:
+    try:
+        values = tuple(int(value) for value in raw.replace(",", " ").split())
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(f"{label} must contain integers") from error
+    if not values or any(value <= 0 for value in values):
+        raise argparse.ArgumentTypeError(f"{label} must contain positive integers")
+    if len(set(values)) != len(values):
+        raise argparse.ArgumentTypeError(f"{label} contains duplicates")
+    return values
+
+
+def parse_profiles(raw: str) -> tuple[str, ...]:
+    profiles = tuple(raw.replace(",", " ").split())
+    if not profiles:
+        raise argparse.ArgumentTypeError("at least one Rust cache profile is required")
+    invalid = set(profiles) - {"bounded", "unbounded"}
+    if invalid:
+        raise argparse.ArgumentTypeError(f"unknown Rust cache profiles: {sorted(invalid)}")
+    if len(set(profiles)) != len(profiles):
+        raise argparse.ArgumentTypeError("Rust cache profiles contain duplicates")
+    return profiles
+
+
+def read_csv(path: Path, expected_header: str) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        header = handle.readline().rstrip("\r\n")
+        handle.seek(0)
+        rows = list(csv.DictReader(handle))
+    if header != expected_header:
+        raise EvaluationError(f"header mismatch in {path}: {header!r}")
+    if not rows:
+        raise EvaluationError(f"no rows in {path}")
+    return rows
+
+
+def validate_rows(sample: Sample, rows: Sequence[dict[str, str]]) -> None:
+    operations = tuple(row.get("operation", "") for row in rows)
+    if operations != sample.expected_operations:
+        raise EvaluationError(
+            f"operation sequence mismatch for {sample.slug}: {operations!r}"
+        )
+    expected_implementation = (
+        "rust-lifecycle" if sample.domain == "lifecycle" else sample.participant.runner_implementation
+    )
+    for row in rows:
+        if row.get("implementation") != expected_implementation:
+            raise EvaluationError(f"implementation mismatch for {sample.slug}")
+        if row.get("validated") != "true":
+            raise EvaluationError(f"unvalidated row for {sample.slug}")
+        if row.get("revision") != sample.participant.revision:
+            raise EvaluationError(f"revision mismatch for {sample.slug}")
+        for field in ("operations", "elapsed_ns", "result_count"):
+            try:
+                value = int(row[field])
+            except (KeyError, ValueError) as error:
+                raise EvaluationError(f"invalid {field} for {sample.slug}") from error
+            if value < 0:
+                raise EvaluationError(f"negative {field} for {sample.slug}")
+        for field in ("ns_per_op", "ops_per_sec"):
+            try:
+                value = float(row[field])
+            except (KeyError, ValueError) as error:
+                raise EvaluationError(f"invalid {field} for {sample.slug}") from error
+            if value != value or value in (float("inf"), float("-inf")):
+                raise EvaluationError(f"non-finite {field} for {sample.slug}")
+
+
+def parse_peak_rss(path: Path) -> int:
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r"^\s*(\d+)\s+maximum resident set size\s*$", text, re.MULTILINE)
+    if match:
+        return int(match.group(1))
+    match = re.search(r"Maximum resident set size \(kbytes\):\s*(\d+)", text)
+    if match:
+        return int(match.group(1)) * 1024
+    raise EvaluationError(f"peak RSS is missing from {path}")
+
+
+def atomic_json(path: Path, value: dict[str, object]) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(value, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def sample_command(sample: Sample) -> list[str]:
+    return [str(sample.participant.binary), *sample.arguments]
+
+
+def load_completed_sample(
+    sample: Sample,
+    state_path: Path,
+    csv_path: Path,
+    time_path: Path,
+    fingerprint: str,
+) -> tuple[list[dict[str, str]], int] | None:
+    if not state_path.is_file():
+        return None
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as error:
+        raise EvaluationError(f"invalid resume state {state_path}: {error}") from error
+    expected = {
+        "fingerprint": fingerprint,
+        "command": sample_command(sample),
+        "profile": sample.participant.profile,
+        "revision": sample.participant.revision,
+        "exit_status": 0,
+    }
+    for field, value in expected.items():
+        if state.get(field) != value:
+            raise EvaluationError(
+                f"resume state mismatch for {sample.slug} field={field}: "
+                f"{state.get(field)!r} != {value!r}"
+            )
+    if not csv_path.is_file() or not time_path.is_file():
+        raise EvaluationError(f"resume state exists but artifacts are missing for {sample.slug}")
+    artifact_paths = {
+        "stdout_sha256": csv_path,
+        "stderr_sha256": csv_path.with_suffix(".stderr"),
+        "time_sha256": time_path,
+    }
+    for field, artifact_path in artifact_paths.items():
+        if not artifact_path.is_file():
+            raise EvaluationError(
+                f"resume state exists but artifact is missing for {sample.slug}: {artifact_path}"
+            )
+        actual_digest = sha256_file(artifact_path)
+        if state.get(field) != actual_digest:
+            raise EvaluationError(
+                f"resume artifact mismatch for {sample.slug} field={field}"
+            )
+    header = TREE_HEADER if sample.domain == "tree" else VERSION_HEADER
+    rows = read_csv(csv_path, header)
+    validate_rows(sample, rows)
+    peak_rss = parse_peak_rss(time_path)
+    if state.get("peak_rss_bytes") != peak_rss:
+        raise EvaluationError(f"resume RSS mismatch for {sample.slug}")
+    return rows, peak_rss
+
+
+def run_sample(
+    sample: Sample,
+    raw_dir: Path,
+    state_dir: Path,
+    fingerprint: str,
+    time_bin: Path,
+    time_mode: str,
+    resume: bool,
+) -> tuple[list[dict[str, str]], int]:
+    prefix = raw_dir / sample.slug
+    csv_path = prefix.with_suffix(".csv")
+    stderr_path = prefix.with_suffix(".stderr")
+    time_path = prefix.with_suffix(".time")
+    state_path = state_dir / f"{sample.slug}.json"
+    if resume:
+        completed = load_completed_sample(
+            sample, state_path, csv_path, time_path, fingerprint
+        )
+        if completed is not None:
+            print(f"reusing {sample.slug}", file=sys.stderr, flush=True)
+            return completed
+    elif any(path.exists() for path in (csv_path, stderr_path, time_path, state_path)):
+        raise EvaluationError(f"sample artifacts already exist: {sample.slug}")
+
+    command = sample_command(sample)
+    env = os.environ.copy()
+    env.update(
+        {
+            "RAYON_NUM_THREADS": "1",
+            "GOMAXPROCS": "1",
+            "BENCH_REVISION": sample.participant.revision,
+        }
+    )
+    if sample.participant.implementation == "rust":
+        env["PROLLY_BENCH_CACHE_PROFILE"] = sample.participant.profile
+        env.pop("PROLLY_COMPARE_CACHE_NODES", None)
+        env.pop("PROLLY_COMPARE_CACHE_BYTES", None)
+    else:
+        env.pop("PROLLY_BENCH_CACHE_PROFILE", None)
+    print(f"running {sample.slug}", file=sys.stderr, flush=True)
+    with csv_path.open("w", encoding="utf-8") as stdout, stderr_path.open(
+        "w", encoding="utf-8"
+    ) as stderr:
+        completed = subprocess.run(
+            [str(time_bin), time_mode, "-o", str(time_path), *command],
+            env=env,
+            stdout=stdout,
+            stderr=stderr,
+            check=False,
+        )
+    if completed.returncode != 0:
+        raise EvaluationError(
+            f"sample failed exit={completed.returncode}: {sample.slug}; see {stderr_path}"
+        )
+    header = TREE_HEADER if sample.domain == "tree" else VERSION_HEADER
+    rows = read_csv(csv_path, header)
+    validate_rows(sample, rows)
+    peak_rss = parse_peak_rss(time_path)
+    atomic_json(
+        state_path,
+        {
+            "fingerprint": fingerprint,
+            "command": command,
+            "profile": sample.participant.profile,
+            "revision": sample.participant.revision,
+            "exit_status": 0,
+            "peak_rss_bytes": peak_rss,
+            "stdout": str(csv_path),
+            "stderr": str(stderr_path),
+            "time": str(time_path),
+            "stdout_sha256": sha256_file(csv_path),
+            "stderr_sha256": sha256_file(stderr_path),
+            "time_sha256": sha256_file(time_path),
+        },
+    )
+    return rows, peak_rss
+
+
+def rotate(values: Sequence[Participant], offset: int) -> tuple[Participant, ...]:
+    split = offset % len(values)
+    return tuple((*values[split:], *values[:split]))
+
+
+def tree_samples(
+    participants: Sequence[Participant], sizes: Sequence[int], runs: int
+) -> Iterable[Sample]:
+    for records in sizes:
+        for repetition in range(1, runs + 1):
+            for phase in ("fresh", "mutation"):
+                for workload in ("append", "random", "clustered"):
+                    order = rotate(participants, records + repetition + len(phase) + len(workload))
+                    for participant in order:
+                        yield Sample(
+                            "tree",
+                            participant,
+                            repetition,
+                            ("--records", str(records), "--phase", phase, "--workload", workload),
+                            (str(records), phase, workload),
+                            TREE_OPERATIONS,
+                        )
+
+
+def version_samples(
+    participants: Sequence[Participant],
+    sizes: Sequence[int],
+    runs: int,
+    densities: Sequence[int],
+    localities: Sequence[str],
+) -> Iterable[Sample]:
+    scenarios = []
+    if 0 in densities:
+        scenarios.append((0, "none"))
+    scenarios.extend(
+        (density, locality)
+        for density in densities
+        if density != 0
+        for locality in localities
+    )
+    for records in sizes:
+        for repetition in range(1, runs + 1):
+            for density, locality in scenarios:
+                operations = VERSION_ZERO_OPERATIONS if density == 0 else VERSION_CHANGED_OPERATIONS
+                order = rotate(participants, records + repetition + density + len(locality))
+                for participant in order:
+                    yield Sample(
+                        "version",
+                        participant,
+                        repetition,
+                        (
+                            "--records",
+                            str(records),
+                            "--density",
+                            str(density),
+                            "--locality",
+                            locality,
+                        ),
+                        (str(records), str(density), locality),
+                        operations,
+                    )
+
+
+def lifecycle_samples(
+    participants: Sequence[Participant],
+    sizes: Sequence[int],
+    runs: int,
+    densities: Sequence[int],
+    localities: Sequence[str],
+) -> Iterable[Sample]:
+    for records in sizes:
+        for repetition in range(1, runs + 1):
+            publish_scenarios = [
+                ("publish", density, locality)
+                for density in densities
+                if density != 0
+                for locality in localities
+            ]
+            other_scenarios = [
+                (scenario, 0, "none") for scenario in ("read", "rollback", "prune")
+            ]
+            for scenario, density, locality in (*publish_scenarios, *other_scenarios):
+                order = rotate(participants, records + repetition + density + len(scenario))
+                for participant in order:
+                    yield Sample(
+                        "lifecycle",
+                        participant,
+                        repetition,
+                        (
+                            "--records",
+                            str(records),
+                            "--scenario",
+                            scenario,
+                            "--density",
+                            str(density),
+                            "--locality",
+                            locality,
+                        ),
+                        (str(records), scenario, str(density), locality),
+                        LIFECYCLE_OPERATIONS[scenario],
+                    )
+
+
+def validate_profile_pairs(
+    rows: Sequence[dict[str, str]], profiles: Sequence[str], invariants: Sequence[str]
+) -> None:
+    groups: dict[tuple[str, ...], dict[str, dict[str, str]]] = {}
+    domain_fields = (
+        ("records", "phase", "workload", "operation", "repetition")
+        if "phase" in rows[0]
+        else ("records", "density", "locality", "operation", "relationship", "repetition")
+    )
+    for row in rows:
+        key = tuple(row[field] for field in domain_fields)
+        groups.setdefault(key, {})[row["cache_profile"]] = row
+    expected = {"native", *profiles}
+    for key, group in groups.items():
+        if set(group) != expected:
+            raise EvaluationError(f"incomplete profile group {key}: {sorted(group)}")
+        go = group["native"]
+        for profile in profiles:
+            rust = group[profile]
+            for field in invariants:
+                if rust[field] != go[field]:
+                    raise EvaluationError(
+                        f"profile mismatch {key} profile={profile} field={field}: "
+                        f"{rust[field]!r} != {go[field]!r}"
+                    )
+            if rust["operation"] != "patch_generate" and rust["result_count"] != go["result_count"]:
+                raise EvaluationError(f"result_count mismatch {key} profile={profile}")
+
+
+def validate_rust_profiles(
+    rows: Sequence[dict[str, str]], profiles: Sequence[str], invariants: Sequence[str]
+) -> None:
+    groups: dict[tuple[str, ...], dict[str, dict[str, str]]] = {}
+    for row in rows:
+        key = (
+            row["records"],
+            row["density"],
+            row["locality"],
+            row["operation"],
+            row["relationship"],
+            row["repetition"],
+        )
+        groups.setdefault(key, {})[row["cache_profile"]] = row
+    expected = set(profiles)
+    for key, group in groups.items():
+        if set(group) != expected:
+            raise EvaluationError(f"incomplete Rust profile group {key}: {sorted(group)}")
+        baseline = group[profiles[0]]
+        for profile in profiles[1:]:
+            candidate = group[profile]
+            for field in invariants:
+                if candidate[field] != baseline[field]:
+                    raise EvaluationError(
+                        f"Rust profile mismatch {key} profile={profile} field={field}: "
+                        f"{candidate[field]!r} != {baseline[field]!r}"
+                    )
+
+
+def write_rows(path: Path, rows: Sequence[dict[str, str]], fieldnames: Sequence[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+    temporary.replace(path)
+
+
+def execute_samples(
+    samples: Iterable[Sample],
+    output: Path,
+    fingerprint: str,
+    time_bin: Path,
+    time_mode: str,
+    resume: bool,
+) -> list[dict[str, str]]:
+    raw_dir = output / "raw"
+    state_dir = output / "state"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    normalized: list[dict[str, str]] = []
+    for sample in samples:
+        rows, peak_rss = run_sample(
+            sample, raw_dir, state_dir, fingerprint, time_bin, time_mode, resume
+        )
+        for row in rows:
+            normalized.append(
+                {
+                    **row,
+                    "repetition": str(sample.repetition),
+                    "peak_rss_bytes": str(peak_rss),
+                    "cache_profile": sample.participant.profile,
+                }
+            )
+    return normalized
+
+
+def smoke_samples(
+    tree_participants: Sequence[Participant],
+    version_participants: Sequence[Participant],
+) -> Iterable[Sample]:
+    for participant in tree_participants:
+        yield Sample(
+            "tree",
+            participant,
+            1,
+            ("--records", "10000", "--phase", "fresh", "--workload", "random"),
+            ("smoke", "10000", "fresh", "random"),
+            TREE_OPERATIONS,
+        )
+    for participant in version_participants:
+        yield Sample(
+            "version",
+            participant,
+            1,
+            ("--records", "10000", "--density", "1", "--locality", "random"),
+            ("smoke", "10000", "1", "random"),
+            VERSION_CHANGED_OPERATIONS,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--fingerprint", required=True)
+    parser.add_argument("--rust-revision", required=True)
+    parser.add_argument("--go-revision", required=True)
+    parser.add_argument("--rust-tree", required=True, type=Path)
+    parser.add_argument("--go-tree", required=True, type=Path)
+    parser.add_argument("--rust-version", required=True, type=Path)
+    parser.add_argument("--go-version", required=True, type=Path)
+    parser.add_argument("--rust-lifecycle", required=True, type=Path)
+    parser.add_argument("--sizes", default="10000 50000 1000000 5000000 10000000")
+    parser.add_argument("--runs", type=int, default=3)
+    parser.add_argument("--densities", default="0 1 30")
+    parser.add_argument("--localities", default="append random clustered")
+    parser.add_argument("--rust-cache-profiles", default="bounded unbounded")
+    parser.add_argument("--lifecycle", choices=("0", "1"), default="1")
+    parser.add_argument("--time-bin", type=Path, default=Path("/usr/bin/time"))
+    parser.add_argument("--time-mode", choices=("-l", "-v"), default="-l")
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--skip-smoke", action="store_true")
+    args = parser.parse_args()
+    if args.runs <= 0:
+        parser.error("--runs must be positive")
+    sizes = parse_positive_list(args.sizes, "sizes")
+    densities = tuple(int(value) for value in args.densities.replace(",", " ").split())
+    if not densities or any(value not in (0, 1, 30) for value in densities):
+        parser.error("--densities must contain 0, 1, and/or 30")
+    if len(set(densities)) != len(densities):
+        parser.error("--densities contains duplicates")
+    localities = tuple(args.localities.replace(",", " ").split())
+    if not localities or set(localities) - {"append", "random", "clustered"}:
+        parser.error("--localities contains an unsupported value")
+    if len(set(localities)) != len(localities):
+        parser.error("--localities contains duplicates")
+    profiles = parse_profiles(args.rust_cache_profiles)
+    for binary in (
+        args.rust_tree,
+        args.go_tree,
+        args.rust_version,
+        args.go_version,
+        args.rust_lifecycle,
+        args.time_bin,
+    ):
+        if not binary.is_file():
+            parser.error(f"executable does not exist: {binary}")
+
+    rust_tree = tuple(
+        Participant("rust", profile, args.rust_tree, args.rust_revision)
+        for profile in profiles
+    )
+    rust_version = tuple(
+        Participant("rust", profile, args.rust_version, args.rust_revision)
+        for profile in profiles
+    )
+    rust_lifecycle = tuple(
+        Participant("rust", profile, args.rust_lifecycle, args.rust_revision)
+        for profile in profiles
+    )
+    tree_participants = (
+        Participant("dolt-go", "native", args.go_tree, args.go_revision),
+        *rust_tree,
+    )
+    version_participants = (
+        Participant("dolt-go", "native", args.go_version, args.go_revision),
+        *rust_version,
+    )
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    if not args.skip_smoke:
+        smoke_output = args.output / "smoke"
+        smoke_rows = execute_samples(
+            smoke_samples(tree_participants, version_participants),
+            smoke_output,
+            args.fingerprint,
+            args.time_bin,
+            args.time_mode,
+            args.resume,
+        )
+        tree_smoke = [row for row in smoke_rows if row["contract_version"] == "prolly-compare-v1"]
+        version_smoke = [row for row in smoke_rows if row["contract_version"] == "prolly-version-compare-v3"]
+        validate_profile_pairs(tree_smoke, profiles, TREE_INVARIANTS)
+        validate_profile_pairs(version_smoke, profiles, VERSION_INVARIANTS)
+
+    tree_output = args.output / "tree"
+    tree_rows = execute_samples(
+        tree_samples(tree_participants, sizes, args.runs),
+        tree_output,
+        args.fingerprint,
+        args.time_bin,
+        args.time_mode,
+        args.resume,
+    )
+    validate_profile_pairs(tree_rows, profiles, TREE_INVARIANTS)
+    tree_fields = [*TREE_HEADER.split(","), "repetition", "peak_rss_bytes", "cache_profile"]
+    write_rows(tree_output / "results.csv", tree_rows, tree_fields)
+
+    version_output = args.output / "version"
+    version_rows = execute_samples(
+        version_samples(version_participants, sizes, args.runs, densities, localities),
+        version_output,
+        args.fingerprint,
+        args.time_bin,
+        args.time_mode,
+        args.resume,
+    )
+    validate_profile_pairs(version_rows, profiles, VERSION_INVARIANTS)
+    version_fields = [*VERSION_HEADER.split(","), "repetition", "peak_rss_bytes", "cache_profile"]
+    write_rows(version_output / "results-common.csv", version_rows, version_fields)
+
+    lifecycle_rows: list[dict[str, str]] = []
+    if args.lifecycle == "1":
+        lifecycle_rows = execute_samples(
+            lifecycle_samples(rust_lifecycle, sizes, args.runs, densities, localities),
+            args.output / "lifecycle",
+            args.fingerprint,
+            args.time_bin,
+            args.time_mode,
+            args.resume,
+        )
+        validate_rust_profiles(lifecycle_rows, profiles, LIFECYCLE_INVARIANTS)
+    write_rows(
+        args.output / "lifecycle" / "results.csv",
+        lifecycle_rows,
+        version_fields,
+    )
+    print(args.output)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except EvaluationError as error:
+        raise SystemExit(f"evaluation failed: {error}") from error

--- a/scripts/run_prolly_evaluation.sh
+++ b/scripts/run_prolly_evaluation.sh
@@ -1,0 +1,329 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+PROFILE=${BENCH_PROFILE:-canonical}
+OUT=${BENCH_OUT:-"$ROOT/performance-results/prolly-evaluation-$(date -u +%Y%m%dT%H%M%SZ)"}
+RESUME=${BENCH_RESUME:-0}
+SKIP_BUILD=${BENCH_SKIP_BUILD:-0}
+SKIP_SMOKE=${BENCH_SKIP_SMOKE:-0}
+TIME_BIN=${BENCH_TIME_BIN:-/usr/bin/time}
+DOLT_REPO_URL=${DOLT_REPO_URL:-https://github.com/dolthub/dolt.git}
+DOLT_CACHE=${DOLT_CACHE:-"$ROOT/target/dolt-benchmark"}
+DOLT_REQUESTED_REV=${DOLT_REV:-}
+RUST_CACHE_PROFILES=${BENCH_RUST_CACHE_PROFILES:-"bounded unbounded"}
+RUN_LIFECYCLE=${BENCH_LIFECYCLE:-1}
+
+case "$PROFILE" in
+    smoke)
+        SIZES=${BENCH_SIZES:-10000}
+        RUNS=${BENCH_RUNS:-1}
+        DENSITIES=${BENCH_DENSITIES:-1}
+        LOCALITIES=${BENCH_LOCALITIES:-random}
+        RUN_LIFECYCLE=${BENCH_LIFECYCLE:-0}
+        ;;
+    canonical)
+        SIZES=${BENCH_SIZES:-"10000 50000 1000000 5000000 10000000"}
+        RUNS=${BENCH_RUNS:-3}
+        DENSITIES=${BENCH_DENSITIES:-"0 1 30"}
+        LOCALITIES=${BENCH_LOCALITIES:-"append random clustered"}
+        ;;
+    *)
+        printf 'BENCH_PROFILE must be smoke or canonical: %s\n' "$PROFILE" >&2
+        exit 2
+        ;;
+esac
+
+case "$OUT" in
+    /*) ;;
+    *) OUT="$ROOT/$OUT" ;;
+esac
+case "$DOLT_CACHE" in
+    /*) ;;
+    *) DOLT_CACHE="$ROOT/$DOLT_CACHE" ;;
+esac
+
+if [ "$RUNS" -le 0 ]; then
+    printf 'BENCH_RUNS must be positive\n' >&2
+    exit 2
+fi
+if [ "$RESUME" != 0 ] && [ "$RESUME" != 1 ]; then
+    printf 'BENCH_RESUME must be 0 or 1\n' >&2
+    exit 2
+fi
+if [ "$RUN_LIFECYCLE" != 0 ] && [ "$RUN_LIFECYCLE" != 1 ]; then
+    printf 'BENCH_LIFECYCLE must be 0 or 1\n' >&2
+    exit 2
+fi
+
+sha256_file() {
+    shasum -a 256 "$1" | awk '{ print $1 }'
+}
+
+source_tree_hash() {
+    (
+        cd "$ROOT"
+        set -- src Cargo.toml
+        if [ -f Cargo.lock ]; then
+            set -- "$@" Cargo.lock
+        fi
+        find "$@" -type f |
+            LC_ALL=C sort |
+            while IFS= read -r source_file; do
+                printf '%s\t%s\n' "$source_file" "$(sha256_file "$source_file")"
+            done |
+            shasum -a 256 |
+            awk '{ print $1 }'
+    )
+}
+
+directory_hash() {
+    (
+        cd "$1"
+        find . -type f |
+            LC_ALL=C sort |
+            while IFS= read -r source_file; do
+                printf '%s\t%s\n' "$source_file" "$(sha256_file "$source_file")"
+            done |
+            shasum -a 256 |
+            awk '{ print $1 }'
+    )
+}
+
+framework_hash() {
+    for source_file in \
+        scripts/run_prolly_evaluation.sh \
+        scripts/prolly_evaluation_runner.py \
+        scripts/summarize_prolly_evaluation.py \
+        scripts/prolly_process_metrics.py; do
+        printf '%s\t%s\n' "$source_file" "$(sha256_file "$ROOT/$source_file")"
+    done | shasum -a 256 | awk '{ print $1 }'
+}
+
+require_executable() {
+    if [ ! -x "$1" ]; then
+        printf 'required executable is missing: %s\n' "$1" >&2
+        exit 2
+    fi
+}
+
+manifest_value() {
+    sed -n "s/^$1=//p" "$OUT/manifest.txt"
+}
+
+TREE_GO_SOURCE="$ROOT/benchmarks/dolt-prolly-compare"
+VERSION_GO_SOURCE="$ROOT/benchmarks/dolt-prolly-version-compare"
+
+RESUME_FROM_ARTIFACTS=0
+if [ "$RESUME" -eq 1 ] && [ -f "$OUT/manifest.txt" ] && [ "${BENCH_REBUILD_ON_RESUME:-0}" -ne 1 ]; then
+    RESUME_FROM_ARTIFACTS=1
+fi
+
+if [ "$RESUME_FROM_ARTIFACTS" -eq 1 ]; then
+    RUST_TREE_BIN="$OUT/bin/rust-prolly-compare"
+    RUST_VERSION_BIN="$OUT/bin/rust-prolly-version-compare"
+    RUST_LIFECYCLE_BIN="$OUT/bin/rust-prolly-version-lifecycle"
+    GO_TREE_BIN="$OUT/bin/dolt-go-prolly-compare"
+    GO_VERSION_BIN="$OUT/bin/dolt-go-prolly-version-compare"
+    RUST_COMMIT=$(manifest_value rust_commit)
+    DOLT_SHA=$(manifest_value dolt_commit)
+elif [ "$SKIP_BUILD" -eq 1 ]; then
+    RUST_TREE_BIN=${PROLLY_EVAL_RUST_TREE_BIN:?PROLLY_EVAL_RUST_TREE_BIN is required with BENCH_SKIP_BUILD=1}
+    RUST_VERSION_BIN=${PROLLY_EVAL_RUST_VERSION_BIN:?PROLLY_EVAL_RUST_VERSION_BIN is required with BENCH_SKIP_BUILD=1}
+    RUST_LIFECYCLE_BIN=${PROLLY_EVAL_RUST_LIFECYCLE_BIN:?PROLLY_EVAL_RUST_LIFECYCLE_BIN is required with BENCH_SKIP_BUILD=1}
+    GO_TREE_BIN=${PROLLY_EVAL_GO_TREE_BIN:?PROLLY_EVAL_GO_TREE_BIN is required with BENCH_SKIP_BUILD=1}
+    GO_VERSION_BIN=${PROLLY_EVAL_GO_VERSION_BIN:?PROLLY_EVAL_GO_VERSION_BIN is required with BENCH_SKIP_BUILD=1}
+    RUST_COMMIT=$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || printf unknown)
+    DOLT_SHA=${DOLT_REQUESTED_REV:-external}
+else
+    if [ ! -d "$DOLT_CACHE/.git" ]; then
+        if [ -e "$DOLT_CACHE" ]; then
+            printf 'DOLT_CACHE exists but is not a git checkout: %s\n' "$DOLT_CACHE" >&2
+            exit 2
+        fi
+        mkdir -p "$(dirname -- "$DOLT_CACHE")"
+        git clone --filter=blob:none --no-checkout "$DOLT_REPO_URL" "$DOLT_CACHE"
+    fi
+    if [ -n "$DOLT_REQUESTED_REV" ]; then
+        if ! git -C "$DOLT_CACHE" rev-parse --verify "${DOLT_REQUESTED_REV}^{commit}" >/dev/null 2>&1; then
+            git -C "$DOLT_CACHE" fetch origin "$DOLT_REQUESTED_REV"
+        fi
+        DOLT_SHA=$(git -C "$DOLT_CACHE" rev-parse --verify "${DOLT_REQUESTED_REV}^{commit}")
+    else
+        git -C "$DOLT_CACHE" fetch --prune origin main
+        DOLT_SHA=$(git -C "$DOLT_CACHE" rev-parse origin/main)
+    fi
+    git -C "$DOLT_CACHE" checkout --detach "$DOLT_SHA"
+
+    mkdir -p "$DOLT_CACHE/go/cmd/prolly-compare"
+    cp "$TREE_GO_SOURCE/main.go" "$DOLT_CACHE/go/cmd/prolly-compare/main.go"
+    cp "$TREE_GO_SOURCE/main_test.go" "$DOLT_CACHE/go/cmd/prolly-compare/main_test.go"
+    mkdir -p "$DOLT_CACHE/go/cmd/prolly-version-compare"
+    cp "$VERSION_GO_SOURCE/main.go" "$DOLT_CACHE/go/cmd/prolly-version-compare/main.go"
+    cp "$VERSION_GO_SOURCE/workload.go" "$DOLT_CACHE/go/cmd/prolly-version-compare/workload.go"
+
+    RUST_TARGET=$(cargo metadata --manifest-path "$ROOT/Cargo.toml" --no-deps --format-version 1 |
+        sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+    if [ -z "$RUST_TARGET" ]; then
+        printf 'cargo metadata did not return a target directory\n' >&2
+        exit 2
+    fi
+    cargo build --manifest-path "$ROOT/Cargo.toml" --release \
+        --bin prolly_compare --bin prolly_version_compare --bin prolly_version_lifecycle
+    RUST_TREE_BIN="$RUST_TARGET/release/prolly_compare"
+    RUST_VERSION_BIN="$RUST_TARGET/release/prolly_version_compare"
+    RUST_LIFECYCLE_BIN="$RUST_TARGET/release/prolly_version_lifecycle"
+    (
+        cd "$DOLT_CACHE/go"
+        go test ./cmd/prolly-compare ./cmd/prolly-version-compare
+        go build -trimpath -o "$DOLT_CACHE/go/prolly-compare" ./cmd/prolly-compare
+        go build -trimpath -o "$DOLT_CACHE/go/prolly-version-compare" ./cmd/prolly-version-compare
+    )
+    GO_TREE_BIN="$DOLT_CACHE/go/prolly-compare"
+    GO_VERSION_BIN="$DOLT_CACHE/go/prolly-version-compare"
+    RUST_COMMIT=$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || printf unknown)
+fi
+
+for binary in "$RUST_TREE_BIN" "$RUST_VERSION_BIN" "$RUST_LIFECYCLE_BIN" "$GO_TREE_BIN" "$GO_VERSION_BIN" "$TIME_BIN"; do
+    require_executable "$binary"
+done
+
+RUST_SOURCE_HASH=$(source_tree_hash)
+FRAMEWORK_HASH=$(framework_hash)
+TREE_GO_SOURCE_HASH=$(directory_hash "$TREE_GO_SOURCE")
+VERSION_GO_SOURCE_HASH=$(directory_hash "$VERSION_GO_SOURCE")
+RUST_REVISION="$(printf '%s' "$RUST_COMMIT" | cut -c1-12)+src.$(printf '%s' "$RUST_SOURCE_HASH" | cut -c1-12)"
+DOLT_REVISION="$(printf '%s' "$DOLT_SHA" | cut -c1-12)+tree.$(printf '%s' "$TREE_GO_SOURCE_HASH" | cut -c1-8)+version.$(printf '%s' "$VERSION_GO_SOURCE_HASH" | cut -c1-8)"
+
+if "$TIME_BIN" -l -o /dev/null /usr/bin/true >/dev/null 2>&1; then
+    TIME_MODE=-l
+else
+    TIME_MODE=-v
+fi
+
+CONFIG_FILE=$(mktemp "${TMPDIR:-/tmp}/prolly-evaluation-config.XXXXXX")
+cleanup_config() {
+    rm -f "$CONFIG_FILE"
+}
+trap cleanup_config EXIT HUP INT TERM
+{
+    printf 'schema=prolly-evaluation-v1\n'
+    printf 'profile=%s\n' "$PROFILE"
+    printf 'rust_commit=%s\n' "$RUST_COMMIT"
+    printf 'rust_source_sha256=%s\n' "$RUST_SOURCE_HASH"
+    printf 'rust_revision=%s\n' "$RUST_REVISION"
+    printf 'dolt_repository=%s\n' "$DOLT_REPO_URL"
+    printf 'dolt_commit=%s\n' "$DOLT_SHA"
+    printf 'dolt_revision=%s\n' "$DOLT_REVISION"
+    printf 'tree_go_source_sha256=%s\n' "$TREE_GO_SOURCE_HASH"
+    printf 'version_go_source_sha256=%s\n' "$VERSION_GO_SOURCE_HASH"
+    printf 'framework_sha256=%s\n' "$FRAMEWORK_HASH"
+    printf 'rust_tree_binary_sha256=%s\n' "$(sha256_file "$RUST_TREE_BIN")"
+    printf 'rust_version_binary_sha256=%s\n' "$(sha256_file "$RUST_VERSION_BIN")"
+    printf 'rust_lifecycle_binary_sha256=%s\n' "$(sha256_file "$RUST_LIFECYCLE_BIN")"
+    printf 'go_tree_binary_sha256=%s\n' "$(sha256_file "$GO_TREE_BIN")"
+    printf 'go_version_binary_sha256=%s\n' "$(sha256_file "$GO_VERSION_BIN")"
+    printf 'time_binary_sha256=%s\n' "$(sha256_file "$TIME_BIN")"
+    printf 'sizes=%s\n' "$SIZES"
+    printf 'runs=%s\n' "$RUNS"
+    printf 'densities=%s\n' "$DENSITIES"
+    printf 'localities=%s\n' "$LOCALITIES"
+    printf 'rust_cache_profiles=%s\n' "$RUST_CACHE_PROFILES"
+    printf 'lifecycle=%s\n' "$RUN_LIFECYCLE"
+    printf 'worker_threads=1\n'
+    printf 'storage=in-memory\n'
+    printf 'time_mode=%s\n' "$TIME_MODE"
+} >"$CONFIG_FILE"
+FINGERPRINT=$(sha256_file "$CONFIG_FILE")
+printf 'fingerprint=%s\n' "$FINGERPRINT" >>"$CONFIG_FILE"
+
+if [ -e "$OUT" ] && [ "$RESUME" -ne 1 ]; then
+    printf 'output already exists; use a new BENCH_OUT or BENCH_RESUME=1: %s\n' "$OUT" >&2
+    exit 2
+fi
+mkdir -p "$OUT"
+LOCK_DIR="$OUT/.lock"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    if [ "$RESUME" -eq 1 ] && [ -f "$LOCK_DIR/pid" ]; then
+        lock_pid=$(sed -n '1p' "$LOCK_DIR/pid")
+        if ! kill -0 "$lock_pid" 2>/dev/null; then
+            rm -rf "$LOCK_DIR"
+            mkdir "$LOCK_DIR"
+        else
+            printf 'evaluation output is locked by pid %s: %s\n' "$lock_pid" "$OUT" >&2
+            exit 2
+        fi
+    else
+        printf 'evaluation output is locked: %s\n' "$OUT" >&2
+        exit 2
+    fi
+fi
+printf '%s\n' "$$" >"$LOCK_DIR/pid"
+cleanup_all() {
+    rm -rf "$LOCK_DIR"
+    cleanup_config
+}
+trap cleanup_all EXIT HUP INT TERM
+
+if [ "$RESUME" -eq 1 ]; then
+    if [ ! -f "$OUT/manifest.txt" ]; then
+        printf 'cannot resume without manifest.txt: %s\n' "$OUT" >&2
+        exit 2
+    fi
+    if ! cmp -s "$CONFIG_FILE" "$OUT/manifest.txt"; then
+        printf 'resume provenance mismatch; configuration or binaries changed: %s\n' "$OUT" >&2
+        diff -u "$OUT/manifest.txt" "$CONFIG_FILE" >&2 || true
+        exit 2
+    fi
+else
+    cp "$CONFIG_FILE" "$OUT/manifest.txt"
+    mkdir -p "$OUT/bin"
+    cp "$RUST_TREE_BIN" "$OUT/bin/rust-prolly-compare"
+    cp "$RUST_VERSION_BIN" "$OUT/bin/rust-prolly-version-compare"
+    cp "$RUST_LIFECYCLE_BIN" "$OUT/bin/rust-prolly-version-lifecycle"
+    cp "$GO_TREE_BIN" "$OUT/bin/dolt-go-prolly-compare"
+    cp "$GO_VERSION_BIN" "$OUT/bin/dolt-go-prolly-version-compare"
+    {
+        printf 'generated_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        printf 'host=%s\n' "$(hostname)"
+        printf 'os=%s\n' "$(uname -a)"
+        if command -v sysctl >/dev/null 2>&1; then
+            printf 'cpu=%s\n' "$(sysctl -n machdep.cpu.brand_string 2>/dev/null || true)"
+            printf 'memory_bytes=%s\n' "$(sysctl -n hw.memsize 2>/dev/null || true)"
+        fi
+        rustc -Vv
+        go version
+    } >"$OUT/machine.txt"
+fi
+
+# COMPLETE is a commit marker for the fully validated artifact set, not merely a
+# record that an earlier invocation once reached the end.
+rm -f "$OUT/COMPLETE"
+
+set -- python3 "$ROOT/scripts/prolly_evaluation_runner.py" \
+    --output "$OUT" \
+    --fingerprint "$FINGERPRINT" \
+    --rust-revision "$RUST_REVISION" \
+    --go-revision "$DOLT_REVISION" \
+    --rust-tree "$OUT/bin/rust-prolly-compare" \
+    --go-tree "$OUT/bin/dolt-go-prolly-compare" \
+    --rust-version "$OUT/bin/rust-prolly-version-compare" \
+    --go-version "$OUT/bin/dolt-go-prolly-version-compare" \
+    --rust-lifecycle "$OUT/bin/rust-prolly-version-lifecycle" \
+    --sizes "$SIZES" \
+    --runs "$RUNS" \
+    --densities "$DENSITIES" \
+    --localities "$LOCALITIES" \
+    --rust-cache-profiles "$RUST_CACHE_PROFILES" \
+    --lifecycle "$RUN_LIFECYCLE" \
+    --time-bin "$TIME_BIN" \
+    --time-mode="$TIME_MODE"
+if [ "$RESUME" -eq 1 ]; then
+    set -- "$@" --resume
+fi
+if [ "$SKIP_SMOKE" -eq 1 ]; then
+    set -- "$@" --skip-smoke
+fi
+"$@"
+python3 "$ROOT/scripts/summarize_prolly_evaluation.py" --output "$OUT"
+printf 'evaluation complete: %s/report.md\n' "$OUT"

--- a/scripts/summarize_prolly_evaluation.py
+++ b/scripts/summarize_prolly_evaluation.py
@@ -1,0 +1,859 @@
+#!/usr/bin/env python3
+"""Validate and summarize a bounded/unbounded Rust versus Dolt-Go evaluation."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import statistics
+from collections import Counter, defaultdict
+from itertools import product
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+TREE_OPERATIONS = ("write", "point_read", "range_scan")
+PHASES = ("fresh", "mutation")
+WORKLOADS = ("append", "random", "clustered")
+VERSION_ZERO_OPERATIONS = (
+    "full_diff",
+    "range_diff",
+    "patch_generate",
+    "patch_apply",
+    "merge_noop",
+)
+VERSION_CHANGED_OPERATIONS = (
+    "full_diff",
+    "range_diff",
+    "patch_generate",
+    "patch_apply",
+    "merge_disjoint",
+    "merge_convergent",
+    "merge_conflict",
+)
+LIFECYCLE_OPERATIONS = {
+    "publish": ("version_publish",),
+    "read": (
+        "head_resolve",
+        "snapshot_resolve",
+        "historical_point_read",
+        "historical_range_scan",
+        "version_list",
+    ),
+    "rollback": ("rollback",),
+    "prune": ("retention_prune",),
+}
+TREE_INVARIANTS = (
+    "contract_version",
+    "records",
+    "phase",
+    "workload",
+    "operation",
+    "operations",
+    "workload_digest",
+    "result_count",
+    "validated",
+)
+VERSION_INVARIANTS = (
+    "contract_version",
+    "records",
+    "density",
+    "locality",
+    "operation",
+    "relationship",
+    "operations",
+    "workload_digest",
+    "result_digest",
+    "base_count",
+    "target_count",
+    "conflict_count",
+    "validated",
+)
+LIFECYCLE_INVARIANTS = (
+    "contract_version",
+    "records",
+    "density",
+    "locality",
+    "operation",
+    "relationship",
+    "operations",
+    "workload_digest",
+    "result_count",
+    "base_count",
+    "target_count",
+    "conflict_count",
+    "validated",
+)
+
+
+class SummaryError(RuntimeError):
+    pass
+
+
+def read_manifest(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        raise SummaryError(f"manifest is missing: {path}")
+    manifest = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            manifest[key] = value
+    required = {
+        "fingerprint",
+        "rust_revision",
+        "dolt_revision",
+        "sizes",
+        "runs",
+        "densities",
+        "localities",
+        "rust_cache_profiles",
+        "lifecycle",
+    }
+    missing = required - set(manifest)
+    if missing:
+        raise SummaryError(f"manifest fields are missing: {sorted(missing)}")
+    return manifest
+
+
+def read_rows(path: Path, allow_empty: bool = False) -> list[dict[str, str]]:
+    if not path.is_file():
+        raise SummaryError(f"results are missing: {path}")
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    if not rows and not allow_empty:
+        raise SummaryError(f"results are empty: {path}")
+    required = {
+        "implementation",
+        "records",
+        "operation",
+        "elapsed_ns",
+        "ns_per_op",
+        "ops_per_sec",
+        "validated",
+        "repetition",
+        "peak_rss_bytes",
+        "cache_profile",
+    }
+    for row in rows:
+        missing = required - set(row)
+        if missing:
+            raise SummaryError(f"row fields are missing in {path}: {sorted(missing)}")
+        if row["validated"] != "true":
+            raise SummaryError(f"unvalidated row in {path}")
+        for field in ("records", "elapsed_ns", "repetition", "peak_rss_bytes"):
+            try:
+                row[field] = int(row[field])
+            except ValueError as error:
+                raise SummaryError(f"invalid {field} in {path}") from error
+        for field in ("ns_per_op", "ops_per_sec"):
+            try:
+                row[field] = float(row[field])
+            except ValueError as error:
+                raise SummaryError(f"invalid {field} in {path}") from error
+            if not math.isfinite(row[field]):
+                raise SummaryError(f"non-finite {field} in {path}")
+    return rows
+
+
+def integers(raw: str) -> tuple[int, ...]:
+    return tuple(int(value) for value in raw.replace(",", " ").split())
+
+
+def words(raw: str) -> tuple[str, ...]:
+    return tuple(raw.replace(",", " ").split())
+
+
+def validate_tree_matrix(
+    rows: Sequence[dict[str, object]], sizes: Sequence[int], runs: int, profiles: Sequence[str]
+) -> None:
+    identities = Counter(
+        (
+            row["implementation"],
+            row["cache_profile"],
+            row["records"],
+            row["phase"],
+            row["workload"],
+            row["operation"],
+            row["repetition"],
+        )
+        for row in rows
+    )
+    duplicates = [key for key, count in identities.items() if count != 1]
+    if duplicates:
+        raise SummaryError(f"duplicate tree rows: {duplicates[:3]}")
+    participants = (("dolt-go", "native"), *(('rust', profile) for profile in profiles))
+    expected = {
+        (implementation, profile, size, phase, workload, operation, repetition)
+        for (implementation, profile), size, phase, workload, operation, repetition in product(
+            participants, sizes, PHASES, WORKLOADS, TREE_OPERATIONS, range(1, runs + 1)
+        )
+    }
+    actual = set(identities)
+    if actual != expected:
+        raise SummaryError(
+            f"incomplete tree matrix: missing={list(expected - actual)[:3]}, "
+            f"extra={list(actual - expected)[:3]}"
+        )
+
+
+def version_scenarios(
+    densities: Sequence[int], localities: Sequence[str]
+) -> Iterable[tuple[int, str, tuple[str, ...]]]:
+    if 0 in densities:
+        yield 0, "none", VERSION_ZERO_OPERATIONS
+    for density in densities:
+        if density == 0:
+            continue
+        for locality in localities:
+            yield density, locality, VERSION_CHANGED_OPERATIONS
+
+
+def validate_version_matrix(
+    rows: Sequence[dict[str, object]],
+    sizes: Sequence[int],
+    runs: int,
+    profiles: Sequence[str],
+    densities: Sequence[int],
+    localities: Sequence[str],
+) -> None:
+    identities = Counter(
+        (
+            row["implementation"],
+            row["cache_profile"],
+            row["records"],
+            int(row["density"]),
+            row["locality"],
+            row["operation"],
+            row["repetition"],
+        )
+        for row in rows
+    )
+    duplicates = [key for key, count in identities.items() if count != 1]
+    if duplicates:
+        raise SummaryError(f"duplicate version rows: {duplicates[:3]}")
+    participants = (("dolt-go", "native"), *(('rust', profile) for profile in profiles))
+    expected = set()
+    for size, repetition, (density, locality, operations), (implementation, profile) in product(
+        sizes,
+        range(1, runs + 1),
+        tuple(version_scenarios(densities, localities)),
+        participants,
+    ):
+        for operation in operations:
+            expected.add(
+                (implementation, profile, size, density, locality, operation, repetition)
+            )
+    actual = set(identities)
+    if actual != expected:
+        raise SummaryError(
+            f"incomplete version matrix: missing={list(expected - actual)[:3]}, "
+            f"extra={list(actual - expected)[:3]}"
+        )
+
+
+def validate_lifecycle_matrix(
+    rows: Sequence[dict[str, object]],
+    sizes: Sequence[int],
+    runs: int,
+    profiles: Sequence[str],
+    densities: Sequence[int],
+    localities: Sequence[str],
+    enabled: bool,
+) -> None:
+    identities = Counter(
+        (
+            row["implementation"],
+            row["cache_profile"],
+            row["records"],
+            int(row["density"]),
+            row["locality"],
+            row["operation"],
+            row["relationship"],
+            row["repetition"],
+        )
+        for row in rows
+    )
+    duplicates = [key for key, count in identities.items() if count != 1]
+    if duplicates:
+        raise SummaryError(f"duplicate lifecycle rows: {duplicates[:3]}")
+    expected = set()
+    if enabled:
+        for size, repetition, profile in product(
+            sizes, range(1, runs + 1), profiles
+        ):
+            for density in densities:
+                if density == 0:
+                    continue
+                for locality in localities:
+                    expected.add(
+                        (
+                            "rust-lifecycle",
+                            profile,
+                            size,
+                            density,
+                            locality,
+                            "version_publish",
+                            "publish",
+                            repetition,
+                        )
+                    )
+            for scenario in ("read", "rollback", "prune"):
+                for operation in LIFECYCLE_OPERATIONS[scenario]:
+                    expected.add(
+                        (
+                            "rust-lifecycle",
+                            profile,
+                            size,
+                            0,
+                            "none",
+                            operation,
+                            scenario,
+                            repetition,
+                        )
+                    )
+    actual = set(identities)
+    if actual != expected:
+        raise SummaryError(
+            f"incomplete lifecycle matrix: missing={list(expected - actual)[:3]}, "
+            f"extra={list(actual - expected)[:3]}"
+        )
+
+
+def validate_comparison_identity(
+    rows: Sequence[dict[str, object]],
+    profiles: Sequence[str],
+    domain: str,
+) -> None:
+    key_fields = (
+        ("records", "phase", "workload", "operation", "repetition")
+        if domain == "tree"
+        else (
+            "records",
+            "density",
+            "locality",
+            "operation",
+            "relationship",
+            "repetition",
+        )
+    )
+    invariants = TREE_INVARIANTS if domain == "tree" else VERSION_INVARIANTS
+    grouped = defaultdict(dict)
+    for row in rows:
+        key = tuple(row[field] for field in key_fields)
+        grouped[key][row["cache_profile"]] = row
+    expected = {"native", *profiles}
+    for key, group in grouped.items():
+        if set(group) != expected:
+            raise SummaryError(f"incomplete {domain} profile identity: {key}")
+        go = group["native"]
+        for profile in profiles:
+            rust = group[profile]
+            for field in invariants:
+                if rust[field] != go[field]:
+                    raise SummaryError(
+                        f"{domain} identity mismatch {key} profile={profile} "
+                        f"field={field}: {rust[field]!r} != {go[field]!r}"
+                    )
+            if domain == "version" and rust["operation"] != "patch_generate":
+                if rust["result_count"] != go["result_count"]:
+                    raise SummaryError(
+                        f"version result_count mismatch {key} profile={profile}"
+                    )
+
+
+def validate_lifecycle_identity(
+    rows: Sequence[dict[str, object]], profiles: Sequence[str]
+) -> None:
+    grouped = defaultdict(dict)
+    for row in rows:
+        key = (
+            row["records"],
+            row["density"],
+            row["locality"],
+            row["operation"],
+            row["relationship"],
+            row["repetition"],
+        )
+        grouped[key][row["cache_profile"]] = row
+    expected = set(profiles)
+    for key, group in grouped.items():
+        if set(group) != expected:
+            raise SummaryError(f"incomplete lifecycle profile identity: {key}")
+        baseline = group[profiles[0]]
+        for profile in profiles[1:]:
+            candidate = group[profile]
+            for field in LIFECYCLE_INVARIANTS:
+                if candidate[field] != baseline[field]:
+                    raise SummaryError(
+                        f"lifecycle identity mismatch {key} profile={profile} "
+                        f"field={field}: {candidate[field]!r} != {baseline[field]!r}"
+                    )
+
+
+def cv(values: Sequence[float]) -> float:
+    mean = statistics.fmean(values)
+    return statistics.pstdev(values) / mean * 100.0 if mean else 0.0
+
+
+def quality_label(
+    repetitions: int, consistent: bool, ratio: float, maximum_cv: float
+) -> str:
+    if repetitions < 3:
+        return "insufficient_repetitions"
+    if not consistent:
+        return "winner_flip"
+    if 0.95 <= ratio <= 1.05:
+        return "narrow"
+    if maximum_cv > 25.0:
+        return "high_variance"
+    return "stable"
+
+
+def safe_ratio(numerator: float, denominator: float) -> float:
+    if denominator:
+        return numerator / denominator
+    return 1.0 if numerator == 0 else math.inf
+
+
+def comparison_summary(
+    rows: Sequence[dict[str, object]], profiles: Sequence[str], domain: str
+) -> list[dict[str, object]]:
+    scenario_fields = (
+        ("records", "phase", "workload", "operation")
+        if domain == "tree"
+        else ("records", "density", "locality", "operation", "relationship")
+    )
+    grouped: dict[tuple[object, ...], dict[str, list[dict[str, object]]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for row in rows:
+        key = tuple(row[field] for field in scenario_fields)
+        grouped[key][str(row["cache_profile"])].append(row)
+    summary = []
+    for key in sorted(grouped):
+        group = grouped[key]
+        go_rows = sorted(group["native"], key=lambda row: int(row["repetition"]))
+        for profile in profiles:
+            rust_rows = sorted(group[profile], key=lambda row: int(row["repetition"]))
+            if len(rust_rows) != len(go_rows):
+                raise SummaryError(f"profile repetition mismatch: {key} {profile}")
+            rust_elapsed = [int(row["elapsed_ns"]) for row in rust_rows]
+            go_elapsed = [int(row["elapsed_ns"]) for row in go_rows]
+            rust_median = statistics.median(rust_elapsed)
+            go_median = statistics.median(go_elapsed)
+            ratio = safe_ratio(go_median, rust_median)
+            winner = "rust" if ratio > 1 else "dolt-go" if ratio < 1 else "tie"
+            per_run = [
+                "rust" if int(rust["elapsed_ns"]) < int(go["elapsed_ns"]) else "dolt-go"
+                if int(go["elapsed_ns"]) < int(rust["elapsed_ns"]) else "tie"
+                for rust, go in zip(rust_rows, go_rows)
+            ]
+            rust_cv = cv(rust_elapsed)
+            go_cv = cv(go_elapsed)
+            result = {field: value for field, value in zip(scenario_fields, key)}
+            result.update(
+                {
+                    "cache_profile": profile,
+                    "runs": len(rust_rows),
+                    "rust_median_ns": rust_median,
+                    "go_median_ns": go_median,
+                    "rust_median_ns_per_op": statistics.median(
+                        float(row["ns_per_op"]) for row in rust_rows
+                    ),
+                    "go_median_ns_per_op": statistics.median(
+                        float(row["ns_per_op"]) for row in go_rows
+                    ),
+                    "rust_cv_percent": rust_cv,
+                    "go_cv_percent": go_cv,
+                    "rust_median_peak_rss_bytes": statistics.median(
+                        int(row["peak_rss_bytes"]) for row in rust_rows
+                    ),
+                    "go_median_peak_rss_bytes": statistics.median(
+                        int(row["peak_rss_bytes"]) for row in go_rows
+                    ),
+                    "rust_vs_go": ratio,
+                    "winner": winner,
+                    "winner_consistent": len(set(per_run)) == 1,
+                    "quality": quality_label(
+                        len(rust_rows),
+                        len(set(per_run)) == 1,
+                        ratio,
+                        max(rust_cv, go_cv),
+                    ),
+                }
+            )
+            summary.append(result)
+    return summary
+
+
+def lifecycle_summary(
+    rows: Sequence[dict[str, object]], profiles: Sequence[str], runs: int
+) -> list[dict[str, object]]:
+    grouped = defaultdict(list)
+    digest_groups = defaultdict(set)
+    for row in rows:
+        scenario = (
+            row["records"],
+            row["density"],
+            row["locality"],
+            row["operation"],
+            row["relationship"],
+        )
+        key = (
+            *scenario,
+            row["cache_profile"],
+        )
+        grouped[key].append(row)
+        digest_groups[(*scenario, row["repetition"])].add(row["result_digest"])
+    summary = []
+    for key in sorted(grouped):
+        items = grouped[key]
+        if key[-1] not in profiles or len(items) != runs:
+            raise SummaryError(f"invalid lifecycle group: {key}")
+        elapsed = [int(row["elapsed_ns"]) for row in items]
+        summary.append(
+            {
+                "records": key[0],
+                "density": key[1],
+                "locality": key[2],
+                "operation": key[3],
+                "relationship": key[4],
+                "cache_profile": key[5],
+                "runs": runs,
+                "median_ns": statistics.median(elapsed),
+                "median_ns_per_op": statistics.median(float(row["ns_per_op"]) for row in items),
+                "cv_percent": cv(elapsed),
+                "median_peak_rss_bytes": statistics.median(
+                    int(row["peak_rss_bytes"]) for row in items
+                ),
+                "result_digest_consistent": all(
+                    len(digest_groups[(*key[:-1], repetition)]) == 1
+                    for repetition in range(1, runs + 1)
+                ),
+            }
+        )
+    return summary
+
+
+def cache_effect(
+    summary: Sequence[dict[str, object]], domain: str
+) -> list[dict[str, object]]:
+    if {str(row["cache_profile"]) for row in summary} != {"bounded", "unbounded"}:
+        return []
+    fields = (
+        ("records", "phase", "workload", "operation")
+        if domain == "tree"
+        else ("records", "density", "locality", "operation", "relationship")
+    )
+    grouped = defaultdict(dict)
+    for row in summary:
+        key = tuple(row[field] for field in fields)
+        grouped[key][row["cache_profile"]] = row
+    effects = []
+    for key in sorted(grouped):
+        bounded = grouped[key]["bounded"]
+        unbounded = grouped[key]["unbounded"]
+        result = {field: value for field, value in zip(fields, key)}
+        result.update(
+            {
+                "bounded_rust_median_ns": bounded["rust_median_ns"],
+                "unbounded_rust_median_ns": unbounded["rust_median_ns"],
+                "unbounded_speedup": safe_ratio(
+                    float(bounded["rust_median_ns"]),
+                    float(unbounded["rust_median_ns"]),
+                ),
+                "bounded_rust_median_peak_rss_bytes": bounded[
+                    "rust_median_peak_rss_bytes"
+                ],
+                "unbounded_rust_median_peak_rss_bytes": unbounded[
+                    "rust_median_peak_rss_bytes"
+                ],
+                "rss_ratio": safe_ratio(
+                    float(unbounded["rust_median_peak_rss_bytes"]),
+                    float(bounded["rust_median_peak_rss_bytes"]),
+                ),
+            }
+        )
+        effects.append(result)
+    return effects
+
+
+def write_csv(path: Path, rows: Sequence[dict[str, object]], fields: Sequence[str] | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if rows:
+        fields = tuple(rows[0])
+    elif fields is None:
+        raise SummaryError(f"cannot write empty CSV without fields: {path}")
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+    temporary.replace(path)
+
+
+def format_duration(value: object) -> str:
+    ns = float(value)
+    if ns >= 1_000_000_000:
+        return f"{ns / 1_000_000_000:.3f} s"
+    if ns >= 1_000_000:
+        return f"{ns / 1_000_000:.3f} ms"
+    if ns >= 1_000:
+        return f"{ns / 1_000:.3f} us"
+    return f"{ns:.1f} ns"
+
+
+def render_report(
+    path: Path,
+    manifest: dict[str, str],
+    tree: Sequence[dict[str, object]],
+    version: Sequence[dict[str, object]],
+    lifecycle: Sequence[dict[str, object]],
+) -> None:
+    profiles = words(manifest["rust_cache_profiles"])
+    maximum_size = max(int(row["records"]) for row in tree)
+    lines = [
+        "# Repeatable Dolt Go vs Rust Prolly Evaluation",
+        "",
+        "One pinned Dolt Go baseline is compared with bounded and unbounded Rust cache profiles. All figures are medians from process-isolated, single-worker, in-memory runs.",
+        "",
+        "## Provenance",
+        "",
+        f"- Fingerprint: `{manifest['fingerprint']}`",
+        f"- Rust: `{manifest['rust_revision']}`",
+        f"- Dolt Go: `{manifest['dolt_revision']}`",
+        f"- Sizes: `{manifest['sizes']}`; repetitions: {manifest['runs']}",
+        f"- Rust cache profiles: `{manifest['rust_cache_profiles']}`",
+        "",
+        "## Winner summary",
+        "",
+        "| Domain | Rust profile | Rust wins | Dolt Go wins | Ties | Unstable/narrow groups |",
+        "|---|---|---:|---:|---:|---:|",
+    ]
+    for domain, rows in (("tree", tree), ("version", version)):
+        for profile in profiles:
+            selected = [row for row in rows if row["cache_profile"] == profile]
+            winners = Counter(str(row["winner"]) for row in selected)
+            flagged = sum(row["quality"] != "stable" for row in selected)
+            lines.append(
+                f"| {domain} | {profile} | {winners['rust']} | {winners['dolt-go']} | "
+                f"{winners['tie']} | {flagged} |"
+            )
+    lines.extend(
+        [
+            "",
+            f"## Tree operations at {maximum_size:,} records",
+            "",
+            "| Profile | Phase | Workload | Operation | Rust | Dolt Go | Rust vs Go | Winner | Quality | Rust RSS |",
+            "|---|---|---|---|---:|---:|---:|---|---|---:|",
+        ]
+    )
+    for row in tree:
+        if int(row["records"]) != maximum_size:
+            continue
+        lines.append(
+            f"| {row['cache_profile']} | {row['phase']} | {row['workload']} | {row['operation']} | "
+            f"{float(row['rust_median_ns_per_op']):.3f} ns/op | {float(row['go_median_ns_per_op']):.3f} ns/op | "
+            f"{float(row['rust_vs_go']):.2f}x | {row['winner']} | {row['quality']} | "
+            f"{float(row['rust_median_peak_rss_bytes']) / 2**30:.2f} GiB |"
+        )
+    lines.extend(
+        [
+            "",
+            f"## Version operations at {maximum_size:,} records",
+            "",
+            "| Profile | Density | Locality | Operation | Rust | Dolt Go | Rust vs Go | Winner | Quality | Rust RSS |",
+            "|---|---:|---|---|---:|---:|---:|---|---|---:|",
+        ]
+    )
+    for row in version:
+        if int(row["records"]) != maximum_size:
+            continue
+        lines.append(
+            f"| {row['cache_profile']} | {row['density']}% | {row['locality']} | {row['operation']} | "
+            f"{format_duration(row['rust_median_ns'])} | {format_duration(row['go_median_ns'])} | "
+            f"{float(row['rust_vs_go']):.2f}x | {row['winner']} | {row['quality']} | "
+            f"{float(row['rust_median_peak_rss_bytes']) / 2**30:.2f} GiB |"
+        )
+    if lifecycle:
+        lines.extend(
+            [
+                "",
+                f"## Rust lifecycle at {maximum_size:,} records",
+                "",
+                "| Profile | Density | Locality | Operation | Median | CV | RSS | Result identity |",
+                "|---|---:|---|---|---:|---:|---:|---|",
+            ]
+        )
+        for row in lifecycle:
+            if int(row["records"]) != maximum_size:
+                continue
+            lines.append(
+                f"| {row['cache_profile']} | {row['density']}% | {row['locality']} | "
+                f"{row['operation']} | {format_duration(row['median_ns'])} | "
+                f"{float(row['cv_percent']):.2f}% | "
+                f"{float(row['median_peak_rss_bytes']) / 2**30:.2f} GiB | "
+                f"{'match' if row['result_digest_consistent'] else 'DIVERGED'} |"
+            )
+    all_rows = [*tree, *version]
+    lifecycle_divergences = {
+        (
+            row["records"],
+            row["density"],
+            row["locality"],
+            row["operation"],
+            row["relationship"],
+        )
+        for row in lifecycle
+        if not bool(row["result_digest_consistent"])
+    }
+    lines.extend(
+        [
+            "",
+            "## Reproducibility audit",
+            "",
+            "- Complete configured tree matrix: PASS",
+            "- Complete configured version matrix: PASS",
+            "- Cross-profile and cross-language logical identity: PASS",
+            f"- Lifecycle result-digest divergence groups: {len(lifecycle_divergences)} "
+            f"({'WARN' if lifecycle_divergences else 'PASS'})",
+            "- All runner validation flags: PASS",
+            f"- Publication repetition gate: {'PASS' if int(manifest['runs']) >= 3 else 'SMOKE ONLY'}",
+            f"- Winner-direction flip groups: {sum(not bool(row['winner_consistent']) for row in all_rows)}",
+            f"- Groups with CV above 25%: {sum(max(float(row['rust_cv_percent']), float(row['go_cv_percent'])) > 25 for row in all_rows)}",
+            "",
+            "`Rust vs Go` is Go median latency divided by Rust median latency. Values above 1.0 favor Rust. `insufficient_repetitions`, `winner_flip`, `narrow`, and `high_variance` rows should not be used as strong winner claims.",
+            "",
+        ]
+    )
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    manifest = read_manifest(args.output / "manifest.txt")
+    sizes = integers(manifest["sizes"])
+    runs = int(manifest["runs"])
+    profiles = words(manifest["rust_cache_profiles"])
+    densities = integers(manifest["densities"])
+    localities = words(manifest["localities"])
+    tree_rows = read_rows(args.output / "tree" / "results.csv")
+    version_rows = read_rows(args.output / "version" / "results-common.csv")
+    lifecycle_enabled = manifest["lifecycle"] == "1"
+    lifecycle_rows = read_rows(
+        args.output / "lifecycle" / "results.csv", allow_empty=not lifecycle_enabled
+    )
+    validate_tree_matrix(tree_rows, sizes, runs, profiles)
+    validate_comparison_identity(tree_rows, profiles, "tree")
+    validate_version_matrix(
+        version_rows, sizes, runs, profiles, densities, localities
+    )
+    validate_comparison_identity(version_rows, profiles, "version")
+    validate_lifecycle_matrix(
+        lifecycle_rows,
+        sizes,
+        runs,
+        profiles,
+        densities,
+        localities,
+        lifecycle_enabled,
+    )
+    validate_lifecycle_identity(lifecycle_rows, profiles)
+    tree_summary = comparison_summary(tree_rows, profiles, "tree")
+    version_summary = comparison_summary(version_rows, profiles, "version")
+    life_summary = lifecycle_summary(lifecycle_rows, profiles, runs)
+    write_csv(args.output / "tree" / "summary.csv", tree_summary)
+    write_csv(args.output / "version" / "summary.csv", version_summary)
+    write_csv(
+        args.output / "lifecycle" / "summary.csv",
+        life_summary,
+        fields=(
+            "records",
+            "density",
+            "locality",
+            "operation",
+            "relationship",
+            "cache_profile",
+            "runs",
+            "median_ns",
+            "median_ns_per_op",
+            "cv_percent",
+            "median_peak_rss_bytes",
+            "result_digest_consistent",
+        ),
+    )
+    write_csv(
+        args.output / "tree" / "cache-effect.csv",
+        cache_effect(tree_summary, "tree"),
+        fields=(
+            "records",
+            "phase",
+            "workload",
+            "operation",
+            "bounded_rust_median_ns",
+            "unbounded_rust_median_ns",
+            "unbounded_speedup",
+            "bounded_rust_median_peak_rss_bytes",
+            "unbounded_rust_median_peak_rss_bytes",
+            "rss_ratio",
+        ),
+    )
+    write_csv(
+        args.output / "version" / "cache-effect.csv",
+        cache_effect(version_summary, "version"),
+        fields=(
+            "records",
+            "density",
+            "locality",
+            "operation",
+            "relationship",
+            "bounded_rust_median_ns",
+            "unbounded_rust_median_ns",
+            "unbounded_speedup",
+            "bounded_rust_median_peak_rss_bytes",
+            "unbounded_rust_median_peak_rss_bytes",
+            "rss_ratio",
+        ),
+    )
+    render_report(
+        args.output / "report.md",
+        manifest,
+        tree_summary,
+        version_summary,
+        life_summary,
+    )
+    warning_path = args.output / "WARNINGS"
+    lifecycle_divergences = sorted(
+        {
+            (
+                row["records"],
+                row["density"],
+                row["locality"],
+                row["operation"],
+                row["relationship"],
+            )
+            for row in life_summary
+            if not bool(row["result_digest_consistent"])
+        }
+    )
+    if lifecycle_divergences:
+        warning_path.write_text(
+            "Lifecycle result digests differ across Rust cache profiles for:\n"
+            + "\n".join(",".join(map(str, item)) for item in lifecycle_divergences)
+            + "\n",
+            encoding="utf-8",
+        )
+    else:
+        warning_path.unlink(missing_ok=True)
+    (args.output / "COMPLETE").write_text(manifest["fingerprint"] + "\n", encoding="utf-8")
+    print(args.output / "report.md")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SummaryError as error:
+        raise SystemExit(f"invalid evaluation results: {error}") from error

--- a/scripts/tests/test_prolly_evaluation_framework.py
+++ b/scripts/tests/test_prolly_evaluation_framework.py
@@ -1,0 +1,352 @@
+import csv
+import json
+import os
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from scripts.summarize_prolly_evaluation import quality_label, safe_ratio
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DRIVER = ROOT / "scripts" / "run_prolly_evaluation.sh"
+
+
+def executable(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+class ProllyEvaluationFrameworkTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.log = self.root / "invocations.log"
+        self.runner = self.root / "runner.py"
+        executable(
+            self.runner,
+            r'''
+            #!/usr/bin/env python3
+            import os
+            import sys
+
+            domain, implementation = sys.argv[1:3]
+            args = dict(zip(sys.argv[3::2], sys.argv[4::2]))
+            profile = os.environ.get("PROLLY_BENCH_CACHE_PROFILE", "native")
+            with open(os.environ["FAKE_INVOCATION_LOG"], "a", encoding="utf-8") as log:
+                log.write(f"{domain},{implementation},{profile},{sys.argv[3:]}\n")
+            revision = os.environ["BENCH_REVISION"]
+            if domain == "tree":
+                records = int(args["--records"])
+                phase = args["--phase"]
+                workload = args["--workload"]
+                digests = {
+                    ("fresh", "append"): "51f55fcd59187cbf",
+                    ("fresh", "random"): "004197dd790a1245",
+                    ("fresh", "clustered"): "86e38047f6ae04b3",
+                    ("mutation", "append"): "2ef1df79e1226620",
+                    ("mutation", "random"): "3bc7e45ef276a1c5",
+                    ("mutation", "clustered"): "5caed8dbd3056277",
+                }
+                writes = records if phase == "fresh" else records * 30 // 100
+                result_count = records if phase == "fresh" else records + writes
+                ns = 20 if implementation == "dolt-go" else 15 if profile == "bounded" else 10
+                print("implementation,revision,contract_version,records,phase,workload,operation,operations,elapsed_ns,ns_per_op,ops_per_sec,workload_digest,result_count,validated")
+                for operation, operations in (("write", writes), ("point_read", records), ("range_scan", result_count)):
+                    elapsed = ns * operations
+                    print(f"{implementation},{revision},prolly-compare-v1,{records},{phase},{workload},{operation},{operations},{elapsed},{ns:.3f},{1_000_000_000/ns:.3f},{digests[(phase, workload)]},{result_count},true")
+                raise SystemExit(0)
+
+            records = int(args["--records"])
+            density = int(args.get("--density", "0"))
+            locality = args.get("--locality", "none")
+            if domain == "lifecycle":
+                scenario = args["--scenario"]
+                operations = {
+                    "publish": ("version_publish",),
+                    "read": ("head_resolve", "snapshot_resolve", "historical_point_read", "historical_range_scan", "version_list"),
+                    "rollback": ("rollback",),
+                    "prune": ("retention_prune",),
+                }[scenario]
+                runner_implementation = "rust-lifecycle"
+            else:
+                scenario = "common"
+                operations = (
+                    "full_diff", "range_diff", "patch_generate", "patch_apply",
+                    "merge_noop" if density == 0 else "merge_disjoint",
+                ) if density == 0 else (
+                    "full_diff", "range_diff", "patch_generate", "patch_apply",
+                    "merge_disjoint", "merge_convergent", "merge_conflict",
+                )
+                runner_implementation = implementation
+            ns = 20 if implementation == "dolt-go" else 15 if profile == "bounded" else 10
+            relationship = {
+                "full_diff": "compare", "range_diff": "compare",
+                "patch_generate": "compare", "patch_apply": "compare",
+                "merge_noop": "noop", "merge_disjoint": "disjoint",
+                "merge_convergent": "convergent", "merge_conflict": "conflict",
+                "version_publish": "publish", "head_resolve": "read",
+                "snapshot_resolve": "read", "historical_point_read": "read",
+                "historical_range_scan": "read", "version_list": "read",
+                "rollback": "rollback", "retention_prune": "prune",
+            }
+            print("implementation,revision,contract_version,records,density,locality,operation,relationship,operations,elapsed_ns,ns_per_op,ops_per_sec,workload_digest,result_digest,result_count,base_count,target_count,conflict_count,validated")
+            for operation in operations:
+                units = max(1, records * max(1, density) // 100)
+                elapsed = ns * units
+                conflicts = units if operation == "merge_conflict" else 0
+                print(f"{runner_implementation},{revision},prolly-version-compare-v3,{records},{density},{locality},{operation},{relationship[operation]},{units},{elapsed},{ns:.3f},{1_000_000_000/ns:.3f},1111111111111111,2222222222222222,{units},{records},{records},{conflicts},true")
+            ''',
+        )
+        for name, domain, implementation in (
+            ("rust-tree", "tree", "rust"),
+            ("go-tree", "tree", "dolt-go"),
+            ("rust-version", "version", "rust"),
+            ("go-version", "version", "dolt-go"),
+            ("rust-lifecycle", "lifecycle", "rust"),
+        ):
+            executable(
+                self.bin / name,
+                f'''#!/bin/sh
+                exec python3 "{self.runner}" {domain} {implementation} "$@"
+                ''',
+            )
+        self.time = self.bin / "time"
+        executable(
+            self.time,
+            r'''
+            #!/bin/sh
+            set +e
+            mode=$1
+            shift
+            output=
+            if [ "$1" = -o ]; then
+                output=$2
+                shift 2
+            fi
+            "$@"
+            status=$?
+            if [ "$mode" = -l ]; then
+                metric='1048576 maximum resident set size'
+            else
+                metric='Maximum resident set size (kbytes): 1024'
+            fi
+            if [ -n "$output" ]; then
+                printf '%s\n' "$metric" >"$output"
+            else
+                printf '%s\n' "$metric" >&2
+            fi
+            exit "$status"
+            ''',
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def environment(self, output: Path, resume: bool = False) -> dict[str, str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "BENCH_PROFILE": "smoke",
+                "BENCH_OUT": str(output),
+                "BENCH_SKIP_BUILD": "1",
+                "BENCH_SKIP_SMOKE": "1",
+                "BENCH_RESUME": "1" if resume else "0",
+                "BENCH_LIFECYCLE": "1",
+                "BENCH_TIME_BIN": str(self.time),
+                "BENCH_RUST_CACHE_PROFILES": "bounded unbounded",
+                "DOLT_REV": "0123456789abcdef0123456789abcdef01234567",
+                "PROLLY_EVAL_RUST_TREE_BIN": str(self.bin / "rust-tree"),
+                "PROLLY_EVAL_GO_TREE_BIN": str(self.bin / "go-tree"),
+                "PROLLY_EVAL_RUST_VERSION_BIN": str(self.bin / "rust-version"),
+                "PROLLY_EVAL_GO_VERSION_BIN": str(self.bin / "go-version"),
+                "PROLLY_EVAL_RUST_LIFECYCLE_BIN": str(self.bin / "rust-lifecycle"),
+                "FAKE_INVOCATION_LOG": str(self.log),
+            }
+        )
+        return env
+
+    def run_driver(self, output: Path, resume: bool = False) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(DRIVER)],
+            cwd=ROOT,
+            env=self.environment(output, resume),
+            text=True,
+            capture_output=True,
+        )
+
+    def test_profiles_share_one_go_baseline_and_resume_without_rerunning(self) -> None:
+        output = self.root / "results"
+        first = self.run_driver(output)
+        self.assertEqual(first.returncode, 0, first.stderr)
+
+        with (output / "tree" / "results.csv").open(newline="") as handle:
+            tree = list(csv.DictReader(handle))
+        with (output / "version" / "results-common.csv").open(newline="") as handle:
+            version = list(csv.DictReader(handle))
+        with (output / "lifecycle" / "results.csv").open(newline="") as handle:
+            lifecycle = list(csv.DictReader(handle))
+        self.assertEqual({row["cache_profile"] for row in tree}, {"native", "bounded", "unbounded"})
+        self.assertEqual({row["cache_profile"] for row in version}, {"native", "bounded", "unbounded"})
+        self.assertEqual(len(tree), 54)
+        self.assertEqual(len(version), 21)
+        self.assertEqual(len(lifecycle), 16)
+        self.assertEqual(
+            {row["cache_profile"] for row in lifecycle}, {"bounded", "unbounded"}
+        )
+        self.assertTrue((output / "COMPLETE").is_file())
+        self.assertTrue((output / "report.md").is_file())
+
+        invocations = self.log.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(sum(",dolt-go,native," in line for line in invocations), 7)
+        self.assertEqual(sum(",rust,bounded," in line for line in invocations), 11)
+        self.assertEqual(sum(",rust,unbounded," in line for line in invocations), 11)
+
+        for binary in (
+            "rust-tree",
+            "go-tree",
+            "rust-version",
+            "go-version",
+            "rust-lifecycle",
+        ):
+            (self.bin / binary).unlink()
+        resumed = self.run_driver(output, resume=True)
+        self.assertEqual(resumed.returncode, 0, resumed.stderr)
+        self.assertEqual(self.log.read_text(encoding="utf-8").splitlines(), invocations)
+        self.assertIn("reusing", resumed.stderr)
+
+        lock = output / ".lock"
+        lock.mkdir()
+        (lock / "pid").write_text(f"{os.getpid()}\n", encoding="utf-8")
+        locked = self.run_driver(output, resume=True)
+        self.assertNotEqual(locked.returncode, 0)
+        self.assertIn("is locked", locked.stderr)
+        (lock / "pid").unlink()
+        lock.rmdir()
+
+        lifecycle_path = output / "lifecycle" / "results.csv"
+        with lifecycle_path.open(newline="") as handle:
+            lifecycle_rows = list(csv.DictReader(handle))
+            lifecycle_fields = list(lifecycle_rows[0])
+        diverged_rows = [dict(row) for row in lifecycle_rows]
+        next(
+            row
+            for row in diverged_rows
+            if row["cache_profile"] == "unbounded"
+            and row["operation"] == "head_resolve"
+        )["result_digest"] = "3333333333333333"
+        with lifecycle_path.open("w", newline="") as handle:
+            writer = csv.DictWriter(
+                handle, fieldnames=lifecycle_fields, lineterminator="\n"
+            )
+            writer.writeheader()
+            writer.writerows(diverged_rows)
+        warned = subprocess.run(
+            [
+                "python3",
+                str(ROOT / "scripts" / "summarize_prolly_evaluation.py"),
+                "--output",
+                str(output),
+            ],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(warned.returncode, 0, warned.stderr)
+        self.assertTrue((output / "WARNINGS").is_file())
+        self.assertIn(
+            "Lifecycle result-digest divergence groups: 1 (WARN)",
+            (output / "report.md").read_text(encoding="utf-8"),
+        )
+        with lifecycle_path.open("w", newline="") as handle:
+            writer = csv.DictWriter(
+                handle, fieldnames=lifecycle_fields, lineterminator="\n"
+            )
+            writer.writeheader()
+            writer.writerows(lifecycle_rows)
+        clean = subprocess.run(
+            [
+                "python3",
+                str(ROOT / "scripts" / "summarize_prolly_evaluation.py"),
+                "--output",
+                str(output),
+            ],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(clean.returncode, 0, clean.stderr)
+        self.assertFalse((output / "WARNINGS").exists())
+
+        tree_path = output / "tree" / "results.csv"
+        with tree_path.open(newline="") as handle:
+            tampered_rows = list(csv.DictReader(handle))
+            fieldnames = list(tampered_rows[0])
+        next(
+            row
+            for row in tampered_rows
+            if row["implementation"] == "rust"
+            and row["cache_profile"] == "bounded"
+        )["workload_digest"] = "tampered"
+        with tree_path.open("w", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fieldnames, lineterminator="\n")
+            writer.writeheader()
+            writer.writerows(tampered_rows)
+        summary = subprocess.run(
+            [
+                "python3",
+                str(ROOT / "scripts" / "summarize_prolly_evaluation.py"),
+                "--output",
+                str(output),
+            ],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(summary.returncode, 0)
+        self.assertIn("identity mismatch", summary.stderr)
+
+    def test_resume_fails_closed_when_sample_state_is_tampered(self) -> None:
+        output = self.root / "tampered"
+        first = self.run_driver(output)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        state_path = next((output / "tree" / "state").glob("*.json"))
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["fingerprint"] = "tampered"
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+
+        resumed = self.run_driver(output, resume=True)
+        self.assertNotEqual(resumed.returncode, 0)
+        self.assertIn("resume state mismatch", resumed.stderr)
+        self.assertFalse((output / "COMPLETE").exists())
+
+    def test_resume_fails_closed_when_raw_sample_is_tampered(self) -> None:
+        output = self.root / "tampered-raw"
+        first = self.run_driver(output)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        raw_path = next((output / "tree" / "raw").glob("*.csv"))
+        raw_path.write_bytes(raw_path.read_bytes() + b"\n")
+
+        resumed = self.run_driver(output, resume=True)
+        self.assertNotEqual(resumed.returncode, 0)
+        self.assertIn("resume artifact mismatch", resumed.stderr)
+        self.assertFalse((output / "COMPLETE").exists())
+
+    def test_zero_duration_ratios_remain_reportable(self) -> None:
+        self.assertEqual(safe_ratio(0, 0), 1.0)
+        self.assertEqual(safe_ratio(10, 0), float("inf"))
+        self.assertEqual(safe_ratio(10, 5), 2.0)
+
+    def test_smoke_repetition_is_not_labeled_stable(self) -> None:
+        self.assertEqual(
+            quality_label(1, True, 2.0, 0.0), "insufficient_repetitions"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/bin/prolly_benchmark_support/config.rs
+++ b/src/bin/prolly_benchmark_support/config.rs
@@ -1,0 +1,50 @@
+use std::env;
+
+use prolly::Config;
+
+pub const CACHE_PROFILE_ENV: &str = "PROLLY_BENCH_CACHE_PROFILE";
+
+pub fn benchmark_config() -> Config {
+    match env::var(CACHE_PROFILE_ENV) {
+        Ok(value) => config_for_profile(Some(&value)),
+        Err(env::VarError::NotPresent) => config_for_profile(None),
+        Err(error) => panic!("cannot read {CACHE_PROFILE_ENV}: {error}"),
+    }
+}
+
+fn config_for_profile(profile: Option<&str>) -> Config {
+    match profile {
+        Some("unbounded") => Config::builder().unbounded_node_cache().build(),
+        Some("bounded") | None => Config::default(),
+        Some(value) => {
+            panic!("invalid {CACHE_PROFILE_ENV}={value:?}; expected bounded or unbounded")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::config_for_profile;
+
+    #[test]
+    fn bounded_is_the_default_profile() {
+        let implicit = config_for_profile(None);
+        let explicit = config_for_profile(Some("bounded"));
+        assert_eq!(implicit, explicit);
+        assert!(explicit.runtime.node_cache_max_nodes.is_some());
+        assert!(explicit.runtime.node_cache_max_bytes.is_some());
+    }
+
+    #[test]
+    fn unbounded_removes_both_cache_limits() {
+        let config = config_for_profile(Some("unbounded"));
+        assert_eq!(config.runtime.node_cache_max_nodes, None);
+        assert_eq!(config.runtime.node_cache_max_bytes, None);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected bounded or unbounded")]
+    fn invalid_profile_fails_closed() {
+        let _ = config_for_profile(Some("other"));
+    }
+}

--- a/src/bin/prolly_compare.rs
+++ b/src/bin/prolly_compare.rs
@@ -1,3 +1,6 @@
+#[path = "prolly_benchmark_support/config.rs"]
+mod benchmark_config;
+
 use std::env;
 use std::hint::black_box;
 use std::sync::Arc;
@@ -127,7 +130,14 @@ fn run_scenario(args: &Args) -> ScenarioResult {
     if let Some(max_bytes) = env_usize("PROLLY_COMPARE_CACHE_BYTES") {
         config = config.node_cache_max_bytes(max_bytes);
     }
-    let manager = Prolly::new(store, config.build());
+    let explicit_limits = env::var_os("PROLLY_COMPARE_CACHE_NODES").is_some()
+        || env::var_os("PROLLY_COMPARE_CACHE_BYTES").is_some();
+    let config = if explicit_limits {
+        config.build()
+    } else {
+        benchmark_config::benchmark_config()
+    };
+    let manager = Prolly::new(store, config);
     let (tree, write_operations, write_elapsed, digest, result_count) = match args.phase {
         Phase::Fresh => {
             let (tree, elapsed, digest) = build_fresh(&manager, args.records, args.workload);

--- a/src/bin/prolly_version_compare.rs
+++ b/src/bin/prolly_version_compare.rs
@@ -1,3 +1,5 @@
+#[path = "prolly_benchmark_support/config.rs"]
+mod benchmark_config;
 #[path = "prolly_version_support/mod.rs"]
 mod support;
 
@@ -16,8 +18,7 @@ unsafe extern "C" {
 }
 
 use prolly::{
-    BorrowedMergeResolver, Config, ConflictRef, Diff, MemStore, MergeDecision, Mutation, Prolly,
-    Tree,
+    BorrowedMergeResolver, ConflictRef, Diff, MemStore, MergeDecision, Mutation, Prolly, Tree,
 };
 use support::{
     base_mutations, branch_mutations, change_count, conflicting_mutations, digest_diffs,
@@ -50,7 +51,10 @@ fn main() {
 }
 
 fn run(args: &Args) -> Vec<Measurement<'static>> {
-    let manager = Prolly::new(Arc::new(MemStore::new()), Config::default());
+    let manager = Prolly::new(
+        Arc::new(MemStore::new()),
+        benchmark_config::benchmark_config(),
+    );
     let base = build(&manager, None, base_mutations(args.records));
     let base_summary = tree_summary(&manager, &base);
     assert_eq!(base_summary.0, args.records);

--- a/src/bin/prolly_version_lifecycle.rs
+++ b/src/bin/prolly_version_lifecycle.rs
@@ -1,3 +1,5 @@
+#[path = "prolly_benchmark_support/config.rs"]
+mod benchmark_config;
 #[path = "prolly_version_support/mod.rs"]
 mod support;
 
@@ -6,7 +8,7 @@ use std::hint::black_box;
 use std::sync::Arc;
 use std::time::Instant;
 
-use prolly::{Config, MapVersion, MemStore, Mutation, Prolly};
+use prolly::{MapVersion, MemStore, Mutation, Prolly};
 use support::{
     base_mutations, branch_mutations, digest_bytes, digest_entry, digest_u64, key_for_id,
     value_for, Locality, FNV_OFFSET,
@@ -118,7 +120,10 @@ fn parse_args() -> Args {
 }
 
 fn run_publish(args: &Args) -> Vec<Measurement<'static>> {
-    let manager = Prolly::new(Arc::new(MemStore::new()), Config::default());
+    let manager = Prolly::new(
+        Arc::new(MemStore::new()),
+        benchmark_config::benchmark_config(),
+    );
     let map = manager.versioned_map(b"version-lifecycle-publish");
     let base = map
         .apply_at_millis(base_mutations(args.records), 1)
@@ -152,12 +157,14 @@ fn run_publish(args: &Args) -> Vec<Measurement<'static>> {
 }
 
 fn run_read(args: &Args) -> Vec<Measurement<'static>> {
-    let manager = Prolly::new(Arc::new(MemStore::new()), Config::default());
+    let manager = Prolly::new(
+        Arc::new(MemStore::new()),
+        benchmark_config::benchmark_config(),
+    );
     let map = manager.versioned_map(b"version-lifecycle-read");
-    let versions = build_history(&map, args.records);
+    let (versions, history_digest) = build_history(&map, args.records);
     let head_id = versions.last().expect("history has head").id.clone();
     let base_count = args.records;
-    let history_digest = digest_versions(&versions);
     let mut rows = Vec::new();
 
     let started = Instant::now();
@@ -271,12 +278,14 @@ fn run_read(args: &Args) -> Vec<Measurement<'static>> {
 }
 
 fn run_rollback(args: &Args) -> Vec<Measurement<'static>> {
-    let manager = Prolly::new(Arc::new(MemStore::new()), Config::default());
+    let manager = Prolly::new(
+        Arc::new(MemStore::new()),
+        benchmark_config::benchmark_config(),
+    );
     let map = manager.versioned_map(b"version-lifecycle-rollback");
-    let versions = build_history(&map, args.records);
+    let (versions, workload) = build_history(&map, args.records);
     let first = &versions[HISTORY_DEPTH / 4].id;
     let second = &versions[HISTORY_DEPTH * 3 / 4].id;
-    let workload = digest_versions(&versions);
     let started = Instant::now();
     let mut result_digest = FNV_OFFSET;
     for index in 0..ROLLBACK_REPETITIONS {
@@ -301,13 +310,15 @@ fn run_rollback(args: &Args) -> Vec<Measurement<'static>> {
 }
 
 fn run_prune(args: &Args) -> Vec<Measurement<'static>> {
-    let manager = Prolly::new(Arc::new(MemStore::new()), Config::default());
+    let manager = Prolly::new(
+        Arc::new(MemStore::new()),
+        benchmark_config::benchmark_config(),
+    );
     let map = manager.versioned_map(b"version-lifecycle-prune");
-    let versions = build_history(&map, args.records);
+    let (versions, workload) = build_history(&map, args.records);
     let old_head = versions[HISTORY_DEPTH / 4].id.clone();
     map.rollback_to(&old_head)
         .expect("pre-prune rollback succeeds");
-    let workload = digest_versions(&versions);
     let started = Instant::now();
     let result = map.prune_versions(black_box(10)).expect("pruning succeeds");
     let elapsed = started.elapsed().as_nanos();
@@ -333,27 +344,29 @@ fn run_prune(args: &Args) -> Vec<Measurement<'static>> {
 fn build_history<'a>(
     map: &prolly::VersionedMap<'a, Arc<MemStore>>,
     records: usize,
-) -> Vec<MapVersion> {
+) -> (Vec<MapVersion>, u64) {
     let mut versions = Vec::with_capacity(HISTORY_DEPTH);
+    let base = base_mutations(records);
+    let mut workload_digest =
+        support::workload_digest(records, "lifecycle-history-v1", &[base.as_slice()]);
     versions.push(
-        map.apply_at_millis(base_mutations(records), 1)
+        map.apply_at_millis(base, 1)
             .expect("base history version publishes"),
     );
     for index in 1..HISTORY_DEPTH {
         let position = index % records;
+        let key = key_for_id(position * 2);
+        let val = value_for((position * 2) as u64, 10 + index as u64);
+        workload_digest = digest_u64(workload_digest, 1);
+        workload_digest = digest_bytes(workload_digest, &[1]);
+        workload_digest = digest_entry(workload_digest, &key, &val);
         versions.push(
-            map.apply_at_millis(
-                vec![Mutation::Upsert {
-                    key: key_for_id(position * 2),
-                    val: value_for((position * 2) as u64, 10 + index as u64),
-                }],
-                index as u64 + 1,
-            )
-            .expect("history version publishes"),
+            map.apply_at_millis(vec![Mutation::Upsert { key, val }], index as u64 + 1)
+                .expect("history version publishes"),
         );
     }
     assert_eq!(map.versions().expect("history lists").len(), HISTORY_DEPTH);
-    versions
+    (versions, digest_u64(workload_digest, HISTORY_DEPTH as u64))
 }
 
 fn historical_read_digest<S: prolly::Store>(


### PR DESCRIPTION
## Summary

- add a canonical process-isolated Dolt-Go versus Rust prolly evaluation driver
- compare one native Go baseline with bounded and unbounded Rust cache profiles
- cover build, 30% mutation, point reads, range scans, diff, patch, merge, and Rust lifecycle workloads
- capture exact provenance, binaries, peak RSS, durable per-sample state, and SHA-256 artifact hashes
- add strict matrix/identity validation, resumability, quality labels, lifecycle warnings, and operator documentation

## Verification

- 19 Python integration and regression tests
- 3 Rust cache-profile tests
- cargo fmt --check
- Python compilation and shell syntax checks
- real 10K smoke against Dolt 9e80d3aa2cf8ff473765f5603af32304d72c67b5
- offline resume reused and revalidated all 35 samples without rebuilding or rerunning

## Note

The real smoke surfaced five version-ID-derived lifecycle digest divergences between bounded and unbounded Rust profiles. The framework records these in WARNINGS and keeps those lifecycle rows out of publishable performance claims until they are investigated; common tree/version logical identity passed.