### PR TITLE
feat: add redb store adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1013,6 +1013,8 @@ Optional adapter crates:
 - [`prolly-store-turso`](stores/prolly-store-turso/README.md): native local
   asynchronous Turso Database backend, with explicit cloud push/pull behind
   its optional `turso-cloud-sync` feature.
+- [`prolly-store-redb`](stores/prolly-store-redb/README.md): pure-Rust,
+  single-file redb backend with atomic transactions.
 - `prolly-store-rocksdb`: embedded RocksDB backend.
 - `prolly-store-pglite`: PGlite/Node sidecar backend.
 - `prolly-store-slatedb`: object-store-backed SlateDB backend.
@@ -1031,6 +1033,7 @@ cargo test --features async-store
 cargo test --features tokio
 cargo test --manifest-path stores/prolly-store-sqlite/Cargo.toml
 cargo test --manifest-path stores/prolly-store-turso/Cargo.toml
+cargo test --manifest-path stores/prolly-store-redb/Cargo.toml
 cargo test --manifest-path stores/prolly-store-rocksdb/Cargo.toml
 cargo test --manifest-path stores/prolly-store-pglite/Cargo.toml
 cargo test --manifest-path stores/prolly-store-slatedb/Cargo.toml
@@ -2058,6 +2061,7 @@ Run shared store contract coverage:
 cargo test --test store_conformance
 cargo test --features async-store --test async_store
 cargo test --manifest-path stores/prolly-store-sqlite/Cargo.toml
+cargo test --manifest-path stores/prolly-store-redb/Cargo.toml
 cargo test --manifest-path stores/prolly-store-rocksdb/Cargo.toml
 cargo test --manifest-path stores/prolly-store-slatedb/Cargo.toml
 cargo test --manifest-path stores/prolly-store-pglite/Cargo.toml

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -181,6 +181,7 @@ Current store families include:
 - `MemStore`: in-memory development and tests.
 - `FileNodeStore`: file-backed node storage.
 - `prolly-store-sqlite`: durable embedded SQLite adapter.
+- `prolly-store-redb`: pure-Rust, single-file redb adapter.
 - `prolly-store-rocksdb`: RocksDB adapter.
 - `prolly-store-slatedb`: SlateDB adapter.
 - `prolly-store-pglite`: PGlite adapter.

