### PR TITLE
refactor(redb): make prolly_nodes the encoded default

### DIFF
--- a/benchmarks/redb-correctness/src/main.rs
+++ b/benchmarks/redb-correctness/src/main.rs
@@ -385,8 +385,7 @@ fn model_diff(base: &BTreeMap<Vec<u8>, Vec<u8>>, target: &BTreeMap<Vec<u8>, Vec<
 }
 
 fn legacy_engine_migration(path: &Path) {
-    const NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes_v3");
-    const LEGACY_NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes");
+    const NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes");
 
     let config = Config::builder()
         .min_chunk_size(32)
@@ -416,7 +415,8 @@ fn legacy_engine_migration(path: &Path) {
     let mut decoded_nodes = Vec::new();
     for entry in nodes.iter().unwrap() {
         let (key, value) = entry.unwrap();
-        let (encoding, stored) = value.value().split_first().unwrap();
+        let envelope = value.value().strip_prefix(b"PRN1").unwrap();
+        let (encoding, stored) = envelope.split_first().unwrap();
         let decoded = match *encoding {
             0 => stored.to_vec(),
             1 => lz4_flex::decompress_size_prepended(stored).unwrap(),
@@ -429,10 +429,8 @@ fn legacy_engine_migration(path: &Path) {
     let transaction = database.begin_write().unwrap();
     {
         let mut nodes = transaction.open_table(NODES).unwrap();
-        let mut legacy = transaction.open_table(LEGACY_NODES).unwrap();
         for (key, value) in &decoded_nodes {
-            legacy.insert(key.as_slice(), value.as_slice()).unwrap();
-            nodes.remove(key.as_slice()).unwrap();
+            nodes.insert(key.as_slice(), value.as_slice()).unwrap();
         }
     }
     transaction.commit().unwrap();
@@ -627,20 +625,19 @@ fn randomized_reopen_differential(path: &Path, seed: u64) {
 }
 
 fn inspect_storage(path: &Path) {
-    const NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes_v3");
-    const LEGACY_NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes");
+    const NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes");
 
     let database = Database::open(path).unwrap();
     let transaction = database.begin_read().unwrap();
     let nodes = transaction.open_table(NODES).unwrap();
-    let legacy = transaction.open_table(LEGACY_NODES).unwrap();
     let mut raw_nodes = 0_u64;
     let mut compressed_nodes = 0_u64;
     let mut stored_bytes = 0_u64;
     let mut decoded_bytes = 0_u64;
     for entry in nodes.iter().unwrap() {
         let (key, value) = entry.unwrap();
-        let (encoding, stored) = value.value().split_first().unwrap();
+        let envelope = value.value().strip_prefix(b"PRN1").unwrap();
+        let (encoding, stored) = envelope.split_first().unwrap();
         let decoded = match *encoding {
             0 => {
                 raw_nodes += 1;
@@ -659,7 +656,6 @@ fn inspect_storage(path: &Path) {
     }
     assert!(raw_nodes > 0);
     assert!(compressed_nodes > 0);
-    assert_eq!(legacy.iter().unwrap().count(), 0);
     println!(
         "STORAGE,raw_nodes={raw_nodes},compressed_nodes={compressed_nodes},stored_bytes={stored_bytes},decoded_bytes={decoded_bytes}"
     );

--- a/stores/prolly-store-redb/README.md
+++ b/stores/prolly-store-redb/README.md
@@ -107,16 +107,17 @@ stale post-commit data.
 
 ## Storage model
 
-The adapter creates five typed tables inside one redb file:
+The adapter creates four typed tables inside one redb file:
 
-- `prolly_nodes_v3` stores content-addressed nodes with an explicit raw or LZ4
-  encoding. Nodes smaller than 8 KiB and nodes that do not compress smaller are
-  stored raw. Raw values are copied directly into space reserved in redb's
-  B-tree page, avoiding an intermediate serialized node allocation.
+- `prolly_nodes` is the default content-addressed node table. New values use a
+  versioned envelope with an explicit raw or LZ4 encoding. Nodes smaller than
+  8 KiB and nodes that do not compress smaller are stored raw. Raw values are
+  copied directly into space reserved in redb's B-tree page, avoiding an
+  intermediate serialized node allocation. Unenveloped raw values created by
+  adapter 0.3.0 remain readable and gain the envelope when updated.
 - `prolly_nodes_v2` retains the tuple-encoded node layout from the initial 0.3.1
-  implementation. Existing nodes remain readable and move to v3 when updated.
-- `prolly_nodes` is the legacy raw-node table retained for transparent reads of
-  databases created by adapter 0.3.0. New and updated nodes move to the v2 table.
+  implementation. Existing nodes remain readable and move to the default
+  `prolly_nodes` table when updated.
 - `prolly_roots` stores encoded named-root manifests.
 - `prolly_hints` stores advisory values by `(namespace, key)`.
 

--- a/stores/prolly-store-redb/src/lib.rs
+++ b/stores/prolly-store-redb/src/lib.rs
@@ -21,18 +21,18 @@ use prolly::{
 
 pub use redb::Durability;
 
-const LEGACY_NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes");
 const V2_NODES: TableDefinition<&[u8], (u8, &[u8])> = TableDefinition::new("prolly_nodes_v2");
-const NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes_v3");
+const NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes");
 const ROOTS: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_roots");
 const HINTS: TableDefinition<(&[u8], &[u8]), &[u8]> = TableDefinition::new("prolly_hints");
 
 const NODE_ENCODING_RAW: u8 = 0;
 const NODE_ENCODING_LZ4: u8 = 1;
+const NODE_ENVELOPE_MAGIC: &[u8; 4] = b"PRN1";
+const NODE_ENVELOPE_HEADER_BYTES: usize = NODE_ENVELOPE_MAGIC.len() + 1;
 const MIN_COMPRESSIBLE_NODE_BYTES: usize = 8 * 1024;
 const DEFAULT_NODE_READ_CACHE_SIZE_BYTES: usize = 128 * 1024 * 1024;
 
-type NodeTable<'txn> = redb::Table<'txn, &'static [u8], &'static [u8]>;
 type V2NodeTable<'txn> = redb::Table<'txn, &'static [u8], (u8, &'static [u8])>;
 
 /// Configuration for [`RedbStore`].
@@ -229,7 +229,6 @@ pub struct RedbStore {
     node_read_transaction: RwLock<Option<redb::ReadTransaction>>,
     compress_nodes: bool,
     v2_nodes_present: AtomicBool,
-    legacy_nodes_present: AtomicBool,
 }
 
 impl std::fmt::Debug for RedbStore {
@@ -245,10 +244,6 @@ impl std::fmt::Debug for RedbStore {
             .field(
                 "v2_nodes_present",
                 &self.v2_nodes_present.load(Ordering::Relaxed),
-            )
-            .field(
-                "legacy_nodes_present",
-                &self.legacy_nodes_present.load(Ordering::Relaxed),
             )
             .finish_non_exhaustive()
     }
@@ -295,7 +290,6 @@ impl RedbStore {
             node_read_transaction: RwLock::new(None),
             compress_nodes: options.compress_nodes,
             v2_nodes_present: AtomicBool::new(false),
-            legacy_nodes_present: AtomicBool::new(false),
         };
         store.initialize_tables()?;
         Ok(store)
@@ -315,15 +309,8 @@ impl RedbStore {
 
     fn initialize_tables(&self) -> Result<(), RedbStoreError> {
         let transaction = self.begin_write("failed to begin table initialization")?;
-        let legacy_nodes_present;
         let v2_nodes_present;
         {
-            let legacy_nodes = transaction.open_table(LEGACY_NODES).map_err(|error| {
-                RedbStoreError::with_source("failed to initialize legacy node table", error)
-            })?;
-            legacy_nodes_present = !legacy_nodes.is_empty().map_err(|error| {
-                RedbStoreError::with_source("failed to inspect legacy node table", error)
-            })?;
             let v2_nodes = transaction.open_table(V2_NODES).map_err(|error| {
                 RedbStoreError::with_source("failed to initialize v2 node table", error)
             })?;
@@ -343,8 +330,6 @@ impl RedbStore {
         transaction.commit().map_err(|error| {
             RedbStoreError::with_source("failed to commit table initialization", error)
         })?;
-        self.legacy_nodes_present
-            .store(legacy_nodes_present, Ordering::Relaxed);
         self.v2_nodes_present
             .store(v2_nodes_present, Ordering::Relaxed);
         Ok(())
@@ -361,25 +346,6 @@ impl RedbStore {
                 RedbStoreError::with_source("failed to configure transaction durability", error)
             })?;
         Ok(transaction)
-    }
-
-    fn open_legacy_nodes_for_write<'txn>(
-        &self,
-        transaction: &'txn WriteTransaction,
-        operation: &str,
-    ) -> Result<Option<NodeTable<'txn>>, RedbStoreError> {
-        if !self.legacy_nodes_present.load(Ordering::Relaxed) {
-            return Ok(None);
-        }
-        transaction
-            .open_table(LEGACY_NODES)
-            .map(Some)
-            .map_err(|error| {
-                RedbStoreError::with_source(
-                    format!("failed to open legacy node table for {operation}"),
-                    error,
-                )
-            })
     }
 
     fn open_v2_nodes_for_write<'txn>(
@@ -439,18 +405,6 @@ impl RedbStore {
                     })
                 })
                 .transpose()?;
-            let legacy = self
-                .legacy_nodes_present
-                .load(Ordering::Relaxed)
-                .then(|| {
-                    transaction.open_table(LEGACY_NODES).map_err(|error| {
-                        RedbStoreError::with_source(
-                            "failed to open legacy node table for reading",
-                            error,
-                        )
-                    })
-                })
-                .transpose()?;
             if !missing.windows(2).all(|pair| pair[0].1 <= pair[1].1) {
                 missing.sort_unstable_by(|left, right| left.1.cmp(right.1));
             }
@@ -474,22 +428,10 @@ impl RedbStore {
                     let (encoding, bytes) = value.value();
                     Some(Arc::from(decode_v2_stored_node(encoding, bytes)?))
                 } else {
-                    legacy
-                        .as_ref()
-                        .map(|legacy| {
-                            legacy
-                                .get(*key)
-                                .map_err(|error| {
-                                    RedbStoreError::with_source("failed to read legacy node", error)
-                                })
-                                .map(|value| value.map(|value| Arc::from(value.value())))
-                        })
-                        .transpose()?
-                        .flatten()
+                    None
                 };
                 loaded_values.push(value);
             }
-            drop(legacy);
             drop(v2);
             drop(table);
             drop(transaction_guard);
@@ -529,18 +471,6 @@ impl RedbStore {
                 })
             })
             .transpose()?;
-        let legacy = self
-            .legacy_nodes_present
-            .load(Ordering::Relaxed)
-            .then(|| {
-                transaction.open_table(LEGACY_NODES).map_err(|error| {
-                    RedbStoreError::with_source(
-                        "failed to open legacy node table for reading",
-                        error,
-                    )
-                })
-            })
-            .transpose()?;
         let mut order = (0..keys.len()).collect::<Vec<_>>();
         if !keys.windows(2).all(|pair| pair[0] <= pair[1]) {
             order.sort_unstable_by(|&left, &right| keys[left].cmp(keys[right]));
@@ -566,18 +496,7 @@ impl RedbStore {
                 let (encoding, bytes) = value.value();
                 decode_v2_stored_node(encoding, bytes).map(Some)
             } else {
-                legacy
-                    .as_ref()
-                    .map(|legacy| {
-                        legacy
-                            .get(key)
-                            .map(|value| value.map(|value| value.value().to_vec()))
-                            .map_err(|error| {
-                                RedbStoreError::with_source("failed to read legacy node", error)
-                            })
-                    })
-                    .transpose()
-                    .map(|value| value.flatten())
+                Ok(None)
             }?;
         }
         Ok(values)
@@ -662,7 +581,6 @@ impl Store for RedbStore {
                 RedbStoreError::with_source("failed to open node table for writing", error)
             })?;
             let mut v2 = self.open_v2_nodes_for_write(&transaction, "writing")?;
-            let mut legacy = self.open_legacy_nodes_for_write(&transaction, "writing")?;
             let mut compression_scratch = Vec::new();
             insert_stored_node(
                 &mut table,
@@ -675,11 +593,6 @@ impl Store for RedbStore {
             if let Some(v2) = v2.as_mut() {
                 v2.remove(key).map_err(|error| {
                     RedbStoreError::with_source("failed to remove superseded v2 node", error)
-                })?;
-            }
-            if let Some(legacy) = legacy.as_mut() {
-                legacy.remove(key).map_err(|error| {
-                    RedbStoreError::with_source("failed to remove superseded legacy node", error)
                 })?;
             }
         }
@@ -697,18 +610,12 @@ impl Store for RedbStore {
                 RedbStoreError::with_source("failed to open node table for deletion", error)
             })?;
             let mut v2 = self.open_v2_nodes_for_write(&transaction, "deletion")?;
-            let mut legacy = self.open_legacy_nodes_for_write(&transaction, "deletion")?;
             table
                 .remove(key)
                 .map_err(|error| RedbStoreError::with_source("failed to delete node", error))?;
             if let Some(v2) = v2.as_mut() {
                 v2.remove(key).map_err(|error| {
                     RedbStoreError::with_source("failed to delete v2 node", error)
-                })?;
-            }
-            if let Some(legacy) = legacy.as_mut() {
-                legacy.remove(key).map_err(|error| {
-                    RedbStoreError::with_source("failed to delete legacy node", error)
                 })?;
             }
         }
@@ -726,7 +633,6 @@ impl Store for RedbStore {
                 RedbStoreError::with_source("failed to open node table for batch", error)
             })?;
             let mut v2 = self.open_v2_nodes_for_write(&transaction, "batch")?;
