### PR TITLE
perf: optimize redb prolly node storage

### DIFF
--- a/stores/prolly-store-redb/Cargo.toml
+++ b/stores/prolly-store-redb/Cargo.toml
@@ -3,7 +3,7 @@ name = "prolly-store-redb"
 description = "redb store adapter for prolly-map."
 edition = "2021"
 rust-version = "1.89"
-version = "0.3.0"
+version = "0.3.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crabbuild/prolly"
 homepage = "https://github.com/crabbuild/prolly"
@@ -17,6 +17,9 @@ name = "prolly_store_redb"
 path = "src/lib.rs"
 
 [dependencies]
+ahash = "0.8.12"
+lz4_flex = "0.11.5"
+parking_lot = "0.12.4"
 prolly = { package = "prolly-map", path = "../..", version = "0.5.0" }
 redb = "4.1.0"
 

--- a/stores/prolly-store-redb/README.md
+++ b/stores/prolly-store-redb/README.md
@@ -4,6 +4,8 @@ Pure-Rust [`redb`](https://crates.io/crates/redb) storage adapter for
 [`prolly-map`](https://crates.io/crates/prolly-map). It provides a persistent,
 synchronous, single-file backend with atomic write batches, named-root
 compare-and-swap, deterministic scans, advisory hints, and strict transactions.
+Large nodes are transparently LZ4-compressed, immutable publications are ordered
+for redb's B-tree, and decoded nodes support retained shared reads.
 
 ## Requirements and installation
 
@@ -52,7 +54,8 @@ named roots in a later process.
 
 `RedbStoreConfig` controls redb's page cache and transaction durability. The
 defaults are a 1 GiB cache and `Durability::Immediate`, which guarantees that a
-successful commit is persistent when it returns.
+successful commit is persistent when it returns. Existing `RedbStoreConfig`
+struct literals remain compatible with adapter 0.3.1.
 
 ```rust,no_run
 use prolly_store_redb::{Durability, RedbStore, RedbStoreConfig};
@@ -73,11 +76,41 @@ crash is acceptable. It does not weaken transaction atomicity or consistency,
 but such commits are not guaranteed to reach disk until a later immediate
 commit.
 
+Use `RedbStoreOptions` when tuning the decoded-node read cache separately from
+redb's encoded page cache:
+
+```rust,no_run
+use prolly_store_redb::{Durability, RedbStore, RedbStoreConfig, RedbStoreOptions};
+
+let store = RedbStore::open_with_options(
+    "./data/app.prolly.redb",
+    RedbStoreOptions {
+        database: RedbStoreConfig {
+            cache_size_bytes: 64 * 1024 * 1024,
+            durability: Durability::Immediate,
+        },
+        node_read_cache_size_bytes: 128 * 1024 * 1024,
+        compress_nodes: true,
+    },
+)?;
+# drop(store);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Set `node_read_cache_size_bytes` to zero to disable decoded-node retention.
+The page-cache and node-cache limits are separate memory budgets. Compression
+is enabled by default; update-heavy workloads can set `compress_nodes` to
+`false` when write latency matters more than file size.
+
 ## Storage model
 
-The adapter creates three typed tables inside one redb file:
+The adapter creates four typed tables inside one redb file:
 
-- `prolly_nodes` stores content-addressed node bytes by CID.
+- `prolly_nodes_v2` stores content-addressed nodes with an explicit raw or LZ4
+  encoding. Nodes smaller than 8 KiB and nodes that do not compress smaller are
+  stored raw.
+- `prolly_nodes` is the legacy raw-node table retained for transparent reads of
+  databases created by adapter 0.3.0. New and updated nodes move to the v2 table.
 - `prolly_roots` stores encoded named-root manifests.
 - `prolly_hints` stores advisory values by `(namespace, key)`.
 
@@ -102,6 +135,14 @@ writable database handle for the same file.
 The adapter persists hints but does not advertise a preference for rightmost-
 path hints. That preference is workload-dependent and should be enabled only
 after measurement.
+
+## Compaction
+
+Deleting or replacing data makes pages reusable but does not necessarily shrink
+the file immediately. Call `RedbStore::compact(&mut self)` during an explicit
+maintenance window to let redb relocate live pages and truncate reclaimable
+space. Compaction preserves nodes, roots, and hints, requires exclusive mutable
+access to the store, and may perform substantial I/O.
 
 ## Testing
 

--- a/stores/prolly-store-redb/src/lib.rs
+++ b/stores/prolly-store-redb/src/lib.rs
@@ -1,10 +1,16 @@
 #![doc = include_str!("../README.md")]
 
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 use std::error::Error as StdError;
 use std::path::Path;
+use std::sync::Arc;
 
-use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition, WriteTransaction};
+use ahash::AHashMap;
+use parking_lot::Mutex;
+use redb::{
+    Database, ReadableDatabase, ReadableTable, ReadableTableMetadata, TableDefinition,
+    WriteTransaction,
+};
 
 use prolly::{
     BatchOp, Cid, Error, ManifestStore, ManifestStoreScan, ManifestUpdate, NamedRootManifest,
@@ -14,9 +20,15 @@ use prolly::{
 
 pub use redb::Durability;
 
-const NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes");
+const LEGACY_NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes");
+const NODES: TableDefinition<&[u8], (u8, &[u8])> = TableDefinition::new("prolly_nodes_v2");
 const ROOTS: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_roots");
 const HINTS: TableDefinition<(&[u8], &[u8]), &[u8]> = TableDefinition::new("prolly_hints");
+
+const NODE_ENCODING_RAW: u8 = 0;
+const NODE_ENCODING_LZ4: u8 = 1;
+const MIN_COMPRESSIBLE_NODE_BYTES: usize = 8 * 1024;
+const DEFAULT_NODE_READ_CACHE_SIZE_BYTES: usize = 128 * 1024 * 1024;
 
 /// Configuration for [`RedbStore`].
 #[derive(Debug, Clone, Copy)]
@@ -32,6 +44,128 @@ impl Default for RedbStoreConfig {
         Self {
             cache_size_bytes: 1024 * 1024 * 1024,
             durability: Durability::Immediate,
+        }
+    }
+}
+
+/// Extended adapter options that preserve [`RedbStoreConfig`] compatibility.
+///
+/// Redb's page cache stores encoded database pages, while the node read cache
+/// retains decoded immutable prolly nodes. Their memory budgets are separate.
+#[derive(Debug, Clone, Copy)]
+pub struct RedbStoreOptions {
+    /// Redb database configuration.
+    pub database: RedbStoreConfig,
+    /// Maximum decoded node bytes retained for native shared reads.
+    ///
+    /// Set this to zero to disable retention without changing read semantics.
+    pub node_read_cache_size_bytes: usize,
+    /// Transparently LZ4-compress large nodes when it reduces their size.
+    pub compress_nodes: bool,
+}
+
+impl Default for RedbStoreOptions {
+    fn default() -> Self {
+        Self {
+            database: RedbStoreConfig::default(),
+            node_read_cache_size_bytes: DEFAULT_NODE_READ_CACHE_SIZE_BYTES,
+            compress_nodes: true,
+        }
+    }
+}
+
+struct NodeReadCache {
+    values: AHashMap<Vec<u8>, Arc<[u8]>>,
+    retained_bytes: usize,
+    max_bytes: usize,
+    generation: u64,
+}
+
+impl NodeReadCache {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            values: AHashMap::new(),
+            retained_bytes: 0,
+            max_bytes,
+            generation: 0,
+        }
+    }
+
+    fn get(&self, key: &[u8]) -> Option<Arc<[u8]>> {
+        self.values.get(key).cloned()
+    }
+
+    fn insert(&mut self, key: &[u8], value: Arc<[u8]>) {
+        if self.max_bytes == 0 || value.len() > self.max_bytes {
+            return;
+        }
+        if let Some(previous) = self.values.remove(key) {
+            self.retained_bytes = self.retained_bytes.saturating_sub(previous.len());
+        }
+        if self.retained_bytes.saturating_add(value.len()) > self.max_bytes {
+            self.values.clear();
+            self.retained_bytes = 0;
+        }
+        self.retained_bytes = self.retained_bytes.saturating_add(value.len());
+        self.values.insert(key.to_vec(), value);
+    }
+
+    fn remove(&mut self, key: &[u8]) {
+        if let Some(value) = self.values.remove(key) {
+            self.retained_bytes = self.retained_bytes.saturating_sub(value.len());
+        }
+    }
+
+    fn invalidate<'a>(&mut self, keys: impl IntoIterator<Item = &'a [u8]>) {
+        self.generation = self.generation.wrapping_add(1);
+        for key in keys {
+            self.remove(key);
+        }
+    }
+}
+
+struct OrderedBatchReadPlan<'a> {
+    unique_keys: Vec<&'a [u8]>,
+    positions: Option<Vec<usize>>,
+}
+
+impl<'a> OrderedBatchReadPlan<'a> {
+    fn new(keys: &[&'a [u8]]) -> Self {
+        let mut unique_indexes = HashMap::with_capacity(keys.len());
+        let mut unique_keys = Vec::with_capacity(keys.len());
+        let mut positions = None;
+        for key in keys {
+            match unique_indexes.entry(*key) {
+                Entry::Occupied(entry) => positions
+                    .get_or_insert_with(|| (0..unique_keys.len()).collect::<Vec<_>>())
+                    .push(*entry.get()),
+                Entry::Vacant(entry) => {
+                    let index = unique_keys.len();
+                    unique_keys.push(*key);
+                    if let Some(positions) = positions.as_mut() {
+                        positions.push(index);
+                    }
+                    entry.insert(index);
+                }
+            }
+        }
+        Self {
+            unique_keys,
+            positions,
+        }
+    }
+
+    fn unique_keys(&self) -> &[&'a [u8]] {
+        &self.unique_keys
+    }
+
+    fn expand<T: Clone>(&self, values: Vec<Option<T>>) -> Vec<Option<T>> {
+        match &self.positions {
+            Some(positions) => positions
+                .iter()
+                .map(|&index| values[index].clone())
+                .collect(),
+            None => values,
         }
     }
 }
@@ -85,6 +219,8 @@ impl StdError for RedbStoreError {
 pub struct RedbStore {
     db: Database,
     durability: Durability,
+    node_read_cache: Mutex<NodeReadCache>,
+    compress_nodes: bool,
 }
 
 impl std::fmt::Debug for RedbStore {
@@ -92,6 +228,11 @@ impl std::fmt::Debug for RedbStore {
         formatter
             .debug_struct("RedbStore")
             .field("durability", &self.durability)
+            .field(
+                "node_read_cache_size_bytes",
+                &self.node_read_cache.lock().max_bytes,
+            )
+            .field("compress_nodes", &self.compress_nodes)
             .finish_non_exhaustive()
     }
 }
@@ -107,8 +248,22 @@ impl RedbStore {
         path: impl AsRef<Path>,
         config: RedbStoreConfig,
     ) -> Result<Self, RedbStoreError> {
+        Self::open_with_options(
+            path,
+            RedbStoreOptions {
+                database: config,
+                ..RedbStoreOptions::default()
+            },
+        )
+    }
+
+    /// Open an existing database or create one with database and adapter tuning.
+    pub fn open_with_options(
+        path: impl AsRef<Path>,
+        options: RedbStoreOptions,
+    ) -> Result<Self, RedbStoreError> {
         let mut builder = Database::builder();
-        builder.set_cache_size(config.cache_size_bytes);
+        builder.set_cache_size(options.database.cache_size_bytes);
         let db = builder.create(path.as_ref()).map_err(|error| {
             RedbStoreError::with_source(
                 format!("failed to open database at {:?}", path.as_ref()),
@@ -117,15 +272,31 @@ impl RedbStore {
         })?;
         let store = Self {
             db,
-            durability: config.durability,
+            durability: options.database.durability,
+            node_read_cache: Mutex::new(NodeReadCache::new(options.node_read_cache_size_bytes)),
+            compress_nodes: options.compress_nodes,
         };
         store.initialize_tables()?;
         Ok(store)
     }
 
+    /// Reclaim free pages and compact the database file where possible.
+    ///
+    /// Returns `true` when redb performed compaction and `false` when the file
+    /// cannot be compacted further. The store must be mutably borrowed so no
+    /// concurrent operation can begin while redb rewrites the file.
+    pub fn compact(&mut self) -> Result<bool, RedbStoreError> {
+        self.db
+            .compact()
+            .map_err(|error| RedbStoreError::with_source("failed to compact database", error))
+    }
+
     fn initialize_tables(&self) -> Result<(), RedbStoreError> {
         let transaction = self.begin_write("failed to begin table initialization")?;
         {
+            let _legacy_nodes = transaction.open_table(LEGACY_NODES).map_err(|error| {
+                RedbStoreError::with_source("failed to initialize legacy node table", error)
+            })?;
             let _nodes = transaction.open_table(NODES).map_err(|error| {
                 RedbStoreError::with_source("failed to initialize node table", error)
             })?;
@@ -154,21 +325,115 @@ impl RedbStore {
         Ok(transaction)
     }
 
-    fn read_nodes_ordered(&self, keys: &[&[u8]]) -> Result<Vec<Option<Vec<u8>>>, RedbStoreError> {
+    fn read_nodes_shared_ordered_unique(
+        &self,
+        keys: &[&[u8]],
+    ) -> Result<Vec<Option<Arc<[u8]>>>, RedbStoreError> {
+        loop {
+            let mut values = vec![None; keys.len()];
+            let mut missing = Vec::new();
+            let read_generation = {
+                let cache = self.node_read_cache.lock();
+                for (position, key) in keys.iter().enumerate() {
+                    match cache.get(key) {
+                        Some(value) => values[position] = Some(value),
+                        None => missing.push((position, *key)),
+                    }
+                }
+                cache.generation
+            };
+            if missing.is_empty() {
+                return Ok(values);
+            }
+
+            let transaction = self.db.begin_read().map_err(|error| {
+                RedbStoreError::with_source("failed to begin node read transaction", error)
+            })?;
+            let table = transaction.open_table(NODES).map_err(|error| {
+                RedbStoreError::with_source("failed to open node table for reading", error)
+            })?;
+            let legacy = transaction.open_table(LEGACY_NODES).map_err(|error| {
+                RedbStoreError::with_source("failed to open legacy node table for reading", error)
+            })?;
+            let mut loaded_values: Vec<Option<Arc<[u8]>>> = Vec::with_capacity(missing.len());
+            for (_, key) in &missing {
+                let value = if let Some(value) = table
+                    .get(*key)
+                    .map_err(|error| RedbStoreError::with_source("failed to read node", error))?
+                {
+                    let (encoding, bytes) = value.value();
+                    Some(Arc::from(decode_stored_node(encoding, bytes)?))
+                } else {
+                    legacy
+                        .get(*key)
+                        .map_err(|error| {
+                            RedbStoreError::with_source("failed to read legacy node", error)
+                        })?
+                        .map(|value| Arc::from(value.value()))
+                };
+                loaded_values.push(value);
+            }
+            drop(legacy);
+            drop(table);
+            drop(transaction);
+
+            let mut cache = self.node_read_cache.lock();
+            if cache.generation != read_generation {
+                continue;
+            }
+            for ((position, key), loaded) in missing.into_iter().zip(loaded_values) {
+                if let Some(loaded) = loaded {
+                    cache.insert(key, loaded.clone());
+                    values[position] = Some(loaded);
+                }
+            }
+            return Ok(values);
+        }
+    }
+
+    fn read_nodes_owned_ordered_unique_uncached(
+        &self,
+        keys: &[&[u8]],
+    ) -> Result<Vec<Option<Vec<u8>>>, RedbStoreError> {
         let transaction = self.db.begin_read().map_err(|error| {
             RedbStoreError::with_source("failed to begin node read transaction", error)
         })?;
         let table = transaction.open_table(NODES).map_err(|error| {
             RedbStoreError::with_source("failed to open node table for reading", error)
         })?;
+        let legacy = transaction.open_table(LEGACY_NODES).map_err(|error| {
+            RedbStoreError::with_source("failed to open legacy node table for reading", error)
+        })?;
         keys.iter()
             .map(|key| {
-                table
+                if let Some(value) = table
                     .get(*key)
-                    .map(|value| value.map(|guard| guard.value().to_vec()))
-                    .map_err(|error| RedbStoreError::with_source("failed to read node", error))
+                    .map_err(|error| RedbStoreError::with_source("failed to read node", error))?
+                {
+                    let (encoding, bytes) = value.value();
+                    decode_stored_node(encoding, bytes).map(Some)
+                } else {
+                    legacy
+                        .get(*key)
+                        .map(|value| value.map(|value| value.value().to_vec()))
+                        .map_err(|error| {
+                            RedbStoreError::with_source("failed to read legacy node", error)
+                        })
+                }
             })
             .collect()
+    }
+
+    fn node_read_cache_enabled(&self) -> bool {
+        self.node_read_cache.lock().max_bytes != 0
+    }
+
+    fn invalidate_node(&self, key: &[u8]) {
+        self.node_read_cache.lock().invalidate([key]);
+    }
+
+    fn invalidate_nodes<'a>(&self, keys: impl IntoIterator<Item = &'a [u8]>) {
+        self.node_read_cache.lock().invalidate(keys);
     }
 }
 
@@ -176,16 +441,44 @@ impl Store for RedbStore {
     type Error = RedbStoreError;
 
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
-        let transaction = self.db.begin_read().map_err(|error| {
-            RedbStoreError::with_source("failed to begin node read transaction", error)
-        })?;
-        let table = transaction.open_table(NODES).map_err(|error| {
-            RedbStoreError::with_source("failed to open node table for reading", error)
-        })?;
-        table
-            .get(key)
-            .map(|value| value.map(|guard| guard.value().to_vec()))
-            .map_err(|error| RedbStoreError::with_source("failed to read node", error))
+        if self.node_read_cache_enabled() {
+            self.get_shared(key)
+                .map(|value| value.map(|value| value.as_ref().to_vec()))
+        } else {
+            self.read_nodes_owned_ordered_unique_uncached(&[key])
+                .map(|mut values| values.pop().flatten())
+        }
+    }
+
+    fn get_shared(&self, key: &[u8]) -> Result<Option<Arc<[u8]>>, Self::Error> {
+        if self.node_read_cache_enabled() {
+            self.read_nodes_shared_ordered_unique(&[key])
+                .map(|mut values| values.pop().flatten())
+        } else {
+            self.read_nodes_owned_ordered_unique_uncached(&[key])
+                .map(|mut values| values.pop().flatten().map(Arc::from))
+        }
+    }
+
+    fn batch_get_shared_ordered_unique(
+        &self,
+        keys: &[&[u8]],
+    ) -> Result<Vec<Option<Arc<[u8]>>>, Self::Error> {
+        if self.node_read_cache_enabled() {
+            self.read_nodes_shared_ordered_unique(keys)
+        } else {
+            self.read_nodes_owned_ordered_unique_uncached(keys)
+                .map(|values| {
+                    values
+                        .into_iter()
+                        .map(|value| value.map(Arc::from))
+                        .collect()
+                })
+        }
+    }
+
+    fn has_native_shared_reads(&self) -> bool {
+        self.node_read_cache_enabled()
     }
 
     fn put(&self, key: &[u8], value: &[u8]) -> Result<(), Self::Error> {
@@ -194,13 +487,29 @@ impl Store for RedbStore {
             let mut table = transaction.open_table(NODES).map_err(|error| {
                 RedbStoreError::with_source("failed to open node table for writing", error)
             })?;
+            let mut legacy = transaction.open_table(LEGACY_NODES).map_err(|error| {
+                RedbStoreError::with_source("failed to open legacy node table for writing", error)
+            })?;
+            let remove_legacy = !legacy.is_empty().map_err(|error| {
+                RedbStoreError::with_source("failed to inspect legacy node table", error)
+            })?;
+            let mut compression_scratch = Vec::new();
+            let (encoding, stored) =
+                encode_stored_node(self.compress_nodes, value, &mut compression_scratch);
             table
-                .insert(key, value)
+                .insert(key, (encoding, stored))
                 .map_err(|error| RedbStoreError::with_source("failed to write node", error))?;
+            if remove_legacy {
+                legacy.remove(key).map_err(|error| {
+                    RedbStoreError::with_source("failed to remove superseded legacy node", error)
+                })?;
+            }
         }
         transaction
             .commit()
-            .map_err(|error| RedbStoreError::with_source("failed to commit node write", error))
+            .map_err(|error| RedbStoreError::with_source("failed to commit node write", error))?;
+        self.invalidate_node(key);
+        Ok(())
     }
 
     fn delete(&self, key: &[u8]) -> Result<(), Self::Error> {
@@ -209,13 +518,21 @@ impl Store for RedbStore {
             let mut table = transaction.open_table(NODES).map_err(|error| {
                 RedbStoreError::with_source("failed to open node table for deletion", error)
             })?;
+            let mut legacy = transaction.open_table(LEGACY_NODES).map_err(|error| {
+                RedbStoreError::with_source("failed to open legacy node table for deletion", error)
+            })?;
             table
                 .remove(key)
                 .map_err(|error| RedbStoreError::with_source("failed to delete node", error))?;
+            legacy.remove(key).map_err(|error| {
+                RedbStoreError::with_source("failed to delete legacy node", error)
+            })?;
         }
-        transaction
-            .commit()
-            .map_err(|error| RedbStoreError::with_source("failed to commit node deletion", error))
+        transaction.commit().map_err(|error| {
+            RedbStoreError::with_source("failed to commit node deletion", error)
+        })?;
+        self.invalidate_node(key);
+        Ok(())
     }
 
     fn batch(&self, ops: &[BatchOp]) -> Result<(), Self::Error> {
@@ -224,16 +541,42 @@ impl Store for RedbStore {
             let mut table = transaction.open_table(NODES).map_err(|error| {
                 RedbStoreError::with_source("failed to open node table for batch", error)
             })?;
+            let mut legacy = transaction.open_table(LEGACY_NODES).map_err(|error| {
+                RedbStoreError::with_source("failed to open legacy node table for batch", error)
+            })?;
+            let remove_legacy = !legacy.is_empty().map_err(|error| {
+                RedbStoreError::with_source("failed to inspect legacy node table", error)
+            })?;
+            let mut compression_scratch = Vec::new();
             for op in ops {
                 match op {
                     BatchOp::Upsert { key, value } => {
-                        table.insert(*key, *value).map_err(|error| {
+                        let (encoding, stored) = encode_stored_node(
+                            self.compress_nodes,
+                            value,
+                            &mut compression_scratch,
+                        );
+                        table.insert(*key, (encoding, stored)).map_err(|error| {
                             RedbStoreError::with_source("failed to write node in batch", error)
                         })?;
+                        if remove_legacy {
+                            legacy.remove(*key).map_err(|error| {
+                                RedbStoreError::with_source(
+                                    "failed to remove superseded legacy node in batch",
+                                    error,
+                                )
+                            })?;
+                        }
                     }
                     BatchOp::Delete { key } => {
                         table.remove(*key).map_err(|error| {
                             RedbStoreError::with_source("failed to delete node in batch", error)
+                        })?;
+                        legacy.remove(*key).map_err(|error| {
+                            RedbStoreError::with_source(
+                                "failed to delete legacy node in batch",
+                                error,
+                            )
                         })?;
                     }
                 }
@@ -241,27 +584,45 @@ impl Store for RedbStore {
         }
         transaction
             .commit()
-            .map_err(|error| RedbStoreError::with_source("failed to commit node batch", error))
+            .map_err(|error| RedbStoreError::with_source("failed to commit node batch", error))?;
+        self.invalidate_nodes(ops.iter().map(|op| match op {
+            BatchOp::Upsert { key, .. } | BatchOp::Delete { key } => *key,
+        }));
+        Ok(())
     }
 
     fn batch_get(&self, keys: &[&[u8]]) -> Result<HashMap<Vec<u8>, Vec<u8>>, Self::Error> {
-        let values = self.read_nodes_ordered(keys)?;
-        Ok(keys
-            .iter()
-            .zip(values)
-            .filter_map(|(key, value)| value.map(|value| (key.to_vec(), value)))
-            .collect())
+        let plan = OrderedBatchReadPlan::new(keys);
+        let values = self.batch_get_ordered_unique(plan.unique_keys())?;
+        let mut results = HashMap::with_capacity(plan.unique_keys().len());
+        for (key, value) in plan.unique_keys().iter().zip(values) {
+            if let Some(value) = value {
+                results.insert(key.to_vec(), value);
+            }
+        }
+        Ok(results)
     }
 
     fn batch_get_ordered(&self, keys: &[&[u8]]) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
-        self.read_nodes_ordered(keys)
+        let plan = OrderedBatchReadPlan::new(keys);
+        let values = self.batch_get_ordered_unique(plan.unique_keys())?;
+        Ok(plan.expand(values))
     }
 
     fn batch_get_ordered_unique(
         &self,
         keys: &[&[u8]],
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
-        self.read_nodes_ordered(keys)
+        if self.node_read_cache_enabled() {
+            self.read_nodes_shared_ordered_unique(keys).map(|values| {
+                values
+                    .into_iter()
+                    .map(|value| value.map(|value| value.as_ref().to_vec()))
+                    .collect()
+            })
+        } else {
+            self.read_nodes_owned_ordered_unique_uncached(keys)
+        }
     }
 
     fn prefers_batch_reads(&self) -> bool {
@@ -274,15 +635,37 @@ impl Store for RedbStore {
             let mut table = transaction.open_table(NODES).map_err(|error| {
                 RedbStoreError::with_source("failed to open node table for batch put", error)
             })?;
-            for (key, value) in entries {
-                table.insert(*key, *value).map_err(|error| {
+            let mut legacy = transaction.open_table(LEGACY_NODES).map_err(|error| {
+                RedbStoreError::with_source("failed to open legacy node table for batch put", error)
+            })?;
+            let remove_legacy = !legacy.is_empty().map_err(|error| {
+                RedbStoreError::with_source("failed to inspect legacy node table", error)
+            })?;
+            let mut order = (0..entries.len()).collect::<Vec<_>>();
+            order.sort_by(|&left, &right| entries[left].0.cmp(entries[right].0));
+            let mut compression_scratch = Vec::new();
+            for index in order {
+                let (key, value) = entries[index];
+                let (encoding, stored) =
+                    encode_stored_node(self.compress_nodes, value, &mut compression_scratch);
+                table.insert(key, (encoding, stored)).map_err(|error| {
                     RedbStoreError::with_source("failed to write node in batch put", error)
                 })?;
+                if remove_legacy {
+                    legacy.remove(key).map_err(|error| {
+                        RedbStoreError::with_source(
+                            "failed to remove superseded legacy node in batch put",
+                            error,
+                        )
+                    })?;
+                }
             }
         }
-        transaction
-            .commit()
-            .map_err(|error| RedbStoreError::with_source("failed to commit node batch put", error))
+        transaction.commit().map_err(|error| {
+            RedbStoreError::with_source("failed to commit node batch put", error)
+        })?;
+        self.invalidate_nodes(entries.iter().map(|(key, _)| *key));
+        Ok(())
     }
 
     fn supports_hints(&self) -> bool {
@@ -329,13 +712,38 @@ impl Store for RedbStore {
             let mut nodes = transaction.open_table(NODES).map_err(|error| {
                 RedbStoreError::with_source("failed to open node table for publication", error)
             })?;
+            let mut legacy = transaction.open_table(LEGACY_NODES).map_err(|error| {
+                RedbStoreError::with_source(
+                    "failed to open legacy node table for publication",
+                    error,
+                )
+            })?;
+            let remove_legacy = !legacy.is_empty().map_err(|error| {
+                RedbStoreError::with_source("failed to inspect legacy node table", error)
+            })?;
             let mut hints = transaction.open_table(HINTS).map_err(|error| {
                 RedbStoreError::with_source("failed to open hint table for publication", error)
             })?;
-            for (node_key, node_value) in entries {
-                nodes.insert(*node_key, *node_value).map_err(|error| {
-                    RedbStoreError::with_source("failed to publish node", error)
-                })?;
+            let mut order = (0..entries.len()).collect::<Vec<_>>();
+            order.sort_by(|&left, &right| entries[left].0.cmp(entries[right].0));
+            let mut compression_scratch = Vec::new();
+            for index in order {
+                let (node_key, node_value) = entries[index];
+                let (encoding, stored) =
+                    encode_stored_node(self.compress_nodes, node_value, &mut compression_scratch);
+                nodes
+                    .insert(node_key, (encoding, stored))
+                    .map_err(|error| {
+                        RedbStoreError::with_source("failed to publish node", error)
+                    })?;
+                if remove_legacy {
+                    legacy.remove(node_key).map_err(|error| {
+                        RedbStoreError::with_source(
+                            "failed to remove superseded legacy node during publication",
+                            error,
+                        )
+                    })?;
+                }
             }
             hints
                 .insert((namespace, key), value)
@@ -343,7 +751,9 @@ impl Store for RedbStore {
         }
         transaction.commit().map_err(|error| {
             RedbStoreError::with_source("failed to commit node and hint publication", error)
-        })
+        })?;
+        self.invalidate_nodes(entries.iter().map(|(key, _)| *key));
+        Ok(())
     }
 }
 
@@ -357,24 +767,29 @@ impl NodeStoreScan for RedbStore {
         let table = transaction.open_table(NODES).map_err(|error| {
             RedbStoreError::with_source("failed to open node table for scanning", error)
         })?;
-        let iterator = table
-            .iter()
-            .map_err(|error| RedbStoreError::with_source("failed to iterate node table", error))?;
+        let legacy = transaction.open_table(LEGACY_NODES).map_err(|error| {
+            RedbStoreError::with_source("failed to open legacy node table for scanning", error)
+        })?;
         let mut cids = Vec::new();
-        for entry in iterator {
+        for entry in table
+            .iter()
+            .map_err(|error| RedbStoreError::with_source("failed to iterate node table", error))?
+        {
             let (key, _) = entry.map_err(|error| {
                 RedbStoreError::with_source("failed to read node scan entry", error)
             })?;
-            let raw = key.value();
-            let bytes: [u8; 32] = raw.try_into().map_err(|_| {
-                RedbStoreError::message(format!(
-                    "node key has invalid CID length {}, expected 32",
-                    raw.len()
-                ))
+            cids.push(cid_from_store_key(key.value())?);
+        }
+        for entry in legacy.iter().map_err(|error| {
+            RedbStoreError::with_source("failed to iterate legacy node table", error)
+        })? {
+            let (key, _) = entry.map_err(|error| {
+                RedbStoreError::with_source("failed to read legacy node scan entry", error)
             })?;
-            cids.push(Cid(bytes));
+            cids.push(cid_from_store_key(key.value())?);
         }
         cids.sort_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
+        cids.dedup();
         Ok(cids)
     }
 }
@@ -518,6 +933,18 @@ impl TransactionalStore for RedbStore {
                     error,
                 ))
             })?;
+            let mut legacy_nodes = transaction.open_table(LEGACY_NODES).map_err(|error| {
+                store_error(RedbStoreError::with_source(
+                    "failed to open legacy node table for strict transaction",
+                    error,
+                ))
+            })?;
+            let remove_legacy = !legacy_nodes.is_empty().map_err(|error| {
+                store_error(RedbStoreError::with_source(
+                    "failed to inspect legacy node table",
+                    error,
+                ))
+            })?;
             let mut roots = transaction.open_table(ROOTS).map_err(|error| {
                 store_error(RedbStoreError::with_source(
                     "failed to open root table for strict transaction",
@@ -549,22 +976,42 @@ impl TransactionalStore for RedbStore {
                 }
             }
 
+            let mut compression_scratch = Vec::new();
             for write in node_writes {
                 match write {
                     TransactionNodeWrite::Upsert { key, value } => {
+                        let (encoding, stored) = encode_stored_node(
+                            self.compress_nodes,
+                            value,
+                            &mut compression_scratch,
+                        );
                         nodes
-                            .insert(key.as_slice(), value.as_slice())
+                            .insert(key.as_slice(), (encoding, stored))
                             .map_err(|error| {
                                 store_error(RedbStoreError::with_source(
                                     "failed to write node in strict transaction",
                                     error,
                                 ))
                             })?;
+                        if remove_legacy {
+                            legacy_nodes.remove(key.as_slice()).map_err(|error| {
+                                store_error(RedbStoreError::with_source(
+                                    "failed to remove superseded legacy node in strict transaction",
+                                    error,
+                                ))
+                            })?;
+                        }
                     }
                     TransactionNodeWrite::Delete { key } => {
                         nodes.remove(key.as_slice()).map_err(|error| {
                             store_error(RedbStoreError::with_source(
                                 "failed to delete node in strict transaction",
+                                error,
+                            ))
+                        })?;
+                        legacy_nodes.remove(key.as_slice()).map_err(|error| {
+                            store_error(RedbStoreError::with_source(
+                                "failed to delete legacy node in strict transaction",
                                 error,
                             ))
                         })?;
@@ -602,10 +1049,58 @@ impl TransactionalStore for RedbStore {
                 error,
             ))
         })?;
+        self.invalidate_nodes(node_writes.iter().map(|write| match write {
+            TransactionNodeWrite::Upsert { key, .. } | TransactionNodeWrite::Delete { key } => {
+                key.as_slice()
+            }
+        }));
         Ok(TransactionUpdate::Applied {
             nodes_written: node_writes.len(),
             roots_written: root_writes.len(),
         })
+    }
+}
+
+fn cid_from_store_key(key: &[u8]) -> Result<Cid, RedbStoreError> {
+    let bytes: [u8; 32] = key.try_into().map_err(|_| {
+        RedbStoreError::message(format!(
+            "node key has invalid CID length {}, expected 32",
+            key.len()
+        ))
+    })?;
+    Ok(Cid(bytes))
+}
+
+fn encode_stored_node<'a>(
+    compress: bool,
+    node: &'a [u8],
+    scratch: &'a mut Vec<u8>,
+) -> (u8, &'a [u8]) {
+    if !compress || node.len() < MIN_COMPRESSIBLE_NODE_BYTES || node.len() > u32::MAX as usize {
+        return (NODE_ENCODING_RAW, node);
+    }
+    let maximum = 4 + lz4_flex::block::get_maximum_output_size(node.len());
+    scratch.clear();
+    scratch.resize(maximum, 0);
+    scratch[..4].copy_from_slice(&(node.len() as u32).to_le_bytes());
+    let compressed_len = lz4_flex::block::compress_into(node, &mut scratch[4..])
+        .expect("maximum LZ4 output size is sufficient");
+    let stored_len = 4 + compressed_len;
+    if stored_len >= node.len() {
+        return (NODE_ENCODING_RAW, node);
+    }
+    scratch.truncate(stored_len);
+    (NODE_ENCODING_LZ4, scratch)
+}
+
+fn decode_stored_node(encoding: u8, node: &[u8]) -> Result<Vec<u8>, RedbStoreError> {
+    match encoding {
+        NODE_ENCODING_RAW => Ok(node.to_vec()),
+        NODE_ENCODING_LZ4 => lz4_flex::decompress_size_prepended(node)
+            .map_err(|error| RedbStoreError::with_source("failed to decompress node", error)),
+        other => Err(RedbStoreError::message(format!(
+            "unsupported node encoding {other}"
+        ))),
     }
 }
 

--- a/stores/prolly-store-redb/tests/redb_store.rs
+++ b/stores/prolly-store-redb/tests/redb_store.rs
@@ -7,7 +7,8 @@ use prolly::{
     NodeStoreScan, Prolly, PublicationOrigin, RootCondition, RootManifest, RootWrite, Store,
     TransactionNodeWrite, TransactionUpdate, TransactionalStore,
 };
-use prolly_store_redb::{Durability, RedbStore, RedbStoreConfig};
+use prolly_store_redb::{Durability, RedbStore, RedbStoreConfig, RedbStoreOptions};
+use redb::{Database, ReadableDatabase, TableDefinition};
 
 #[test]
 fn redb_store_satisfies_store_contract() {
@@ -134,6 +135,173 @@ fn redb_store_accepts_custom_cache_and_durability() {
     .unwrap();
     store.put(b"configured", b"value").unwrap();
     assert_eq!(store.get(b"configured").unwrap(), Some(b"value".to_vec()));
+    drop(store);
+    remove_db(&path);
+}
+
+#[test]
+fn redb_store_retains_native_shared_reads() {
+    let path = temp_db_path("shared-reads");
+    remove_db(&path);
+    let store = RedbStore::open_with_options(
+        &path,
+        RedbStoreOptions {
+            database: RedbStoreConfig {
+                cache_size_bytes: 8 * 1024 * 1024,
+                durability: Durability::None,
+            },
+            node_read_cache_size_bytes: 1024 * 1024,
+            compress_nodes: true,
+        },
+    )
+    .unwrap();
+    store.put(b"shared", b"immutable-value").unwrap();
+
+    assert!(store.has_native_shared_reads());
+    let first = store.get_shared(b"shared").unwrap().unwrap();
+    let second = store.get_shared(b"shared").unwrap().unwrap();
+    assert!(Arc::ptr_eq(&first, &second));
+    store.put(b"shared", b"replacement").unwrap();
+    let replacement = store.get_shared(b"shared").unwrap().unwrap();
+    assert_eq!(replacement.as_ref(), b"replacement");
+    assert!(!Arc::ptr_eq(&first, &replacement));
+    drop(store);
+    remove_db(&path);
+}
+
+#[test]
+fn redb_store_compresses_large_nodes_transparently() {
+    const NODES_V2: TableDefinition<&[u8], (u8, &[u8])> = TableDefinition::new("prolly_nodes_v2");
+
+    let path = temp_db_path("compressed-nodes");
+    remove_db(&path);
+    let key = Cid::from_bytes(b"compressible-node");
+    let value = vec![0x5a; 64 * 1024];
+    {
+        let store = RedbStore::open(&path).unwrap();
+        store.put(key.as_bytes(), &value).unwrap();
+        assert_eq!(store.get(key.as_bytes()).unwrap(), Some(value.clone()));
+    }
+
+    let database = Database::open(&path).unwrap();
+    let transaction = database.begin_read().unwrap();
+    let table = transaction.open_table(NODES_V2).unwrap();
+    let stored = table.get(key.as_bytes()).unwrap().unwrap();
+    let (encoding, bytes) = stored.value();
+    assert_eq!(encoding, 1);
+    assert!(bytes.len() < value.len() / 4);
+    drop(stored);
+    drop(table);
+    drop(transaction);
+    drop(database);
+    remove_db(&path);
+}
+
+#[test]
+fn redb_store_can_disable_cache_and_compression() {
+    const NODES_V2: TableDefinition<&[u8], (u8, &[u8])> = TableDefinition::new("prolly_nodes_v2");
+
+    let path = temp_db_path("uncompressed-nodes");
+    remove_db(&path);
+    let key = Cid::from_bytes(b"uncompressed-node");
+    let value = vec![0x5a; 16 * 1024];
+    {
+        let store = RedbStore::open_with_options(
+            &path,
+            RedbStoreOptions {
+                database: RedbStoreConfig::default(),
+                node_read_cache_size_bytes: 0,
+                compress_nodes: false,
+            },
+        )
+        .unwrap();
+        assert!(!store.has_native_shared_reads());
+        store.put(key.as_bytes(), &value).unwrap();
+        assert_eq!(store.get(key.as_bytes()).unwrap(), Some(value.clone()));
+    }
+
+    let database = Database::open(&path).unwrap();
+    let transaction = database.begin_read().unwrap();
+    let table = transaction.open_table(NODES_V2).unwrap();
+    let stored = table.get(key.as_bytes()).unwrap().unwrap();
+    let (encoding, bytes) = stored.value();
+    assert_eq!(encoding, 0);
+    assert_eq!(bytes, value);
+    drop(stored);
+    drop(table);
+    drop(transaction);
+    drop(database);
+    remove_db(&path);
+}
+
+#[test]
+fn redb_store_reads_legacy_raw_node_table() {
+    const LEGACY_NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes");
+
+    let path = temp_db_path("legacy-nodes");
+    remove_db(&path);
+    let key = Cid::from_bytes(b"legacy-node");
+    let current_key = Cid::from_bytes(b"current-node");
+    {
+        let database = Database::create(&path).unwrap();
+        let transaction = database.begin_write().unwrap();
+        {
+            let mut table = transaction.open_table(LEGACY_NODES).unwrap();
+            table
+                .insert(key.as_bytes(), b"legacy-value".as_slice())
+                .unwrap();
+        }
+        transaction.commit().unwrap();
+    }
+
+    let store = RedbStore::open(&path).unwrap();
+    assert_eq!(
+        store.get(key.as_bytes()).unwrap(),
+        Some(b"legacy-value".to_vec())
+    );
+    store.put(current_key.as_bytes(), b"current-value").unwrap();
+    let mut expected = vec![key.clone(), current_key];
+    expected.sort_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
+    assert_eq!(store.list_node_cids().unwrap(), expected);
+
+    store.put(key.as_bytes(), b"migrated-value").unwrap();
+    assert_eq!(
+        store.get(key.as_bytes()).unwrap(),
+        Some(b"migrated-value".to_vec())
+    );
+    assert_eq!(store.list_node_cids().unwrap(), expected);
+    drop(store);
+    remove_db(&path);
+}
+
+#[test]
+fn redb_store_compaction_preserves_data() {
+    let path = temp_db_path("compaction");
+    remove_db(&path);
+    let key = Cid::from_bytes(b"retained-node");
+    let mut store = RedbStore::open(&path).unwrap();
+    store.put(key.as_bytes(), b"retained-value").unwrap();
+    for index in 0_u32..256 {
+        store
+            .put(&index.to_be_bytes(), &vec![index as u8; 16 * 1024])
+            .unwrap();
+    }
+    for index in 0_u32..256 {
+        store.delete(&index.to_be_bytes()).unwrap();
+    }
+
+    let _compacted = store.compact().unwrap();
+    assert_eq!(
+        store.get(key.as_bytes()).unwrap(),
+        Some(b"retained-value".to_vec())
+    );
+    drop(store);
+
+    let store = RedbStore::open(&path).unwrap();
+    assert_eq!(
+        store.get(key.as_bytes()).unwrap(),
+        Some(b"retained-value".to_vec())
+    );
     drop(store);
     remove_db(&path);
 }


### PR DESCRIPTION
## Summary

- sort immutable node publications by CID before inserting into redb
- add versioned, transparent LZ4 node encoding with fallback for adapter 0.3.0 raw-node files
- add retained native shared reads with race-safe invalidation and configurable memory limits
- expose an explicit `RedbStore::compact` maintenance lifecycle
- preserve `RedbStoreConfig` source compatibility through additive `RedbStoreOptions`
- bump the not-yet-republished adapter package to 0.3.1

## 1M-record verification

Release build on Apple M2 Max, redb `Durability::Immediate`, 3-run medians, 192 MiB total adapter budget:

| profile | build records/s | random reads/s | full scan records/s | scattered updates/s | build bytes | updated bytes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| redb compressed, write-tuned | 2.41M | 124k | 7.40M | 38.2k | 33,689,600 | 67,375,104 |
| redb uncompressed, write-tuned | 2.16M | 124k | 7.56M | 51.1k | 67,375,104 | 134,746,112 |
| SQLite compressed baseline | 3.80M | 125k | 8.54M | 65.6k | 14,548,992 | 26,345,472 |

Compared with the original redb adapter, default compression improved build throughput from 1.83M to 2.41M records/s and halved both measured file sizes. The uncompressed latency profile improved build throughput by about 18% and scattered-update throughput by about 14%. Explicit compaction reduced the compressed post-update file from 67,375,104 to 36,859,904 bytes in 93 ms. All roots, counts, reads, scan checksums, and update probes matched.

## Compatibility and validation

- existing 0.3.0 redb files reopen through legacy-table fallback
- Rust 1.89: 17 integration tests and 3 doctests
- current stable: clippy with warnings denied
- rustdoc with warnings denied
- packaged 0.3.1 source verified against crates.io dependencies