--- a/stores/prolly-store-redb/Cargo.toml
+++ b/stores/prolly-store-redb/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "prolly-store-redb"
+description = "redb store adapter for prolly-map."
+edition = "2021"
+rust-version = "1.89"
+version = "0.3.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/crabbuild/prolly"
+homepage = "https://github.com/crabbuild/prolly"
+documentation = "https://docs.rs/prolly-store-redb"
+readme = "README.md"
+keywords = ["prolly-tree", "storage", "database", "redb"]
+categories = ["database-implementations"]
+
+[lib]
+name = "prolly_store_redb"
+path = "src/lib.rs"
+
+[dependencies]
+prolly = { package = "prolly-map", path = "../..", version = "0.5.0" }
+redb = "4.1.0"
+
+[dev-dependencies]
+prolly-store-test = { path = "../prolly-store-test" }
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/stores/prolly-store-redb/README.md
+++ b/stores/prolly-store-redb/README.md
@@ -1,0 +1,115 @@
+# prolly-store-redb
+
+Pure-Rust [`redb`](https://crates.io/crates/redb) storage adapter for
+[`prolly-map`](https://crates.io/crates/prolly-map). It provides a persistent,
+synchronous, single-file backend with atomic write batches, named-root
+compare-and-swap, deterministic scans, advisory hints, and strict transactions.
+
+## Requirements and installation
+
+This adapter uses redb 4.1 and requires Rust 1.89 or newer. The higher toolchain
+requirement is isolated to this crate; `prolly-map` itself continues to support
+its lower minimum Rust version.
+
+```toml
+[dependencies]
+prolly-map = "0.5"
+prolly-store-redb = "0.3"
+```
+
+Redb is implemented in Rust and does not require a C or C++ toolchain.
+
+## Quick start
+
+```rust,no_run
+use prolly::{Config, Prolly};
+use prolly_store_redb::RedbStore;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let store = RedbStore::open("./data/app.prolly.redb")?;
+    let prolly = Prolly::new(store, Config::default());
+
+    let tree = prolly.put(
+        &prolly.create(),
+        b"project/name".to_vec(),
+        b"CrabDB".to_vec(),
+    )?;
+    prolly.publish_named_root(b"main", &tree)?;
+
+    let loaded = prolly.load_named_root(b"main")?.expect("main root");
+    assert_eq!(
+        prolly.get(&loaded, b"project/name")?,
+        Some(b"CrabDB".to_vec())
+    );
+    Ok(())
+}
+```
+
+Dropping the map closes the database. Reopen the same file to load published
+named roots in a later process.
+
+## Configuration
+
+`RedbStoreConfig` controls redb's page cache and transaction durability. The
+defaults are a 1 GiB cache and `Durability::Immediate`, which guarantees that a
+successful commit is persistent when it returns.
+
+```rust,no_run
+use prolly_store_redb::{Durability, RedbStore, RedbStoreConfig};
+
+let store = RedbStore::open_with_config(
+    "./data/app.prolly.redb",
+    RedbStoreConfig {
+        cache_size_bytes: 128 * 1024 * 1024,
+        durability: Durability::Immediate,
+    },
+)?;
+# drop(store);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+`Durability::None` can improve throughput when loss of recent commits after a
+crash is acceptable. It does not weaken transaction atomicity or consistency,
+but such commits are not guaranteed to reach disk until a later immediate
+commit.
+
+## Storage model
+
+The adapter creates three typed tables inside one redb file:
+
+- `prolly_nodes` stores content-addressed node bytes by CID.
+- `prolly_roots` stores encoded named-root manifests.
+- `prolly_hints` stores advisory values by `(namespace, key)`.
+
+Separate tables keep garbage-collection scans isolated from mutable metadata.
+Back up the complete `.redb` file; named-root prefixes provide logical
+organization, not physical tenant isolation.
+
+## Transactions and concurrency
+
+The adapter implements `Store`, `ManifestStore`, `ManifestStoreScan`,
+`NodeStoreScan`, and `TransactionalStore`. Batches and node-plus-hint
+publication commit atomically. Root compare-and-swap reads, validates, and
+updates a manifest in one redb write transaction.
+
+Strict transactions validate every named-root precondition before applying any
+node or root write, then commit all changes together. A stale condition aborts
+the transaction without applying staged writes. Redb supports concurrent
+snapshot readers and serializes writers; reuse one `RedbStore` or an
+`Arc<RedbStore>` across threads. Platforms with file locking reject a second
+writable database handle for the same file.
+
+The adapter persists hints but does not advertise a preference for rightmost-
+path hints. That preference is workload-dependent and should be enabled only
+after measurement.
+
+## Testing
+
+Run the adapter's conformance, transaction, persistence, and concurrency tests:
+
+```bash
+cargo test --manifest-path stores/prolly-store-redb/Cargo.toml
+```
+
+See the [`prolly-map` API documentation](https://docs.rs/prolly-map) for map,
+transaction, diff, merge, indexing, and garbage-collection APIs.

--- a/stores/prolly-store-redb/examples/basic_usage.rs
+++ b/stores/prolly-store-redb/examples/basic_usage.rs
@@ -1,0 +1,21 @@
+use prolly::{Config, Prolly};
+use prolly_store_redb::RedbStore;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let store = RedbStore::open("./data/app.prolly.redb")?;
+    let prolly = Prolly::new(store, Config::default());
+
+    let tree = prolly.put(
+        &prolly.create(),
+        b"project/name".to_vec(),
+        b"CrabDB".to_vec(),
+    )?;
+    prolly.publish_named_root(b"main", &tree)?;
+
+    let loaded = prolly.load_named_root(b"main")?.expect("main root");
+    assert_eq!(
+        prolly.get(&loaded, b"project/name")?,
+        Some(b"CrabDB".to_vec())
+    );
+    Ok(())
+}

--- a/stores/prolly-store-redb/src/lib.rs
+++ b/stores/prolly-store-redb/src/lib.rs
@@ -1,0 +1,625 @@
+#![doc = include_str!("../README.md")]
+
+use std::collections::HashMap;
+use std::error::Error as StdError;
+use std::path::Path;
+
+use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition, WriteTransaction};
+
+use prolly::{
+    BatchOp, Cid, Error, ManifestStore, ManifestStoreScan, ManifestUpdate, NamedRootManifest,
+    NodeStoreScan, RootCondition, RootManifest, RootWrite, Store, TransactionConflict,
+    TransactionNodeWrite, TransactionUpdate, TransactionalStore,
+};
+
+pub use redb::Durability;
+
+const NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes");
+const ROOTS: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_roots");
+const HINTS: TableDefinition<(&[u8], &[u8]), &[u8]> = TableDefinition::new("prolly_hints");
+
+/// Configuration for [`RedbStore`].
+#[derive(Debug, Clone, Copy)]
+pub struct RedbStoreConfig {
+    /// Maximum bytes redb may use for its in-memory page cache.
+    pub cache_size_bytes: usize,
+    /// Durability applied to every committed write transaction.
+    pub durability: Durability,
+}
+
+impl Default for RedbStoreConfig {
+    fn default() -> Self {
+        Self {
+            cache_size_bytes: 1024 * 1024 * 1024,
+            durability: Durability::Immediate,
+        }
+    }
+}
+
+/// Error returned by [`RedbStore`] operations.
+#[derive(Debug)]
+pub struct RedbStoreError {
+    message: String,
+    source: Option<Box<dyn StdError + Send + Sync>>,
+}
+
+impl RedbStoreError {
+    fn message(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    fn with_source(
+        context: impl Into<String>,
+        source: impl StdError + Send + Sync + 'static,
+    ) -> Self {
+        let context = context.into();
+        Self {
+            message: format!("{context}: {source}"),
+            source: Some(Box::new(source)),
+        }
+    }
+}
+
+impl std::fmt::Display for RedbStoreError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "redb store error: {}", self.message)
+    }
+}
+
+impl StdError for RedbStoreError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.source
+            .as_deref()
+            .map(|source| source as &(dyn StdError + 'static))
+    }
+}
+
+/// Persistent synchronous prolly store backed by redb.
+///
+/// The store keeps nodes, named roots, and advisory hints in separate redb
+/// tables. All mutation methods commit through redb transactions, and strict
+/// prolly transactions atomically validate roots and update nodes and roots.
+pub struct RedbStore {
+    db: Database,
+    durability: Durability,
+}
+
+impl std::fmt::Debug for RedbStore {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RedbStore")
+            .field("durability", &self.durability)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RedbStore {
+    /// Open an existing redb database or create one with default settings.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, RedbStoreError> {
+        Self::open_with_config(path, RedbStoreConfig::default())
+    }
+
+    /// Open an existing redb database or create one with `config`.
+    pub fn open_with_config(
+        path: impl AsRef<Path>,
+        config: RedbStoreConfig,
+    ) -> Result<Self, RedbStoreError> {
+        let mut builder = Database::builder();
+        builder.set_cache_size(config.cache_size_bytes);
+        let db = builder.create(path.as_ref()).map_err(|error| {
+            RedbStoreError::with_source(
+                format!("failed to open database at {:?}", path.as_ref()),
+                error,
+            )
+        })?;
+        let store = Self {
+            db,
+            durability: config.durability,
+        };
+        store.initialize_tables()?;
+        Ok(store)
+    }
+
+    fn initialize_tables(&self) -> Result<(), RedbStoreError> {
+        let transaction = self.begin_write("failed to begin table initialization")?;
+        {
+            let _nodes = transaction.open_table(NODES).map_err(|error| {
+                RedbStoreError::with_source("failed to initialize node table", error)
+            })?;
+            let _roots = transaction.open_table(ROOTS).map_err(|error| {
+                RedbStoreError::with_source("failed to initialize root table", error)
+            })?;
+            let _hints = transaction.open_table(HINTS).map_err(|error| {
+                RedbStoreError::with_source("failed to initialize hint table", error)
+            })?;
+        }
+        transaction.commit().map_err(|error| {
+            RedbStoreError::with_source("failed to commit table initialization", error)
+        })
+    }
+
+    fn begin_write(&self, context: &str) -> Result<WriteTransaction, RedbStoreError> {
+        let mut transaction = self
+            .db
+            .begin_write()
+            .map_err(|error| RedbStoreError::with_source(context, error))?;
+        transaction
+            .set_durability(self.durability)
+            .map_err(|error| {
+                RedbStoreError::with_source("failed to configure transaction durability", error)
+            })?;
+        Ok(transaction)
+    }
+
+    fn read_nodes_ordered(&self, keys: &[&[u8]]) -> Result<Vec<Option<Vec<u8>>>, RedbStoreError> {
+        let transaction = self.db.begin_read().map_err(|error| {
+            RedbStoreError::with_source("failed to begin node read transaction", error)
+        })?;
+        let table = transaction.open_table(NODES).map_err(|error| {
+            RedbStoreError::with_source("failed to open node table for reading", error)
+        })?;
+        keys.iter()
+            .map(|key| {
+                table
+                    .get(*key)
+                    .map(|value| value.map(|guard| guard.value().to_vec()))
+                    .map_err(|error| RedbStoreError::with_source("failed to read node", error))
+            })
+            .collect()
+    }
+}
+
+impl Store for RedbStore {
+    type Error = RedbStoreError;
+
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        let transaction = self.db.begin_read().map_err(|error| {
+            RedbStoreError::with_source("failed to begin node read transaction", error)
+        })?;
+        let table = transaction.open_table(NODES).map_err(|error| {
+            RedbStoreError::with_source("failed to open node table for reading", error)
+        })?;
+        table
+            .get(key)
+            .map(|value| value.map(|guard| guard.value().to_vec()))
+            .map_err(|error| RedbStoreError::with_source("failed to read node", error))
+    }
+
+    fn put(&self, key: &[u8], value: &[u8]) -> Result<(), Self::Error> {
+        let transaction = self.begin_write("failed to begin node write transaction")?;
+        {
+            let mut table = transaction.open_table(NODES).map_err(|error| {
+                RedbStoreError::with_source("failed to open node table for writing", error)
+            })?;
+            table
+                .insert(key, value)
+                .map_err(|error| RedbStoreError::with_source("failed to write node", error))?;
+        }
+        transaction
+            .commit()
+            .map_err(|error| RedbStoreError::with_source("failed to commit node write", error))
+    }
+
+    fn delete(&self, key: &[u8]) -> Result<(), Self::Error> {
+        let transaction = self.begin_write("failed to begin node delete transaction")?;
+        {
+            let mut table = transaction.open_table(NODES).map_err(|error| {
+                RedbStoreError::with_source("failed to open node table for deletion", error)
+            })?;
+            table
+                .remove(key)
+                .map_err(|error| RedbStoreError::with_source("failed to delete node", error))?;
+        }
+        transaction
+            .commit()
+            .map_err(|error| RedbStoreError::with_source("failed to commit node deletion", error))
+    }
+
+    fn batch(&self, ops: &[BatchOp]) -> Result<(), Self::Error> {
+        let transaction = self.begin_write("failed to begin node batch transaction")?;
+        {
+            let mut table = transaction.open_table(NODES).map_err(|error| {
+                RedbStoreError::with_source("failed to open node table for batch", error)
+            })?;
+            for op in ops {
+                match op {
+                    BatchOp::Upsert { key, value } => {
+                        table.insert(*key, *value).map_err(|error| {
+                            RedbStoreError::with_source("failed to write node in batch", error)
+                        })?;
+                    }
+                    BatchOp::Delete { key } => {
+                        table.remove(*key).map_err(|error| {
+                            RedbStoreError::with_source("failed to delete node in batch", error)
+                        })?;
+                    }
+                }
+            }
+        }
+        transaction
+            .commit()
+            .map_err(|error| RedbStoreError::with_source("failed to commit node batch", error))
+    }
+
+    fn batch_get(&self, keys: &[&[u8]]) -> Result<HashMap<Vec<u8>, Vec<u8>>, Self::Error> {
+        let values = self.read_nodes_ordered(keys)?;
+        Ok(keys
+            .iter()
+            .zip(values)
+            .filter_map(|(key, value)| value.map(|value| (key.to_vec(), value)))
+            .collect())
+    }
+
+    fn batch_get_ordered(&self, keys: &[&[u8]]) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
+        self.read_nodes_ordered(keys)
+    }
+
+    fn batch_get_ordered_unique(
+        &self,
+        keys: &[&[u8]],
+    ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
+        self.read_nodes_ordered(keys)
+    }
+
+    fn prefers_batch_reads(&self) -> bool {
+        true
+    }
+
+    fn batch_put(&self, entries: &[(&[u8], &[u8])]) -> Result<(), Self::Error> {
+        let transaction = self.begin_write("failed to begin node batch-put transaction")?;
+        {
+            let mut table = transaction.open_table(NODES).map_err(|error| {
+                RedbStoreError::with_source("failed to open node table for batch put", error)
+            })?;
+            for (key, value) in entries {
+                table.insert(*key, *value).map_err(|error| {
+                    RedbStoreError::with_source("failed to write node in batch put", error)
+                })?;
+            }
+        }
+        transaction
+            .commit()
+            .map_err(|error| RedbStoreError::with_source("failed to commit node batch put", error))
+    }
+
+    fn supports_hints(&self) -> bool {
+        true
+    }
+
+    fn get_hint(&self, namespace: &[u8], key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        let transaction = self.db.begin_read().map_err(|error| {
+            RedbStoreError::with_source("failed to begin hint read transaction", error)
+        })?;
+        let table = transaction.open_table(HINTS).map_err(|error| {
+            RedbStoreError::with_source("failed to open hint table for reading", error)
+        })?;
+        table
+            .get((namespace, key))
+            .map(|value| value.map(|guard| guard.value().to_vec()))
+            .map_err(|error| RedbStoreError::with_source("failed to read hint", error))
+    }
+
+    fn put_hint(&self, namespace: &[u8], key: &[u8], value: &[u8]) -> Result<(), Self::Error> {
+        let transaction = self.begin_write("failed to begin hint write transaction")?;
+        {
+            let mut table = transaction.open_table(HINTS).map_err(|error| {
+                RedbStoreError::with_source("failed to open hint table for writing", error)
+            })?;
+            table
+                .insert((namespace, key), value)
+                .map_err(|error| RedbStoreError::with_source("failed to write hint", error))?;
+        }
+        transaction
+            .commit()
+            .map_err(|error| RedbStoreError::with_source("failed to commit hint write", error))
+    }
+
+    fn batch_put_with_hint(
+        &self,
+        entries: &[(&[u8], &[u8])],
+        namespace: &[u8],
+        key: &[u8],
+        value: &[u8],
+    ) -> Result<(), Self::Error> {
+        let transaction = self.begin_write("failed to begin node and hint transaction")?;
+        {
+            let mut nodes = transaction.open_table(NODES).map_err(|error| {
+                RedbStoreError::with_source("failed to open node table for publication", error)
+            })?;
+            let mut hints = transaction.open_table(HINTS).map_err(|error| {
+                RedbStoreError::with_source("failed to open hint table for publication", error)
+            })?;
+            for (node_key, node_value) in entries {
+                nodes.insert(*node_key, *node_value).map_err(|error| {
+                    RedbStoreError::with_source("failed to publish node", error)
+                })?;
+            }
+            hints
+                .insert((namespace, key), value)
+                .map_err(|error| RedbStoreError::with_source("failed to publish hint", error))?;
+        }
+        transaction.commit().map_err(|error| {
+            RedbStoreError::with_source("failed to commit node and hint publication", error)
+        })
+    }
+}
+
+impl NodeStoreScan for RedbStore {
+    type Error = RedbStoreError;
+
+    fn list_node_cids(&self) -> Result<Vec<Cid>, Self::Error> {
+        let transaction = self.db.begin_read().map_err(|error| {
+            RedbStoreError::with_source("failed to begin node scan transaction", error)
+        })?;
+        let table = transaction.open_table(NODES).map_err(|error| {
+            RedbStoreError::with_source("failed to open node table for scanning", error)
+        })?;
+        let iterator = table
+            .iter()
+            .map_err(|error| RedbStoreError::with_source("failed to iterate node table", error))?;
+        let mut cids = Vec::new();
+        for entry in iterator {
+            let (key, _) = entry.map_err(|error| {
+                RedbStoreError::with_source("failed to read node scan entry", error)
+            })?;
+            let raw = key.value();
+            let bytes: [u8; 32] = raw.try_into().map_err(|_| {
+                RedbStoreError::message(format!(
+                    "node key has invalid CID length {}, expected 32",
+                    raw.len()
+                ))
+            })?;
+            cids.push(Cid(bytes));
+        }
+        cids.sort_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
+        Ok(cids)
+    }
+}
+
+impl ManifestStore for RedbStore {
+    type Error = RedbStoreError;
+
+    fn get_root(&self, name: &[u8]) -> Result<Option<RootManifest>, Self::Error> {
+        let transaction = self.db.begin_read().map_err(|error| {
+            RedbStoreError::with_source("failed to begin root read transaction", error)
+        })?;
+        let table = transaction.open_table(ROOTS).map_err(|error| {
+            RedbStoreError::with_source("failed to open root table for reading", error)
+        })?;
+        let value = table
+            .get(name)
+            .map_err(|error| RedbStoreError::with_source("failed to read root manifest", error))?;
+        value
+            .map(|guard| decode_root_manifest(guard.value()))
+            .transpose()
+    }
+
+    fn put_root(&self, name: &[u8], manifest: &RootManifest) -> Result<(), Self::Error> {
+        let bytes = encode_root_manifest(manifest)?;
+        let transaction = self.begin_write("failed to begin root write transaction")?;
+        {
+            let mut table = transaction.open_table(ROOTS).map_err(|error| {
+                RedbStoreError::with_source("failed to open root table for writing", error)
+            })?;
+            table.insert(name, bytes.as_slice()).map_err(|error| {
+                RedbStoreError::with_source("failed to write root manifest", error)
+            })?;
+        }
+        transaction
+            .commit()
+            .map_err(|error| RedbStoreError::with_source("failed to commit root write", error))
+    }
+
+    fn delete_root(&self, name: &[u8]) -> Result<(), Self::Error> {
+        let transaction = self.begin_write("failed to begin root delete transaction")?;
+        {
+            let mut table = transaction.open_table(ROOTS).map_err(|error| {
+                RedbStoreError::with_source("failed to open root table for deletion", error)
+            })?;
+            table.remove(name).map_err(|error| {
+                RedbStoreError::with_source("failed to delete root manifest", error)
+            })?;
+        }
+        transaction
+            .commit()
+            .map_err(|error| RedbStoreError::with_source("failed to commit root deletion", error))
+    }
+
+    fn compare_and_swap_root(
+        &self,
+        name: &[u8],
+        expected: Option<&RootManifest>,
+        new: Option<&RootManifest>,
+    ) -> Result<ManifestUpdate, Self::Error> {
+        let new_bytes = new.map(encode_root_manifest).transpose()?;
+        let transaction = self.begin_write("failed to begin root CAS transaction")?;
+        {
+            let mut table = transaction.open_table(ROOTS).map_err(|error| {
+                RedbStoreError::with_source("failed to open root table for CAS", error)
+            })?;
+            let current = {
+                let value = table.get(name).map_err(|error| {
+                    RedbStoreError::with_source("failed to read root during CAS", error)
+                })?;
+                value
+                    .map(|guard| decode_root_manifest(guard.value()))
+                    .transpose()?
+            };
+            if current.as_ref() != expected {
+                return Ok(ManifestUpdate::Conflict { current });
+            }
+            match new_bytes.as_deref() {
+                Some(bytes) => {
+                    table.insert(name, bytes).map_err(|error| {
+                        RedbStoreError::with_source("failed to write root during CAS", error)
+                    })?;
+                }
+                None => {
+                    table.remove(name).map_err(|error| {
+                        RedbStoreError::with_source("failed to delete root during CAS", error)
+                    })?;
+                }
+            }
+        }
+        transaction
+            .commit()
+            .map_err(|error| RedbStoreError::with_source("failed to commit root CAS", error))?;
+        Ok(ManifestUpdate::Applied)
+    }
+}
+
+impl ManifestStoreScan for RedbStore {
+    fn list_roots(&self) -> Result<Vec<NamedRootManifest>, Self::Error> {
+        let transaction = self.db.begin_read().map_err(|error| {
+            RedbStoreError::with_source("failed to begin root scan transaction", error)
+        })?;
+        let table = transaction.open_table(ROOTS).map_err(|error| {
+            RedbStoreError::with_source("failed to open root table for scanning", error)
+        })?;
+        let iterator = table
+            .iter()
+            .map_err(|error| RedbStoreError::with_source("failed to iterate root table", error))?;
+        let mut roots = Vec::new();
+        for entry in iterator {
+            let (name, manifest) = entry.map_err(|error| {
+                RedbStoreError::with_source("failed to read root scan entry", error)
+            })?;
+            roots.push(NamedRootManifest::new(
+                name.value().to_vec(),
+                decode_root_manifest(manifest.value())?,
+            ));
+        }
+        roots.sort_by(|left, right| left.name.cmp(&right.name));
+        Ok(roots)
+    }
+}
+
+impl TransactionalStore for RedbStore {
+    fn supports_transactions(&self) -> bool {
+        true
+    }
+
+    fn commit_transaction(
+        &self,
+        node_writes: &[TransactionNodeWrite],
+        root_conditions: &[RootCondition],
+        root_writes: &[RootWrite],
+    ) -> Result<TransactionUpdate, Error> {
+        let transaction = self
+            .begin_write("failed to begin strict transaction")
+            .map_err(store_error)?;
+        {
+            let mut nodes = transaction.open_table(NODES).map_err(|error| {
+                store_error(RedbStoreError::with_source(
+                    "failed to open node table for strict transaction",
+                    error,
+                ))
+            })?;
+            let mut roots = transaction.open_table(ROOTS).map_err(|error| {
+                store_error(RedbStoreError::with_source(
+                    "failed to open root table for strict transaction",
+                    error,
+                ))
+            })?;
+
+            for condition in root_conditions {
+                let current = {
+                    let value = roots.get(condition.name.as_slice()).map_err(|error| {
+                        store_error(RedbStoreError::with_source(
+                            "failed to read root condition",
+                            error,
+                        ))
+                    })?;
+                    value
+                        .map(|guard| decode_root_manifest(guard.value()))
+                        .transpose()
+                        .map_err(store_error)?
+                };
+                if current != condition.expected {
+                    return Ok(TransactionUpdate::Conflict(Box::new(
+                        TransactionConflict::new(
+                            condition.name.clone(),
+                            condition.expected.clone(),
+                            current,
+                        ),
+                    )));
+                }
+            }
+
+            for write in node_writes {
+                match write {
+                    TransactionNodeWrite::Upsert { key, value } => {
+                        nodes
+                            .insert(key.as_slice(), value.as_slice())
+                            .map_err(|error| {
+                                store_error(RedbStoreError::with_source(
+                                    "failed to write node in strict transaction",
+                                    error,
+                                ))
+                            })?;
+                    }
+                    TransactionNodeWrite::Delete { key } => {
+                        nodes.remove(key.as_slice()).map_err(|error| {
+                            store_error(RedbStoreError::with_source(
+                                "failed to delete node in strict transaction",
+                                error,
+                            ))
+                        })?;
+                    }
+                }
+            }
+
+            for write in root_writes {
+                match write {
+                    RootWrite::Put { name, manifest } => {
+                        let bytes = encode_root_manifest(manifest).map_err(store_error)?;
+                        roots
+                            .insert(name.as_slice(), bytes.as_slice())
+                            .map_err(|error| {
+                                store_error(RedbStoreError::with_source(
+                                    "failed to write root in strict transaction",
+                                    error,
+                                ))
+                            })?;
+                    }
+                    RootWrite::Delete { name } => {
+                        roots.remove(name.as_slice()).map_err(|error| {
+                            store_error(RedbStoreError::with_source(
+                                "failed to delete root in strict transaction",
+                                error,
+                            ))
+                        })?;
+                    }
+                }
+            }
+        }
+        transaction.commit().map_err(|error| {
+            store_error(RedbStoreError::with_source(
+                "failed to commit strict transaction",
+                error,
+            ))
+        })?;
+        Ok(TransactionUpdate::Applied {
+            nodes_written: node_writes.len(),
+            roots_written: root_writes.len(),
+        })
+    }
+}
+
+fn encode_root_manifest(manifest: &RootManifest) -> Result<Vec<u8>, RedbStoreError> {
+    manifest
+        .to_bytes()
+        .map_err(|error| RedbStoreError::with_source("failed to encode root manifest", error))
+}
+
+fn decode_root_manifest(bytes: &[u8]) -> Result<RootManifest, RedbStoreError> {
+    RootManifest::from_bytes(bytes)
+        .map_err(|error| RedbStoreError::with_source("failed to decode root manifest", error))
+}
+
+fn store_error(error: RedbStoreError) -> Error {
+    Error::Store(Box::new(error))
+}

--- a/stores/prolly-store-redb/tests/redb_store.rs
+++ b/stores/prolly-store-redb/tests/redb_store.rs
@@ -1,0 +1,282 @@
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Barrier};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use prolly::{
+    Cid, Config, ManifestStore, ManifestUpdate, NodePublication, NodePublicationHint,
+    NodeStoreScan, Prolly, PublicationOrigin, RootCondition, RootManifest, RootWrite, Store,
+    TransactionNodeWrite, TransactionUpdate, TransactionalStore,
+};
+use prolly_store_redb::{Durability, RedbStore, RedbStoreConfig};
+
+#[test]
+fn redb_store_satisfies_store_contract() {
+    with_store("store-contract", |store| {
+        prolly_store_test::assert_store_contract(store);
+    });
+}
+
+#[test]
+fn redb_store_satisfies_manifest_store_contract() {
+    with_store("manifest-contract", |store| {
+        prolly_store_test::assert_manifest_store_contract(store);
+    });
+}
+
+#[test]
+fn redb_store_satisfies_node_store_scan_contract() {
+    let path = temp_db_path("scan-contract");
+    remove_db(&path);
+    prolly_store_test::assert_node_store_scan_contract(RedbStore::open(&path).unwrap());
+    remove_db(&path);
+}
+
+#[test]
+fn redb_store_supports_strict_indexed_maps() {
+    let path = temp_db_path("indexed-map");
+    remove_db(&path);
+    prolly_store_test::assert_indexed_map_contract(RedbStore::open(&path).unwrap());
+    remove_db(&path);
+}
+
+#[test]
+fn redb_store_persists_named_root_across_reopen() {
+    let path = temp_db_path("root-reopen");
+    remove_db(&path);
+    let config = Config::builder()
+        .min_chunk_size(2)
+        .max_chunk_size(4)
+        .chunking_factor(2)
+        .build();
+
+    let tree = {
+        let prolly = Prolly::new(RedbStore::open(&path).unwrap(), config.clone());
+        let tree = prolly
+            .put(
+                &prolly.create(),
+                b"project/name".to_vec(),
+                b"CrabDB".to_vec(),
+            )
+            .unwrap();
+        prolly.publish_named_root(b"main", &tree).unwrap();
+        tree
+    };
+
+    {
+        let prolly = Prolly::new(RedbStore::open(&path).unwrap(), config);
+        let loaded = prolly.load_named_root(b"main").unwrap().unwrap();
+        assert_eq!(loaded, tree);
+        assert_eq!(
+            prolly.get(&loaded, b"project/name").unwrap(),
+            Some(b"CrabDB".to_vec())
+        );
+    }
+    remove_db(&path);
+}
+
+#[test]
+fn redb_store_persists_distinct_composite_hints() {
+    let path = temp_db_path("hints");
+    remove_db(&path);
+    {
+        let store = RedbStore::open(&path).unwrap();
+        assert!(store.supports_hints());
+        assert!(!store.prefers_rightmost_path_hints());
+        store.put_hint(b"a", b"bc", b"first").unwrap();
+        store.put_hint(b"ab", b"c", b"second").unwrap();
+    }
+    {
+        let store = RedbStore::open(&path).unwrap();
+        assert_eq!(
+            store.get_hint(b"a", b"bc").unwrap(),
+            Some(b"first".to_vec())
+        );
+        assert_eq!(
+            store.get_hint(b"ab", b"c").unwrap(),
+            Some(b"second".to_vec())
+        );
+    }
+    remove_db(&path);
+}
+
+#[test]
+fn redb_store_publishes_nodes_and_hint_together() {
+    with_store("publication", |store| {
+        let node = b"published-node";
+        let cid = Cid::from_bytes(node);
+        let entries = [(cid.as_bytes(), node.as_slice())];
+        store
+            .publish_nodes(NodePublication::with_hint(
+                &entries,
+                NodePublicationHint::new(b"tree", b"rightmost", b"path"),
+                PublicationOrigin::PointUpsert,
+            ))
+            .unwrap();
+        assert_eq!(store.get(cid.as_bytes()).unwrap(), Some(node.to_vec()));
+        assert_eq!(
+            store.get_hint(b"tree", b"rightmost").unwrap(),
+            Some(b"path".to_vec())
+        );
+    });
+}
+
+#[test]
+fn redb_store_accepts_custom_cache_and_durability() {
+    let path = temp_db_path("configured");
+    remove_db(&path);
+    let store = RedbStore::open_with_config(
+        &path,
+        RedbStoreConfig {
+            cache_size_bytes: 8 * 1024 * 1024,
+            durability: Durability::None,
+        },
+    )
+    .unwrap();
+    store.put(b"configured", b"value").unwrap();
+    assert_eq!(store.get(b"configured").unwrap(), Some(b"value".to_vec()));
+    drop(store);
+    remove_db(&path);
+}
+
+#[test]
+fn redb_store_serializes_competing_root_cas() {
+    let path = temp_db_path("concurrent-cas");
+    remove_db(&path);
+    let store = Arc::new(RedbStore::open(&path).unwrap());
+    let barrier = Arc::new(Barrier::new(3));
+    let first = RootManifest::new(Some(Cid::from_bytes(b"first")), Config::default());
+    let second = RootManifest::new(Some(Cid::from_bytes(b"second")), Config::default());
+
+    let handles = [first.clone(), second.clone()].map(|manifest| {
+        let store = Arc::clone(&store);
+        let barrier = Arc::clone(&barrier);
+        std::thread::spawn(move || {
+            barrier.wait();
+            store
+                .compare_and_swap_root(b"main", None, Some(&manifest))
+                .unwrap()
+        })
+    });
+    barrier.wait();
+    let results = handles.map(|handle| handle.join().unwrap());
+
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| matches!(result, ManifestUpdate::Applied))
+            .count(),
+        1
+    );
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| matches!(result, ManifestUpdate::Conflict { .. }))
+            .count(),
+        1
+    );
+    assert!(matches!(
+        store.get_root(b"main").unwrap(),
+        Some(current) if current == first || current == second
+    ));
+    drop(store);
+    remove_db(&path);
+}
+
+#[test]
+fn redb_store_conflict_aborts_all_staged_writes() {
+    with_store("transaction-conflict", |store| {
+        let current = RootManifest::new(Some(Cid::from_bytes(b"current")), Config::default());
+        let stale = RootManifest::new(Some(Cid::from_bytes(b"stale")), Config::default());
+        let replacement =
+            RootManifest::new(Some(Cid::from_bytes(b"replacement")), Config::default());
+        store.put_root(b"main", &current).unwrap();
+
+        let update = store
+            .commit_transaction(
+                &[TransactionNodeWrite::Upsert {
+                    key: b"uncommitted-node".to_vec(),
+                    value: b"uncommitted-value".to_vec(),
+                }],
+                &[RootCondition::new(b"main".to_vec(), Some(stale))],
+                &[RootWrite::Put {
+                    name: b"main".to_vec(),
+                    manifest: replacement,
+                }],
+            )
+            .unwrap();
+
+        assert!(matches!(update, TransactionUpdate::Conflict(_)));
+        assert_eq!(store.get(b"uncommitted-node").unwrap(), None);
+        assert_eq!(store.get_root(b"main").unwrap(), Some(current));
+    });
+}
+
+#[test]
+fn redb_store_commits_nodes_and_roots_atomically() {
+    with_store("transaction-success", |store| {
+        let manifest = RootManifest::new(
+            Some(Cid::from_bytes(b"transaction-root")),
+            Config::default(),
+        );
+        let update = store
+            .commit_transaction(
+                &[TransactionNodeWrite::Upsert {
+                    key: b"transaction-node".to_vec(),
+                    value: b"transaction-value".to_vec(),
+                }],
+                &[RootCondition::new(b"main".to_vec(), None)],
+                &[RootWrite::Put {
+                    name: b"main".to_vec(),
+                    manifest: manifest.clone(),
+                }],
+            )
+            .unwrap();
+
+        assert_eq!(
+            update,
+            TransactionUpdate::Applied {
+                nodes_written: 1,
+                roots_written: 1,
+            }
+        );
+        assert_eq!(
+            store.get(b"transaction-node").unwrap(),
+            Some(b"transaction-value".to_vec())
+        );
+        assert_eq!(store.get_root(b"main").unwrap(), Some(manifest));
+    });
+}
+
+#[test]
+fn redb_store_rejects_malformed_node_keys_during_scan() {
+    with_store("malformed-node-key", |store| {
+        store.put(b"not-a-cid", b"value").unwrap();
+        let error = store.list_node_cids().unwrap_err();
+        assert!(error.to_string().contains("invalid CID length"));
+    });
+}
+
+fn with_store(label: &str, test: impl FnOnce(&RedbStore)) {
+    let path = temp_db_path(label);
+    remove_db(&path);
+    {
+        let store = RedbStore::open(&path).unwrap();
+        test(&store);
+    }
+    remove_db(&path);
+}
+
+fn temp_db_path(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "prolly-redb-{label}-{}-{nanos}.redb",
+        std::process::id()
+    ))
+}
+
+fn remove_db(path: &Path) {
+    let _ = std::fs::remove_file(path);
+}


### PR DESCRIPTION
## Summary

- add a pure-Rust `prolly-store-redb` adapter backed by redb 4.1
- implement node storage, named roots, deterministic scans, advisory hints, CAS, and strict atomic transactions
- optimize prolly-node storage with CID-sorted publication, transparent configurable LZ4 encoding, retained native shared reads, and explicit compaction
- preserve adapter 0.3.0 database compatibility through legacy-table fallback and bump the pending crate to 0.3.1
- keep `RedbStoreConfig` source-compatible and add `RedbStoreOptions` for decoded-cache and compression tuning

## User impact

Applications get a synchronous, single-file embedded backend without a native C/C++ dependency. The adapter requires Rust 1.89 because redb 4.1 sets that compiler floor. Existing 0.3.0 files reopen transparently; updated nodes migrate to the versioned encoded table.

## 1M-record verification

Release build on Apple M2 Max, redb `Durability::Immediate`, 3-run medians, 192 MiB total adapter budget:

| profile | build records/s | random reads/s | full scan records/s | scattered updates/s | build bytes | updated bytes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| redb compressed, write-tuned | 2.41M | 124k | 7.40M | 38.2k | 33,689,600 | 67,375,104 |
| redb uncompressed, write-tuned | 2.16M | 124k | 7.56M | 51.1k | 67,375,104 | 134,746,112 |
| SQLite compressed baseline | 3.80M | 125k | 8.54M | 65.6k | 14,548,992 | 26,345,472 |

Compared with the original redb adapter, default compression improved build throughput from 1.83M to 2.41M records/s and halved both measured file sizes. The uncompressed latency profile still improved build throughput by about 18% and scattered-update throughput by about 14%. Explicit compaction reduced the compressed post-update file from 67,375,104 to 36,859,904 bytes in 93 ms. All roots, counts, reads, scan checksums, and update probes matched.

## Validation

- Rust 1.89: 17 integration tests and 3 doctests
- current stable: clippy with warnings denied
- rustdoc with warnings denied
- format and diff checks
- packaged 0.3.1 source verified against crates.io dependencies