-            let mut legacy = self.open_legacy_nodes_for_write(&transaction, "batch")?;
             let mut compression_scratch = Vec::new();
             for op in ops {
                 match op {
@@ -749,14 +655,6 @@ impl Store for RedbStore {
                                 )
                             })?;
                         }
-                        if let Some(legacy) = legacy.as_mut() {
-                            legacy.remove(*key).map_err(|error| {
-                                RedbStoreError::with_source(
-                                    "failed to remove superseded legacy node in batch",
-                                    error,
-                                )
-                            })?;
-                        }
                     }
                     BatchOp::Delete { key } => {
                         table.remove(*key).map_err(|error| {
@@ -766,14 +664,6 @@ impl Store for RedbStore {
                             v2.remove(*key).map_err(|error| {
                                 RedbStoreError::with_source(
                                     "failed to delete v2 node in batch",
-                                    error,
-                                )
-                            })?;
-                        }
-                        if let Some(legacy) = legacy.as_mut() {
-                            legacy.remove(*key).map_err(|error| {
-                                RedbStoreError::with_source(
-                                    "failed to delete legacy node in batch",
                                     error,
                                 )
                             })?;
@@ -836,7 +726,6 @@ impl Store for RedbStore {
                 RedbStoreError::with_source("failed to open node table for batch put", error)
             })?;
             let mut v2 = self.open_v2_nodes_for_write(&transaction, "batch put")?;
-            let mut legacy = self.open_legacy_nodes_for_write(&transaction, "batch put")?;
             let mut order = (0..entries.len()).collect::<Vec<_>>();
             order.sort_by(|&left, &right| entries[left].0.cmp(entries[right].0));
             let mut compression_scratch = Vec::new();
@@ -856,14 +745,6 @@ impl Store for RedbStore {
                     v2.remove(key).map_err(|error| {
                         RedbStoreError::with_source(
                             "failed to remove superseded v2 node in batch put",
-                            error,
-                        )
-                    })?;
-                }
-                if let Some(legacy) = legacy.as_mut() {
-                    legacy.remove(key).map_err(|error| {
-                        RedbStoreError::with_source(
-                            "failed to remove superseded legacy node in batch put",
                             error,
                         )
                     })?;
@@ -922,7 +803,6 @@ impl Store for RedbStore {
                 RedbStoreError::with_source("failed to open node table for publication", error)
             })?;
             let mut v2 = self.open_v2_nodes_for_write(&transaction, "publication")?;
-            let mut legacy = self.open_legacy_nodes_for_write(&transaction, "publication")?;
             let mut hints = transaction.open_table(HINTS).map_err(|error| {
                 RedbStoreError::with_source("failed to open hint table for publication", error)
             })?;
@@ -943,14 +823,6 @@ impl Store for RedbStore {
                     v2.remove(node_key).map_err(|error| {
                         RedbStoreError::with_source(
                             "failed to remove superseded v2 node during publication",
-                            error,
-                        )
-                    })?;
-                }
-                if let Some(legacy) = legacy.as_mut() {
-                    legacy.remove(node_key).map_err(|error| {
-                        RedbStoreError::with_source(
-                            "failed to remove superseded legacy node during publication",
                             error,
                         )
                     })?;
@@ -997,19 +869,6 @@ impl NodeStoreScan for RedbStore {
             })? {
                 let (key, _) = entry.map_err(|error| {
                     RedbStoreError::with_source("failed to read v2 node scan entry", error)
-                })?;
-                cids.push(cid_from_store_key(key.value())?);
-            }
-        }
-        if self.legacy_nodes_present.load(Ordering::Relaxed) {
-            let legacy = transaction.open_table(LEGACY_NODES).map_err(|error| {
-                RedbStoreError::with_source("failed to open legacy node table for scanning", error)
-            })?;
-            for entry in legacy.iter().map_err(|error| {
-                RedbStoreError::with_source("failed to iterate legacy node table", error)
-            })? {
-                let (key, _) = entry.map_err(|error| {
-                    RedbStoreError::with_source("failed to read legacy node scan entry", error)
                 })?;
                 cids.push(cid_from_store_key(key.value())?);
             }
@@ -1162,9 +1021,6 @@ impl TransactionalStore for RedbStore {
             let mut v2_nodes = self
                 .open_v2_nodes_for_write(&transaction, "strict transaction")
                 .map_err(store_error)?;
-            let mut legacy_nodes = self
-                .open_legacy_nodes_for_write(&transaction, "strict transaction")
-                .map_err(store_error)?;
             let mut roots = transaction.open_table(ROOTS).map_err(|error| {
                 store_error(RedbStoreError::with_source(
                     "failed to open root table for strict transaction",
@@ -1221,14 +1077,6 @@ impl TransactionalStore for RedbStore {
                                 ))
                             })?;
                         }
-                        if let Some(legacy_nodes) = legacy_nodes.as_mut() {
-                            legacy_nodes.remove(key.as_slice()).map_err(|error| {
-                                store_error(RedbStoreError::with_source(
-                                    "failed to remove superseded legacy node in strict transaction",
-                                    error,
-                                ))
-                            })?;
-                        }
                     }
                     TransactionNodeWrite::Delete { key } => {
                         nodes.remove(key.as_slice()).map_err(|error| {
@@ -1241,14 +1089,6 @@ impl TransactionalStore for RedbStore {
                             v2_nodes.remove(key.as_slice()).map_err(|error| {
                                 store_error(RedbStoreError::with_source(
                                     "failed to delete v2 node in strict transaction",
-                                    error,
-                                ))
-                            })?;
-                        }
-                        if let Some(legacy_nodes) = legacy_nodes.as_mut() {
-                            legacy_nodes.remove(key.as_slice()).map_err(|error| {
-                                store_error(RedbStoreError::with_source(
-                                    "failed to delete legacy node in strict transaction",
                                     error,
                                 ))
                             })?;
@@ -1317,30 +1157,39 @@ fn insert_stored_node(
     scratch: &mut Vec<u8>,
 ) -> redb::Result {
     if compress && node.len() >= MIN_COMPRESSIBLE_NODE_BYTES && node.len() <= u32::MAX as usize {
-        let maximum = 5 + lz4_flex::block::get_maximum_output_size(node.len());
+        let compressed_header_bytes = NODE_ENVELOPE_HEADER_BYTES + 4;
+        let maximum =
+            compressed_header_bytes + lz4_flex::block::get_maximum_output_size(node.len());
         scratch.clear();
         scratch.resize(maximum, 0);
-        scratch[0] = NODE_ENCODING_LZ4;
-        scratch[1..5].copy_from_slice(&(node.len() as u32).to_le_bytes());
-        let compressed_len = lz4_flex::block::compress_into(node, &mut scratch[5..])
-            .expect("maximum LZ4 output size is sufficient");
-        let stored_len = 5 + compressed_len;
-        if stored_len < 1 + node.len() {
+        scratch[..NODE_ENVELOPE_MAGIC.len()].copy_from_slice(NODE_ENVELOPE_MAGIC);
+        scratch[NODE_ENVELOPE_MAGIC.len()] = NODE_ENCODING_LZ4;
+        scratch[NODE_ENVELOPE_HEADER_BYTES..compressed_header_bytes]
+            .copy_from_slice(&(node.len() as u32).to_le_bytes());
+        let compressed_len =
+            lz4_flex::block::compress_into(node, &mut scratch[compressed_header_bytes..])
+                .expect("maximum LZ4 output size is sufficient");
+        let stored_len = compressed_header_bytes + compressed_len;
+        if stored_len < NODE_ENVELOPE_HEADER_BYTES + node.len() {
             scratch.truncate(stored_len);
             table.insert(key, scratch.as_slice())?;
             return Ok(());
         }
     }
 
-    let mut stored = table.insert_reserve(key, 1 + node.len())?;
+    let mut stored = table.insert_reserve(key, NODE_ENVELOPE_HEADER_BYTES + node.len())?;
     let stored = stored.as_mut();
-    stored[0] = NODE_ENCODING_RAW;
-    stored[1..].copy_from_slice(node);
+    stored[..NODE_ENVELOPE_MAGIC.len()].copy_from_slice(NODE_ENVELOPE_MAGIC);
+    stored[NODE_ENVELOPE_MAGIC.len()] = NODE_ENCODING_RAW;
+    stored[NODE_ENVELOPE_HEADER_BYTES..].copy_from_slice(node);
     Ok(())
 }
 
 fn decode_stored_node(stored: &[u8]) -> Result<Vec<u8>, RedbStoreError> {
-    let (&encoding, node) = stored
+    let Some(envelope) = stored.strip_prefix(NODE_ENVELOPE_MAGIC) else {
+        return Ok(stored.to_vec());
+    };
+    let (&encoding, node) = envelope
         .split_first()
         .ok_or_else(|| RedbStoreError::message("stored node is missing its encoding byte"))?;
     match encoding {

--- a/stores/prolly-store-redb/tests/redb_store.rs
+++ b/stores/prolly-store-redb/tests/redb_store.rs
@@ -171,7 +171,7 @@ fn redb_store_retains_native_shared_reads() {
 
 #[test]
 fn redb_store_compresses_large_nodes_transparently() {
-    const NODES_V3: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes_v3");
+    const NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes");
 
     let path = temp_db_path("compressed-nodes");
     remove_db(&path);
@@ -185,9 +185,10 @@ fn redb_store_compresses_large_nodes_transparently() {
 
     let database = Database::open(&path).unwrap();
     let transaction = database.begin_read().unwrap();
-    let table = transaction.open_table(NODES_V3).unwrap();
+    let table = transaction.open_table(NODES).unwrap();
     let stored = table.get(key.as_bytes()).unwrap().unwrap();
-    let (encoding, bytes) = stored.value().split_first().unwrap();
+    let envelope = stored.value().strip_prefix(b"PRN1").unwrap();
+    let (encoding, bytes) = envelope.split_first().unwrap();
     assert_eq!(*encoding, 1);
     assert!(bytes.len() < value.len() / 4);
     drop(stored);
@@ -199,7 +200,7 @@ fn redb_store_compresses_large_nodes_transparently() {
 
 #[test]
 fn redb_store_can_disable_cache_and_compression() {
-    const NODES_V3: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes_v3");
+    const NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes");
 
     let path = temp_db_path("uncompressed-nodes");
     remove_db(&path);
@@ -222,9 +223,10 @@ fn redb_store_can_disable_cache_and_compression() {
 
     let database = Database::open(&path).unwrap();
     let transaction = database.begin_read().unwrap();
-    let table = transaction.open_table(NODES_V3).unwrap();
+    let table = transaction.open_table(NODES).unwrap();
     let stored = table.get(key.as_bytes()).unwrap().unwrap();
-    let (encoding, bytes) = stored.value().split_first().unwrap();
+    let envelope = stored.value().strip_prefix(b"PRN1").unwrap();
+    let (encoding, bytes) = envelope.split_first().unwrap();
     assert_eq!(*encoding, 0);
     assert_eq!(bytes, value);
     drop(stored);
@@ -267,7 +269,7 @@ fn redb_store_refreshes_retained_read_snapshot_after_writes() {
 
 #[test]
 fn redb_store_reads_legacy_raw_node_table() {
-    const LEGACY_NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes");
+    const NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes");
 
     let path = temp_db_path("legacy-nodes");
     remove_db(&path);
@@ -277,7 +279,7 @@ fn redb_store_reads_legacy_raw_node_table() {
         let database = Database::create(&path).unwrap();
         let transaction = database.begin_write().unwrap();
         {
-            let mut table = transaction.open_table(LEGACY_NODES).unwrap();
+            let mut table = transaction.open_table(NODES).unwrap();
             table
                 .insert(key.as_bytes(), b"legacy-value".as_slice())
                 .unwrap();
@@ -302,13 +304,23 @@ fn redb_store_reads_legacy_raw_node_table() {
     );
     assert_eq!(store.list_node_cids().unwrap(), expected);
     drop(store);
+
+    let database = Database::open(&path).unwrap();
+    let transaction = database.begin_read().unwrap();
+    let table = transaction.open_table(NODES).unwrap();
+    let migrated = table.get(key.as_bytes()).unwrap().unwrap();
+    assert!(migrated.value().starts_with(b"PRN1"));
+    drop(migrated);
+    drop(table);
+    drop(transaction);
+    drop(database);
     remove_db(&path);
 }
 
 #[test]
 fn redb_store_reads_and_migrates_v2_encoded_nodes() {
     const NODES_V2: TableDefinition<&[u8], (u8, &[u8])> = TableDefinition::new("prolly_nodes_v2");
-    const NODES_V3: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes_v3");
+    const NODES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("prolly_nodes");
 
     let path = temp_db_path("v2-nodes");
     remove_db(&path);
@@ -331,20 +343,20 @@ fn redb_store_reads_and_migrates_v2_encoded_nodes() {
         Some(b"v2-value".to_vec())
     );
     assert_eq!(store.list_node_cids().unwrap(), vec![key.clone()]);
-    store.put(key.as_bytes(), b"v3-value").unwrap();
+    store.put(key.as_bytes(), b"default-value").unwrap();
     assert_eq!(
         store.get(key.as_bytes()).unwrap(),
-        Some(b"v3-value".to_vec())
+        Some(b"default-value".to_vec())
     );
     drop(store);
 
     let database = Database::open(&path).unwrap();
     let transaction = database.begin_read().unwrap();
     let v2 = transaction.open_table(NODES_V2).unwrap();
-    let v3 = transaction.open_table(NODES_V3).unwrap();
+    let nodes = transaction.open_table(NODES).unwrap();
     assert!(v2.get(key.as_bytes()).unwrap().is_none());
-    assert!(v3.get(key.as_bytes()).unwrap().is_some());
-    drop(v3);
+    assert!(nodes.get(key.as_bytes()).unwrap().is_some());
+    drop(nodes);
     drop(v2);
     drop(transaction);
     drop(database);


### PR DESCRIPTION
## Summary

- make suffix-free `prolly_nodes` the optimized raw/LZ4 default table
- distinguish new encoded rows with a versioned envelope while reading adapter 0.3.0 raw rows in place
- retain `prolly_nodes_v2` only as the tuple-layout compatibility source and migrate those rows into `prolly_nodes` when updated
- remove the intermediate `prolly_nodes_v3` table and its duplicate legacy-table hot paths
- update direct storage audits, migration tests, and documentation for the final layout

## Verification

- Rust 1.89 release tests: 19 integration tests and 3 doctests
- explicit raw-0.3 in-place migration and tuple-v2 migration tests
- full randomized correctness harness: 4 seeds, 128 reopen boundaries, 32,768 mutations, exact MemStore root agreement
- diff/merge/version history, GC, compaction, locking, transaction, and concurrent-writer checks
- stable Clippy with all targets and warnings denied
- Rust 1.89 package build and verification
- complete 1M redb/SQLite matrix after the table rename

The final 1M confirmation retained the performance profile: redb completed about 1.58M builds/s, 113k random reads/s, 6.94M scanned records/s, and 28.3k updates/s in the validation run.
