### PR TITLE
perf(sqlite): harden primary-store concurrency and maintenance

### DIFF
--- a/benchmarks/sqlite-scale/Cargo.lock
+++ b/benchmarks/sqlite-scale/Cargo.lock
@@ -9,11 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "bitflags"
@@ -134,6 +139,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +177,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fs2"
@@ -225,25 +242,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
 ]
 
 [[package]]
@@ -262,12 +267,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -326,6 +342,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -434,7 +459,7 @@ dependencies = [
 name = "prolly-store-sqlite"
 version = "0.3.1"
 dependencies = [
- "ahash",
+ "lru",
  "lz4_flex",
  "parking_lot",
  "prolly-map",
@@ -449,12 +474,6 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -646,7 +665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -681,15 +700,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -772,12 +782,6 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "xxhash-rust"

--- a/benchmarks/sqlite-scale/src/report.rs
+++ b/benchmarks/sqlite-scale/src/report.rs
@@ -197,7 +197,7 @@ pub fn write_report(
     writeln!(file, "## Interpretation limits\n").map_err(|error| error.to_string())?;
     writeln!(
         file,
-        "- End-to-end synchronous `Prolly<SqliteStore>` on one local connection."
+        "- End-to-end synchronous `Prolly<SqliteStore>` on one workload thread; this matrix does not measure read-pool concurrency or group commit."
     )
     .map_err(|error| error.to_string())?;
     writeln!(

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1277,8 +1277,8 @@ Cargo dependencies:
 
 ```toml
 [dependencies]
-prolly-map = "0.4"
-prolly-store-sqlite = "0.1"
+prolly-map = "0.5.1"
+prolly-store-sqlite = "0.3.1"
 ```
 
 Setup:
@@ -1313,13 +1313,14 @@ let prolly = Prolly::new(store, config);
 - Use non-zero `busy_timeout_ms` for contended local writes
 - Publish every durable head as a named root
 - Run `plan_store_gc_for_retention` before sweeping
+- Inspect `metrics()` and `storage_stats()` before changing cache or WAL tuning
+- Use `backup_to` for an online consistent backup and `quick_check` for health checks
+- Quiesce traffic before running the blocking `compact` operation
 - Use `TokioBlockingStore` in async Tokio apps that call a sync SQLite backend
 
 ### Future enhancements
 
 - Add app-level migrations stored under a metadata key
-- Add backup and restore examples
-- Add store health checks before startup
 - Add CLI inspection for SQLite-backed stores
 
 ## Object-store backed snapshots

--- a/stores/prolly-store-sqlite/Cargo.toml
+++ b/stores/prolly-store-sqlite/Cargo.toml
@@ -17,16 +17,17 @@ name = "prolly_store_sqlite"
 path = "src/lib.rs"
 
 [dependencies]
-ahash = "0.8"
+lru = "0.12"
 lz4_flex = "0.11"
 parking_lot = "0.12"
 prolly = { package = "prolly-map", path = "../..", version = "0.5.1" }
-rusqlite = { version = "0.31", features = ["bundled"] }
+rusqlite = { version = "0.31", features = ["backup", "bundled"] }
 
 [dev-dependencies]
 prolly-store-test = { path = "../prolly-store-test" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tempfile = "3.27"
 
 [lints.rust]
 unsafe_code = "allow"

--- a/stores/prolly-store-sqlite/README.md
+++ b/stores/prolly-store-sqlite/README.md
@@ -16,8 +16,8 @@ same store.
 
 ```toml
 [dependencies]
-prolly-map = "0.4"
-prolly-store-sqlite = "0.3.0"
+prolly-map = "0.5.1"
+prolly-store-sqlite = "0.3.1"
 ```
 
 The crate enables `rusqlite`'s bundled SQLite build, so a system SQLite library
@@ -63,19 +63,17 @@ tree handle.
 `SqliteStoreConfig` controls the busy timeout, WAL journaling, SQLite's
 `synchronous=NORMAL` setting, database page size, page cache, WAL checkpoint
 interval, the decoded-node read cache, the minimum node size considered for
-compression, and the maximum memory-mapped read window.
+compression, the maximum memory-mapped read window, the read-connection pool,
+adaptive multi-key reads, background checkpoints, and optional group commit.
 Defaults are a 5-second busy timeout, WAL for file-backed databases,
 `synchronous=NORMAL`, 64 KiB database pages, a 64 MiB page cache, a
-32,768-page automatic checkpoint interval, a 128 MiB decoded-node cache, and a
-256 MiB mapping. Nodes of at least 8 KiB are compressed when LZ4 makes them
-smaller; typical compact nodes remain raw to avoid spending more CPU than the
-write saves. Larger pages pack those node payloads efficiently, while the page
-cache avoids repeated dirty-page spills during bulk publication. The
-decoded-node cache retains shared immutable nodes across
-operations, and the checkpoint interval keeps checkpoint I/O outside typical
-publication commits while retaining bounded WAL growth. The mapping reduces
-page-read syscall overhead without changing transaction or durability
-behavior.
+128 MiB sharded decoded-node cache, a 256 MiB mapping, four thread-affine read
+connections, and a dedicated passive checkpoint worker. The worker begins
+checkpointing after 64 MiB of WAL allocation and caps retained WAL
+allocation at 256 MiB. Nodes of at least 8 KiB are compressed when LZ4 makes
+them smaller; typical compact nodes remain raw to avoid spending more CPU than
+the write saves. Group commit remains disabled unless
+`group_commit_delay_micros` is set.
 
 ```rust,no_run
 use prolly_store_sqlite::{SqliteStore, SqliteStoreConfig};
@@ -87,6 +85,8 @@ let store = SqliteStore::open_with_config(
         enable_wal: true,
         synchronous_normal: false,
         node_compression_min_bytes: 8 * 1024,
+        reader_connections: 4,
+        checkpoint_wal_bytes: 64 * 1024 * 1024,
         ..SqliteStoreConfig::default()
     },
 )?;
@@ -116,10 +116,40 @@ The adapter implements `Store`, `ManifestStore`, scanning, and
 preconditions and apply node and root writes. A stale precondition returns a
 conflict without committing staged changes.
 
-`SqliteStore` owns one connection behind a mutex, so calls through one store are
-thread-safe and serialized. WAL and the busy timeout help when multiple SQLite
-connections contend for a file; application-level concurrency should still be
-measured under the intended workload.
+File-backed stores use one serialized writer and a pool of read-only
+connections. By default, the first reading thread reuses the writer connection
+to preserve SQLite's single-thread page and statement cache fast path. Other
+calling threads remain affine to one reader, allowing independent threads to
+read in parallel with WAL publication. Set `primary_reader_uses_writer` to
+`false` when every application thread should use the read-only pool. In-memory
+and caller-supplied connections retain the single-connection behavior.
+
+Set `group_commit_delay_micros` to a small non-zero window when many threads
+publish independent immutable-node batches. Concurrent publications collected
+inside that window share one durable SQLite transaction; every caller returns
+only after that transaction commits. Root compare-and-swap transactions remain
+strictly serialized and are never merged implicitly.
+
+## Operations and maintenance
+
+`metrics()` reports decoded-cache activity, publication and transaction counts,
+compression savings, checkpoint activity, and SQLite pager hit, miss, write,
+and spill counters. `storage_stats()` reports page, freelist, database, and WAL
+frame sizes.
+
+Use `checkpoint` for an explicit passive, full, restart, or truncate checkpoint.
+The default background worker keeps checkpoint synchronization out of the
+writer's commit path. `quick_check` provides a fast structural health check,
+`backup_to` creates a consistent online backup, `optimize` runs bounded SQLite
+planner maintenance, and `compact` runs an explicit blocking `VACUUM` after the
+application has quiesced traffic.
+
+Tree reachability and garbage collection are provided by `prolly-map`:
+`plan_store_gc_for_retention` performs the dry run and
+`sweep_store_gc_for_retention` deletes unreachable nodes through one SQLite
+batch transaction. Inspect `storage_stats().free_bytes` after sweeping and run
+`compact` during an appropriate maintenance window when filesystem reclamation
+is needed.
 
 Deleting a named root does not immediately delete unreachable nodes. Plan
 retention and garbage collection before pruning content-addressed data.

--- a/stores/prolly-store-sqlite/src/lib.rs
+++ b/stores/prolly-store-sqlite/src/lib.rs
@@ -1,13 +1,16 @@
 #![doc = include_str!("../README.md")]
 
+use std::cell::Cell;
 use std::collections::{hash_map::Entry, HashMap};
-use std::path::Path;
-use std::sync::Arc;
-use std::time::Duration;
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{mpsc, Arc, OnceLock};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
-use ahash::AHashMap;
-use parking_lot::{Mutex, MutexGuard};
-#[cfg(unix)]
+use lru::LruCache;
+use parking_lot::{Condvar, Mutex, MutexGuard};
 use rusqlite::OpenFlags;
 use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
 
@@ -17,60 +20,204 @@ use prolly::{
     Store, TransactionConflict, TransactionNodeWrite, TransactionUpdate, TransactionalStore,
 };
 
-struct NodeReadCache {
-    values: AHashMap<Vec<u8>, Arc<[u8]>>,
+const DEFAULT_NODE_CACHE_SHARDS: usize = 16;
+static NEXT_SQLITE_READER_SLOT: AtomicUsize = AtomicUsize::new(0);
+
+thread_local! {
+    static SQLITE_READER_SLOT: Cell<usize> = const { Cell::new(usize::MAX) };
+}
+
+struct NodeReadCacheShard {
+    values: LruCache<Vec<u8>, Arc<[u8]>>,
     retained_bytes: usize,
     max_bytes: usize,
 }
 
-impl NodeReadCache {
+impl NodeReadCacheShard {
     fn new(max_bytes: usize) -> Self {
         Self {
-            values: AHashMap::new(),
+            values: LruCache::unbounded(),
             retained_bytes: 0,
             max_bytes,
         }
     }
 
-    fn get(&self, key: &[u8]) -> Option<Arc<[u8]>> {
+    fn get(&mut self, key: &[u8]) -> Option<Arc<[u8]>> {
         self.values.get(key).cloned()
     }
 
-    fn insert(&mut self, key: &[u8], value: Arc<[u8]>) {
+    fn insert(&mut self, key: &[u8], value: Arc<[u8]>) -> usize {
         if self.max_bytes == 0 || value.len() > self.max_bytes {
-            return;
+            return 0;
         }
-        let previous = self.values.remove(key);
+        let mut evictions = 0usize;
+        let previous = self.values.pop(key);
         self.retained_bytes = self
             .retained_bytes
-            .saturating_sub(previous.as_ref().map_or(0, |value| value.len()));
-        if self.retained_bytes.saturating_add(value.len()) > self.max_bytes {
-            self.values.clear();
-            self.retained_bytes = 0;
+            .saturating_sub(previous.as_ref().map_or(0, |entry| entry.len()));
+        let target_bytes = self.max_bytes.saturating_sub(value.len());
+        while self.retained_bytes > target_bytes {
+            if let Some((_, evicted)) = self.values.pop_lru() {
+                self.retained_bytes = self.retained_bytes.saturating_sub(evicted.len());
+                evictions = evictions.saturating_add(1);
+            } else {
+                break;
+            }
         }
         self.retained_bytes = self.retained_bytes.saturating_add(value.len());
-        self.values.insert(key.to_vec(), value);
+        self.values.put(key.to_vec(), value);
+        evictions
     }
 
-    fn insert_immutable(&mut self, key: &[u8], value: Arc<[u8]>) {
+    fn insert_immutable(&mut self, key: &[u8], value: Arc<[u8]>) -> usize {
         if self.max_bytes == 0 || value.len() > self.max_bytes {
-            return;
+            return 0;
         }
-        if self.retained_bytes.saturating_add(value.len()) > self.max_bytes {
-            self.values.clear();
-            self.retained_bytes = 0;
+        if self.get(key).is_some() {
+            return 0;
         }
-        if let Entry::Vacant(entry) = self.values.entry(key.to_vec()) {
-            self.retained_bytes = self.retained_bytes.saturating_add(value.len());
-            entry.insert(value);
-        }
+        self.insert(key, value)
     }
 
     fn remove(&mut self, key: &[u8]) {
-        if let Some(value) = self.values.remove(key) {
+        if let Some(value) = self.values.pop(key) {
             self.retained_bytes = self.retained_bytes.saturating_sub(value.len());
         }
     }
+}
+
+struct ShardedNodeReadCache {
+    shards: Box<[Mutex<NodeReadCacheShard>]>,
+    metrics: Arc<SqliteMetricsInner>,
+}
+
+impl ShardedNodeReadCache {
+    fn new(max_bytes: usize, shard_count: usize, metrics: Arc<SqliteMetricsInner>) -> Self {
+        let shard_count = if max_bytes == 0 {
+            1
+        } else {
+            shard_count.max(1)
+        };
+        let shard_bytes = max_bytes.div_ceil(shard_count);
+        let shards = (0..shard_count)
+            .map(|_| Mutex::new(NodeReadCacheShard::new(shard_bytes)))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self { shards, metrics }
+    }
+
+    fn shard_index(&self, key: &[u8]) -> usize {
+        let hash = key
+            .iter()
+            .take(8)
+            .fold(0xcbf29ce484222325u64, |hash, byte| {
+                (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+            });
+        hash as usize % self.shards.len()
+    }
+
+    fn get(&self, key: &[u8]) -> Option<Arc<[u8]>> {
+        let value = self.shards[self.shard_index(key)].lock().get(key);
+        if value.is_some() {
+            self.metrics.node_cache_hits.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.metrics
+                .node_cache_misses
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        value
+    }
+
+    fn insert(&self, key: &[u8], value: Arc<[u8]>) {
+        let evictions = self.shards[self.shard_index(key)].lock().insert(key, value);
+        self.metrics
+            .node_cache_evictions
+            .fetch_add(evictions as u64, Ordering::Relaxed);
+    }
+
+    fn insert_immutable(&self, key: &[u8], value: Arc<[u8]>) {
+        let evictions = self.shards[self.shard_index(key)]
+            .lock()
+            .insert_immutable(key, value);
+        self.metrics
+            .node_cache_evictions
+            .fetch_add(evictions as u64, Ordering::Relaxed);
+    }
+
+    fn remove(&self, key: &[u8]) {
+        self.shards[self.shard_index(key)].lock().remove(key);
+    }
+
+    fn retained_bytes(&self) -> usize {
+        self.shards
+            .iter()
+            .map(|shard| shard.lock().retained_bytes)
+            .sum()
+    }
+
+    fn entries(&self) -> usize {
+        self.shards
+            .iter()
+            .map(|shard| shard.lock().values.len())
+            .sum()
+    }
+}
+
+#[derive(Default)]
+struct SqliteMetricsInner {
+    node_cache_hits: AtomicU64,
+    node_cache_misses: AtomicU64,
+    node_cache_evictions: AtomicU64,
+    sql_reads: AtomicU64,
+    write_transactions: AtomicU64,
+    published_nodes: AtomicU64,
+    grouped_publications: AtomicU64,
+    checkpoint_attempts: AtomicU64,
+    checkpoint_busy: AtomicU64,
+    checkpointed_frames: AtomicU64,
+    compressed_input_bytes: AtomicU64,
+    compressed_stored_bytes: AtomicU64,
+}
+
+/// Runtime counters for the SQLite adapter and SQLite pager.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct SqliteStoreMetrics {
+    /// Decoded-node reads served by the adapter cache.
+    pub node_cache_hits: u64,
+    /// Decoded-node reads not found in the adapter cache.
+    pub node_cache_misses: u64,
+    /// Decoded nodes removed to keep cache shards within their bounds.
+    pub node_cache_evictions: u64,
+    /// Decoded nodes currently retained by all cache shards.
+    pub node_cache_entries: usize,
+    /// Decoded node payload bytes currently retained by all cache shards.
+    pub node_cache_retained_bytes: usize,
+    /// SQLite node-read statements executed after cache misses.
+    pub sql_reads: u64,
+    /// Successfully committed SQLite write transactions.
+    pub write_transactions: u64,
+    /// Immutable nodes submitted by successfully committed publications.
+    pub published_nodes: u64,
+    /// Publications committed alongside another publication by group commit.
+    pub grouped_publications: u64,
+    /// Explicit and background WAL checkpoint attempts.
+    pub checkpoint_attempts: u64,
+    /// Checkpoint attempts that could not complete because a reader was active.
+    pub checkpoint_busy: u64,
+    /// Frames reported as checkpointed by the latest checkpoint attempt.
+    pub checkpointed_frames: u64,
+    /// Uncompressed input bytes considered by successful node publications.
+    pub compressed_input_bytes: u64,
+    /// Stored bytes produced for those node publications.
+    pub compressed_stored_bytes: u64,
+    /// SQLite page-cache hits reported across all open connections.
+    pub sqlite_page_cache_hits: u64,
+    /// SQLite page-cache misses reported across all open connections.
+    pub sqlite_page_cache_misses: u64,
+    /// SQLite page-cache writes reported across all open connections.
+    pub sqlite_page_cache_writes: u64,
+    /// SQLite page-cache spills reported across all open connections.
+    pub sqlite_page_cache_spills: u64,
 }
 
 struct OrderedBatchReadPlan<'a> {
@@ -159,7 +306,6 @@ CREATE TABLE IF NOT EXISTS prolly_roots (
 ) WITHOUT ROWID;";
 
 const SELECT_SQL: &str = "SELECT encoding, node FROM prolly_nodes WHERE cid = ?1";
-const MAX_BATCH_SELECT_KEYS: usize = 256;
 const SELECT_NODE_CIDS_SQL: &str = "SELECT cid FROM prolly_nodes ORDER BY cid";
 const UPSERT_SQL: &str = "\
 INSERT INTO prolly_nodes (cid, encoding, node)
@@ -220,6 +366,32 @@ pub struct SqliteStoreConfig {
     /// This avoids per-page read syscalls for large immutable prolly nodes while
     /// retaining SQLite's normal transactional and durability guarantees.
     pub mmap_size_bytes: u64,
+    /// Number of read-only SQLite connections used for concurrent cache misses,
+    /// scans, and manifest reads. In-memory and externally supplied connections
+    /// use the writer connection regardless of this value.
+    pub reader_connections: usize,
+    /// Let the first thread that reads from a file-backed store reuse the writer
+    /// connection. This preserves the single-thread page and statement cache
+    /// fast path while other threads use the read-only pool.
+    pub primary_reader_uses_writer: bool,
+    /// Number of independently locked decoded-node cache shards.
+    pub node_read_cache_shards: usize,
+    /// Maximum SQLite variables used by one native multi-key read statement.
+    pub max_batch_select_keys: usize,
+    /// Run passive WAL checkpoints on a dedicated connection instead of in the
+    /// latency-sensitive commit path.
+    pub background_checkpoints: bool,
+    /// Run a passive checkpoint after the WAL file reaches this allocation.
+    pub checkpoint_wal_bytes: u64,
+    /// Maximum delay between background checkpoint inspections.
+    pub checkpoint_interval_ms: u64,
+    /// Maximum retained WAL allocation after the log is reset.
+    pub journal_size_limit_bytes: u64,
+    /// Optional window used to combine concurrent immutable-node publications
+    /// into one durable SQLite transaction. Zero disables group commit.
+    pub group_commit_delay_micros: u64,
+    /// Maximum number of nodes combined in one grouped publication transaction.
+    pub group_commit_max_nodes: usize,
 }
 
 impl Default for SqliteStoreConfig {
@@ -234,6 +406,16 @@ impl Default for SqliteStoreConfig {
             node_read_cache_size_bytes: 128 * 1024 * 1024,
             node_compression_min_bytes: 8 * 1024,
             mmap_size_bytes: 256 * 1024 * 1024,
+            reader_connections: 4,
+            primary_reader_uses_writer: true,
+            node_read_cache_shards: DEFAULT_NODE_CACHE_SHARDS,
+            max_batch_select_keys: 128,
+            background_checkpoints: true,
+            checkpoint_wal_bytes: 64 * 1024 * 1024,
+            checkpoint_interval_ms: 1_000,
+            journal_size_limit_bytes: 256 * 1024 * 1024,
+            group_commit_delay_micros: 0,
+            group_commit_max_nodes: 16_384,
         }
     }
 }
@@ -286,14 +468,138 @@ impl From<rusqlite::Error> for SqliteStoreError {
     }
 }
 
+enum ReadConnectionGuard<'a> {
+    Writer(MutexGuard<'a, Connection>),
+    Reader(MutexGuard<'a, Connection>),
+}
+
+impl Deref for ReadConnectionGuard<'_> {
+    type Target = Connection;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Writer(conn) | Self::Reader(conn) => conn,
+        }
+    }
+}
+
+/// WAL checkpoint modes exposed by [`SqliteStore::checkpoint`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SqliteCheckpointMode {
+    Passive,
+    Full,
+    Restart,
+    Truncate,
+}
+
+impl SqliteCheckpointMode {
+    const fn sql(self) -> &'static str {
+        match self {
+            Self::Passive => "PRAGMA wal_checkpoint(PASSIVE)",
+            Self::Full => "PRAGMA wal_checkpoint(FULL)",
+            Self::Restart => "PRAGMA wal_checkpoint(RESTART)",
+            Self::Truncate => "PRAGMA wal_checkpoint(TRUNCATE)",
+        }
+    }
+}
+
+/// Result returned by a WAL checkpoint operation.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct SqliteCheckpointStats {
+    /// Whether SQLite reported a busy reader or writer during the checkpoint.
+    pub busy: bool,
+    /// Frames present in the WAL when SQLite inspected it.
+    pub log_frames: u64,
+    /// Frames already copied back to the database file.
+    pub checkpointed_frames: u64,
+}
+
+/// File and freelist statistics useful for maintenance decisions.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct SqliteStorageStats {
+    /// Configured database page size.
+    pub page_size_bytes: u64,
+    /// Total pages currently allocated in the database file.
+    pub page_count: u64,
+    /// Allocated pages currently present on SQLite's freelist.
+    pub freelist_pages: u64,
+    /// Logical database allocation (`page_size_bytes * page_count`).
+    pub database_bytes: u64,
+    /// Reclaimable database allocation (`page_size_bytes * freelist_pages`).
+    pub free_bytes: u64,
+    /// Bytes currently allocated to the WAL file, including retained capacity.
+    pub wal_bytes: u64,
+}
+
+enum CheckpointSignal {
+    WriteCommitted,
+    Shutdown,
+}
+
+struct CheckpointWorker {
+    sender: mpsc::Sender<CheckpointSignal>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl CheckpointWorker {
+    fn notify_write(&self) {
+        let _ = self.sender.send(CheckpointSignal::WriteCommitted);
+    }
+}
+
+impl Drop for CheckpointWorker {
+    fn drop(&mut self) {
+        let _ = self.sender.send(CheckpointSignal::Shutdown);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+struct OwnedPublication {
+    entries: Vec<(Vec<u8>, Vec<u8>)>,
+    hint: Option<(Vec<u8>, Vec<u8>, Vec<u8>)>,
+    origin: PublicationOrigin,
+}
+
+struct PublicationCompletion {
+    result: Mutex<Option<Result<(), String>>>,
+    ready: Condvar,
+}
+
+struct PendingPublication {
+    publication: OwnedPublication,
+    completion: Arc<PublicationCompletion>,
+}
+
+#[derive(Default)]
+struct PublicationGroupState {
+    queue: Vec<PendingPublication>,
+    flushing: bool,
+}
+
+struct PublicationGroupCommit {
+    delay: Duration,
+    max_nodes: usize,
+    state: Mutex<PublicationGroupState>,
+}
+
 /// SQLite-backed storage backend for Prolly Trees.
 ///
 /// This store persists content-addressed nodes in a single SQLite table and
 /// supports atomic batch operations through transactions.
 pub struct SqliteStore {
-    conn: Mutex<Connection>,
-    node_read_cache: Mutex<NodeReadCache>,
+    writer: Mutex<Connection>,
+    readers: Box<[Mutex<Connection>]>,
+    primary_reader_thread: OnceLock<thread::ThreadId>,
+    primary_reader_uses_writer: bool,
+    node_read_cache: ShardedNodeReadCache,
     node_compression_min_bytes: usize,
+    max_batch_select_keys: usize,
+    metrics: Arc<SqliteMetricsInner>,
+    checkpoint_worker: Option<CheckpointWorker>,
+    group_commit: Option<PublicationGroupCommit>,
+    wal_path: Option<PathBuf>,
 }
 
 /// Identity obtained from SQLite's actual open main-database file descriptor.
@@ -318,13 +624,17 @@ impl SqliteStore {
         path: P,
         config: SqliteStoreConfig,
     ) -> Result<Self, SqliteStoreError> {
-        let conn = Connection::open(path.as_ref()).map_err(|e| {
-            SqliteStoreError::from_sqlite(
-                e,
-                format!("Failed to open database at {:?}", path.as_ref()),
-            )
+        let path = path.as_ref().to_path_buf();
+        let conn = Connection::open_with_flags(
+            &path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE
+                | OpenFlags::SQLITE_OPEN_CREATE
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .map_err(|e| {
+            SqliteStoreError::from_sqlite(e, format!("Failed to open database at {path:?}"))
         })?;
-        Self::from_connection(conn, config)
+        Self::from_connection(conn, config.clone())?.attach_file_runtime(path, &config, None)
     }
 
     /// Open an existing SQLite database with default runtime configuration.
@@ -336,6 +646,14 @@ impl SqliteStore {
         Self::open_existing_verified(path, |_| Ok(()))
     }
 
+    /// Open an existing database with explicit runtime configuration.
+    pub fn open_existing_with_config<P: AsRef<Path>>(
+        path: P,
+        config: SqliteStoreConfig,
+    ) -> Result<Self, SqliteStoreError> {
+        Self::open_existing_verified_with_config(path, config, |_| Ok(()))
+    }
+
     /// Open an existing database and verify SQLite's actual main-file handle
     /// before executing any pragma, schema statement, or other SQL.
     #[cfg(unix)]
@@ -344,24 +662,60 @@ impl SqliteStore {
         P: AsRef<Path>,
         F: FnOnce(SqliteMainFileIdentity) -> Result<(), SqliteStoreError>,
     {
+        Self::open_existing_verified_with_config(path, SqliteStoreConfig::default(), verifier)
+    }
+
+    /// Open and verify an existing database with explicit runtime tuning.
+    #[cfg(unix)]
+    pub fn open_existing_verified_with_config<P, F>(
+        path: P,
+        config: SqliteStoreConfig,
+        verifier: F,
+    ) -> Result<Self, SqliteStoreError>
+    where
+        P: AsRef<Path>,
+        F: FnOnce(SqliteMainFileIdentity) -> Result<(), SqliteStoreError>,
+    {
+        let path = path.as_ref().to_path_buf();
         let conn = Connection::open_with_flags(
-            path.as_ref(),
+            &path,
             OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )
         .map_err(|error| {
             SqliteStoreError::from_sqlite(
                 error,
-                format!("Failed to open existing database at {:?}", path.as_ref()),
+                format!("Failed to open existing database at {path:?}"),
             )
         })?;
-        verifier(sqlite_main_file_identity(&conn)?)?;
-        Self::from_existing_connection(conn, SqliteStoreConfig::default())
+        let identity = sqlite_main_file_identity(&conn)?;
+        verifier(identity)?;
+        Self::from_existing_connection(conn, config.clone())?.attach_file_runtime(
+            path,
+            &config,
+            Some(identity),
+        )
     }
 
     /// Non-Unix platforms cannot currently prove the SQLite VFS handle's
     /// identity before SQL runs, so verified opens fail closed there.
     #[cfg(not(unix))]
     pub fn open_existing_verified<P, F>(_path: P, _verifier: F) -> Result<Self, SqliteStoreError>
+    where
+        P: AsRef<Path>,
+        F: FnOnce(SqliteMainFileIdentity) -> Result<(), SqliteStoreError>,
+    {
+        Err(SqliteStoreError::new(
+            "verified existing SQLite opens are unsupported on this platform",
+        ))
+    }
+
+    /// Non-Unix platforms cannot verify SQLite's actual main-file handle.
+    #[cfg(not(unix))]
+    pub fn open_existing_verified_with_config<P, F>(
+        _path: P,
+        _config: SqliteStoreConfig,
+        _verifier: F,
+    ) -> Result<Self, SqliteStoreError>
     where
         P: AsRef<Path>,
         F: FnOnce(SqliteMainFileIdentity) -> Result<(), SqliteStoreError>,
@@ -382,13 +736,7 @@ impl SqliteStore {
         conn: Connection,
         config: SqliteStoreConfig,
     ) -> Result<Self, SqliteStoreError> {
-        if !(512..=65_536).contains(&config.page_size_bytes)
-            || !config.page_size_bytes.is_power_of_two()
-        {
-            return Err(SqliteStoreError::new(
-                "page_size_bytes must be a power of two from 512 through 65536",
-            ));
-        }
+        Self::validate_config(&config)?;
         // Applied before WAL or schema creation so new stores use pages large
         // enough to pack several compressed prolly nodes per B-tree page.
         conn.pragma_update(None, "page_size", config.page_size_bytes)
@@ -401,10 +749,27 @@ impl SqliteStore {
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to initialize hint schema"))?;
         conn.execute_batch(CREATE_ROOTS_TABLE_SQL)
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to initialize root schema"))?;
+        let metrics = Arc::new(SqliteMetricsInner::default());
         Ok(Self {
-            conn: Mutex::new(conn),
-            node_read_cache: Mutex::new(NodeReadCache::new(config.node_read_cache_size_bytes)),
+            writer: Mutex::new(conn),
+            readers: Box::new([]),
+            primary_reader_thread: OnceLock::new(),
+            primary_reader_uses_writer: config.primary_reader_uses_writer,
+            node_read_cache: ShardedNodeReadCache::new(
+                config.node_read_cache_size_bytes,
+                config.node_read_cache_shards,
+                metrics.clone(),
+            ),
             node_compression_min_bytes: config.node_compression_min_bytes,
+            max_batch_select_keys: config.max_batch_select_keys.max(1),
+            metrics,
+            checkpoint_worker: None,
+            group_commit: (config.group_commit_delay_micros > 0).then(|| PublicationGroupCommit {
+                delay: Duration::from_micros(config.group_commit_delay_micros),
+                max_nodes: config.group_commit_max_nodes.max(1),
+                state: Mutex::new(PublicationGroupState::default()),
+            }),
+            wal_path: None,
         })
     }
 
@@ -412,12 +777,103 @@ impl SqliteStore {
         conn: Connection,
         config: SqliteStoreConfig,
     ) -> Result<Self, SqliteStoreError> {
+        Self::validate_config(&config)?;
         Self::apply_runtime_config(&conn, &config)?;
+        let metrics = Arc::new(SqliteMetricsInner::default());
         Ok(Self {
-            conn: Mutex::new(conn),
-            node_read_cache: Mutex::new(NodeReadCache::new(config.node_read_cache_size_bytes)),
+            writer: Mutex::new(conn),
+            readers: Box::new([]),
+            primary_reader_thread: OnceLock::new(),
+            primary_reader_uses_writer: config.primary_reader_uses_writer,
+            node_read_cache: ShardedNodeReadCache::new(
+                config.node_read_cache_size_bytes,
+                config.node_read_cache_shards,
+                metrics.clone(),
+            ),
             node_compression_min_bytes: config.node_compression_min_bytes,
+            max_batch_select_keys: config.max_batch_select_keys.max(1),
+            metrics,
+            checkpoint_worker: None,
+            group_commit: (config.group_commit_delay_micros > 0).then(|| PublicationGroupCommit {
+                delay: Duration::from_micros(config.group_commit_delay_micros),
+                max_nodes: config.group_commit_max_nodes.max(1),
+                state: Mutex::new(PublicationGroupState::default()),
+            }),
+            wal_path: None,
         })
+    }
+
+    fn validate_config(config: &SqliteStoreConfig) -> Result<(), SqliteStoreError> {
+        if !(512..=65_536).contains(&config.page_size_bytes)
+            || !config.page_size_bytes.is_power_of_two()
+        {
+            return Err(SqliteStoreError::new(
+                "page_size_bytes must be a power of two from 512 through 65536",
+            ));
+        }
+        if config.reader_connections > 64 {
+            return Err(SqliteStoreError::new(
+                "reader_connections must not exceed 64",
+            ));
+        }
+        if !(1..=256).contains(&config.node_read_cache_shards) {
+            return Err(SqliteStoreError::new(
+                "node_read_cache_shards must be from 1 through 256",
+            ));
+        }
+        if config.max_batch_select_keys == 0 {
+            return Err(SqliteStoreError::new(
+                "max_batch_select_keys must be greater than zero",
+            ));
+        }
+        if config.group_commit_delay_micros > 0 && config.group_commit_max_nodes == 0 {
+            return Err(SqliteStoreError::new(
+                "group_commit_max_nodes must be greater than zero when group commit is enabled",
+            ));
+        }
+        Ok(())
+    }
+
+    fn attach_file_runtime(
+        mut self,
+        path: PathBuf,
+        config: &SqliteStoreConfig,
+        expected_identity: Option<SqliteMainFileIdentity>,
+    ) -> Result<Self, SqliteStoreError> {
+        let mut readers = Vec::with_capacity(config.reader_connections);
+        for _ in 0..config.reader_connections {
+            let reader = Connection::open_with_flags(
+                &path,
+                OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+            )
+            .map_err(|error| {
+                SqliteStoreError::from_sqlite(error, "Failed to open SQLite read connection")
+            })?;
+            #[cfg(unix)]
+            if let Some(expected) = expected_identity {
+                let actual = sqlite_main_file_identity(&reader)?;
+                if actual.device != expected.device || actual.inode != expected.inode {
+                    return Err(SqliteStoreError::new(
+                        "SQLite read connection resolved to a different database file",
+                    ));
+                }
+            }
+            Self::apply_reader_runtime_config(&reader, config)?;
+            readers.push(Mutex::new(reader));
+        }
+        self.readers = readers.into_boxed_slice();
+        self.wal_path = Some(wal_path_for(&path));
+        if config.enable_wal && config.background_checkpoints {
+            self.writer
+                .lock()
+                .pragma_update(None, "wal_autocheckpoint", 0)
+                .map_err(|error| {
+                    SqliteStoreError::from_sqlite(error, "Failed to disable writer autocheckpoint")
+                })?;
+            self.checkpoint_worker =
+                Some(spawn_checkpoint_worker(path, config, self.metrics.clone())?);
+        }
+        Ok(self)
     }
 
     fn apply_runtime_config(
@@ -448,19 +904,536 @@ impl SqliteStore {
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to set cache_size"))?;
         conn.pragma_update(None, "wal_autocheckpoint", config.wal_autocheckpoint_pages)
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to set WAL autocheckpoint"))?;
+        conn.pragma_update(
+            None,
+            "journal_size_limit",
+            config.journal_size_limit_bytes.min(i64::MAX as u64) as i64,
+        )
+        .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to set journal_size_limit"))?;
         conn.pragma_update(None, "mmap_size", config.mmap_size_bytes)
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to set mmap_size"))?;
         Ok(())
     }
 
+    fn apply_reader_runtime_config(
+        conn: &Connection,
+        config: &SqliteStoreConfig,
+    ) -> Result<(), SqliteStoreError> {
+        conn.busy_timeout(Duration::from_millis(config.busy_timeout_ms))
+            .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to set reader busy timeout"))?;
+        conn.pragma_update(None, "query_only", true)
+            .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to enable query_only"))?;
+        let reader_cache_bytes = config
+            .page_cache_size_bytes
+            .checked_div(config.reader_connections.max(1) as u64)
+            .unwrap_or(config.page_cache_size_bytes)
+            .max(1024 * 1024);
+        let cache_kib = -(reader_cache_bytes.div_ceil(1024).min(i64::MAX as u64) as i64);
+        conn.pragma_update(None, "cache_size", cache_kib)
+            .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to set reader cache_size"))?;
+        conn.pragma_update(None, "mmap_size", config.mmap_size_bytes)
+            .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to set reader mmap_size"))?;
+        Ok(())
+    }
+
     fn connection(&self) -> Result<MutexGuard<'_, Connection>, SqliteStoreError> {
-        Ok(self.conn.lock())
+        Ok(self.writer.lock())
     }
 
-    fn node_read_cache(&self) -> Result<MutexGuard<'_, NodeReadCache>, SqliteStoreError> {
-        Ok(self.node_read_cache.lock())
+    fn read_connection(&self) -> Result<ReadConnectionGuard<'_>, SqliteStoreError> {
+        if self.readers.is_empty() {
+            return Ok(ReadConnectionGuard::Writer(self.writer.lock()));
+        }
+        if self.primary_reader_uses_writer {
+            let current = thread::current().id();
+            let primary = self.primary_reader_thread.get_or_init(|| current);
+            if *primary == current {
+                return Ok(ReadConnectionGuard::Writer(self.writer.lock()));
+            }
+        }
+        let index = SQLITE_READER_SLOT.with(|slot| {
+            let current = slot.get();
+            if current == usize::MAX {
+                let assigned = NEXT_SQLITE_READER_SLOT.fetch_add(1, Ordering::Relaxed);
+                slot.set(assigned);
+                assigned
+            } else {
+                current
+            }
+        }) % self.readers.len();
+        Ok(ReadConnectionGuard::Reader(self.readers[index].lock()))
     }
 
+    fn write_committed(&self) {
+        self.metrics
+            .write_transactions
+            .fetch_add(1, Ordering::Relaxed);
+        if let Some(worker) = &self.checkpoint_worker {
+            worker.notify_write();
+        }
+    }
+
+    fn record_compression(&self, input_len: usize, encoding: i64, stored_len: usize) {
+        if encoding == NODE_ENCODING_LZ4 {
+            self.metrics
+                .compressed_input_bytes
+                .fetch_add(input_len as u64, Ordering::Relaxed);
+            self.metrics
+                .compressed_stored_bytes
+                .fetch_add(stored_len as u64, Ordering::Relaxed);
+        }
+    }
+
+    fn own_publication(publication: NodePublication<'_>) -> OwnedPublication {
+        OwnedPublication {
+            entries: publication
+                .entries()
+                .iter()
+                .map(|(key, value)| (key.to_vec(), value.to_vec()))
+                .collect(),
+            hint: publication.hint().map(|hint| {
+                (
+                    hint.namespace().to_vec(),
+                    hint.key().to_vec(),
+                    hint.value().to_vec(),
+                )
+            }),
+            origin: publication.origin(),
+        }
+    }
+
+    fn publish_owned_batch(
+        &self,
+        publications: &[&OwnedPublication],
+    ) -> Result<(), SqliteStoreError> {
+        let mut conn = self.connection()?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| {
+                SqliteStoreError::from_sqlite(error, "Failed to start grouped node publication")
+            })?;
+        {
+            let mut insert = tx.prepare_cached(INSERT_IMMUTABLE_SQL).map_err(|error| {
+                SqliteStoreError::from_sqlite(error, "Failed to prepare grouped node publication")
+            })?;
+            let mut compression_scratch = Vec::new();
+            for publication in publications {
+                let mut ordered = publication.entries.iter().collect::<Vec<_>>();
+                ordered.sort_by(|left, right| left.0.cmp(&right.0));
+                for (key, input) in ordered {
+                    let (encoding, stored) = encode_stored_node_into(
+                        input,
+                        &mut compression_scratch,
+                        self.node_compression_min_bytes,
+                    );
+                    self.record_compression(input.len(), encoding, stored.len());
+                    insert
+                        .execute(params![key, encoding, stored])
+                        .map_err(|error| {
+                            SqliteStoreError::from_sqlite(
+                                error,
+                                "Failed to publish grouped immutable node",
+                            )
+                        })?;
+                }
+            }
+        }
+        for publication in publications {
+            if let Some((namespace, key, value)) = &publication.hint {
+                tx.execute(UPSERT_HINT_SQL, params![namespace, key, value])
+                    .map_err(|error| {
+                        SqliteStoreError::from_sqlite(
+                            error,
+                            "Failed to write grouped publication hint",
+                        )
+                    })?;
+            }
+        }
+        tx.commit().map_err(|error| {
+            SqliteStoreError::from_sqlite(error, "Failed to commit grouped node publication")
+        })?;
+        drop(conn);
+        self.write_committed();
+        self.metrics.grouped_publications.fetch_add(
+            publications.len().saturating_sub(1) as u64,
+            Ordering::Relaxed,
+        );
+        self.metrics.published_nodes.fetch_add(
+            publications
+                .iter()
+                .map(|publication| publication.entries.len() as u64)
+                .sum(),
+            Ordering::Relaxed,
+        );
+        for publication in publications {
+            if !matches!(
+                publication.origin,
+                PublicationOrigin::TreeBuild | PublicationOrigin::Merge
+            ) {
+                for (key, value) in &publication.entries {
+                    self.node_read_cache
+                        .insert_immutable(key, Arc::from(value.as_slice()));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn publish_grouped(&self, publication: NodePublication<'_>) -> Result<(), SqliteStoreError> {
+        let group = self
+            .group_commit
+            .as_ref()
+            .expect("grouped publication requires configured coordinator");
+        let completion = Arc::new(PublicationCompletion {
+            result: Mutex::new(None),
+            ready: Condvar::new(),
+        });
+        let leader = {
+            let mut state = group.state.lock();
+            state.queue.push(PendingPublication {
+                publication: Self::own_publication(publication),
+                completion: completion.clone(),
+            });
+            if state.flushing {
+                false
+            } else {
+                state.flushing = true;
+                true
+            }
+        };
+
+        if leader {
+            thread::sleep(group.delay);
+            loop {
+                let pending = {
+                    let mut state = group.state.lock();
+                    if state.queue.is_empty() {
+                        state.flushing = false;
+                        break;
+                    }
+                    let mut nodes = 0usize;
+                    let take = state
+                        .queue
+                        .iter()
+                        .take_while(|pending| {
+                            if nodes > 0
+                                && nodes.saturating_add(pending.publication.entries.len())
+                                    > group.max_nodes
+                            {
+                                return false;
+                            }
+                            nodes = nodes.saturating_add(pending.publication.entries.len());
+                            true
+                        })
+                        .count()
+                        .max(1);
+                    state.queue.drain(..take).collect::<Vec<_>>()
+                };
+                let publications = pending
+                    .iter()
+                    .map(|pending| &pending.publication)
+                    .collect::<Vec<_>>();
+                let result = self
+                    .publish_owned_batch(&publications)
+                    .map_err(|error| error.to_string());
+                for pending in pending {
+                    let mut slot = pending.completion.result.lock();
+                    *slot = Some(result.clone());
+                    pending.completion.ready.notify_one();
+                }
+            }
+        }
+
+        let mut result = completion.result.lock();
+        while result.is_none() {
+            completion.ready.wait(&mut result);
+        }
+        result
+            .take()
+            .expect("group publication completion must be populated")
+            .map_err(SqliteStoreError::new)
+    }
+
+    /// Number of read-only connections available for concurrent reads.
+    pub fn reader_connection_count(&self) -> usize {
+        self.readers.len()
+    }
+
+    /// Return adapter and SQLite pager counters without resetting them.
+    pub fn metrics(&self) -> Result<SqliteStoreMetrics, SqliteStoreError> {
+        let mut pager = SqlitePagerMetrics::default();
+        {
+            let writer = self.writer.lock();
+            pager.add_connection(&writer)?;
+        }
+        for reader in &self.readers {
+            pager.add_connection(&reader.lock())?;
+        }
+        Ok(SqliteStoreMetrics {
+            node_cache_hits: self.metrics.node_cache_hits.load(Ordering::Relaxed),
+            node_cache_misses: self.metrics.node_cache_misses.load(Ordering::Relaxed),
+            node_cache_evictions: self.metrics.node_cache_evictions.load(Ordering::Relaxed),
+            node_cache_entries: self.node_read_cache.entries(),
+            node_cache_retained_bytes: self.node_read_cache.retained_bytes(),
+            sql_reads: self.metrics.sql_reads.load(Ordering::Relaxed),
+            write_transactions: self.metrics.write_transactions.load(Ordering::Relaxed),
+            published_nodes: self.metrics.published_nodes.load(Ordering::Relaxed),
+            grouped_publications: self.metrics.grouped_publications.load(Ordering::Relaxed),
+            checkpoint_attempts: self.metrics.checkpoint_attempts.load(Ordering::Relaxed),
+            checkpoint_busy: self.metrics.checkpoint_busy.load(Ordering::Relaxed),
+            checkpointed_frames: self.metrics.checkpointed_frames.load(Ordering::Relaxed),
+            compressed_input_bytes: self.metrics.compressed_input_bytes.load(Ordering::Relaxed),
+            compressed_stored_bytes: self.metrics.compressed_stored_bytes.load(Ordering::Relaxed),
+            sqlite_page_cache_hits: pager.hits,
+            sqlite_page_cache_misses: pager.misses,
+            sqlite_page_cache_writes: pager.writes,
+            sqlite_page_cache_spills: pager.spills,
+        })
+    }
+
+    /// Run an explicit WAL checkpoint and return SQLite's frame counters.
+    pub fn checkpoint(
+        &self,
+        mode: SqliteCheckpointMode,
+    ) -> Result<SqliteCheckpointStats, SqliteStoreError> {
+        let conn = self.connection()?;
+        let stats = run_checkpoint(&conn, mode)?;
+        record_checkpoint_metrics(&self.metrics, stats);
+        Ok(stats)
+    }
+
+    /// Return database size, freelist, and WAL allocation statistics.
+    pub fn storage_stats(&self) -> Result<SqliteStorageStats, SqliteStoreError> {
+        let conn = self.read_connection()?;
+        let page_size: u64 = conn
+            .query_row("PRAGMA page_size", [], |row| row.get(0))
+            .map_err(|error| SqliteStoreError::from_sqlite(error, "Failed to read page_size"))?;
+        let page_count: u64 = conn
+            .query_row("PRAGMA page_count", [], |row| row.get(0))
+            .map_err(|error| SqliteStoreError::from_sqlite(error, "Failed to read page_count"))?;
+        let freelist_pages: u64 = conn
+            .query_row("PRAGMA freelist_count", [], |row| row.get(0))
+            .map_err(|error| {
+                SqliteStoreError::from_sqlite(error, "Failed to read freelist_count")
+            })?;
+        let wal_bytes = self
+            .wal_path
+            .as_ref()
+            .and_then(|path| std::fs::metadata(path).ok())
+            .map_or(0, |metadata| metadata.len());
+        Ok(SqliteStorageStats {
+            page_size_bytes: page_size,
+            page_count,
+            freelist_pages,
+            database_bytes: page_size.saturating_mul(page_count),
+            free_bytes: page_size.saturating_mul(freelist_pages),
+            wal_bytes,
+        })
+    }
+
+    /// Create a consistent online backup using SQLite's backup API.
+    pub fn backup_to<P: AsRef<Path>>(&self, path: P) -> Result<(), SqliteStoreError> {
+        let conn = self.read_connection()?;
+        conn.backup(rusqlite::DatabaseName::Main, path, None)
+            .map_err(|error| SqliteStoreError::from_sqlite(error, "Failed to back up database"))
+    }
+
+    /// Rebuild the database to reclaim free pages and reduce fragmentation.
+    /// Callers should quiesce application traffic before invoking this method.
+    pub fn compact(&self) -> Result<(), SqliteStoreError> {
+        let conn = self.connection()?;
+        conn.execute_batch("VACUUM")
+            .map_err(|error| SqliteStoreError::from_sqlite(error, "Failed to compact database"))?;
+        drop(conn);
+        self.write_committed();
+        Ok(())
+    }
+
+    /// Ask SQLite to perform bounded planner and connection maintenance.
+    pub fn optimize(&self) -> Result<(), SqliteStoreError> {
+        let conn = self.connection()?;
+        conn.execute_batch("PRAGMA optimize")
+            .map_err(|error| SqliteStoreError::from_sqlite(error, "Failed to optimize database"))
+    }
+
+    /// Run SQLite's fast structural consistency check.
+    pub fn quick_check(&self) -> Result<(), SqliteStoreError> {
+        let conn = self.read_connection()?;
+        let result: String = conn
+            .query_row("PRAGMA quick_check", [], |row| row.get(0))
+            .map_err(|error| SqliteStoreError::from_sqlite(error, "Failed to check database"))?;
+        if result == "ok" {
+            Ok(())
+        } else {
+            Err(SqliteStoreError::new(format!(
+                "SQLite quick_check failed: {result}"
+            )))
+        }
+    }
+}
+
+#[derive(Default)]
+struct SqlitePagerMetrics {
+    hits: u64,
+    misses: u64,
+    writes: u64,
+    spills: u64,
+}
+
+impl SqlitePagerMetrics {
+    fn add_connection(&mut self, conn: &Connection) -> Result<(), SqliteStoreError> {
+        self.hits = self.hits.saturating_add(connection_db_status(
+            conn,
+            rusqlite::ffi::SQLITE_DBSTATUS_CACHE_HIT,
+        )?);
+        self.misses = self.misses.saturating_add(connection_db_status(
+            conn,
+            rusqlite::ffi::SQLITE_DBSTATUS_CACHE_MISS,
+        )?);
+        self.writes = self.writes.saturating_add(connection_db_status(
+            conn,
+            rusqlite::ffi::SQLITE_DBSTATUS_CACHE_WRITE,
+        )?);
+        self.spills = self.spills.saturating_add(connection_db_status(
+            conn,
+            rusqlite::ffi::SQLITE_DBSTATUS_CACHE_SPILL,
+        )?);
+        Ok(())
+    }
+}
+
+fn connection_db_status(conn: &Connection, operation: i32) -> Result<u64, SqliteStoreError> {
+    let mut current = 0;
+    let mut highwater = 0;
+    // SAFETY: the connection remains locked for the call and both output
+    // pointers refer to initialized integers valid for the duration of it.
+    let code = unsafe {
+        rusqlite::ffi::sqlite3_db_status(conn.handle(), operation, &mut current, &mut highwater, 0)
+    };
+    if code == rusqlite::ffi::SQLITE_OK {
+        Ok(current.max(0) as u64)
+    } else {
+        Err(SqliteStoreError::new(format!(
+            "sqlite3_db_status failed with code {code}"
+        )))
+    }
+}
+
+fn run_checkpoint(
+    conn: &Connection,
+    mode: SqliteCheckpointMode,
+) -> Result<SqliteCheckpointStats, SqliteStoreError> {
+    let (busy, log, checkpointed): (i64, i64, i64) = conn
+        .query_row(mode.sql(), [], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })
+        .map_err(|error| SqliteStoreError::from_sqlite(error, "Failed to checkpoint WAL"))?;
+    Ok(SqliteCheckpointStats {
+        busy: busy != 0,
+        log_frames: log.max(0) as u64,
+        checkpointed_frames: checkpointed.max(0) as u64,
+    })
+}
+
+fn record_checkpoint_metrics(metrics: &SqliteMetricsInner, stats: SqliteCheckpointStats) {
+    metrics.checkpoint_attempts.fetch_add(1, Ordering::Relaxed);
+    if stats.busy {
+        metrics.checkpoint_busy.fetch_add(1, Ordering::Relaxed);
+    }
+    metrics
+        .checkpointed_frames
+        .store(stats.checkpointed_frames, Ordering::Relaxed);
+}
+
+fn spawn_checkpoint_worker(
+    path: PathBuf,
+    config: &SqliteStoreConfig,
+    metrics: Arc<SqliteMetricsInner>,
+) -> Result<CheckpointWorker, SqliteStoreError> {
+    let conn = Connection::open_with_flags(
+        &path,
+        OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|error| {
+        SqliteStoreError::from_sqlite(error, "Failed to open checkpoint connection")
+    })?;
+    conn.busy_timeout(Duration::from_millis(config.busy_timeout_ms))
+        .map_err(|error| {
+            SqliteStoreError::from_sqlite(error, "Failed to configure checkpoint timeout")
+        })?;
+    conn.pragma_update(None, "wal_autocheckpoint", 0)
+        .map_err(|error| {
+            SqliteStoreError::from_sqlite(error, "Failed to disable checkpoint autocheckpoint")
+        })?;
+    conn.pragma_update(
+        None,
+        "journal_size_limit",
+        config.journal_size_limit_bytes.min(i64::MAX as u64) as i64,
+    )
+    .map_err(|error| {
+        SqliteStoreError::from_sqlite(error, "Failed to configure checkpoint journal limit")
+    })?;
+    let wal_path = wal_path_for(&path);
+    let threshold = config.checkpoint_wal_bytes;
+    let interval = Duration::from_millis(config.checkpoint_interval_ms.max(1));
+    let (sender, receiver) = mpsc::channel();
+    let handle = thread::Builder::new()
+        .name("prolly-sqlite-checkpoint".to_string())
+        .spawn(move || {
+            let mut writes_pending = false;
+            let mut next_inspection = Instant::now() + interval;
+            loop {
+                let signal = receiver
+                    .recv_timeout(next_inspection.saturating_duration_since(Instant::now()));
+                if matches!(signal, Ok(CheckpointSignal::Shutdown)) {
+                    if let Ok(stats) = run_checkpoint(&conn, SqliteCheckpointMode::Truncate) {
+                        record_checkpoint_metrics(&metrics, stats);
+                    }
+                    break;
+                }
+                if matches!(signal, Ok(CheckpointSignal::WriteCommitted)) {
+                    writes_pending = true;
+                }
+                while let Ok(signal) = receiver.try_recv() {
+                    if matches!(signal, CheckpointSignal::Shutdown) {
+                        if let Ok(stats) = run_checkpoint(&conn, SqliteCheckpointMode::Truncate) {
+                            record_checkpoint_metrics(&metrics, stats);
+                        }
+                        return;
+                    }
+                    writes_pending = true;
+                }
+                if Instant::now() < next_inspection {
+                    continue;
+                }
+                next_inspection = Instant::now() + interval;
+                if !writes_pending {
+                    continue;
+                }
+                let wal_bytes = std::fs::metadata(&wal_path)
+                    .map(|metadata| metadata.len())
+                    .unwrap_or(0);
+                if wal_bytes >= threshold {
+                    if let Ok(stats) = run_checkpoint(&conn, SqliteCheckpointMode::Passive) {
+                        record_checkpoint_metrics(&metrics, stats);
+                        writes_pending = stats.busy || stats.checkpointed_frames < stats.log_frames;
+                    }
+                }
+            }
+        })
+        .map_err(|error| {
+            SqliteStoreError::new(format!("failed to spawn checkpoint worker: {error}"))
+        })?;
+    Ok(CheckpointWorker {
+        sender,
+        handle: Some(handle),
+    })
+}
+
+fn wal_path_for(path: &Path) -> PathBuf {
+    let mut wal_path = path.as_os_str().to_os_string();
+    wal_path.push("-wal");
+    PathBuf::from(wal_path)
 }
 
 fn ensure_node_encoding_column(conn: &Connection) -> Result<(), SqliteStoreError> {
@@ -501,8 +1474,7 @@ const NODE_ENCODING_RAW: i64 = 0;
 const NODE_ENCODING_LZ4: i64 = 1;
 fn encode_stored_node(node: &[u8], min_compressible_bytes: usize) -> (i64, Vec<u8>) {
     let mut scratch = Vec::new();
-    let (encoding, stored) =
-        encode_stored_node_into(node, &mut scratch, min_compressible_bytes);
+    let (encoding, stored) = encode_stored_node_into(node, &mut scratch, min_compressible_bytes);
     (encoding, stored.to_vec())
 }
 
@@ -542,6 +1514,7 @@ fn decode_stored_node_ref(encoding: i64, node: &[u8]) -> Result<Vec<u8>, SqliteS
 fn select_nodes_ordered_unique(
     conn: &Connection,
     keys: &[&[u8]],
+    configured_max_keys: usize,
 ) -> Result<Vec<Option<Vec<u8>>>, SqliteStoreError> {
     if keys.is_empty() {
         return Ok(Vec::new());
@@ -581,7 +1554,18 @@ fn select_nodes_ordered_unique(
         .collect::<HashMap<_, _>>();
     let mut values = vec![None; keys.len()];
 
-    for chunk in keys.chunks(MAX_BATCH_SELECT_KEYS) {
+    // SAFETY: the connection remains locked for this call and sqlite3_limit
+    // only reads the current per-connection variable bound for a negative value.
+    let sqlite_max_keys = unsafe {
+        rusqlite::ffi::sqlite3_limit(
+            conn.handle(),
+            rusqlite::ffi::SQLITE_LIMIT_VARIABLE_NUMBER,
+            -1,
+        )
+    }
+    .max(1) as usize;
+    let max_keys = configured_max_keys.max(1).min(sqlite_max_keys);
+    for chunk in keys.chunks(max_keys) {
         let placeholders = (1..=chunk.len())
             .map(|index| format!("?{index}"))
             .collect::<Vec<_>>()
@@ -686,10 +1670,11 @@ impl Store for SqliteStore {
     type Error = SqliteStoreError;
 
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
-        if let Some(value) = self.node_read_cache()?.get(key) {
+        if let Some(value) = self.node_read_cache.get(key) {
             return Ok(Some(value.as_ref().to_vec()));
         }
-        let conn = self.connection()?;
+        let conn = self.read_connection()?;
+        self.metrics.sql_reads.fetch_add(1, Ordering::Relaxed);
         let mut stmt = conn
             .prepare_cached(SELECT_SQL)
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to prepare point read"))?;
@@ -712,18 +1697,19 @@ impl Store for SqliteStore {
             SqliteStoreError::new(format!("Failed to borrow node bytes: {error}"))
         })?;
         let decoded: Arc<[u8]> = Arc::from(decode_stored_node_ref(encoding, node)?);
-        self.node_read_cache()?.insert(key, decoded.clone());
+        self.node_read_cache.insert(key, decoded.clone());
         Ok(Some(decoded.as_ref().to_vec()))
     }
 
     fn get_shared(&self, key: &[u8]) -> Result<Option<Arc<[u8]>>, Self::Error> {
-        if let Some(value) = self.node_read_cache()?.get(key) {
+        if let Some(value) = self.node_read_cache.get(key) {
             return Ok(Some(value));
         }
-        let conn = self.connection()?;
-        let mut stmt = conn.prepare_cached(SELECT_SQL).map_err(|e| {
-            SqliteStoreError::from_sqlite(e, "Failed to prepare shared point read")
-        })?;
+        let conn = self.read_connection()?;
+        self.metrics.sql_reads.fetch_add(1, Ordering::Relaxed);
+        let mut stmt = conn
+            .prepare_cached(SELECT_SQL)
+            .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to prepare shared point read"))?;
         let mut rows = stmt
             .query(params![key])
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to read shared key"))?;
@@ -743,7 +1729,7 @@ impl Store for SqliteStore {
             SqliteStoreError::new(format!("Failed to borrow node bytes: {error}"))
         })?;
         let decoded: Arc<[u8]> = Arc::from(decode_stored_node_ref(encoding, node)?);
-        self.node_read_cache()?.insert(key, decoded.clone());
+        self.node_read_cache.insert(key, decoded.clone());
         Ok(Some(decoded))
     }
 
@@ -753,11 +1739,13 @@ impl Store for SqliteStore {
 
     fn put(&self, key: &[u8], value: &[u8]) -> Result<(), Self::Error> {
         let conn = self.connection()?;
-        let (encoding, stored) =
-            encode_stored_node(value, self.node_compression_min_bytes);
+        let (encoding, stored) = encode_stored_node(value, self.node_compression_min_bytes);
+        self.record_compression(value.len(), encoding, stored.len());
         conn.execute(UPSERT_SQL, params![key, encoding, stored])
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to write key"))?;
-        self.node_read_cache()?.insert(key, Arc::from(value));
+        drop(conn);
+        self.write_committed();
+        self.node_read_cache.insert(key, Arc::from(value));
         Ok(())
     }
 
@@ -765,7 +1753,9 @@ impl Store for SqliteStore {
         let conn = self.connection()?;
         conn.execute(DELETE_SQL, params![key])
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to delete key"))?;
-        self.node_read_cache()?.remove(key);
+        drop(conn);
+        self.write_committed();
+        self.node_read_cache.remove(key);
         Ok(())
     }
 
@@ -787,14 +1777,18 @@ impl Store for SqliteStore {
             for op in ops {
                 match op {
                     BatchOp::Upsert { key, value } => {
-                        let (encoding, value) = encode_stored_node_into(
+                        let input_len = value.len();
+                        let (encoding, stored) = encode_stored_node_into(
                             value,
                             &mut compression_scratch,
                             self.node_compression_min_bytes,
                         );
-                        upsert.execute(params![key, encoding, value]).map_err(|e| {
-                            SqliteStoreError::from_sqlite(e, "Failed to write key in batch")
-                        })?;
+                        self.record_compression(input_len, encoding, stored.len());
+                        upsert
+                            .execute(params![key, encoding, stored])
+                            .map_err(|e| {
+                                SqliteStoreError::from_sqlite(e, "Failed to write key in batch")
+                            })?;
                     }
                     BatchOp::Delete { key } => {
                         delete.execute(params![key]).map_err(|e| {
@@ -807,10 +1801,13 @@ impl Store for SqliteStore {
 
         tx.commit()
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to commit transaction"))?;
-        let mut cache = self.node_read_cache()?;
+        drop(conn);
+        self.write_committed();
         for op in ops {
             match op {
-                BatchOp::Upsert { key, .. } | BatchOp::Delete { key } => cache.remove(key),
+                BatchOp::Upsert { key, .. } | BatchOp::Delete { key } => {
+                    self.node_read_cache.remove(key)
+                }
             }
         }
         Ok(())
@@ -857,26 +1854,24 @@ impl Store for SqliteStore {
     ) -> Result<Vec<Option<Arc<[u8]>>>, Self::Error> {
         let mut values = vec![None; keys.len()];
         let mut missing = Vec::new();
-        {
-            let cache = self.node_read_cache()?;
-            for (position, key) in keys.iter().enumerate() {
-                match cache.get(key) {
-                    Some(value) => values[position] = Some(value),
-                    None => missing.push((position, *key)),
-                }
+        for (position, key) in keys.iter().enumerate() {
+            match self.node_read_cache.get(key) {
+                Some(value) => values[position] = Some(value),
+                None => missing.push((position, *key)),
             }
         }
         if missing.is_empty() {
             return Ok(values);
         }
         let missing_keys = missing.iter().map(|(_, key)| *key).collect::<Vec<_>>();
-        let conn = self.connection()?;
-        let loaded = select_nodes_ordered_unique(&conn, &missing_keys)?;
-        let mut cache = self.node_read_cache()?;
+        let conn = self.read_connection()?;
+        self.metrics.sql_reads.fetch_add(1, Ordering::Relaxed);
+        let loaded = select_nodes_ordered_unique(&conn, &missing_keys, self.max_batch_select_keys)?;
+        drop(conn);
         for ((position, key), loaded) in missing.into_iter().zip(loaded) {
             if let Some(loaded) = loaded {
                 let loaded: Arc<[u8]> = Arc::from(loaded);
-                cache.insert(key, loaded.clone());
+                self.node_read_cache.insert(key, loaded.clone());
                 values[position] = Some(loaded);
             }
         }
@@ -901,12 +1896,14 @@ impl Store for SqliteStore {
             ordered.sort_by(|left, right| left.0.cmp(right.0));
             let mut compression_scratch = Vec::new();
             for &&(key, value) in &ordered {
-                let (encoding, value) = encode_stored_node_into(
+                let input_len = value.len();
+                let (encoding, stored) = encode_stored_node_into(
                     value,
                     &mut compression_scratch,
                     self.node_compression_min_bytes,
                 );
-                stmt.execute(params![key, encoding, value]).map_err(|e| {
+                self.record_compression(input_len, encoding, stored.len());
+                stmt.execute(params![key, encoding, stored]).map_err(|e| {
                     SqliteStoreError::from_sqlite(e, "Failed to write key in batch_put")
                 })?;
             }
@@ -914,9 +1911,10 @@ impl Store for SqliteStore {
 
         tx.commit()
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to commit transaction"))?;
-        let mut cache = self.node_read_cache()?;
+        drop(conn);
+        self.write_committed();
         for &(key, _) in entries {
-            cache.remove(key);
+            self.node_read_cache.remove(key);
         }
         Ok(())
     }
@@ -926,7 +1924,8 @@ impl Store for SqliteStore {
     }
 
     fn get_hint(&self, namespace: &[u8], key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
-        let conn = self.connection()?;
+        let conn = self.read_connection()?;
+        self.metrics.sql_reads.fetch_add(1, Ordering::Relaxed);
         conn.query_row(
             "SELECT value FROM prolly_hints WHERE namespace = ?1 AND key = ?2",
             params![namespace, key],
@@ -946,6 +1945,8 @@ impl Store for SqliteStore {
             params![namespace, key, value],
         )
         .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to write hint"))?;
+        drop(conn);
+        self.write_committed();
         Ok(())
     }
 
@@ -969,13 +1970,15 @@ impl Store for SqliteStore {
             ordered.sort_by(|left, right| left.0.cmp(right.0));
             let mut compression_scratch = Vec::new();
             for &&(key, value) in &ordered {
-                let (encoding, value) = encode_stored_node_into(
+                let input_len = value.len();
+                let (encoding, stored) = encode_stored_node_into(
                     value,
                     &mut compression_scratch,
                     self.node_compression_min_bytes,
                 );
+                self.record_compression(input_len, encoding, stored.len());
                 upsert_node
-                    .execute(params![key, encoding, value])
+                    .execute(params![key, encoding, stored])
                     .map_err(|e| {
                         SqliteStoreError::from_sqlite(e, "Failed to write key in batch_put")
                     })?;
@@ -993,14 +1996,18 @@ impl Store for SqliteStore {
 
         tx.commit()
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to commit transaction"))?;
-        let mut cache = self.node_read_cache()?;
+        drop(conn);
+        self.write_committed();
         for &(key, _) in entries {
-            cache.remove(key);
+            self.node_read_cache.remove(key);
         }
         Ok(())
     }
 
     fn publish_nodes(&self, publication: NodePublication<'_>) -> Result<(), Self::Error> {
+        if self.group_commit.is_some() {
+            return self.publish_grouped(publication);
+        }
         let mut conn = self.connection()?;
         let tx = conn
             .transaction_with_behavior(TransactionBehavior::Immediate)
@@ -1018,13 +2025,15 @@ impl Store for SqliteStore {
             ordered.sort_by(|left, right| left.0.cmp(right.0));
             let mut compression_scratch = Vec::new();
             for &&(key, value) in &ordered {
-                let (encoding, value) = encode_stored_node_into(
+                let input_len = value.len();
+                let (encoding, stored) = encode_stored_node_into(
                     value,
                     &mut compression_scratch,
                     self.node_compression_min_bytes,
                 );
+                self.record_compression(input_len, encoding, stored.len());
                 insert
-                    .execute(params![key, encoding, value])
+                    .execute(params![key, encoding, stored])
                     .map_err(|error| {
                         SqliteStoreError::from_sqlite(error, "Failed to publish immutable node")
                     })?;
@@ -1042,6 +2051,11 @@ impl Store for SqliteStore {
         tx.commit().map_err(|error| {
             SqliteStoreError::from_sqlite(error, "Failed to commit node publication")
         })?;
+        drop(conn);
+        self.write_committed();
+        self.metrics
+            .published_nodes
+            .fetch_add(publication.entries().len() as u64, Ordering::Relaxed);
         // Batch and merge branches are commonly read immediately. A full tree
         // build already leaves its decoded nodes in the manager cache, so
         // duplicating every serialized node here only adds publication cost.
@@ -1049,9 +2063,8 @@ impl Store for SqliteStore {
             publication.origin(),
             PublicationOrigin::TreeBuild | PublicationOrigin::Merge
         ) {
-            let mut cache = self.node_read_cache()?;
             for &(key, value) in publication.entries() {
-                cache.insert_immutable(key, Arc::from(value));
+                self.node_read_cache.insert_immutable(key, Arc::from(value));
             }
         }
         Ok(())
@@ -1062,7 +2075,8 @@ impl NodeStoreScan for SqliteStore {
     type Error = SqliteStoreError;
 
     fn list_node_cids(&self) -> Result<Vec<Cid>, Self::Error> {
-        let conn = self.connection()?;
+        let conn = self.read_connection()?;
+        self.metrics.sql_reads.fetch_add(1, Ordering::Relaxed);
         let mut stmt = conn
             .prepare_cached(SELECT_NODE_CIDS_SQL)
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to prepare node CID listing"))?;
@@ -1085,7 +2099,8 @@ impl ManifestStore for SqliteStore {
     type Error = SqliteStoreError;
 
     fn get_root(&self, name: &[u8]) -> Result<Option<RootManifest>, Self::Error> {
-        let conn = self.connection()?;
+        let conn = self.read_connection()?;
+        self.metrics.sql_reads.fetch_add(1, Ordering::Relaxed);
         let bytes = conn
             .query_row(SELECT_ROOT_SQL, params![name], |row| row.get(0))
             .optional()
@@ -1098,6 +2113,8 @@ impl ManifestStore for SqliteStore {
         let bytes = encode_root_manifest(manifest)?;
         conn.execute(UPSERT_ROOT_SQL, params![name, bytes])
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to write root manifest"))?;
+        drop(conn);
+        self.write_committed();
         Ok(())
     }
 
@@ -1105,6 +2122,8 @@ impl ManifestStore for SqliteStore {
         let conn = self.connection()?;
         conn.execute(DELETE_ROOT_SQL, params![name])
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to delete root manifest"))?;
+        drop(conn);
+        self.write_committed();
         Ok(())
     }
 
@@ -1149,13 +2168,16 @@ impl ManifestStore for SqliteStore {
 
         tx.commit()
             .map_err(|e| SqliteStoreError::from_sqlite(e, "Failed to commit root transaction"))?;
+        drop(conn);
+        self.write_committed();
         Ok(ManifestUpdate::Applied)
     }
 }
 
 impl ManifestStoreScan for SqliteStore {
     fn list_roots(&self) -> Result<Vec<NamedRootManifest>, Self::Error> {
-        let conn = self.connection()?;
+        let conn = self.read_connection()?;
+        self.metrics.sql_reads.fetch_add(1, Ordering::Relaxed);
         let mut stmt = conn.prepare_cached(SELECT_ROOTS_SQL).map_err(|e| {
             SqliteStoreError::from_sqlite(e, "Failed to prepare root manifest listing")
         })?;
@@ -1241,10 +2263,11 @@ impl TransactionalStore for SqliteStore {
             for write in node_writes {
                 match write {
                     TransactionNodeWrite::Upsert { key, value } => {
-                        let (encoding, value) =
+                        let (encoding, stored) =
                             encode_stored_node(value, self.node_compression_min_bytes);
+                        self.record_compression(value.len(), encoding, stored.len());
                         upsert_node
-                            .execute(params![key, encoding, value])
+                            .execute(params![key, encoding, stored])
                             .map_err(|err| {
                                 Error::Store(Box::new(SqliteStoreError::from_sqlite(
                                     err,
@@ -1307,13 +2330,12 @@ impl TransactionalStore for SqliteStore {
                 "Failed to commit transaction",
             )))
         })?;
-        let mut cache = self
-            .node_read_cache()
-            .map_err(|err| Error::Store(Box::new(err)))?;
+        drop(conn);
+        self.write_committed();
         for write in node_writes {
             match write {
                 TransactionNodeWrite::Upsert { key, .. } | TransactionNodeWrite::Delete { key } => {
-                    cache.remove(key)
+                    self.node_read_cache.remove(key)
                 }
             }
         }
@@ -1496,8 +2518,8 @@ mod tests {
             node_compression_min_bytes: 32 * 1024,
             ..SqliteStoreConfig::default()
         };
-        let store = SqliteStore::from_connection(Connection::open_in_memory().unwrap(), config)
-            .unwrap();
+        let store =
+            SqliteStore::from_connection(Connection::open_in_memory().unwrap(), config).unwrap();
         let node = vec![b'x'; 16 * 1024];
 
         store.put(b"raw", &node).unwrap();
@@ -1537,5 +2559,237 @@ mod tests {
             )
             .unwrap();
         assert_eq!(encoding, NODE_ENCODING_RAW);
+    }
+
+    #[test]
+    fn file_store_opens_reader_pool_and_disables_writer_autocheckpoint() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = SqliteStoreConfig {
+            reader_connections: 3,
+            background_checkpoints: true,
+            ..SqliteStoreConfig::default()
+        };
+        let store =
+            SqliteStore::open_with_config(directory.path().join("store.db"), config).unwrap();
+
+        assert_eq!(store.reader_connection_count(), 3);
+        let writer = store.connection().unwrap();
+        let autocheckpoint: u32 = writer
+            .query_row("PRAGMA wal_autocheckpoint", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(autocheckpoint, 0);
+    }
+
+    #[test]
+    fn primary_reader_reuses_writer_and_other_threads_use_the_pool() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = SqliteStoreConfig {
+            background_checkpoints: false,
+            reader_connections: 2,
+            ..SqliteStoreConfig::default()
+        };
+        let store = Arc::new(
+            SqliteStore::open_with_config(directory.path().join("store.db"), config).unwrap(),
+        );
+
+        assert!(matches!(
+            store.read_connection().unwrap(),
+            ReadConnectionGuard::Writer(_)
+        ));
+        let other = {
+            let store = store.clone();
+            thread::spawn(move || {
+                matches!(
+                    store.read_connection().unwrap(),
+                    ReadConnectionGuard::Reader(_)
+                )
+            })
+        };
+        assert!(other.join().unwrap());
+    }
+
+    #[test]
+    fn reader_pool_serves_reads_while_the_writer_commits() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = SqliteStoreConfig {
+            background_checkpoints: false,
+            node_read_cache_size_bytes: 0,
+            reader_connections: 4,
+            ..SqliteStoreConfig::default()
+        };
+        let store = Arc::new(
+            SqliteStore::open_with_config(directory.path().join("store.db"), config).unwrap(),
+        );
+        store.put(b"stable", b"value").unwrap();
+        let barrier = Arc::new(std::sync::Barrier::new(5));
+        let readers = (0..4)
+            .map(|_| {
+                let store = store.clone();
+                let barrier = barrier.clone();
+                thread::spawn(move || {
+                    barrier.wait();
+                    for _ in 0..100 {
+                        assert_eq!(store.get(b"stable").unwrap(), Some(b"value".to_vec()));
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        barrier.wait();
+        for index in 0u32..100 {
+            store
+                .put(&index.to_be_bytes(), &index.wrapping_add(1).to_be_bytes())
+                .unwrap();
+        }
+        for reader in readers {
+            reader.join().unwrap();
+        }
+
+        assert!(store.metrics().unwrap().sql_reads >= 400);
+    }
+
+    #[test]
+    fn background_checkpoint_worker_processes_committed_wal_frames() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = SqliteStoreConfig {
+            background_checkpoints: true,
+            checkpoint_interval_ms: 5,
+            checkpoint_wal_bytes: 1,
+            reader_connections: 1,
+            ..SqliteStoreConfig::default()
+        };
+        let store =
+            SqliteStore::open_with_config(directory.path().join("store.db"), config).unwrap();
+        store.put(b"key", b"value").unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while store.metrics().unwrap().checkpoint_attempts == 0 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
+        }
+
+        let metrics = store.metrics().unwrap();
+        assert!(metrics.checkpoint_attempts >= 1);
+        assert!(metrics.checkpointed_frames >= 1);
+    }
+
+    #[test]
+    fn adaptive_batch_reads_cross_the_legacy_256_key_boundary() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = SqliteStoreConfig {
+            background_checkpoints: false,
+            max_batch_select_keys: 512,
+            node_read_cache_size_bytes: 0,
+            reader_connections: 2,
+            ..SqliteStoreConfig::default()
+        };
+        let store =
+            SqliteStore::open_with_config(directory.path().join("store.db"), config).unwrap();
+        let keys = (0u32..600)
+            .map(|index| index.to_be_bytes().to_vec())
+            .collect::<Vec<_>>();
+        let values = (0u32..600)
+            .map(|index| format!("value-{index}").into_bytes())
+            .collect::<Vec<_>>();
+        let entries = keys
+            .iter()
+            .zip(&values)
+            .map(|(key, value)| (key.as_slice(), value.as_slice()))
+            .collect::<Vec<_>>();
+        store.batch_put(&entries).unwrap();
+        let key_refs = keys.iter().map(Vec::as_slice).collect::<Vec<_>>();
+
+        let observed = store.batch_get_ordered_unique(&key_refs).unwrap();
+
+        assert_eq!(observed.len(), values.len());
+        assert!(observed
+            .iter()
+            .zip(values)
+            .all(|(observed, expected)| observed.as_deref() == Some(expected.as_slice())));
+    }
+
+    #[test]
+    fn sharded_cache_eviction_and_sqlite_metrics_are_reported() {
+        let config = SqliteStoreConfig {
+            node_read_cache_size_bytes: 16,
+            node_read_cache_shards: 1,
+            ..SqliteStoreConfig::default()
+        };
+        let store =
+            SqliteStore::from_connection(Connection::open_in_memory().unwrap(), config).unwrap();
+        store.put(b"a", b"123456789012").unwrap();
+        store.put(b"b", b"abcdefghijkl").unwrap();
+        assert_eq!(store.get(b"a").unwrap(), Some(b"123456789012".to_vec()));
+
+        let metrics = store.metrics().unwrap();
+        assert!(metrics.node_cache_evictions >= 1);
+        assert!(metrics.node_cache_misses >= 1);
+        assert!(metrics.sql_reads >= 1);
+        assert!(metrics.sqlite_page_cache_hits + metrics.sqlite_page_cache_misses > 0);
+    }
+
+    #[test]
+    fn group_commit_combines_concurrent_publications() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = SqliteStoreConfig {
+            background_checkpoints: false,
+            group_commit_delay_micros: 20_000,
+            group_commit_max_nodes: 64,
+            reader_connections: 2,
+            ..SqliteStoreConfig::default()
+        };
+        let store = Arc::new(
+            SqliteStore::open_with_config(directory.path().join("store.db"), config).unwrap(),
+        );
+        let barrier = Arc::new(std::sync::Barrier::new(8));
+        let threads = (0u8..8)
+            .map(|index| {
+                let store = store.clone();
+                let barrier = barrier.clone();
+                thread::spawn(move || {
+                    let key = vec![index; 32];
+                    let value = vec![index.wrapping_add(1); 128];
+                    let entries = [(key.as_slice(), value.as_slice())];
+                    barrier.wait();
+                    store
+                        .publish_nodes(NodePublication::new(
+                            &entries,
+                            PublicationOrigin::PointUpsert,
+                        ))
+                        .unwrap();
+                })
+            })
+            .collect::<Vec<_>>();
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        let metrics = store.metrics().unwrap();
+        assert_eq!(metrics.published_nodes, 8);
+        assert!(metrics.grouped_publications >= 1);
+        assert!(metrics.write_transactions < 8);
+    }
+
+    #[test]
+    fn checkpoint_backup_compaction_and_quick_check_are_available() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory.path().join("store.db");
+        let backup = directory.path().join("backup.db");
+        let config = SqliteStoreConfig {
+            background_checkpoints: false,
+            reader_connections: 2,
+            ..SqliteStoreConfig::default()
+        };
+        let store = SqliteStore::open_with_config(&database, config).unwrap();
+        store.put(b"key", b"value").unwrap();
+
+        let checkpoint = store.checkpoint(SqliteCheckpointMode::Passive).unwrap();
+        assert!(checkpoint.checkpointed_frames <= checkpoint.log_frames);
+        store.quick_check().unwrap();
+        store.backup_to(&backup).unwrap();
+        store.compact().unwrap();
+        let stats = store.storage_stats().unwrap();
+        assert!(stats.page_count > 0);
+
+        let backup_store = SqliteStore::open_existing(&backup).unwrap();
+        assert_eq!(backup_store.get(b"key").unwrap(), Some(b"value".to_vec()));
     }
 }

--- a/stores/prolly-store-sqlite/tests/sqlite_store.rs
+++ b/stores/prolly-store-sqlite/tests/sqlite_store.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use prolly::{Config, Error, Prolly};
+use prolly::{Config, Error, NamedRootRetention, Prolly};
 use prolly_store_sqlite::SqliteStore;
 
 #[test]
@@ -60,6 +60,33 @@ fn sqlite_store_commits_and_rolls_back_strict_transactions() {
     });
     assert!(matches!(result, Err(Error::Serialize(_))));
     assert_eq!(prolly.load_named_root(b"main").unwrap(), Some(committed));
+}
+
+#[test]
+fn sqlite_store_sweeps_nodes_unreachable_from_retained_named_roots() {
+    let store = SqliteStore::open_in_memory().unwrap();
+    let prolly = Prolly::new(store, Config::default());
+    let _orphan = prolly
+        .put(&prolly.create(), b"orphan".to_vec(), b"discard".to_vec())
+        .unwrap();
+    let retained = prolly
+        .put(&prolly.create(), b"live".to_vec(), b"retain".to_vec())
+        .unwrap();
+    prolly.publish_named_root(b"main", &retained).unwrap();
+
+    let plan = prolly
+        .plan_store_gc_for_retention(&NamedRootRetention::all())
+        .unwrap();
+    assert!(plan.reclaimable_nodes >= 1);
+
+    let sweep = prolly
+        .sweep_store_gc_for_retention(&NamedRootRetention::all())
+        .unwrap();
+    assert_eq!(sweep.deleted_nodes, plan.reclaimable_nodes);
+    assert_eq!(
+        prolly.get(&retained, b"live").unwrap(),
+        Some(b"retain".to_vec())
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Harden `prolly-store-sqlite` for use as the primary local store:

- use a serialized writer plus a thread-affine read-only connection pool
- preserve the single-thread fast path by letting the first reader reuse the writer connection
- move WAL checkpoints to a dedicated background worker with bounded WAL allocation
- expose adapter, cache, compression, checkpoint, pager, and storage metrics
- add opt-in group commit for concurrent immutable-node publications
- use SQLite-aware bounded batch reads with a measured 128-key default
- replace cache-wide resets with a sharded, byte-bounded LRU
- add checkpoint, backup, optimization, quick-check, compaction, and storage-stat APIs
- document and verify store-wide retention GC against SQLite

## Why

SQLite is the intended primary store for local applications. The previous single-connection design serialized cache misses with writes, performed less predictable cache eviction, and lacked the checkpointing, observability, and maintenance APIs needed for long-running deployments.

During performance validation, the initial read-pool implementation also exposed two regressions: the primary application thread lost the writer connection's page/statement-cache locality, and a 2,048-key SQL batch cap was too large for local SQLite. This PR fixes both by retaining a primary-thread writer-read fast path and selecting the measured 128-key default while keeping the pool available to other threads.

## Impact

Group commit preserves every logical publication while reducing physical durable commits. In the focused 1,600-publication test, 465 SQLite transactions plus 1,135 grouped publications accounted for all 1,600 calls and increased `FULL`-durability throughput from 2,603 to 6,822 publications/s in the latest run.

Across two order-balanced seven-run 10,000-record matrices (14 samples per cell), compared with the pre-hardening store:

- append point puts: +0.4%
- random point puts: +21.8%
- clustered point puts: +25.8%
- median query throughput: +11.8%
- median scan throughput: +18.1%
- overall 25-cell median: +4.6%
- focused 1,024-key batch reads: about +4.2%

Concurrent-read timing remains host-scheduling-sensitive, so the PR does not claim a precise read-pool throughput percentage.

## Validation

- `cargo test --lib` — 502 passed
- `cargo test --manifest-path stores/prolly-store-sqlite/Cargo.toml` — 35 tests/doc-tests passed
- `cargo test --manifest-path benchmarks/sqlite-scale/Cargo.toml` — complete harness suite passed
- `cargo clippy --manifest-path stores/prolly-store-sqlite/Cargo.toml --all-targets -- -D warnings`
- workspace, SQLite crate, and scale-harness formatting checks
- `git diff --check`
- release SQLite smoke matrix — all 25 workload cells completed
