### PR TITLE
Scale the MySQL adapter and add reproducible PostgreSQL comparison harness

### DIFF
--- a/benchmarks/BACKEND_COMPARISON.md
+++ b/benchmarks/BACKEND_COMPARISON.md
@@ -1,4 +1,58 @@
-# Reproduce the PostgreSQL and DynamoDB Local comparison
+# Reproduce backend performance comparisons
+
+## MySQL vs PostgreSQL
+
+Run the controlled local comparison with pinned MySQL 8 and PostgreSQL 16
+containers:
+
+```bash
+./scripts/run_mysql_postgres_comparison.sh
+```
+
+The command runs byte-identical public Prolly build, batch, ordered query,
+concurrent query, diff, and merge workloads. It also runs a shared adapter
+service suite covering bounded batch puts, ordered batch gets, concurrent point
+reads, and contended root compare-and-swap. Request-level p50/p95/p99/p99.9/max
+latency, throughput, conflicts, pool size, and adapter batch size are recorded.
+
+Sweep client and pool saturation cells:
+
+```bash
+BENCH_CLIENTS=1,8,32 \
+BENCH_POOL_SIZES=4,16 \
+./scripts/run_mysql_postgres_service_matrix.sh
+```
+
+Tune one comparison with `BENCH_POOL_SIZE`,
+`BENCH_ADAPTER_BATCH_ITEMS`, `BENCH_CONCURRENCY`, `BENCH_RECORDS`,
+`BENCH_CHANGES`, and `BENCH_SAMPLES`. Every publishable cell uses one excluded
+warmup, at least seven alternating measured repetitions, fresh local volumes,
+and release binaries copied into the result directory.
+
+External managed services are supported only through disposable isolated
+benchmark databases. The destructive acknowledgement and explicit server
+identities are mandatory:
+
+```bash
+BENCH_MODE=external \
+BENCH_EXTERNAL_RESET_ACK=I_UNDERSTAND_BENCHMARK_DATA_WILL_BE_DELETED \
+BENCH_EXTERNAL_POSTGRES_IDENTITY='provider/postgres/version/config' \
+BENCH_EXTERNAL_MYSQL_IDENTITY='provider/mysql/version/config' \
+PROLLY_BACKEND_POSTGRES_URL='postgres://…' \
+PROLLY_BACKEND_MYSQL_URL='mysql://…' \
+./scripts/run_mysql_postgres_comparison.sh
+```
+
+Recorded commands redact URL credentials. External evidence is labeled and
+cannot be mixed with controlled local evidence.
+
+The SQL result directory adds:
+
+- `raw-service-results.csv`: validated adapter/service samples
+- `service-comparison.csv`: paired service statistics
+- `service-report.md`: batch, concurrent-read, and root-contention comparison
+
+## PostgreSQL vs DynamoDB Local
 
 The backend comparison runs byte-identical public Prolly operations against fresh local PostgreSQL and DynamoDB Local containers. It validates complete logical outcomes after timing and refuses incomplete, dirty, resumed, or mismatched evidence.
 

--- a/benchmarks/backend-comparison/Cargo.lock
+++ b/benchmarks/backend-comparison/Cargo.lock
@@ -359,10 +359,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -451,6 +460,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -591,6 +606,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -614,7 +641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -1272,10 +1299,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -1362,6 +1404,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,12 +1435,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1433,6 +1502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,6 +1527,27 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1505,6 +1604,7 @@ dependencies = [
  "prolly-backend-workload-contract",
  "prolly-map",
  "prolly-store-dynamodb",
+ "prolly-store-mysql",
  "prolly-store-postgres",
  "serde",
  "sqlx",
@@ -1556,6 +1656,14 @@ dependencies = [
  "futures-util",
  "prolly-map",
  "tokio",
+]
+
+[[package]]
+name = "prolly-store-mysql"
+version = "0.3.0"
+dependencies = [
+ "prolly-map",
+ "sqlx",
 ]
 
 [[package]]
@@ -1667,6 +1775,26 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1880,6 +2008,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +2057,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,6 +2102,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "sqlx"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,6 +2125,7 @@ checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
+ "sqlx-mysql",
  "sqlx-postgres",
 ]
 
@@ -2027,10 +2193,53 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sqlx-core",
+ "sqlx-mysql",
  "sqlx-postgres",
  "syn 2.0.119",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
 ]
 
 [[package]]

--- a/benchmarks/backend-comparison/Cargo.toml
+++ b/benchmarks/backend-comparison/Cargo.toml
@@ -46,3 +46,8 @@ required-features = ["dynamodb"]
 [[bin]]
 name = "prolly-backend-summarize"
 path = "src/bin/summarize.rs"
+
+[[test]]
+name = "dynamodb_smoke"
+path = "tests/dynamodb_smoke.rs"
+required-features = ["dynamodb"]

--- a/benchmarks/backend-comparison/Cargo.toml
+++ b/benchmarks/backend-comparison/Cargo.toml
@@ -14,9 +14,10 @@ futures-util = "0.3"
 prolly = { package = "prolly-map", path = "../..", features = ["async-store"] }
 prolly-backend-workload-contract = { path = "../backend-workload-contract" }
 prolly-store-dynamodb = { path = "../../stores/prolly-store-dynamodb" }
+prolly-store-mysql = { path = "../../stores/prolly-store-mysql" }
 prolly-store-postgres = { path = "../../stores/prolly-store-postgres" }
 serde = { version = "1.0", features = ["derive"] }
-sqlx = { version = "0.8", default-features = false, features = ["postgres", "runtime-tokio"] }
+sqlx = { version = "0.8", default-features = false, features = ["mysql", "postgres", "runtime-tokio"] }
 tokio = { version = "1.45", features = ["macros", "rt-multi-thread", "time"] }
 
 [dev-dependencies]
@@ -28,6 +29,10 @@ unsafe_code = "forbid"
 [[bin]]
 name = "prolly-backend-postgres"
 path = "src/bin/postgres.rs"
+
+[[bin]]
+name = "prolly-backend-mysql"
+path = "src/bin/mysql.rs"
 
 [[bin]]
 name = "prolly-backend-dynamodb"

--- a/benchmarks/backend-comparison/Cargo.toml
+++ b/benchmarks/backend-comparison/Cargo.toml
@@ -7,13 +7,17 @@ publish = false
 
 [workspace]
 
+[features]
+default = ["dynamodb"]
+dynamodb = ["dep:aws-sdk-dynamodb", "dep:prolly-store-dynamodb"]
+
 [dependencies]
-aws-sdk-dynamodb = "=1.73.0"
+aws-sdk-dynamodb = { version = "=1.73.0", optional = true }
 csv = "1.3"
 futures-util = "0.3"
 prolly = { package = "prolly-map", path = "../..", features = ["async-store"] }
 prolly-backend-workload-contract = { path = "../backend-workload-contract" }
-prolly-store-dynamodb = { path = "../../stores/prolly-store-dynamodb" }
+prolly-store-dynamodb = { path = "../../stores/prolly-store-dynamodb", optional = true }
 prolly-store-mysql = { path = "../../stores/prolly-store-mysql" }
 prolly-store-postgres = { path = "../../stores/prolly-store-postgres" }
 serde = { version = "1.0", features = ["derive"] }
@@ -37,6 +41,7 @@ path = "src/bin/mysql.rs"
 [[bin]]
 name = "prolly-backend-dynamodb"
 path = "src/bin/dynamodb.rs"
+required-features = ["dynamodb"]
 
 [[bin]]
 name = "prolly-backend-summarize"

--- a/benchmarks/backend-comparison/docker-compose.yml
+++ b/benchmarks/backend-comparison/docker-compose.yml
@@ -17,6 +17,23 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
 
+  mysql:
+    image: mysql@sha256:7dcddc01f13bab2f15cde676d44d01f61fc9f99fe7785e86196dfc07d358ae2b
+    environment:
+      MYSQL_DATABASE: prolly
+      MYSQL_PASSWORD: prolly
+      MYSQL_ROOT_PASSWORD: prolly
+      MYSQL_USER: prolly
+    ports:
+      - "127.0.0.1:${PROLLY_BACKEND_MYSQL_PORT:-53307}:3306"
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uprolly -pprolly --silent"]
+      interval: 1s
+      timeout: 2s
+      retries: 90
+    volumes:
+      - mysql-data:/var/lib/mysql
+
   dynamodb:
     image: amazon/dynamodb-local@sha256:d89f8fcc6b1a39cb35976c248ed42a28c66ae00dc043099210f5571e42648ab4
     command: ["-jar", "DynamoDBLocal.jar", "-sharedDb", "-inMemory"]
@@ -25,3 +42,4 @@ services:
 
 volumes:
   postgres-data:
+  mysql-data:

--- a/benchmarks/backend-comparison/src/adapters.rs
+++ b/benchmarks/backend-comparison/src/adapters.rs
@@ -13,9 +13,7 @@ use sqlx::postgres::PgPoolOptions;
 
 #[cfg(feature = "dynamodb")]
 use crate::DynamoDbConnection;
-use crate::{
-    run_service_workload, run_workload, EvidenceRow, RunConfig, ServiceEvidenceRow,
-};
+use crate::{run_service_workload, run_workload, EvidenceRow, RunConfig, ServiceEvidenceRow};
 
 pub async fn run_postgres(config: &RunConfig, url: &str) -> Result<Vec<EvidenceRow>, String> {
     let pool = PgPoolOptions::new()

--- a/benchmarks/backend-comparison/src/adapters.rs
+++ b/benchmarks/backend-comparison/src/adapters.rs
@@ -1,15 +1,30 @@
+use std::num::NonZeroUsize;
+
 use aws_sdk_dynamodb::config::{BehaviorVersion, Credentials, Region};
 use prolly::RemoteProllyStore;
 use prolly_backend_workload_contract::Workload;
 use prolly_store_dynamodb::DynamoDbBackend;
-use prolly_store_postgres::PostgresBackend;
+use prolly_store_mysql::{MySqlBackend, MySqlBackendOptions};
+use prolly_store_postgres::{PostgresBackend, PostgresBackendOptions};
+use sqlx::mysql::MySqlPoolOptions;
+use sqlx::postgres::PgPoolOptions;
 
-use crate::{run_workload, DynamoDbConnection, EvidenceRow, RunConfig};
+use crate::{
+    run_service_workload, run_workload, DynamoDbConnection, EvidenceRow, RunConfig,
+    ServiceEvidenceRow,
+};
 
 pub async fn run_postgres(config: &RunConfig, url: &str) -> Result<Vec<EvidenceRow>, String> {
-    let backend = PostgresBackend::connect(url)
+    let pool = PgPoolOptions::new()
+        .max_connections(config.pool_size)
+        .connect(url)
         .await
         .map_err(|error| format!("failed to connect to PostgreSQL: {error}"))?;
+    let options = PostgresBackendOptions::new(
+        NonZeroUsize::new(config.adapter_batch_items)
+            .ok_or_else(|| "adapter batch items must be positive".to_string())?,
+    );
+    let backend = PostgresBackend::new_with_options(pool, options);
     backend
         .initialize_schema()
         .await
@@ -20,6 +35,97 @@ pub async fn run_postgres(config: &RunConfig, url: &str) -> Result<Vec<EvidenceR
         .map_err(|error| format!("failed to clear PostgreSQL benchmark state: {error}"))?;
     let workload = Workload::generate(config.workload)?;
     run_workload(RemoteProllyStore::new(backend), config, &workload).await
+}
+
+pub async fn run_mysql(config: &RunConfig, url: &str) -> Result<Vec<EvidenceRow>, String> {
+    let pool = MySqlPoolOptions::new()
+        .max_connections(config.pool_size)
+        .connect(url)
+        .await
+        .map_err(|error| format!("failed to connect to MySQL: {error}"))?;
+    let options = MySqlBackendOptions::new(
+        NonZeroUsize::new(config.adapter_batch_items)
+            .ok_or_else(|| "adapter batch items must be positive".to_string())?,
+    );
+    let backend = MySqlBackend::new_with_options(pool, options);
+    backend
+        .initialize_schema()
+        .await
+        .map_err(|error| format!("failed to initialize MySQL schema: {error}"))?;
+    for table in [
+        "prolly_hints",
+        "prolly_roots",
+        "prolly_nodes",
+        "prolly_root_locks",
+    ] {
+        sqlx::query(&format!("TRUNCATE TABLE {table}"))
+            .execute(backend.pool())
+            .await
+            .map_err(|error| format!("failed to clear MySQL table {table}: {error}"))?;
+    }
+    let workload = Workload::generate(config.workload)?;
+    run_workload(RemoteProllyStore::new(backend), config, &workload).await
+}
+
+pub async fn run_postgres_service(
+    config: &RunConfig,
+    url: &str,
+) -> Result<Vec<ServiceEvidenceRow>, String> {
+    let pool = PgPoolOptions::new()
+        .max_connections(config.pool_size)
+        .connect(url)
+        .await
+        .map_err(|error| format!("failed to connect to PostgreSQL: {error}"))?;
+    let backend = PostgresBackend::new_with_options(
+        pool,
+        PostgresBackendOptions::new(
+            NonZeroUsize::new(config.adapter_batch_items)
+                .ok_or_else(|| "adapter batch items must be positive".to_string())?,
+        ),
+    );
+    backend
+        .initialize_schema()
+        .await
+        .map_err(|error| format!("failed to initialize PostgreSQL schema: {error}"))?;
+    sqlx::query("TRUNCATE TABLE prolly_nodes, prolly_hints, prolly_roots")
+        .execute(backend.pool())
+        .await
+        .map_err(|error| format!("failed to clear PostgreSQL service state: {error}"))?;
+    run_service_workload(backend, config).await
+}
+
+pub async fn run_mysql_service(
+    config: &RunConfig,
+    url: &str,
+) -> Result<Vec<ServiceEvidenceRow>, String> {
+    let pool = MySqlPoolOptions::new()
+        .max_connections(config.pool_size)
+        .connect(url)
+        .await
+        .map_err(|error| format!("failed to connect to MySQL: {error}"))?;
+    let backend = MySqlBackend::new_with_options(
+        pool,
+        MySqlBackendOptions::new(
+            NonZeroUsize::new(config.adapter_batch_items)
+                .ok_or_else(|| "adapter batch items must be positive".to_string())?,
+        ),
+    );
+    backend
+        .initialize_schema()
+        .await
+        .map_err(|error| format!("failed to initialize MySQL schema: {error}"))?;
+    for table in [
+        "prolly_hints",
+        "prolly_roots",
+        "prolly_nodes",
+        "prolly_root_locks",
+    ] {
+        sqlx::query(&format!("TRUNCATE TABLE {table}"))
+            .execute(backend.pool())
+            .await
+            .map_err(|error| format!("failed to clear MySQL table {table}: {error}"))?;
+    }
+    run_service_workload(backend, config).await
 }
 
 pub async fn run_dynamodb(

--- a/benchmarks/backend-comparison/src/adapters.rs
+++ b/benchmarks/backend-comparison/src/adapters.rs
@@ -1,17 +1,20 @@
 use std::num::NonZeroUsize;
 
+#[cfg(feature = "dynamodb")]
 use aws_sdk_dynamodb::config::{BehaviorVersion, Credentials, Region};
 use prolly::RemoteProllyStore;
 use prolly_backend_workload_contract::Workload;
+#[cfg(feature = "dynamodb")]
 use prolly_store_dynamodb::DynamoDbBackend;
 use prolly_store_mysql::{MySqlBackend, MySqlBackendOptions};
 use prolly_store_postgres::{PostgresBackend, PostgresBackendOptions};
 use sqlx::mysql::MySqlPoolOptions;
 use sqlx::postgres::PgPoolOptions;
 
+#[cfg(feature = "dynamodb")]
+use crate::DynamoDbConnection;
 use crate::{
-    run_service_workload, run_workload, DynamoDbConnection, EvidenceRow, RunConfig,
-    ServiceEvidenceRow,
+    run_service_workload, run_workload, EvidenceRow, RunConfig, ServiceEvidenceRow,
 };
 
 pub async fn run_postgres(config: &RunConfig, url: &str) -> Result<Vec<EvidenceRow>, String> {
@@ -128,6 +131,7 @@ pub async fn run_mysql_service(
     run_service_workload(backend, config).await
 }
 
+#[cfg(feature = "dynamodb")]
 pub async fn run_dynamodb(
     config: &RunConfig,
     connection: &DynamoDbConnection,

--- a/benchmarks/backend-comparison/src/bin/mysql.rs
+++ b/benchmarks/backend-comparison/src/bin/mysql.rs
@@ -1,0 +1,29 @@
+use prolly_backend_comparison::{
+    parse_binary_args, run_mysql, run_mysql_service, write_rows_new, write_service_rows_new,
+    Backend, ConnectionConfig, Suite,
+};
+
+#[tokio::main]
+async fn main() {
+    if let Err(error) = run().await {
+        eprintln!("MySQL comparison failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), String> {
+    let config = parse_binary_args(Backend::MySql, std::env::args().collect())?;
+    let ConnectionConfig::MySql { url } = &config.connection else {
+        return Err("MySQL binary received a non-MySQL connection".to_string());
+    };
+    match config.suite {
+        Suite::EndToEnd => {
+            let rows = run_mysql(&config.run, url).await?;
+            write_rows_new(&config.run.output, &rows)
+        }
+        Suite::Service => {
+            let rows = run_mysql_service(&config.run, url).await?;
+            write_service_rows_new(&config.run.output, &rows)
+        }
+    }
+}

--- a/benchmarks/backend-comparison/src/bin/postgres.rs
+++ b/benchmarks/backend-comparison/src/bin/postgres.rs
@@ -1,5 +1,6 @@
 use prolly_backend_comparison::{
-    parse_binary_args, run_postgres, write_rows_new, Backend, ConnectionConfig,
+    parse_binary_args, run_postgres, run_postgres_service, write_rows_new, write_service_rows_new,
+    Backend, ConnectionConfig, Suite,
 };
 
 #[tokio::main]
@@ -15,6 +16,14 @@ async fn run() -> Result<(), String> {
     let ConnectionConfig::Postgres { url } = &config.connection else {
         return Err("PostgreSQL binary received a non-PostgreSQL connection".to_string());
     };
-    let rows = run_postgres(&config.run, url).await?;
-    write_rows_new(&config.run.output, &rows)
+    match config.suite {
+        Suite::EndToEnd => {
+            let rows = run_postgres(&config.run, url).await?;
+            write_rows_new(&config.run.output, &rows)
+        }
+        Suite::Service => {
+            let rows = run_postgres_service(&config.run, url).await?;
+            write_service_rows_new(&config.run.output, &rows)
+        }
+    }
 }

--- a/benchmarks/backend-comparison/src/cli.rs
+++ b/benchmarks/backend-comparison/src/cli.rs
@@ -17,6 +17,7 @@ pub struct DynamoDbConnection {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ConnectionConfig {
     Postgres { url: String },
+    MySql { url: String },
     DynamoDb(DynamoDbConnection),
 }
 
@@ -24,6 +25,14 @@ pub enum ConnectionConfig {
 pub struct BinaryConfig {
     pub run: RunConfig,
     pub connection: ConnectionConfig,
+    pub suite: Suite,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Suite {
+    #[default]
+    EndToEnd,
+    Service,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -35,6 +44,8 @@ pub struct RunConfig {
     pub revision: String,
     pub tree_hash: String,
     pub binary_sha256: String,
+    pub pool_size: u32,
+    pub adapter_batch_items: usize,
     pub workload: WorkloadSpec,
 }
 
@@ -58,6 +69,9 @@ impl RunConfig {
         if self.output.as_os_str().is_empty() {
             return Err("output path cannot be empty".to_string());
         }
+        if self.pool_size == 0 || self.adapter_batch_items == 0 {
+            return Err("pool size and adapter batch items must be positive".to_string());
+        }
         Ok(())
     }
 }
@@ -75,7 +89,15 @@ pub fn parse_binary_args(backend: Backend, values: Vec<String>) -> Result<Binary
     let mut samples = None;
     let mut concurrency = None;
     let mut seed = None;
-    let mut url = "postgres://prolly:prolly@127.0.0.1:55433/prolly".to_string();
+    let mut pool_size = 10;
+    let mut adapter_batch_items = 1_000;
+    let mut suite = Suite::EndToEnd;
+    let mut url = match backend {
+        Backend::Postgres => "postgres://prolly:prolly@127.0.0.1:55433/prolly",
+        Backend::MySql => "mysql://prolly:prolly@127.0.0.1:53307/prolly",
+        Backend::DynamoDbLocal => "",
+    }
+    .to_string();
     let mut dynamodb = DynamoDbConnection {
         endpoint: "http://127.0.0.1:58000".to_string(),
         table: "prolly_backend_comparison".to_string(),
@@ -102,6 +124,15 @@ pub fn parse_binary_args(backend: Backend, values: Vec<String>) -> Result<Binary
             "--samples" => samples = Some(number(&value(&mut index)?, flag)?),
             "--concurrency" => concurrency = Some(number(&value(&mut index)?, flag)?),
             "--seed" => seed = Some(parse_seed(&value(&mut index)?)?),
+            "--pool-size" => pool_size = number(&value(&mut index)?, flag)?,
+            "--adapter-batch-items" => adapter_batch_items = number(&value(&mut index)?, flag)?,
+            "--suite" => {
+                suite = match value(&mut index)?.as_str() {
+                    "end-to-end" => Suite::EndToEnd,
+                    "service" => Suite::Service,
+                    value => return Err(format!("invalid --suite: {value}")),
+                }
+            }
             "--url" => url = value(&mut index)?,
             "--endpoint" => dynamodb.endpoint = value(&mut index)?,
             "--table" => dynamodb.table = value(&mut index)?,
@@ -126,6 +157,8 @@ pub fn parse_binary_args(backend: Backend, values: Vec<String>) -> Result<Binary
         revision: required(revision, "--revision")?,
         tree_hash: required(tree_hash, "--tree-hash")?,
         binary_sha256: required(binary_sha256, "--binary-sha256")?,
+        pool_size,
+        adapter_batch_items,
         workload: WorkloadSpec {
             records: required(records, "--records")?,
             value_bytes: required(value_bytes, "--value-bytes")?,
@@ -138,6 +171,7 @@ pub fn parse_binary_args(backend: Backend, values: Vec<String>) -> Result<Binary
     run.validate()?;
     let connection = match backend {
         Backend::Postgres => ConnectionConfig::Postgres { url },
+        Backend::MySql => ConnectionConfig::MySql { url },
         Backend::DynamoDbLocal => {
             if dynamodb.endpoint.is_empty()
                 || dynamodb.table.is_empty()
@@ -151,7 +185,14 @@ pub fn parse_binary_args(backend: Backend, values: Vec<String>) -> Result<Binary
             ConnectionConfig::DynamoDb(dynamodb)
         }
     };
-    Ok(BinaryConfig { run, connection })
+    if backend == Backend::DynamoDbLocal && suite == Suite::Service {
+        return Err("the service suite supports MySQL and PostgreSQL".to_string());
+    }
+    Ok(BinaryConfig {
+        run,
+        connection,
+        suite,
+    })
 }
 
 pub(crate) fn is_hex(value: &str, length: usize) -> bool {
@@ -190,7 +231,10 @@ fn required<T>(value: Option<T>, flag: &str) -> Result<T, String> {
 fn usage(backend: Backend) -> &'static str {
     match backend {
         Backend::Postgres => {
-            "usage: prolly-backend-postgres --output PATH --run-id ID --repetition N --revision SHA --tree-hash SHA --binary-sha256 SHA --records N --value-bytes N --changes N --samples N --concurrency N --seed N [--url URL]"
+            "usage: prolly-backend-postgres --output PATH --run-id ID --repetition N --revision SHA --tree-hash SHA --binary-sha256 SHA --records N --value-bytes N --changes N --samples N --concurrency N --seed N [--pool-size N] [--adapter-batch-items N] [--url URL]"
+        }
+        Backend::MySql => {
+            "usage: prolly-backend-mysql --output PATH --run-id ID --repetition N --revision SHA --tree-hash SHA --binary-sha256 SHA --records N --value-bytes N --changes N --samples N --concurrency N --seed N [--pool-size N] [--adapter-batch-items N] [--url URL]"
         }
         Backend::DynamoDbLocal => {
             "usage: prolly-backend-dynamodb --output PATH --run-id ID --repetition N --revision SHA --tree-hash SHA --binary-sha256 SHA --records N --value-bytes N --changes N --samples N --concurrency N --seed N [--endpoint URL] [--table NAME] [--read-parallelism N] [--batch-get-parallelism N] [--batch-write-parallelism N] [--scan-parallelism N]"
@@ -213,6 +257,8 @@ mod tests {
             revision: "a".repeat(40),
             tree_hash: "b".repeat(40),
             binary_sha256: "c".repeat(64),
+            pool_size: 10,
+            adapter_batch_items: 1_000,
             workload: WorkloadSpec {
                 records: 100,
                 value_bytes: 27,
@@ -262,6 +308,7 @@ mod tests {
         let parsed = parse_binary_args(Backend::Postgres, args).unwrap();
         assert_eq!(parsed.run.repetition, 3);
         assert_eq!(parsed.run.workload.records, 100);
+        assert_eq!(parsed.run.pool_size, 10);
         assert_eq!(
             parsed.connection,
             ConnectionConfig::Postgres {

--- a/benchmarks/backend-comparison/src/evidence.rs
+++ b/benchmarks/backend-comparison/src/evidence.rs
@@ -14,6 +14,8 @@ pub const TIMED_SCOPE_VERSION: &str = "public-prolly-operation-v1";
 #[serde(rename_all = "snake_case")]
 pub enum Backend {
     Postgres,
+    #[serde(rename = "mysql")]
+    MySql,
     DynamoDbLocal,
 }
 
@@ -21,6 +23,7 @@ impl Backend {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Postgres => "postgres",
+            Self::MySql => "mysql",
             Self::DynamoDbLocal => "dynamodb_local",
         }
     }
@@ -38,6 +41,7 @@ impl FromStr for Backend {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "postgres" => Ok(Self::Postgres),
+            "mysql" => Ok(Self::MySql),
             "dynamodb_local" | "dynamodb" => Ok(Self::DynamoDbLocal),
             _ => Err(format!("unsupported backend: {value}")),
         }
@@ -100,11 +104,25 @@ pub struct EvidenceRow {
     pub changes: u64,
     pub samples: u64,
     pub concurrency: u64,
+    #[serde(default)]
+    pub pool_size: u32,
+    #[serde(default)]
+    pub adapter_batch_items: u64,
     pub seed: u64,
     pub logical_operations: u64,
     pub observed_items: u64,
     pub total_ns: u128,
     pub ops_per_sec: f64,
+    #[serde(default)]
+    pub latency_p50_ns: u128,
+    #[serde(default)]
+    pub latency_p95_ns: u128,
+    #[serde(default)]
+    pub latency_p99_ns: u128,
+    #[serde(default)]
+    pub latency_p999_ns: u128,
+    #[serde(default)]
+    pub latency_max_ns: u128,
     pub root: String,
     pub workload_digest: String,
     pub outcome_digest: String,
@@ -168,6 +186,20 @@ impl EvidenceRow {
         {
             return Err("throughput does not match elapsed time".to_string());
         }
+        let has_legacy_latency = self.latency_p50_ns == 0
+            && self.latency_p95_ns == 0
+            && self.latency_p99_ns == 0
+            && self.latency_p999_ns == 0
+            && self.latency_max_ns == 0;
+        if !has_legacy_latency
+            && (self.latency_p50_ns == 0
+                || self.latency_p50_ns > self.latency_p95_ns
+                || self.latency_p95_ns > self.latency_p99_ns
+                || self.latency_p99_ns > self.latency_p999_ns
+                || self.latency_p999_ns > self.latency_max_ns)
+        {
+            return Err("latency distribution is missing or unordered".to_string());
+        }
         Ok(())
     }
 
@@ -189,11 +221,18 @@ impl EvidenceRow {
             changes: 10,
             samples: 10,
             concurrency: 4,
+            pool_size: 10,
+            adapter_batch_items: 1_000,
             seed: 1,
             logical_operations: 100,
             observed_items: 100,
             total_ns: 1_000,
             ops_per_sec: 100_000_000.0,
+            latency_p50_ns: 1_000,
+            latency_p95_ns: 1_000,
+            latency_p99_ns: 1_000,
+            latency_p999_ns: 1_000,
+            latency_max_ns: 1_000,
             root: "d".repeat(64),
             workload_digest: "e".repeat(64),
             outcome_digest: "f".repeat(64),

--- a/benchmarks/backend-comparison/src/lib.rs
+++ b/benchmarks/backend-comparison/src/lib.rs
@@ -7,9 +7,9 @@ pub mod service;
 pub mod statistics;
 pub mod summary;
 
-pub use adapters::{
-    run_dynamodb, run_mysql, run_mysql_service, run_postgres, run_postgres_service,
-};
+#[cfg(feature = "dynamodb")]
+pub use adapters::run_dynamodb;
+pub use adapters::{run_mysql, run_mysql_service, run_postgres, run_postgres_service};
 pub use cli::{
     parse_binary_args, BinaryConfig, ConnectionConfig, DynamoDbConnection, RunConfig, Suite,
 };

--- a/benchmarks/backend-comparison/src/lib.rs
+++ b/benchmarks/backend-comparison/src/lib.rs
@@ -3,13 +3,22 @@ pub mod cli;
 pub mod evidence;
 pub mod measure;
 pub mod runner;
+pub mod service;
 pub mod statistics;
 pub mod summary;
 
-pub use adapters::{run_dynamodb, run_postgres};
-pub use cli::{parse_binary_args, BinaryConfig, ConnectionConfig, DynamoDbConnection, RunConfig};
+pub use adapters::{
+    run_dynamodb, run_mysql, run_mysql_service, run_postgres, run_postgres_service,
+};
+pub use cli::{
+    parse_binary_args, BinaryConfig, ConnectionConfig, DynamoDbConnection, RunConfig, Suite,
+};
 pub use evidence::{
     write_rows_new, Backend, EvidenceRow, Operation, RESULT_SCHEMA, TIMED_SCOPE_VERSION,
 };
 pub use measure::{measure, Measured};
 pub use runner::run_workload;
+pub use service::{
+    run_service_workload, write_service_rows_new, ServiceEvidenceRow, ServiceOperation,
+    SERVICE_SCHEMA,
+};

--- a/benchmarks/backend-comparison/src/runner.rs
+++ b/benchmarks/backend-comparison/src/runner.rs
@@ -6,6 +6,42 @@ use prolly_backend_workload_contract::{
 
 use crate::{measure, EvidenceRow, Operation, RunConfig, RESULT_SCHEMA, TIMED_SCOPE_VERSION};
 
+#[derive(Clone, Copy)]
+struct LatencyDistribution {
+    p50_ns: u128,
+    p95_ns: u128,
+    p99_ns: u128,
+    p999_ns: u128,
+    max_ns: u128,
+}
+
+impl LatencyDistribution {
+    fn total(total_ns: u128) -> Self {
+        Self {
+            p50_ns: total_ns,
+            p95_ns: total_ns,
+            p99_ns: total_ns,
+            p999_ns: total_ns,
+            max_ns: total_ns,
+        }
+    }
+
+    fn from_samples(samples: &[u128]) -> Result<Self, String> {
+        if samples.is_empty() {
+            return Err("latency distribution requires samples".to_string());
+        }
+        let mut sorted = samples.to_vec();
+        sorted.sort_unstable();
+        Ok(Self {
+            p50_ns: percentile(&sorted, 0.50),
+            p95_ns: percentile(&sorted, 0.95),
+            p99_ns: percentile(&sorted, 0.99),
+            p999_ns: percentile(&sorted, 0.999),
+            max_ns: *sorted.last().expect("nonempty samples"),
+        })
+    }
+}
+
 pub async fn run_workload<S>(
     store: S,
     config: &RunConfig,
@@ -41,6 +77,7 @@ where
         Operation::Build,
         workload.spec.records,
         measured_build.elapsed_ns,
+        LatencyDistribution::total(measured_build.elapsed_ns),
         &measured_build.value,
         base_evidence,
     )?];
@@ -64,6 +101,7 @@ where
         Operation::Batch,
         workload.spec.changes,
         measured_batch.elapsed_ns,
+        LatencyDistribution::total(measured_batch.elapsed_ns),
         &measured_batch.value,
         batch_evidence,
     )?);
@@ -80,6 +118,7 @@ where
         Operation::Query,
         workload.spec.samples,
         measured_query.elapsed_ns,
+        LatencyDistribution::total(measured_query.elapsed_ns),
         &base,
         (measured_query.value.len(), query_digest),
     )?);
@@ -91,10 +130,11 @@ where
                 let manager = &concurrent_manager;
                 let base = &base;
                 async move {
+                    let started = std::time::Instant::now();
                     manager
                         .get(base, key)
                         .await
-                        .map(|value| (position, value))
+                        .map(|value| (position, value, started.elapsed().as_nanos()))
                         .map_err(|error| error.to_string())
                 }
             })
@@ -105,10 +145,14 @@ where
     .await
     .map_err(context("concurrent query"))?;
     let mut concurrent_values = measured_concurrent.value;
-    concurrent_values.sort_by_key(|(position, _)| *position);
+    concurrent_values.sort_by_key(|(position, _, _)| *position);
+    let concurrent_latencies = concurrent_values
+        .iter()
+        .map(|(_, _, elapsed_ns)| *elapsed_ns)
+        .collect::<Vec<_>>();
     let concurrent_values = concurrent_values
         .into_iter()
-        .map(|(_, value)| value)
+        .map(|(_, value, _)| value)
         .collect::<Vec<_>>();
     let concurrent_digest = validate_query(workload, &query_keys, &concurrent_values)?;
     rows.push(make_row(
@@ -117,6 +161,7 @@ where
         Operation::ConcurrentQuery,
         workload.spec.samples,
         measured_concurrent.elapsed_ns,
+        LatencyDistribution::from_samples(&concurrent_latencies)?,
         &base,
         (concurrent_values.len(), concurrent_digest),
     )?);
@@ -137,6 +182,7 @@ where
         Operation::Diff,
         workload.spec.changes,
         measured_diff.elapsed_ns,
+        LatencyDistribution::total(measured_diff.elapsed_ns),
         &diff_target,
         (measured_diff.value.len(), diff_digest),
     )?);
@@ -167,6 +213,7 @@ where
         Operation::Merge,
         workload.spec.changes,
         measured_merge.elapsed_ns,
+        LatencyDistribution::total(measured_merge.elapsed_ns),
         &measured_merge.value,
         merge_evidence,
     )?);
@@ -315,6 +362,7 @@ fn make_row(
     operation: Operation,
     logical_operations: usize,
     total_ns: u128,
+    latency: LatencyDistribution,
     tree: &Tree,
     outcome: (usize, Digest),
 ) -> Result<EvidenceRow, String> {
@@ -338,11 +386,18 @@ fn make_row(
         changes: workload.spec.changes as u64,
         samples: workload.spec.samples as u64,
         concurrency: workload.spec.concurrency as u64,
+        pool_size: config.pool_size,
+        adapter_batch_items: config.adapter_batch_items as u64,
         seed: workload.spec.seed,
         logical_operations: logical_operations as u64,
         observed_items: outcome.0 as u64,
         total_ns,
         ops_per_sec: logical_operations as f64 * 1_000_000_000.0 / total_ns as f64,
+        latency_p50_ns: latency.p50_ns,
+        latency_p95_ns: latency.p95_ns,
+        latency_p99_ns: latency.p99_ns,
+        latency_p999_ns: latency.p999_ns,
+        latency_max_ns: latency.max_ns,
         root: hex(root.as_bytes()),
         workload_digest: workload.workload_digest.to_hex(),
         outcome_digest: outcome.1.to_hex(),
@@ -351,6 +406,11 @@ fn make_row(
     };
     row.validate()?;
     Ok(row)
+}
+
+fn percentile(sorted: &[u128], quantile: f64) -> u128 {
+    let rank = (quantile * sorted.len() as f64).ceil().max(1.0) as usize;
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
 }
 
 fn hex(bytes: &[u8]) -> String {
@@ -389,6 +449,8 @@ mod tests {
                 revision: "a".repeat(40),
                 tree_hash: "b".repeat(40),
                 binary_sha256: "c".repeat(64),
+                pool_size: 10,
+                adapter_batch_items: 1_000,
                 workload: spec,
             },
             Workload::generate(spec).unwrap(),

--- a/benchmarks/backend-comparison/src/service.rs
+++ b/benchmarks/backend-comparison/src/service.rs
@@ -1,0 +1,392 @@
+use std::fs::OpenOptions;
+use std::path::Path;
+use std::time::Instant;
+
+use futures_util::stream::{self, StreamExt, TryStreamExt};
+use prolly::{RemoteManifestUpdate, RemoteStoreBackend};
+use serde::{Deserialize, Serialize};
+
+use crate::{Backend, RunConfig};
+
+pub const SERVICE_SCHEMA: &str = "sql-service-comparison-v1";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceOperation {
+    BatchPut,
+    BatchGet,
+    ConcurrentGet,
+    ContendedRootCas,
+}
+
+impl ServiceOperation {
+    pub const ALL: [Self; 4] = [
+        Self::BatchPut,
+        Self::BatchGet,
+        Self::ConcurrentGet,
+        Self::ContendedRootCas,
+    ];
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ServiceEvidenceRow {
+    pub schema: String,
+    pub run_id: String,
+    pub backend: Backend,
+    pub repetition: u32,
+    pub operation: ServiceOperation,
+    pub revision: String,
+    pub tree_hash: String,
+    pub binary_sha256: String,
+    pub clients: u64,
+    pub pool_size: u32,
+    pub adapter_batch_items: u64,
+    pub logical_operations: u64,
+    pub total_ns: u128,
+    pub ops_per_sec: f64,
+    pub p50_ns: u128,
+    pub p95_ns: u128,
+    pub p99_ns: u128,
+    pub p999_ns: u128,
+    pub max_ns: u128,
+    pub applied: u64,
+    pub conflicts: u64,
+    pub validated: bool,
+    pub error: String,
+}
+
+impl ServiceEvidenceRow {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.schema != SERVICE_SCHEMA
+            || self.run_id.is_empty()
+            || self.repetition == 0
+            || self.clients == 0
+            || self.pool_size == 0
+            || self.adapter_batch_items == 0
+            || self.logical_operations == 0
+            || self.total_ns == 0
+            || !self.validated
+            || !self.error.is_empty()
+        {
+            return Err("service evidence is incomplete or invalid".to_string());
+        }
+        if self.p50_ns == 0
+            || self.p50_ns > self.p95_ns
+            || self.p95_ns > self.p99_ns
+            || self.p99_ns > self.p999_ns
+            || self.p999_ns > self.max_ns
+        {
+            return Err("service latency distribution is invalid".to_string());
+        }
+        let expected = self.logical_operations as f64 * 1_000_000_000.0 / self.total_ns as f64;
+        if !self.ops_per_sec.is_finite()
+            || (self.ops_per_sec - expected).abs() > expected.abs().max(1.0) * 1e-9
+        {
+            return Err("service throughput does not match elapsed time".to_string());
+        }
+        Ok(())
+    }
+}
+
+pub async fn run_service_workload<B>(
+    backend: B,
+    config: &RunConfig,
+) -> Result<Vec<ServiceEvidenceRow>, String>
+where
+    B: RemoteStoreBackend + Clone,
+{
+    config.validate()?;
+    let sample_count = config.workload.samples;
+    let entries = (0..sample_count)
+        .map(|id| {
+            (
+                service_key(id),
+                service_value(id, config.workload.value_bytes),
+            )
+        })
+        .collect::<Vec<_>>();
+    let borrowed = entries
+        .iter()
+        .map(|(key, value)| (key.as_slice(), value.as_slice()))
+        .collect::<Vec<_>>();
+
+    let started = Instant::now();
+    backend
+        .batch_put_nodes(&borrowed)
+        .await
+        .map_err(|error| format!("service batch put failed: {error}"))?;
+    let batch_put_ns = started.elapsed().as_nanos();
+    let requested = entries
+        .iter()
+        .map(|(key, _)| key.as_slice())
+        .collect::<Vec<_>>();
+    validate_values(
+        &entries,
+        &backend
+            .batch_get_nodes_ordered(&requested)
+            .await
+            .map_err(|error| format!("service batch-put validation failed: {error}"))?,
+    )?;
+    let mut rows = vec![row(
+        config,
+        ServiceOperation::BatchPut,
+        sample_count,
+        batch_put_ns,
+        Distribution::total(batch_put_ns),
+        0,
+        0,
+    )?];
+
+    let started = Instant::now();
+    let batch_values = backend
+        .batch_get_nodes_ordered(&requested)
+        .await
+        .map_err(|error| format!("service batch get failed: {error}"))?;
+    let batch_get_ns = started.elapsed().as_nanos();
+    validate_values(&entries, &batch_values)?;
+    rows.push(row(
+        config,
+        ServiceOperation::BatchGet,
+        sample_count,
+        batch_get_ns,
+        Distribution::total(batch_get_ns),
+        0,
+        0,
+    )?);
+
+    let started = Instant::now();
+    let reads = stream::iter(entries.iter())
+        .map(|(key, expected)| {
+            let backend = &backend;
+            async move {
+                let sample_started = Instant::now();
+                let actual = backend
+                    .get_node(key)
+                    .await
+                    .map_err(|error| format!("service concurrent get failed: {error}"))?;
+                if actual.as_deref() != Some(expected.as_slice()) {
+                    return Err("service concurrent get returned the wrong value".to_string());
+                }
+                Ok(sample_started.elapsed().as_nanos())
+            }
+        })
+        .buffer_unordered(config.workload.concurrency)
+        .try_collect::<Vec<_>>()
+        .await?;
+    let concurrent_ns = started.elapsed().as_nanos();
+    rows.push(row(
+        config,
+        ServiceOperation::ConcurrentGet,
+        sample_count,
+        concurrent_ns,
+        Distribution::from_samples(&reads)?,
+        0,
+        0,
+    )?);
+
+    let root_name = format!("service:{}:{}", config.run_id, config.repetition).into_bytes();
+    let started = Instant::now();
+    let outcomes = stream::iter(0..config.workload.concurrency)
+        .map(|contender| {
+            let backend = &backend;
+            let root_name = &root_name;
+            async move {
+                let manifest = (contender as u64).to_be_bytes();
+                let sample_started = Instant::now();
+                let outcome = backend
+                    .compare_and_swap_root_manifest(root_name, None, Some(&manifest))
+                    .await
+                    .map_err(|error| format!("service root CAS failed: {error}"))?;
+                Ok::<_, String>((outcome, sample_started.elapsed().as_nanos()))
+            }
+        })
+        .buffer_unordered(config.workload.concurrency)
+        .try_collect::<Vec<_>>()
+        .await?;
+    let cas_ns = started.elapsed().as_nanos();
+    let applied = outcomes
+        .iter()
+        .filter(|(outcome, _)| *outcome == RemoteManifestUpdate::Applied)
+        .count();
+    let conflicts = outcomes.len() - applied;
+    if applied != 1 {
+        return Err(format!(
+            "contended root CAS expected one winner, observed {applied}"
+        ));
+    }
+    let cas_latencies = outcomes
+        .iter()
+        .map(|(_, elapsed)| *elapsed)
+        .collect::<Vec<_>>();
+    rows.push(row(
+        config,
+        ServiceOperation::ContendedRootCas,
+        config.workload.concurrency,
+        cas_ns,
+        Distribution::from_samples(&cas_latencies)?,
+        applied,
+        conflicts,
+    )?);
+    Ok(rows)
+}
+
+pub fn write_service_rows_new(path: &Path, rows: &[ServiceEvidenceRow]) -> Result<(), String> {
+    if rows.is_empty() {
+        return Err("cannot write empty service evidence".to_string());
+    }
+    for row in rows {
+        row.validate()?;
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    }
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| format!("refusing to overwrite {}: {error}", path.display()))?;
+    let mut writer = csv::WriterBuilder::new()
+        .terminator(csv::Terminator::Any(b'\n'))
+        .from_writer(file);
+    for row in rows {
+        writer
+            .serialize(row)
+            .map_err(|error| format!("failed to serialize service evidence: {error}"))?;
+    }
+    writer
+        .flush()
+        .map_err(|error| format!("failed to flush service evidence: {error}"))?;
+    writer
+        .get_ref()
+        .sync_all()
+        .map_err(|error| format!("failed to sync service evidence: {error}"))
+}
+
+#[derive(Clone, Copy)]
+struct Distribution {
+    p50: u128,
+    p95: u128,
+    p99: u128,
+    p999: u128,
+    max: u128,
+}
+
+impl Distribution {
+    fn total(total: u128) -> Self {
+        Self {
+            p50: total,
+            p95: total,
+            p99: total,
+            p999: total,
+            max: total,
+        }
+    }
+
+    fn from_samples(samples: &[u128]) -> Result<Self, String> {
+        if samples.is_empty() {
+            return Err("service latency distribution requires samples".to_string());
+        }
+        let mut sorted = samples.to_vec();
+        sorted.sort_unstable();
+        Ok(Self {
+            p50: percentile(&sorted, 0.50),
+            p95: percentile(&sorted, 0.95),
+            p99: percentile(&sorted, 0.99),
+            p999: percentile(&sorted, 0.999),
+            max: *sorted.last().expect("nonempty samples"),
+        })
+    }
+}
+
+fn row(
+    config: &RunConfig,
+    operation: ServiceOperation,
+    logical_operations: usize,
+    total_ns: u128,
+    distribution: Distribution,
+    applied: usize,
+    conflicts: usize,
+) -> Result<ServiceEvidenceRow, String> {
+    let row = ServiceEvidenceRow {
+        schema: SERVICE_SCHEMA.to_string(),
+        run_id: config.run_id.clone(),
+        backend: config.backend,
+        repetition: config.repetition,
+        operation,
+        revision: config.revision.clone(),
+        tree_hash: config.tree_hash.clone(),
+        binary_sha256: config.binary_sha256.clone(),
+        clients: config.workload.concurrency as u64,
+        pool_size: config.pool_size,
+        adapter_batch_items: config.adapter_batch_items as u64,
+        logical_operations: logical_operations as u64,
+        total_ns,
+        ops_per_sec: logical_operations as f64 * 1_000_000_000.0 / total_ns as f64,
+        p50_ns: distribution.p50,
+        p95_ns: distribution.p95,
+        p99_ns: distribution.p99,
+        p999_ns: distribution.p999,
+        max_ns: distribution.max,
+        applied: applied as u64,
+        conflicts: conflicts as u64,
+        validated: true,
+        error: String::new(),
+    };
+    row.validate()?;
+    Ok(row)
+}
+
+fn service_key(id: usize) -> Vec<u8> {
+    let mut key = vec![0_u8; 32];
+    key[..8].copy_from_slice(&(id as u64).to_be_bytes());
+    for (position, byte) in key[8..].iter_mut().enumerate() {
+        *byte = (id as u8).wrapping_add(position as u8);
+    }
+    key
+}
+
+fn service_value(id: usize, len: usize) -> Vec<u8> {
+    (0..len)
+        .map(|position| (id as u8).wrapping_mul(31).wrapping_add(position as u8))
+        .collect()
+}
+
+fn validate_values(
+    entries: &[(Vec<u8>, Vec<u8>)],
+    values: &[Option<Vec<u8>>],
+) -> Result<(), String> {
+    if entries.len() != values.len() {
+        return Err("service batch result length differs".to_string());
+    }
+    for (position, ((_, expected), actual)) in entries.iter().zip(values).enumerate() {
+        if actual.as_deref() != Some(expected.as_slice()) {
+            return Err(format!(
+                "service batch value differs at position {position}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn percentile(sorted: &[u128], quantile: f64) -> u128 {
+    let rank = (quantile * sorted.len() as f64).ceil().max(1.0) as usize;
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_keys_are_fixed_width_and_unique() {
+        assert_eq!(service_key(1).len(), 32);
+        assert_ne!(service_key(1), service_key(2));
+    }
+
+    #[test]
+    fn service_percentiles_use_nearest_rank() {
+        assert_eq!(percentile(&[10, 20, 30, 40, 50], 0.50), 30);
+        assert_eq!(percentile(&[10, 20, 30, 40, 50], 0.99), 50);
+    }
+}

--- a/benchmarks/backend-comparison/src/statistics.rs
+++ b/benchmarks/backend-comparison/src/statistics.rs
@@ -11,16 +11,16 @@ pub struct ConfidenceInterval {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Winner {
-    Postgres,
-    DynamoDbLocal,
+    BackendA,
+    BackendB,
     Inconclusive,
 }
 
 impl fmt::Display for Winner {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(match self {
-            Self::Postgres => "PostgreSQL",
-            Self::DynamoDbLocal => "DynamoDB Local",
+            Self::BackendA => "backend A",
+            Self::BackendB => "backend B",
             Self::Inconclusive => "inconclusive",
         })
     }
@@ -64,38 +64,38 @@ pub fn coefficient_of_variation(values: &[f64]) -> f64 {
 }
 
 pub fn paired_bootstrap_ratio_ci(
-    postgres: &[f64],
-    dynamodb: &[f64],
+    backend_a: &[f64],
+    backend_b: &[f64],
     resamples: usize,
     seed: u64,
 ) -> Result<ConfidenceInterval, String> {
-    if postgres.len() != dynamodb.len() || postgres.len() < 2 {
+    if backend_a.len() != backend_b.len() || backend_a.len() < 2 {
         return Err("paired bootstrap requires equal samples with at least two pairs".to_string());
     }
     if resamples < 100 {
         return Err("paired bootstrap requires at least 100 resamples".to_string());
     }
-    if postgres
+    if backend_a
         .iter()
-        .chain(dynamodb)
+        .chain(backend_b)
         .any(|value| !value.is_finite() || *value <= 0.0)
     {
         return Err("paired bootstrap samples must be finite and positive".to_string());
     }
     let mut state = seed;
     let mut ratios = Vec::with_capacity(resamples);
-    let mut postgres_sample = Vec::with_capacity(postgres.len());
-    let mut dynamodb_sample = Vec::with_capacity(dynamodb.len());
+    let mut backend_a_sample = Vec::with_capacity(backend_a.len());
+    let mut backend_b_sample = Vec::with_capacity(backend_b.len());
     for _ in 0..resamples {
-        postgres_sample.clear();
-        dynamodb_sample.clear();
-        for _ in 0..postgres.len() {
+        backend_a_sample.clear();
+        backend_b_sample.clear();
+        for _ in 0..backend_a.len() {
             state = splitmix64(state);
-            let index = (state as usize) % postgres.len();
-            postgres_sample.push(postgres[index]);
-            dynamodb_sample.push(dynamodb[index]);
+            let index = (state as usize) % backend_a.len();
+            backend_a_sample.push(backend_a[index]);
+            backend_b_sample.push(backend_b[index]);
         }
-        ratios.push(median(&dynamodb_sample) / median(&postgres_sample));
+        ratios.push(median(&backend_b_sample) / median(&backend_a_sample));
     }
     ratios.sort_by(f64::total_cmp);
     Ok(ConfidenceInterval {
@@ -106,9 +106,9 @@ pub fn paired_bootstrap_ratio_ci(
 
 pub fn classify_winner(ratio: f64, interval: ConfidenceInterval) -> Winner {
     if interval.low > 1.0 && ratio > 1.05 {
-        Winner::Postgres
+        Winner::BackendA
     } else if interval.high < 1.0 && ratio < 1.0 / 1.05 {
-        Winner::DynamoDbLocal
+        Winner::BackendB
     } else {
         Winner::Inconclusive
     }
@@ -141,11 +141,11 @@ mod tests {
 
     #[test]
     fn winner_requires_confidence_and_five_percent_effect() {
-        let postgres = [100.0, 101.0, 99.0, 102.0, 98.0, 100.0, 101.0];
-        let dynamodb = [120.0, 121.0, 119.0, 122.0, 118.0, 120.0, 121.0];
-        let interval = paired_bootstrap_ratio_ci(&postgres, &dynamodb, 10_000, 7).unwrap();
+        let backend_a = [100.0, 101.0, 99.0, 102.0, 98.0, 100.0, 101.0];
+        let backend_b = [120.0, 121.0, 119.0, 122.0, 118.0, 120.0, 121.0];
+        let interval = paired_bootstrap_ratio_ci(&backend_a, &backend_b, 10_000, 7).unwrap();
         assert!(interval.low > 1.0);
-        assert_eq!(classify_winner(1.2, interval), Winner::Postgres);
+        assert_eq!(classify_winner(1.2, interval), Winner::BackendA);
 
         assert_eq!(
             classify_winner(

--- a/benchmarks/backend-comparison/src/summary.rs
+++ b/benchmarks/backend-comparison/src/summary.rs
@@ -536,8 +536,14 @@ fn render_report(summaries: &[SummaryRow], manifest: &Manifest, rows: &[Evidence
         String::new(),
         "- Each row uses byte-identical workloads and complete post-timing validation.".to_string(),
         "- A winner requires a paired bootstrap 95% confidence interval that excludes parity and a median effect above 5%.".to_string(),
-        backend_limitation(manifest.backend_a).to_string(),
-        backend_limitation(manifest.backend_b).to_string(),
+    ]);
+    let backend_a_limitation = backend_limitation(manifest.backend_a);
+    let backend_b_limitation = backend_limitation(manifest.backend_b);
+    lines.push(backend_a_limitation.to_string());
+    if backend_b_limitation != backend_a_limitation {
+        lines.push(backend_b_limitation.to_string());
+    }
+    lines.extend([
         format!(
             "- Environment class is `{}`; do not mix it with another environment class.",
             manifest.environment_class
@@ -697,6 +703,12 @@ mod tests {
         let report = render_report(&summaries, &manifest, &rows);
         assert!(report.contains("# PostgreSQL vs MySQL"));
         assert!(report.contains("MySQL/PG") || report.contains("MySQL/PostgreSQL"));
+        assert_eq!(
+            report
+                .matches("Local SQL container measurements compare")
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/benchmarks/backend-comparison/src/summary.rs
+++ b/benchmarks/backend-comparison/src/summary.rs
@@ -27,17 +27,16 @@ pub struct Manifest {
     pub contract_version: String,
     pub timed_scope_version: String,
     pub result_schema: String,
+    pub environment_class: String,
+    pub backend_a: Backend,
+    pub backend_b: Backend,
     pub repetitions: usize,
     pub lockfile_sha256: String,
     pub config_sha256: String,
     pub commands_sha256: String,
-    pub postgres_binary_sha256: String,
-    pub dynamodb_binary_sha256: String,
+    pub binary_sha256: BTreeMap<Backend, String>,
     pub summarizer_binary_sha256: String,
-    pub postgres_image: String,
-    pub postgres_image_id: String,
-    pub dynamodb_image: String,
-    pub dynamodb_image_id: String,
+    pub images: BTreeMap<Backend, (String, String)>,
 }
 
 impl Manifest {
@@ -57,6 +56,35 @@ impl Manifest {
                 return Err(format!("manifest key is duplicated: {key}"));
             }
         }
+        let backend_a = values
+            .remove("backend_a")
+            .map(|value| value.parse())
+            .transpose()?
+            .unwrap_or(Backend::Postgres);
+        let backend_b = values
+            .remove("backend_b")
+            .map(|value| value.parse())
+            .transpose()?
+            .unwrap_or(Backend::DynamoDbLocal);
+        let environment_class = values
+            .remove("environment_class")
+            .unwrap_or_else(|| "controlled_local".to_string());
+        let mut binary_sha256 = BTreeMap::new();
+        let mut images = BTreeMap::new();
+        for backend in [backend_a, backend_b] {
+            let prefix = manifest_prefix(backend);
+            binary_sha256.insert(
+                backend,
+                take(&mut values, &format!("{prefix}_binary_sha256"))?,
+            );
+            images.insert(
+                backend,
+                (
+                    take(&mut values, &format!("{prefix}_image"))?,
+                    take(&mut values, &format!("{prefix}_image_id"))?,
+                ),
+            );
+        }
         let manifest = Self {
             schema: take(&mut values, "schema")?,
             status: take(&mut values, "status")?,
@@ -68,17 +96,16 @@ impl Manifest {
             contract_version: take(&mut values, "contract_version")?,
             timed_scope_version: take(&mut values, "timed_scope_version")?,
             result_schema: take(&mut values, "result_schema")?,
+            environment_class,
+            backend_a,
+            backend_b,
             repetitions: number(&take(&mut values, "repetitions")?, "repetitions")?,
             lockfile_sha256: take(&mut values, "lockfile_sha256")?,
             config_sha256: take(&mut values, "config_sha256")?,
             commands_sha256: take(&mut values, "commands_sha256")?,
-            postgres_binary_sha256: take(&mut values, "postgres_binary_sha256")?,
-            dynamodb_binary_sha256: take(&mut values, "dynamodb_binary_sha256")?,
+            binary_sha256,
             summarizer_binary_sha256: take(&mut values, "summarizer_binary_sha256")?,
-            postgres_image: take(&mut values, "postgres_image")?,
-            postgres_image_id: take(&mut values, "postgres_image_id")?,
-            dynamodb_image: take(&mut values, "dynamodb_image")?,
-            dynamodb_image_id: take(&mut values, "dynamodb_image_id")?,
+            images,
         };
         if !values.is_empty() {
             return Err(format!(
@@ -100,14 +127,36 @@ impl Manifest {
         if self.repetitions < 7 {
             return Err("publishable comparison requires at least seven repetitions".to_string());
         }
-        if self.run_id.is_empty()
-            || self.contract_version.is_empty()
-            || self.postgres_image.is_empty()
-            || self.postgres_image_id.is_empty()
-            || self.dynamodb_image.is_empty()
-            || self.dynamodb_image_id.is_empty()
-        {
+        if self.backend_a == self.backend_b {
+            return Err("comparison backends must differ".to_string());
+        }
+        if !matches!(
+            self.environment_class.as_str(),
+            "controlled_local" | "external"
+        ) {
+            return Err("environment class must be controlled_local or external".to_string());
+        }
+        if self.run_id.is_empty() || self.contract_version.is_empty() {
             return Err("manifest provenance values cannot be empty".to_string());
+        }
+        for backend in [self.backend_a, self.backend_b] {
+            let binary = self
+                .binary_sha256
+                .get(&backend)
+                .ok_or_else(|| format!("manifest lacks {backend} binary provenance"))?;
+            let (image, image_id) = self
+                .images
+                .get(&backend)
+                .ok_or_else(|| format!("manifest lacks {backend} service provenance"))?;
+            if image.is_empty() || image_id.is_empty() {
+                return Err(format!("{backend} service provenance cannot be empty"));
+            }
+            if binary.len() != 64 || !binary.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+                return Err(format!(
+                    "{}_binary_sha256 is not a 64-character hexadecimal value",
+                    manifest_prefix(backend)
+                ));
+            }
         }
         if self.result_schema != RESULT_SCHEMA || self.timed_scope_version != TIMED_SCOPE_VERSION {
             return Err("manifest result or timing contract is unsupported".to_string());
@@ -118,16 +167,6 @@ impl Manifest {
             ("lockfile_sha256", self.lockfile_sha256.as_str(), 64),
             ("config_sha256", self.config_sha256.as_str(), 64),
             ("commands_sha256", self.commands_sha256.as_str(), 64),
-            (
-                "postgres_binary_sha256",
-                self.postgres_binary_sha256.as_str(),
-                64,
-            ),
-            (
-                "dynamodb_binary_sha256",
-                self.dynamodb_binary_sha256.as_str(),
-                64,
-            ),
             (
                 "summarizer_binary_sha256",
                 self.summarizer_binary_sha256.as_str(),
@@ -145,6 +184,24 @@ impl Manifest {
 
     #[cfg(test)]
     fn example() -> Self {
+        let mut binary_sha256 = BTreeMap::new();
+        binary_sha256.insert(Backend::Postgres, "1".repeat(64));
+        binary_sha256.insert(Backend::DynamoDbLocal, "2".repeat(64));
+        let mut images = BTreeMap::new();
+        images.insert(
+            Backend::Postgres,
+            (
+                "postgres@sha256:test".to_string(),
+                "sha256:postgres".to_string(),
+            ),
+        );
+        images.insert(
+            Backend::DynamoDbLocal,
+            (
+                "dynamodb@sha256:test".to_string(),
+                "sha256:dynamodb".to_string(),
+            ),
+        );
         Self {
             schema: MANIFEST_SCHEMA.to_string(),
             status: "complete".to_string(),
@@ -156,17 +213,16 @@ impl Manifest {
             contract_version: "backend-workload-v1".to_string(),
             timed_scope_version: TIMED_SCOPE_VERSION.to_string(),
             result_schema: RESULT_SCHEMA.to_string(),
+            environment_class: "controlled_local".to_string(),
+            backend_a: Backend::Postgres,
+            backend_b: Backend::DynamoDbLocal,
             repetitions: 7,
             lockfile_sha256: "c".repeat(64),
             config_sha256: "d".repeat(64),
             commands_sha256: "e".repeat(64),
-            postgres_binary_sha256: "1".repeat(64),
-            dynamodb_binary_sha256: "2".repeat(64),
+            binary_sha256,
             summarizer_binary_sha256: "3".repeat(64),
-            postgres_image: "postgres@sha256:test".to_string(),
-            postgres_image_id: "sha256:postgres".to_string(),
-            dynamodb_image: "dynamodb@sha256:test".to_string(),
-            dynamodb_image_id: "sha256:dynamodb".to_string(),
+            images,
         }
     }
 }
@@ -176,19 +232,23 @@ pub struct SummaryRow {
     pub operation: Operation,
     pub logical_operations: u64,
     pub repetitions: usize,
-    pub postgres_median_ms: f64,
-    pub postgres_ops_per_sec: f64,
-    pub postgres_min_ms: f64,
-    pub postgres_max_ms: f64,
-    pub postgres_mad_ms: f64,
-    pub postgres_cv: f64,
-    pub dynamodb_median_ms: f64,
-    pub dynamodb_ops_per_sec: f64,
-    pub dynamodb_min_ms: f64,
-    pub dynamodb_max_ms: f64,
-    pub dynamodb_mad_ms: f64,
-    pub dynamodb_cv: f64,
-    pub dynamodb_to_postgres_latency: f64,
+    pub backend_a: Backend,
+    pub backend_b: Backend,
+    pub backend_a_median_ms: f64,
+    pub backend_a_ops_per_sec: f64,
+    pub backend_a_p99_ms: f64,
+    pub backend_a_min_ms: f64,
+    pub backend_a_max_ms: f64,
+    pub backend_a_mad_ms: f64,
+    pub backend_a_cv: f64,
+    pub backend_b_median_ms: f64,
+    pub backend_b_ops_per_sec: f64,
+    pub backend_b_p99_ms: f64,
+    pub backend_b_min_ms: f64,
+    pub backend_b_max_ms: f64,
+    pub backend_b_mad_ms: f64,
+    pub backend_b_cv: f64,
+    pub backend_b_to_a_latency: f64,
     pub ratio_ci_low: f64,
     pub ratio_ci_high: f64,
     pub winner: Winner,
@@ -233,10 +293,13 @@ pub fn summarize_rows(
                 row.operation, row.repetition
             ));
         }
-        let expected_binary = match row.backend {
-            Backend::Postgres => &manifest.postgres_binary_sha256,
-            Backend::DynamoDbLocal => &manifest.dynamodb_binary_sha256,
-        };
+        if row.backend != manifest.backend_a && row.backend != manifest.backend_b {
+            return Err(format!("unexpected backend in evidence: {}", row.backend));
+        }
+        let expected_binary = manifest
+            .binary_sha256
+            .get(&row.backend)
+            .ok_or_else(|| format!("manifest lacks {} binary identity", row.backend))?;
         if &row.binary_sha256 != expected_binary {
             return Err(format!("binary provenance differs for {}", row.backend));
         }
@@ -258,41 +321,53 @@ pub fn summarize_rows(
 
     let mut summaries = Vec::with_capacity(Operation::ALL.len());
     for operation in Operation::ALL {
-        let mut postgres = Vec::with_capacity(manifest.repetitions);
-        let mut dynamodb = Vec::with_capacity(manifest.repetitions);
+        let mut backend_a = Vec::with_capacity(manifest.repetitions);
+        let mut backend_b = Vec::with_capacity(manifest.repetitions);
+        let mut backend_a_p99 = Vec::with_capacity(manifest.repetitions);
+        let mut backend_b_p99 = Vec::with_capacity(manifest.repetitions);
         let mut logical_operations = None;
         let mut identity = None;
         for repetition in 1..=manifest.repetitions as u32 {
-            let pg = indexed
-                .get(&(Backend::Postgres, operation, repetition))
-                .ok_or_else(|| format!("missing PostgreSQL {operation} repetition {repetition}"))?;
-            let ddb = indexed
-                .get(&(Backend::DynamoDbLocal, operation, repetition))
+            let first = indexed
+                .get(&(manifest.backend_a, operation, repetition))
                 .ok_or_else(|| {
-                    format!("missing DynamoDB Local {operation} repetition {repetition}")
+                    format!(
+                        "missing {} {operation} repetition {repetition}",
+                        manifest.backend_a
+                    )
                 })?;
-            require_equivalent(pg, ddb)?;
+            let second = indexed
+                .get(&(manifest.backend_b, operation, repetition))
+                .ok_or_else(|| {
+                    format!(
+                        "missing {} {operation} repetition {repetition}",
+                        manifest.backend_b
+                    )
+                })?;
+            require_equivalent(first, second)?;
             if let Some(reference) = identity {
-                require_same_workload(reference, pg)?;
+                require_same_workload(reference, first)?;
             } else {
-                identity = Some(*pg);
+                identity = Some(*first);
             }
             match logical_operations {
-                Some(expected) if expected != pg.logical_operations => {
+                Some(expected) if expected != first.logical_operations => {
                     return Err(format!("{operation} logical operation count changed"))
                 }
-                None => logical_operations = Some(pg.logical_operations),
+                None => logical_operations = Some(first.logical_operations),
                 _ => {}
             }
-            postgres.push(pg.total_ns as f64);
-            dynamodb.push(ddb.total_ns as f64);
+            backend_a.push(first.total_ns as f64);
+            backend_b.push(second.total_ns as f64);
+            backend_a_p99.push(row_p99(first) as f64);
+            backend_b_p99.push(row_p99(second) as f64);
         }
-        let pg_median = median(&postgres);
-        let ddb_median = median(&dynamodb);
-        let ratio = ddb_median / pg_median;
+        let backend_a_median = median(&backend_a);
+        let backend_b_median = median(&backend_b);
+        let ratio = backend_b_median / backend_a_median;
         let interval = paired_bootstrap_ratio_ci(
-            &postgres,
-            &dynamodb,
+            &backend_a,
+            &backend_b,
             BOOTSTRAP_RESAMPLES,
             BOOTSTRAP_SEED ^ operation as u64,
         )?;
@@ -301,19 +376,23 @@ pub fn summarize_rows(
             operation,
             logical_operations,
             repetitions: manifest.repetitions,
-            postgres_median_ms: pg_median / 1_000_000.0,
-            postgres_ops_per_sec: logical_operations as f64 * 1_000_000_000.0 / pg_median,
-            postgres_min_ms: min(&postgres) / 1_000_000.0,
-            postgres_max_ms: max(&postgres) / 1_000_000.0,
-            postgres_mad_ms: median_absolute_deviation(&postgres) / 1_000_000.0,
-            postgres_cv: coefficient_of_variation(&postgres),
-            dynamodb_median_ms: ddb_median / 1_000_000.0,
-            dynamodb_ops_per_sec: logical_operations as f64 * 1_000_000_000.0 / ddb_median,
-            dynamodb_min_ms: min(&dynamodb) / 1_000_000.0,
-            dynamodb_max_ms: max(&dynamodb) / 1_000_000.0,
-            dynamodb_mad_ms: median_absolute_deviation(&dynamodb) / 1_000_000.0,
-            dynamodb_cv: coefficient_of_variation(&dynamodb),
-            dynamodb_to_postgres_latency: ratio,
+            backend_a: manifest.backend_a,
+            backend_b: manifest.backend_b,
+            backend_a_median_ms: backend_a_median / 1_000_000.0,
+            backend_a_ops_per_sec: logical_operations as f64 * 1_000_000_000.0 / backend_a_median,
+            backend_a_p99_ms: median(&backend_a_p99) / 1_000_000.0,
+            backend_a_min_ms: min(&backend_a) / 1_000_000.0,
+            backend_a_max_ms: max(&backend_a) / 1_000_000.0,
+            backend_a_mad_ms: median_absolute_deviation(&backend_a) / 1_000_000.0,
+            backend_a_cv: coefficient_of_variation(&backend_a),
+            backend_b_median_ms: backend_b_median / 1_000_000.0,
+            backend_b_ops_per_sec: logical_operations as f64 * 1_000_000_000.0 / backend_b_median,
+            backend_b_p99_ms: median(&backend_b_p99) / 1_000_000.0,
+            backend_b_min_ms: min(&backend_b) / 1_000_000.0,
+            backend_b_max_ms: max(&backend_b) / 1_000_000.0,
+            backend_b_mad_ms: median_absolute_deviation(&backend_b) / 1_000_000.0,
+            backend_b_cv: coefficient_of_variation(&backend_b),
+            backend_b_to_a_latency: ratio,
             ratio_ci_low: interval.low,
             ratio_ci_high: interval.high,
             winner: classify_winner(ratio, interval),
@@ -328,6 +407,8 @@ fn require_same_workload(reference: &EvidenceRow, row: &EvidenceRow) -> Result<(
         || reference.changes != row.changes
         || reference.samples != row.samples
         || reference.concurrency != row.concurrency
+        || reference.pool_size != row.pool_size
+        || reference.adapter_batch_items != row.adapter_batch_items
         || reference.seed != row.seed
         || reference.logical_operations != row.logical_operations
         || reference.observed_items != row.observed_items
@@ -349,6 +430,8 @@ fn require_equivalent(postgres: &EvidenceRow, dynamodb: &EvidenceRow) -> Result<
         || postgres.changes != dynamodb.changes
         || postgres.samples != dynamodb.samples
         || postgres.concurrency != dynamodb.concurrency
+        || postgres.pool_size != dynamodb.pool_size
+        || postgres.adapter_batch_items != dynamodb.adapter_batch_items
         || postgres.seed != dynamodb.seed
         || postgres.logical_operations != dynamodb.logical_operations
         || postgres.observed_items != dynamodb.observed_items
@@ -389,50 +472,62 @@ fn render_csv(summaries: &[SummaryRow]) -> Result<Vec<u8>, String> {
 
 fn render_report(summaries: &[SummaryRow], manifest: &Manifest, rows: &[EvidenceRow]) -> String {
     let first = &rows[0];
+    let backend_a = backend_label(manifest.backend_a);
+    let backend_b = backend_label(manifest.backend_b);
     let mut lines = vec![
-        "# PostgreSQL vs DynamoDB Local".to_string(),
+        format!("# {backend_a} vs {backend_b}"),
         String::new(),
         format!(
-            "This local comparison uses {} records, {}-byte values, concurrency {}, and {} measured repetitions. Latency is lower; throughput is higher.",
-            first.records, first.value_bytes, first.concurrency, manifest.repetitions
+            "This {} comparison uses {} records, {}-byte values, concurrency {}, and {} measured repetitions. Latency is lower; throughput is higher.",
+            manifest.environment_class.replace('_', " "),
+            first.records,
+            first.value_bytes,
+            first.concurrency,
+            manifest.repetitions
         ),
         String::new(),
-        "| Operation | Logical ops | PostgreSQL median | PostgreSQL ops/s | DynamoDB Local median | DynamoDB Local ops/s | DDB/PG 95% CI | Result |".to_string(),
-        "|---|---:|---:|---:|---:|---:|---:|---|".to_string(),
+        format!(
+            "| Operation | Logical ops | {backend_a} median | {backend_a} ops/s | {backend_a} p99 | {backend_b} median | {backend_b} ops/s | {backend_b} p99 | {backend_b}/{backend_a} 95% CI | Result |"
+        ),
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|".to_string(),
     ];
     for row in summaries {
         lines.push(format!(
-            "| {} | {} | {:.2} ms | {:.2} | {:.2} ms | {:.2} | {:.3}–{:.3} | {} |",
+            "| {} | {} | {:.2} ms | {:.2} | {:.2} ms | {:.2} ms | {:.2} | {:.2} ms | {:.3}–{:.3} | {} |",
             row.operation,
             row.logical_operations,
-            row.postgres_median_ms,
-            row.postgres_ops_per_sec,
-            row.dynamodb_median_ms,
-            row.dynamodb_ops_per_sec,
+            row.backend_a_median_ms,
+            row.backend_a_ops_per_sec,
+            row.backend_a_p99_ms,
+            row.backend_b_median_ms,
+            row.backend_b_ops_per_sec,
+            row.backend_b_p99_ms,
             row.ratio_ci_low,
             row.ratio_ci_high,
-            row.winner
+            winner_label(row.winner, manifest)
         ));
     }
     lines.extend([
         String::new(),
         "## Dispersion".to_string(),
         String::new(),
-        "| Operation | PostgreSQL range | PostgreSQL MAD | PostgreSQL CV | DynamoDB Local range | DynamoDB Local MAD | DynamoDB Local CV |".to_string(),
+        format!(
+            "| Operation | {backend_a} range | {backend_a} MAD | {backend_a} CV | {backend_b} range | {backend_b} MAD | {backend_b} CV |"
+        ),
         "|---|---:|---:|---:|---:|---:|---:|".to_string(),
     ]);
     for row in summaries {
         lines.push(format!(
             "| {} | {:.2}–{:.2} ms | {:.2} ms | {:.2}% | {:.2}–{:.2} ms | {:.2} ms | {:.2}% |",
             row.operation,
-            row.postgres_min_ms,
-            row.postgres_max_ms,
-            row.postgres_mad_ms,
-            row.postgres_cv * 100.0,
-            row.dynamodb_min_ms,
-            row.dynamodb_max_ms,
-            row.dynamodb_mad_ms,
-            row.dynamodb_cv * 100.0
+            row.backend_a_min_ms,
+            row.backend_a_max_ms,
+            row.backend_a_mad_ms,
+            row.backend_a_cv * 100.0,
+            row.backend_b_min_ms,
+            row.backend_b_max_ms,
+            row.backend_b_mad_ms,
+            row.backend_b_cv * 100.0
         ));
     }
     lines.extend([
@@ -441,8 +536,12 @@ fn render_report(summaries: &[SummaryRow], manifest: &Manifest, rows: &[Evidence
         String::new(),
         "- Each row uses byte-identical workloads and complete post-timing validation.".to_string(),
         "- A winner requires a paired bootstrap 95% confidence interval that excludes parity and a median effect above 5%.".to_string(),
-        "- DynamoDB Local does not model Amazon DynamoDB network latency, throttling, partitions, capacity, or cost.".to_string(),
-        "- These measurements compare local adapter implementations, not production services.".to_string(),
+        backend_limitation(manifest.backend_a).to_string(),
+        backend_limitation(manifest.backend_b).to_string(),
+        format!(
+            "- Environment class is `{}`; do not mix it with another environment class.",
+            manifest.environment_class
+        ),
         String::new(),
         format!("Run ID: `{}`.", manifest.run_id),
     ]);
@@ -478,6 +577,49 @@ fn write_new(path: &Path, bytes: &[u8]) -> Result<(), String> {
         .map_err(|error| format!("failed to write {}: {error}", path.display()))?;
     file.sync_all()
         .map_err(|error| format!("failed to sync {}: {error}", path.display()))
+}
+
+fn manifest_prefix(backend: Backend) -> &'static str {
+    match backend {
+        Backend::Postgres => "postgres",
+        Backend::MySql => "mysql",
+        Backend::DynamoDbLocal => "dynamodb",
+    }
+}
+
+fn row_p99(row: &EvidenceRow) -> u128 {
+    if row.latency_p99_ns == 0 {
+        row.total_ns
+    } else {
+        row.latency_p99_ns
+    }
+}
+
+fn backend_label(backend: Backend) -> &'static str {
+    match backend {
+        Backend::Postgres => "PostgreSQL",
+        Backend::MySql => "MySQL",
+        Backend::DynamoDbLocal => "DynamoDB Local",
+    }
+}
+
+fn winner_label(winner: Winner, manifest: &Manifest) -> &'static str {
+    match winner {
+        Winner::BackendA => backend_label(manifest.backend_a),
+        Winner::BackendB => backend_label(manifest.backend_b),
+        Winner::Inconclusive => "inconclusive",
+    }
+}
+
+fn backend_limitation(backend: Backend) -> &'static str {
+    match backend {
+        Backend::DynamoDbLocal => {
+            "- DynamoDB Local does not model Amazon DynamoDB network latency, throttling, partitions, capacity, or cost."
+        }
+        Backend::Postgres | Backend::MySql => {
+            "- Local SQL container measurements compare captured adapter and service configurations, not every production deployment."
+        }
+    }
 }
 
 fn min(values: &[f64]) -> f64 {
@@ -531,10 +673,30 @@ mod tests {
         assert_eq!(summaries.len(), Operation::ALL.len());
         assert!(summaries
             .iter()
-            .all(|summary| summary.winner == Winner::Postgres));
+            .all(|summary| summary.winner == Winner::BackendA));
         let report = render_report(&summaries, &manifest, &rows);
         assert!(report.contains("PostgreSQL ops/s"));
         assert!(report.contains("PostgreSQL median"));
+    }
+
+    #[test]
+    fn mysql_postgres_pair_uses_the_same_fail_closed_summary() {
+        let mut manifest = Manifest::example();
+        manifest.backend_b = Backend::MySql;
+        manifest.binary_sha256.remove(&Backend::DynamoDbLocal);
+        manifest
+            .binary_sha256
+            .insert(Backend::MySql, "4".repeat(64));
+        manifest.images.remove(&Backend::DynamoDbLocal);
+        manifest.images.insert(
+            Backend::MySql,
+            ("mysql@sha256:test".to_string(), "sha256:mysql".to_string()),
+        );
+        let rows = fixture_rows(&manifest);
+        let summaries = summarize_rows(&rows, &manifest).unwrap();
+        let report = render_report(&summaries, &manifest, &rows);
+        assert!(report.contains("# PostgreSQL vs MySQL"));
+        assert!(report.contains("MySQL/PG") || report.contains("MySQL/PostgreSQL"));
     }
 
     #[test]
@@ -567,7 +729,7 @@ mod tests {
         for operation in Operation::ALL {
             let operation_digit = char::from_digit(operation as u32 + 3, 16).unwrap();
             for repetition in 1..=manifest.repetitions as u32 {
-                for backend in [Backend::Postgres, Backend::DynamoDbLocal] {
+                for backend in [manifest.backend_a, manifest.backend_b] {
                     let mut row = EvidenceRow::example();
                     row.run_id.clone_from(&manifest.run_id);
                     row.revision.clone_from(&manifest.revision);
@@ -577,15 +739,13 @@ mod tests {
                         .clone_from(&manifest.timed_scope_version);
                     row.schema.clone_from(&manifest.result_schema);
                     row.backend = backend;
-                    row.binary_sha256 = match backend {
-                        Backend::Postgres => manifest.postgres_binary_sha256.clone(),
-                        Backend::DynamoDbLocal => manifest.dynamodb_binary_sha256.clone(),
-                    };
+                    row.binary_sha256 = manifest.binary_sha256[&backend].clone();
                     row.operation = operation;
                     row.repetition = repetition;
-                    row.total_ns = match backend {
-                        Backend::Postgres => 1_000 + repetition as u128,
-                        Backend::DynamoDbLocal => 1_200 + repetition as u128,
+                    row.total_ns = if backend == manifest.backend_a {
+                        1_000 + repetition as u128
+                    } else {
+                        1_200 + repetition as u128
                     };
                     row.ops_per_sec =
                         row.logical_operations as f64 * 1_000_000_000.0 / row.total_ns as f64;

--- a/benchmarks/backend-comparison/tests/dynamodb_smoke.rs
+++ b/benchmarks/backend-comparison/tests/dynamodb_smoke.rs
@@ -29,6 +29,8 @@ fn config(backend: Backend) -> RunConfig {
         revision: "a".repeat(40),
         tree_hash: "b".repeat(40),
         binary_sha256: "c".repeat(64),
+        pool_size: 4,
+        adapter_batch_items: 32,
         workload: WorkloadSpec {
             records: 100,
             value_bytes: 27,

--- a/benchmarks/backend-comparison/tests/mysql_smoke.rs
+++ b/benchmarks/backend-comparison/tests/mysql_smoke.rs
@@ -1,0 +1,32 @@
+use std::path::PathBuf;
+
+use prolly_backend_comparison::{run_mysql, Backend, RunConfig};
+use prolly_backend_workload_contract::{WorkloadSpec, DEFAULT_SEED};
+
+#[tokio::test]
+#[ignore = "requires PROLLY_BACKEND_MYSQL_TEST_URL"]
+async fn mysql_executes_the_common_comparison() {
+    let url = std::env::var("PROLLY_BACKEND_MYSQL_TEST_URL").unwrap();
+    let config = RunConfig {
+        backend: Backend::MySql,
+        output: PathBuf::from("unused.csv"),
+        run_id: "mysql-smoke".to_string(),
+        repetition: 1,
+        revision: "a".repeat(40),
+        tree_hash: "b".repeat(40),
+        binary_sha256: "c".repeat(64),
+        pool_size: 4,
+        adapter_batch_items: 32,
+        workload: WorkloadSpec {
+            records: 100,
+            value_bytes: 27,
+            changes: 10,
+            samples: 10,
+            concurrency: 4,
+            seed: DEFAULT_SEED,
+        },
+    };
+    let rows = run_mysql(&config, &url).await.unwrap();
+    assert_eq!(rows.len(), 6);
+    assert!(rows.iter().all(|row| row.backend == Backend::MySql));
+}

--- a/benchmarks/backend-comparison/tests/postgres_smoke.rs
+++ b/benchmarks/backend-comparison/tests/postgres_smoke.rs
@@ -22,6 +22,8 @@ fn config(backend: Backend) -> RunConfig {
         revision: "a".repeat(40),
         tree_hash: "b".repeat(40),
         binary_sha256: "c".repeat(64),
+        pool_size: 4,
+        adapter_batch_items: 32,
         workload: WorkloadSpec {
             records: 100,
             value_bytes: 27,

--- a/docs/superpowers/plans/2026-07-28-mysql-performance-and-postgres-comparison.md
+++ b/docs/superpowers/plans/2026-07-28-mysql-performance-and-postgres-comparison.md
@@ -1,0 +1,114 @@
+# MySQL Performance and PostgreSQL Comparison Implementation Plan
+
+**Goal:** Make the Rust MySQL adapter scale through bounded set-based SQL and
+provide reproducible end-to-end and service-level MySQL/PostgreSQL comparisons.
+
+**Context:** The MySQL adapter currently loops over individual SQL statements
+for batch reads and writes. The PostgreSQL adapter already provides chunked
+set-based operations. The repository's `backend-comparison` crate already owns
+deterministic end-to-end workloads, fail-closed evidence, paired statistics,
+and PostgreSQL/DynamoDB orchestration. This plan extends those proven paths
+instead of building a parallel benchmark stack.
+
+**Execution style:** Implementation first with context. Production interfaces
+and shared harness paths are implemented before focused regression and
+integration tests are added. Existing conformance tests remain the semantic
+backstop.
+
+## 1. Harden `prolly-store-mysql`
+
+**Files:**
+
+- Modify `stores/prolly-store-mysql/src/lib.rs`
+- Modify `stores/prolly-store-mysql/Cargo.toml`
+- Modify `stores/prolly-store-mysql/tests/mysql_backend.rs`
+- Modify `stores/prolly-store-mysql/README.md`
+
+**Changes:**
+
+- Add `MySqlBackendOptions`, option-aware constructors, and a 1,000-item
+  default batch limit.
+- Use SQLx `QueryBuilder` for bounded multi-row node/root upserts and deletes.
+- Fetch ordered batch reads with bounded `IN` queries and reconstruct order,
+  duplicates, and missing values client-side.
+- Reduce repeated node and root operations with last-write-wins semantics.
+- Add `prolly_root_locks`; acquire sorted lock identities before every root
+  mutation or conditional publication.
+- Keep every multi-chunk public operation atomic.
+- Document batch and pool tuning plus the internal lock table.
+
+## 2. Add MySQL to the shared comparison runner
+
+**Files:**
+
+- Modify `benchmarks/backend-comparison/Cargo.toml`
+- Modify `benchmarks/backend-comparison/src/adapters.rs`
+- Modify `benchmarks/backend-comparison/src/cli.rs`
+- Modify `benchmarks/backend-comparison/src/evidence.rs`
+- Modify `benchmarks/backend-comparison/src/runner.rs`
+- Modify `benchmarks/backend-comparison/src/summary.rs`
+- Add `benchmarks/backend-comparison/src/bin/mysql.rs`
+- Add `benchmarks/backend-comparison/tests/mysql_smoke.rs`
+
+**Changes:**
+
+- Add `Backend::MySql` and MySQL connection parsing.
+- Connect, initialize, clear, and run MySQL through the same generic public
+  operation runner as PostgreSQL.
+- Let summarization accept an explicit backend pair while retaining the
+  PostgreSQL/DynamoDB default.
+- Preserve the result schema's meaning and exact logical-outcome validation.
+
+## 3. Add the SQL service-scale suite
+
+**Files:**
+
+- Add focused service modules under `benchmarks/backend-comparison/src/service/`
+- Add service configuration files under
+  `benchmarks/backend-comparison/workloads/`
+- Add service runner binaries or a backend-selecting service binary
+
+**Changes:**
+
+- Share request generation, client/pool cells, tenant selection, operation
+  mixes, HDR latency histograms, and validation between SQL backends.
+- Sweep adapter batch size, logical batch size, clients, pool size, tenant
+  count, and hot-root share.
+- Record throughput, p50/p95/p99/p99.9/max, conflicts, retries, errors, Prolly
+  counters, and available database diagnostics.
+- Keep backend-specific code limited to pools, resets, and diagnostics.
+
+## 4. Add controlled and external orchestration
+
+**Files:**
+
+- Add `scripts/run_mysql_postgres_comparison.sh`
+- Add `scripts/tests/test_run_mysql_postgres_comparison.py`
+- Extend `benchmarks/backend-comparison/docker-compose.yml`
+- Update `benchmarks/BACKEND_COMPARISON.md`
+
+**Changes:**
+
+- Use pinned MySQL 8 and PostgreSQL 16 images with fresh local volumes.
+- Copy and hash release runners, alternate backend order, exclude warmups, and
+  require seven measured repetitions.
+- Add explicit external mode with disposable-database acknowledgement.
+- Redact URL credentials from captured commands and reports.
+- Fail closed on dirty source, existing output, incomplete runs, or mixed
+  evidence.
+
+## 5. Verify and compare
+
+**Commands:**
+
+- `cargo fmt --all -- --check`
+- `cargo test --manifest-path stores/prolly-store-mysql/Cargo.toml`
+- `cargo clippy --manifest-path stores/prolly-store-mysql/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --manifest-path benchmarks/backend-comparison/Cargo.toml`
+- `python3 -m unittest scripts.tests.test_run_backend_comparison scripts.tests.test_run_mysql_postgres_comparison`
+- Docker-backed MySQL adapter conformance and concurrency tests
+- Controlled smoke comparison through `scripts/run_mysql_postgres_comparison.sh`
+
+After the smoke matrix validates, run a larger local profile and save its raw
+evidence and generated report. Interpret results only for the captured machine,
+Docker allocation, database configuration, adapter revision, and workload.

--- a/docs/superpowers/specs/2026-07-28-mysql-performance-and-postgres-comparison-design.md
+++ b/docs/superpowers/specs/2026-07-28-mysql-performance-and-postgres-comparison-design.md
@@ -1,0 +1,390 @@
+# MySQL adapter performance and PostgreSQL comparison design
+
+## Status
+
+Approved in conversation on 2026-07-28. This document defines the implementation
+contract for hardening the Rust MySQL adapter and producing reproducible
+MySQL/PostgreSQL performance evidence.
+
+## Context
+
+`prolly-store-mysql` implements the complete remote-store contract, but its
+batch paths currently execute one SQL statement per node. Ordered batch reads,
+node batches, node publications with hints, and transactional node writes all
+scale linearly in database round trips. The PostgreSQL adapter already uses
+bounded set-based reads and writes, so a direct comparison of the current
+adapters would mostly measure avoidable MySQL statement amplification.
+
+The repository also has a hardened PostgreSQL/DynamoDB Local comparison
+framework and a PostgreSQL service-scale harness. The new work must reuse those
+contracts and safeguards instead of creating two independent benchmark
+implementations that can drift.
+
+## Goals
+
+1. Remove per-node SQL round trips from MySQL batch paths.
+2. Preserve the remote-store contract, stored node format, public data tables,
+   and atomic publication semantics.
+3. Make concurrent creation and update of named roots safe for absent and
+   existing roots.
+4. Run byte-identical end-to-end Prolly workloads against MySQL and PostgreSQL.
+5. Measure adapter and service scalability across batch sizes, client counts,
+   pool sizes, and root-contention levels.
+6. Make controlled local Docker runs easy to reproduce.
+7. Support externally supplied managed-service URLs without presenting those
+   runs as controlled local evidence.
+8. Emit fail-closed raw evidence, statistical comparisons, and a readable
+   report with complete provenance.
+
+## Non-goals
+
+- Optimizing or benchmarking the Node, JVM, Python, Ruby, or Go MySQL adapters
+- Claiming that one local Docker result predicts every managed MySQL or
+  PostgreSQL deployment
+- Changing public Prolly semantics or its content-addressed wire format
+- Hiding input generation, validation, diagnostics, or database-statistics
+  collection inside timed regions
+- Adding automatic retries that conceal database errors or contention
+- Replacing the existing PostgreSQL/DynamoDB Local comparison mode
+
+## Architecture
+
+The implementation extends the existing trustworthy comparison framework.
+`prolly-store-mysql` remains the production adapter. The shared backend workload
+contract remains the only source of compared workload bytes and expected
+outcomes. The backend-comparison crate gains MySQL support while retaining its
+PostgreSQL and DynamoDB Local runners. A dedicated SQL comparison entry point
+orchestrates MySQL and PostgreSQL without changing the existing
+PostgreSQL/DynamoDB command.
+
+A shared SQL service suite exercises both adapters through the same public
+Prolly and remote-store interfaces. Backend-specific code is restricted to
+connection construction, schema reset, database diagnostics, and adapter
+selection. Workload generation, operation selection, latency collection,
+validation, evidence schemas, regression gates, and report generation are
+shared.
+
+Controlled evidence uses pinned MySQL 8 and PostgreSQL 16 container references,
+fresh service volumes, release binaries copied into the result directory, and
+alternating backend order. Remote mode accepts externally supplied URLs and
+uses the same workload and evidence schema, but records the environment class
+as `external` and cannot be mixed with controlled Docker evidence.
+
+## MySQL adapter hardening
+
+### Additive configuration
+
+Add `MySqlBackendOptions` with a nonzero `max_batch_items`. The default is 1,000
+items. Existing `new` and `connect` constructors keep their signatures and use
+the default. Add `new_with_options`, `connect_with_options`, and `options`.
+Callers continue to control connection-pool size with `sqlx::MySqlPoolOptions`
+and `MySqlBackend::new`; adapter batch size and pool size remain independent.
+
+All SQL builders must also respect MySQL's prepared-statement parameter limit.
+The configured item count is an upper bound, and helpers derive the safe chunk
+size from the number of parameters required per item.
+
+### Set-based node writes
+
+`batch_put_nodes`, upserts in `batch_nodes`, node publication with a hint, and
+transactional node writes use bounded multi-row `INSERT ... ON DUPLICATE KEY
+UPDATE` statements. Duplicate keys are collapsed before SQL generation with
+the last requested operation winning.
+
+Deletes use bounded `DELETE ... WHERE cid IN (...)` statements. A mixed node
+batch first reduces to one final operation per CID, then executes deletes and
+upserts inside one transaction. Statement order cannot affect the final
+logical result because a CID appears in only one reduced set.
+
+An empty node batch or node-publication batch returns without opening a
+transaction when it has no accompanying hint or root work. A publication with
+an empty node set and a hint still updates the hint atomically.
+
+### Ordered batch reads
+
+`batch_get_nodes_ordered` fetches each bounded set with one
+`SELECT cid, node ... WHERE cid IN (...)` query. The adapter reconstructs the
+result from returned CIDs so output order matches input order, duplicate
+requests produce duplicate output slots, and absent CIDs produce `None`.
+
+Duplicate requested CIDs may be collapsed within a SQL chunk because the
+client-side reconstruction preserves their observable multiplicity. Empty
+input returns an empty vector without acquiring a connection.
+
+### Root locking and transactions
+
+`initialize_schema` adds an internal table:
+
+```sql
+CREATE TABLE IF NOT EXISTS prolly_root_locks (
+  name VARBINARY(255) PRIMARY KEY
+);
+```
+
+Existing `prolly_nodes`, `prolly_hints`, and `prolly_roots` rows require no
+migration. The new table contains lock identities only; it is not part of the
+public data model or content-addressed representation.
+
+Before a transaction checks or changes roots, it:
+
+1. Collects and lexicographically sorts the distinct root names.
+2. Inserts missing lock identities with bounded `INSERT IGNORE`.
+3. Acquires the corresponding rows with `SELECT ... FOR UPDATE` in sorted
+   order.
+4. Reads current manifests with bounded set-based queries.
+5. Validates all root conditions.
+6. Applies reduced node and root writes.
+7. Commits once.
+
+The lock row makes an absent root lockable. Sorted acquisition gives competing
+multi-root transactions a common lock order. `put_root_manifest`,
+`delete_root_manifest`, compare-and-swap, and `commit_transaction` all use the
+same locking protocol so callers cannot bypass it through another public
+method.
+
+Root writes are reduced by name with last-write-wins semantics and use bounded
+set-based upserts and deletes. A condition mismatch rolls back without
+publishing node or root changes and returns the current conflicting manifest.
+
+### Error behavior
+
+Every public batch or multi-root transaction remains atomic across all SQL
+chunks. Any SQL failure rolls the transaction back. The adapter does not retry
+deadlocks, timeouts, connection failures, or rejected statements. These errors
+remain visible to the caller, while deterministic locking removes the expected
+cross-root lock-order deadlock.
+
+## Benchmark workload contract
+
+### End-to-end suite
+
+Both adapters run the same deterministic workload bytes for:
+
+- `build`: publish the complete base map
+- `batch`: apply the configured update, insert, and delete set
+- `query`: return an ordered multi-key request
+- `concurrent_query`: execute the same point-read set with bounded concurrency
+- `diff`: create and completely consume the logical diff
+- `merge`: execute a complete deterministic three-way merge
+
+The existing workload contract owns fixed-width keys, values, mutations, query
+order, merge branches, expected maps, expected diffs, canonical roots, and
+workload/outcome digests. Adding MySQL does not create a MySQL-specific
+generator.
+
+### Service and adapter suite
+
+The shared SQL service suite sweeps:
+
+- tree record counts and value sizes
+- adapter batch sizes
+- logical batch sizes
+- client counts
+- SQLx pool sizes
+- tenant and named-root counts
+- independent-root and hot-root traffic shares
+- warmup and measurement durations
+- operation mixes and bounded compare-and-swap retries
+
+The measured operation classes are batch writes, ordered batch reads, point
+reads, versioned commits, diffs, and merges. Each request uses the same cache
+policy on both backends. Pool acquisition time is included in end-to-end
+latency because pool saturation is part of service scalability.
+
+Service rows record attempted and successful throughput, p50, p95, p99,
+p99.9, and maximum latency, compare-and-swap attempts, conflicts, exhausted
+retries, timeouts, SQL errors, validation errors, and worker panics. They also
+record Prolly node/cache/store counters, database statement and I/O diagnostics
+when available, and physical database/table/index sizes.
+
+Database diagnostics are descriptive. Missing optional diagnostics in external
+mode are recorded as unavailable and cannot change semantic validation.
+
+## Timing and validation
+
+Input generation, service reset, fixture construction, result validation,
+diagnostic collection, and report generation are outside timed regions. Each
+end-to-end timer encloses one complete public Prolly operation. Each service
+sample measures one logical request, including connection-pool wait.
+
+Validation runs after timing:
+
+- Builds and batches match expected counts, ordered content digests, and roots.
+- Ordered reads preserve keys, values, missing entries, and duplicates.
+- Concurrent reads return every requested result exactly once.
+- Diffs match complete ordered change records.
+- Merges match the expected conflict count, complete map, digest, and root.
+- Successful publications reopen to the same observable state.
+
+Validation failure invalidates the row. Timings from invalid rows remain
+diagnostic and cannot enter a winner calculation.
+
+## Controlled local orchestration
+
+A publishable local run:
+
+1. Rejects an existing output path.
+2. Requires a committed `HEAD` and clean tracked worktree.
+3. Validates workload dimensions and requires at least seven repetitions.
+4. Builds release binaries and records the dependency lockfile.
+5. Copies and hashes the exact runners and summarizer into the result directory.
+6. Pulls pinned MySQL and PostgreSQL images and records resolved image IDs.
+7. Starts each service with a fresh volume and waits for health.
+8. Runs one excluded warmup per backend.
+9. Alternates backend order across measured repetitions.
+10. Captures exact commands and machine, Docker, service, source, binary, and
+    configuration identity.
+11. Stops and removes service volumes after each isolated invocation.
+12. Writes a failure marker on interruption or error.
+13. Generates a report only after the raw evidence passes all checks.
+
+The result directory is immutable for the invocation. The comparison driver
+does not resume it or append measurements from another environment.
+
+## External service mode
+
+External mode accepts operator-supplied MySQL and PostgreSQL URLs and does not
+start or remove those services. Each URL must point to a disposable, isolated
+benchmark database because the production adapters use fixed table names.
+External execution requires an explicit destructive-reset acknowledgement
+before it clears those benchmark tables; otherwise it fails before connecting.
+It never discovers or selects a database to reset from server metadata.
+
+The manifest records `environment_class=external`, redacts credentials from
+displayed URLs and commands, and captures the server versions and accessible
+configuration. External evidence can be compared only with evidence from the
+same run and environment class. The report states that infrastructure,
+distance, load, and configuration are operator-controlled.
+
+## Evidence and statistics
+
+The common evidence schema gains MySQL as a backend value without changing the
+meaning of existing PostgreSQL/DynamoDB rows. The summarizer accepts an explicit
+two-backend comparison pair. The existing comparison command continues to
+default to PostgreSQL/DynamoDB Local; the SQL command explicitly selects
+MySQL/PostgreSQL.
+
+The summarizer rejects:
+
+- missing, duplicate, or unexpected rows
+- fewer than seven measured repetitions
+- mixed source, binary, workload, schema, environment, or service identities
+- workload or outcome digest mismatches
+- logical result or canonical-root mismatches
+- invalid timing arithmetic or non-finite statistics
+- failed validation
+- dirty, resumed, incomplete, or stale manifests
+- controlled local evidence without pinned resolved images
+
+For every operation and backend, the report includes repetition count, median
+latency, median throughput derived from latency, minimum, maximum, median
+absolute deviation, coefficient of variation, and the deterministic paired
+bootstrap 95% confidence interval for the latency ratio.
+
+A backend is called faster only when the paired interval excludes parity and
+the median latency difference exceeds 5%. Other results are `inconclusive`.
+Service-scale reports emphasize saturation curves and tail latency; they do not
+collapse a client/pool matrix into one universal winner.
+
+## Testing strategy
+
+Development follows red-green-refactor cycles.
+
+### MySQL adapter tests
+
+- option defaults and explicit batch limits
+- empty-batch fast paths
+- ordered reads across chunk boundaries
+- duplicate and missing ordered reads
+- last-write-wins duplicate node mutations
+- bounded multi-row insert and delete statement counts
+- atomic rollback when a later chunk fails
+- atomic node publication with a hint
+- reduced transactional node and root writes
+- compare-and-swap on absent and existing roots
+- concurrent absent-root creation with exactly one valid winner
+- contended existing-root commits with valid serial outcomes
+- multi-root transactions with reversed caller order and no torn publication
+- complete remote-backend conformance
+
+Docker-backed statement-count tests verify that publishing five unique nodes
+with a two-item limit issues exactly three node-insert statements. A forced
+failure in the third chunk must leave none of the earlier chunks committed.
+
+### Harness tests
+
+- MySQL parses and emits the common evidence schema
+- explicit comparison-pair parsing preserves the old default
+- complete MySQL/PostgreSQL fixtures summarize successfully
+- incomplete, duplicate, mismatched, invalid, or mixed-environment fixtures fail
+- percentile, dispersion, bootstrap, and winner calculations remain pinned
+- fake-service orchestration alternates order and excludes warmups
+- local and external manifests are labeled and validated differently
+- credential-bearing URLs are redacted from recorded commands and reports
+- runner failure prevents summarization and writes a failure marker
+
+### End-to-end verification
+
+A controlled Docker smoke run executes both suites on a small deterministic
+dataset. The raw end-to-end rows must have matching workload digests, outcome
+digests, counts, and roots. Every service cell must have the expected operation
+and tenant-class rows with no validation errors or worker panics.
+
+After smoke verification, a larger local run produces the initial checked-in or
+published MySQL/PostgreSQL comparison report. Its claims remain scoped to the
+captured machine, Docker allocation, adapter versions, database configuration,
+and workload.
+
+## Documentation and entry points
+
+The repository documents:
+
+- one command for the controlled MySQL/PostgreSQL comparison
+- one command or flag set for the service-scale matrix
+- configuration profiles for smoke and default runs
+- external URL mode and its evidence limitations
+- adapter batch-size and SQLx pool-size tuning
+- result-directory contents and report interpretation
+- how to rerun the exact workload and regenerate a report
+
+The MySQL adapter README explains set-based batching, the internal root-lock
+table, atomicity, defaults, and how to construct a custom pool and batch size.
+
+## Acceptance criteria
+
+Implementation is complete when:
+
+1. The Rust MySQL adapter replaces per-node batch SQL with bounded set-based
+   operations.
+2. Existing constructors and stored node, hint, and root data remain compatible.
+3. Ordered batch reads preserve order, duplicates, and missing slots.
+4. Multi-chunk batches and transactions roll back atomically on failure.
+5. Concurrent absent and existing root updates satisfy the allowed serial
+   outcomes without torn publication.
+6. The existing remote-store conformance suite passes for MySQL.
+7. The comparison framework supports MySQL/PostgreSQL without breaking the
+   PostgreSQL/DynamoDB Local mode.
+8. Both end-to-end and service/adapter suites use shared workload and evidence
+   code across MySQL and PostgreSQL.
+9. Controlled local runs require pinned images, clean source, fresh volumes,
+   excluded warmups, alternating order, and at least seven repetitions.
+10. External runs are credential-redacted and cannot be confused with
+    controlled local evidence.
+11. Fail-closed analysis rejects incomplete or incomparable results.
+12. Unit, integration, conformance, orchestration, formatting, and strict
+    compilation checks pass.
+13. A Docker smoke comparison passes with matching logical outcomes.
+14. A larger local run produces a provenance-complete MySQL/PostgreSQL report
+    with appropriately scoped conclusions.
+
+## Implementation constraints
+
+- Rust 1.81 remains the minimum supported compiler.
+- No production dependency or public Prolly API is added solely for benchmarks.
+- Adapter changes use `sqlx` and do not require database-specific native client
+  libraries.
+- Randomness is deterministic, seedable, and recorded.
+- Timed code does not include validation or diagnostic collection.
+- Benchmark output defaults outside tracked source unless intentionally
+  promoted.
+- Existing untracked and unrelated worktree content is preserved.

--- a/scripts/run_mysql_postgres_comparison.sh
+++ b/scripts/run_mysql_postgres_comparison.sh
@@ -74,11 +74,19 @@ redact_url() {
 }
 
 record_command() {
-  {
-    printf '%q ' "$@"
-    printf '\n'
-  } >> "$MEASUREMENT_COMMANDS"
+  write_shell_command "$@" >> "$MEASUREMENT_COMMANDS"
   "$@"
+}
+
+write_shell_command() {
+  local separator=""
+  local value
+  for value in "$@"; do
+    printf '%s' "$separator"
+    printf '%q' "$value"
+    separator=" "
+  done
+  printf '\n'
 }
 
 record_runner_command() {
@@ -95,10 +103,7 @@ record_runner_command() {
       [[ "$value" == --url ]] && redact_next=true
     fi
   done
-  {
-    printf '%q ' "${redacted[@]}"
-    printf '\n'
-  } >> "$MEASUREMENT_COMMANDS"
+  write_shell_command "${redacted[@]}" >> "$MEASUREMENT_COMMANDS"
   "${actual[@]}"
 }
 

--- a/scripts/run_mysql_postgres_comparison.sh
+++ b/scripts/run_mysql_postgres_comparison.sh
@@ -1,0 +1,404 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MANIFEST="$REPO_ROOT/benchmarks/backend-comparison/Cargo.toml"
+LOCKFILE="$REPO_ROOT/benchmarks/backend-comparison/Cargo.lock"
+COMPOSE_FILE="$REPO_ROOT/benchmarks/backend-comparison/docker-compose.yml"
+OUTPUT="${BENCH_OUT:-$REPO_ROOT/performance-results/mysql-postgres-$(date -u +%Y%m%dT%H%M%SZ)}"
+MODE="${BENCH_MODE:-local}"
+RECORDS="${BENCH_RECORDS:-1000000}"
+VALUE_BYTES="${BENCH_VALUE_BYTES:-27}"
+CHANGES="${BENCH_CHANGES:-10000}"
+SAMPLES="${BENCH_SAMPLES:-10000}"
+CONCURRENCY="${BENCH_CONCURRENCY:-32}"
+POOL_SIZE="${BENCH_POOL_SIZE:-16}"
+ADAPTER_BATCH_ITEMS="${BENCH_ADAPTER_BATCH_ITEMS:-1000}"
+RUNS="${BENCH_RUNS:-7}"
+SEED="${BENCH_SEED:-0x6a09e667f3bcc909}"
+POSTGRES_PORT="${PROLLY_BACKEND_POSTGRES_PORT:-55433}"
+MYSQL_PORT="${PROLLY_BACKEND_MYSQL_PORT:-53307}"
+POSTGRES_URL="${PROLLY_BACKEND_POSTGRES_URL:-postgres://prolly:prolly@127.0.0.1:${POSTGRES_PORT}/prolly}"
+MYSQL_URL="${PROLLY_BACKEND_MYSQL_URL:-mysql://prolly:prolly@127.0.0.1:${MYSQL_PORT}/prolly}"
+POSTGRES_IMAGE="postgres@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777"
+MYSQL_IMAGE="mysql@sha256:7dcddc01f13bab2f15cde676d44d01f61fc9f99fe7785e86196dfc07d358ae2b"
+POSTGRES_PROJECT="prolly-sql-comparison-postgres"
+MYSQL_PROJECT="prolly-sql-comparison-mysql"
+GIT_BIN="${BENCH_GIT_BIN:-git}"
+DOCKER_BIN="${BENCH_DOCKER_BIN:-docker}"
+CARGO_BIN="${BENCH_CARGO_BIN:-cargo}"
+SHASUM_BIN="${BENCH_SHASUM_BIN:-shasum}"
+MEASUREMENT_COMMANDS=""
+RUN_STARTED=false
+
+cleanup() {
+  if [[ "$MODE" == local ]]; then
+    "$DOCKER_BIN" compose -p "$POSTGRES_PROJECT" -f "$COMPOSE_FILE" down -v \
+      >/dev/null 2>&1 || true
+    "$DOCKER_BIN" compose -p "$MYSQL_PROJECT" -f "$COMPOSE_FILE" down -v \
+      >/dev/null 2>&1 || true
+  fi
+}
+
+finish() {
+  code=$?
+  trap - EXIT
+  cleanup
+  if [[ "$code" != 0 && "$RUN_STARTED" == true && -d "$OUTPUT" ]]; then
+    {
+      printf 'status=failed\n'
+      printf 'exit_code=%s\n' "$code"
+      printf 'failed_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    } > "$OUTPUT/failure.txt"
+  fi
+  exit "$code"
+}
+trap finish EXIT
+
+fail() {
+  printf '%s\n' "$*" >&2
+  exit 2
+}
+
+is_positive_integer() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+sha256_file() {
+  "$SHASUM_BIN" -a 256 "$1" | awk '{print $1}'
+}
+
+redact_url() {
+  printf '%s' "$1" | sed -E 's#(://)[^/@]+@#\1REDACTED@#'
+}
+
+record_command() {
+  {
+    printf '%q ' "$@"
+    printf '\n'
+  } >> "$MEASUREMENT_COMMANDS"
+  "$@"
+}
+
+record_runner_command() {
+  local -a actual=("$@")
+  local -a redacted=()
+  local redact_next=false
+  local value
+  for value in "${actual[@]}"; do
+    if [[ "$redact_next" == true ]]; then
+      redacted+=("$(redact_url "$value")")
+      redact_next=false
+    else
+      redacted+=("$value")
+      [[ "$value" == --url ]] && redact_next=true
+    fi
+  done
+  {
+    printf '%q ' "${redacted[@]}"
+    printf '\n'
+  } >> "$MEASUREMENT_COMMANDS"
+  "${actual[@]}"
+}
+
+[[ "$MODE" == local || "$MODE" == external ]] \
+  || fail "BENCH_MODE must be local or external"
+if [[ "$MODE" == external ]]; then
+  [[ "${BENCH_EXTERNAL_RESET_ACK:-}" == "I_UNDERSTAND_BENCHMARK_DATA_WILL_BE_DELETED" ]] \
+    || fail "external mode requires BENCH_EXTERNAL_RESET_ACK=I_UNDERSTAND_BENCHMARK_DATA_WILL_BE_DELETED"
+  [[ -n "${BENCH_EXTERNAL_POSTGRES_IDENTITY:-}" ]] \
+    || fail "external mode requires BENCH_EXTERNAL_POSTGRES_IDENTITY"
+  [[ -n "${BENCH_EXTERNAL_MYSQL_IDENTITY:-}" ]] \
+    || fail "external mode requires BENCH_EXTERNAL_MYSQL_IDENTITY"
+fi
+[[ ! -e "$OUTPUT" ]] || fail "refusing to overwrite comparison output: $OUTPUT"
+for pair in \
+  "BENCH_RECORDS:$RECORDS" \
+  "BENCH_VALUE_BYTES:$VALUE_BYTES" \
+  "BENCH_CHANGES:$CHANGES" \
+  "BENCH_SAMPLES:$SAMPLES" \
+  "BENCH_CONCURRENCY:$CONCURRENCY" \
+  "BENCH_POOL_SIZE:$POOL_SIZE" \
+  "BENCH_ADAPTER_BATCH_ITEMS:$ADAPTER_BATCH_ITEMS" \
+  "BENCH_RUNS:$RUNS"; do
+  name="${pair%%:*}"
+  value="${pair#*:}"
+  is_positive_integer "$value" || fail "$name must be a positive integer"
+done
+((RUNS >= 7)) || fail "BENCH_RUNS must be at least 7"
+((CHANGES % 2 == 0)) || fail "BENCH_CHANGES must be even"
+((CHANGES <= RECORDS)) || fail "BENCH_CHANGES cannot exceed BENCH_RECORDS"
+((SAMPLES <= RECORDS)) || fail "BENCH_SAMPLES cannot exceed BENCH_RECORDS"
+
+REVISION="$("$GIT_BIN" -C "$REPO_ROOT" rev-parse HEAD)"
+TREE_HASH="$("$GIT_BIN" -C "$REPO_ROOT" rev-parse 'HEAD^{tree}')"
+[[ "$REVISION" =~ ^[0-9a-f]{40}$ ]] || fail "HEAD is not a committed Git revision"
+[[ "$TREE_HASH" =~ ^[0-9a-f]{40}$ ]] || fail "HEAD tree hash is invalid"
+TRACKED_STATUS="$("$GIT_BIN" -C "$REPO_ROOT" status --porcelain --untracked-files=no)"
+[[ -z "$TRACKED_STATUS" ]] || fail "tracked worktree must be clean before comparison"
+
+mkdir -p "$OUTPUT/bin" "$OUTPUT/invocations" "$OUTPUT/warmup"
+RUN_STARTED=true
+MEASUREMENT_COMMANDS="$OUTPUT/measurement-commands.txt"
+: > "$MEASUREMENT_COMMANDS"
+RUN_ID="sql-${REVISION:0:12}-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+
+{
+  printf 'environment_class=%s\n' "$([[ "$MODE" == local ]] && printf controlled_local || printf external)"
+  printf 'records=%s\n' "$RECORDS"
+  printf 'value_bytes=%s\n' "$VALUE_BYTES"
+  printf 'changes=%s\n' "$CHANGES"
+  printf 'samples=%s\n' "$SAMPLES"
+  printf 'concurrency=%s\n' "$CONCURRENCY"
+  printf 'pool_size=%s\n' "$POOL_SIZE"
+  printf 'adapter_batch_items=%s\n' "$ADAPTER_BATCH_ITEMS"
+  printf 'repetitions=%s\n' "$RUNS"
+  printf 'seed=%s\n' "$SEED"
+} > "$OUTPUT/config.txt"
+CONFIG_SHA256="$(sha256_file "$OUTPUT/config.txt")"
+
+{
+  printf 'captured_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  uname -a
+  rustc --version
+  "$CARGO_BIN" --version
+  if [[ "$MODE" == local ]]; then
+    "$DOCKER_BIN" info --format 'docker_server={{.ServerVersion}} os={{.OperatingSystem}} cpus={{.NCPU}} memory={{.MemTotal}}'
+  else
+    printf 'external_postgres_identity=%s\n' "${BENCH_EXTERNAL_POSTGRES_IDENTITY}"
+    printf 'external_mysql_identity=%s\n' "${BENCH_EXTERNAL_MYSQL_IDENTITY}"
+  fi
+} > "$OUTPUT/machine.txt"
+
+if [[ "${BENCH_SKIP_BUILD:-0}" != 1 ]]; then
+  "$CARGO_BIN" build --release --manifest-path "$MANIFEST" 2>&1 | tee "$OUTPUT/build.log"
+  "$CARGO_BIN" tree --manifest-path "$MANIFEST" > "$OUTPUT/dependencies.txt"
+fi
+[[ "$("$GIT_BIN" -C "$REPO_ROOT" rev-parse HEAD)" == "$REVISION" ]] \
+  || fail "HEAD changed during benchmark build"
+[[ -z "$("$GIT_BIN" -C "$REPO_ROOT" status --porcelain --untracked-files=no)" ]] \
+  || fail "tracked worktree changed during benchmark build"
+LOCKFILE_SHA256="$(sha256_file "$LOCKFILE")"
+
+POSTGRES_SOURCE="${BENCH_POSTGRES_EXECUTABLE:-$REPO_ROOT/benchmarks/backend-comparison/target/release/prolly-backend-postgres}"
+MYSQL_SOURCE="${BENCH_MYSQL_EXECUTABLE:-$REPO_ROOT/benchmarks/backend-comparison/target/release/prolly-backend-mysql}"
+SUMMARIZER_SOURCE="${BENCH_SUMMARIZER_EXECUTABLE:-$REPO_ROOT/benchmarks/backend-comparison/target/release/prolly-backend-summarize}"
+SERVICE_SUMMARIZER="${BENCH_SERVICE_SUMMARIZER:-$SCRIPT_DIR/summarize_mysql_postgres_service.py}"
+for executable in "$POSTGRES_SOURCE" "$MYSQL_SOURCE" "$SUMMARIZER_SOURCE"; do
+  [[ -x "$executable" ]] || fail "benchmark executable is missing or not executable: $executable"
+done
+cp "$POSTGRES_SOURCE" "$OUTPUT/bin/prolly-backend-postgres"
+cp "$MYSQL_SOURCE" "$OUTPUT/bin/prolly-backend-mysql"
+cp "$SUMMARIZER_SOURCE" "$OUTPUT/bin/prolly-backend-summarize"
+POSTGRES_EXECUTABLE="$OUTPUT/bin/prolly-backend-postgres"
+MYSQL_EXECUTABLE="$OUTPUT/bin/prolly-backend-mysql"
+SUMMARIZER_EXECUTABLE="$OUTPUT/bin/prolly-backend-summarize"
+POSTGRES_BINARY_SHA256="$(sha256_file "$POSTGRES_EXECUTABLE")"
+MYSQL_BINARY_SHA256="$(sha256_file "$MYSQL_EXECUTABLE")"
+SUMMARIZER_BINARY_SHA256="$(sha256_file "$SUMMARIZER_EXECUTABLE")"
+{
+  printf '%s  %s\n' "$POSTGRES_BINARY_SHA256" "bin/prolly-backend-postgres"
+  printf '%s  %s\n' "$MYSQL_BINARY_SHA256" "bin/prolly-backend-mysql"
+  printf '%s  %s\n' "$SUMMARIZER_BINARY_SHA256" "bin/prolly-backend-summarize"
+} > "$OUTPUT/binaries.sha256"
+
+if [[ "$MODE" == local ]]; then
+  if [[ "${BENCH_SKIP_IMAGE_PULL:-0}" != 1 ]]; then
+    {
+      "$DOCKER_BIN" pull "$POSTGRES_IMAGE"
+      "$DOCKER_BIN" pull "$MYSQL_IMAGE"
+    } > "$OUTPUT/image-pull.log"
+  fi
+  POSTGRES_IMAGE_ID="$("$DOCKER_BIN" image inspect "$POSTGRES_IMAGE" --format '{{.Id}}')"
+  MYSQL_IMAGE_ID="$("$DOCKER_BIN" image inspect "$MYSQL_IMAGE" --format '{{.Id}}')"
+else
+  POSTGRES_IMAGE="external"
+  MYSQL_IMAGE="external"
+  POSTGRES_IMAGE_ID="${BENCH_EXTERNAL_POSTGRES_IDENTITY}"
+  MYSQL_IMAGE_ID="${BENCH_EXTERNAL_MYSQL_IDENTITY}"
+fi
+[[ -n "$POSTGRES_IMAGE_ID" && -n "$MYSQL_IMAGE_ID" ]] \
+  || fail "service identities are unavailable"
+{
+  printf 'postgres_image=%s\n' "$POSTGRES_IMAGE"
+  printf 'postgres_image_id=%s\n' "$POSTGRES_IMAGE_ID"
+  printf 'mysql_image=%s\n' "$MYSQL_IMAGE"
+  printf 'mysql_image_id=%s\n' "$MYSQL_IMAGE_ID"
+} > "$OUTPUT/images.txt"
+
+wait_for_service() {
+  local project="$1"
+  local service="$2"
+  for _ in $(seq 1 120); do
+    health="$("$DOCKER_BIN" inspect --format '{{.State.Health.Status}}' "$project-$service-1" 2>/dev/null || true)"
+    [[ "$health" == healthy ]] && return 0
+    sleep 1
+  done
+  "$DOCKER_BIN" compose -p "$project" -f "$COMPOSE_FILE" logs "$service" >&2 || true
+  return 1
+}
+
+run_backend() {
+  local backend="$1"
+  local repetition="$2"
+  local output="$3"
+  local service_output="$4"
+  local invocation_run_id="$5"
+  local project service executable binary_sha256 url port_env port
+  if [[ "$backend" == postgres ]]; then
+    project="$POSTGRES_PROJECT"
+    service=postgres
+    executable="$POSTGRES_EXECUTABLE"
+    binary_sha256="$POSTGRES_BINARY_SHA256"
+    url="$POSTGRES_URL"
+    port_env=PROLLY_BACKEND_POSTGRES_PORT
+    port="$POSTGRES_PORT"
+  else
+    project="$MYSQL_PROJECT"
+    service=mysql
+    executable="$MYSQL_EXECUTABLE"
+    binary_sha256="$MYSQL_BINARY_SHA256"
+    url="$MYSQL_URL"
+    port_env=PROLLY_BACKEND_MYSQL_PORT
+    port="$MYSQL_PORT"
+  fi
+  if [[ "$MODE" == local ]]; then
+    record_command "$DOCKER_BIN" compose -p "$project" -f "$COMPOSE_FILE" down -v
+    record_command env "$port_env=$port" \
+      "$DOCKER_BIN" compose -p "$project" -f "$COMPOSE_FILE" up -d "$service"
+    wait_for_service "$project" "$service"
+  fi
+  record_runner_command "$executable" \
+    --output "$output" \
+    --run-id "$invocation_run_id" \
+    --repetition "$repetition" \
+    --revision "$REVISION" \
+    --tree-hash "$TREE_HASH" \
+    --binary-sha256 "$binary_sha256" \
+    --records "$RECORDS" \
+    --value-bytes "$VALUE_BYTES" \
+    --changes "$CHANGES" \
+    --samples "$SAMPLES" \
+    --concurrency "$CONCURRENCY" \
+    --pool-size "$POOL_SIZE" \
+    --adapter-batch-items "$ADAPTER_BATCH_ITEMS" \
+    --seed "$SEED" \
+    --url "$url" \
+    --suite end-to-end
+  record_runner_command "$executable" \
+    --output "$service_output" \
+    --run-id "$invocation_run_id" \
+    --repetition "$repetition" \
+    --revision "$REVISION" \
+    --tree-hash "$TREE_HASH" \
+    --binary-sha256 "$binary_sha256" \
+    --records "$RECORDS" \
+    --value-bytes "$VALUE_BYTES" \
+    --changes "$CHANGES" \
+    --samples "$SAMPLES" \
+    --concurrency "$CONCURRENCY" \
+    --pool-size "$POOL_SIZE" \
+    --adapter-batch-items "$ADAPTER_BATCH_ITEMS" \
+    --seed "$SEED" \
+    --url "$url" \
+    --suite service
+  if [[ "$MODE" == local ]]; then
+    record_command "$DOCKER_BIN" compose -p "$project" -f "$COMPOSE_FILE" down -v
+  fi
+}
+
+run_backend postgres 1 "$OUTPUT/warmup/postgres.csv" \
+  "$OUTPUT/warmup/postgres-service.csv" "$RUN_ID-warmup-postgres"
+run_backend mysql 1 "$OUTPUT/warmup/mysql.csv" \
+  "$OUTPUT/warmup/mysql-service.csv" "$RUN_ID-warmup-mysql"
+
+measured_files=()
+measured_service_files=()
+for repetition in $(seq 1 "$RUNS"); do
+  if ((repetition % 2 == 1)); then
+    order=(postgres mysql)
+  else
+    order=(mysql postgres)
+  fi
+  for backend in "${order[@]}"; do
+    file="$OUTPUT/invocations/${repetition}-${backend}.csv"
+    service_file="$OUTPUT/invocations/${repetition}-${backend}-service.csv"
+    run_backend "$backend" "$repetition" "$file" "$service_file" "$RUN_ID"
+    measured_files+=("$file")
+    measured_service_files+=("$service_file")
+  done
+done
+
+RAW_SERVICE_RESULTS="$OUTPUT/raw-service-results.csv"
+first=true
+header=""
+for file in "${measured_service_files[@]}"; do
+  current_header="$(head -n 1 "$file")"
+  if [[ "$first" == true ]]; then
+    cp "$file" "$RAW_SERVICE_RESULTS"
+    header="$current_header"
+    first=false
+  else
+    [[ "$current_header" == "$header" ]] || fail "service evidence headers differ: $file"
+    tail -n +2 "$file" >> "$RAW_SERVICE_RESULTS"
+  fi
+done
+
+RAW_RESULTS="$OUTPUT/raw-results.csv"
+first=true
+header=""
+for file in "${measured_files[@]}"; do
+  current_header="$(head -n 1 "$file")"
+  if [[ "$first" == true ]]; then
+    cp "$file" "$RAW_RESULTS"
+    header="$current_header"
+    first=false
+  else
+    [[ "$current_header" == "$header" ]] || fail "evidence headers differ: $file"
+    tail -n +2 "$file" >> "$RAW_RESULTS"
+  fi
+done
+
+COMMANDS_SHA256="$(sha256_file "$MEASUREMENT_COMMANDS")"
+{
+  printf 'schema=backend-comparison-manifest-v1\n'
+  printf 'status=complete\n'
+  printf 'resumed=false\n'
+  printf 'dirty=false\n'
+  printf 'environment_class=%s\n' "$([[ "$MODE" == local ]] && printf controlled_local || printf external)"
+  printf 'backend_a=postgres\n'
+  printf 'backend_b=mysql\n'
+  printf 'run_id=%s\n' "$RUN_ID"
+  printf 'revision=%s\n' "$REVISION"
+  printf 'tree_hash=%s\n' "$TREE_HASH"
+  printf 'contract_version=backend-workload-v1\n'
+  printf 'timed_scope_version=public-prolly-operation-v1\n'
+  printf 'result_schema=backend-comparison-v1\n'
+  printf 'repetitions=%s\n' "$RUNS"
+  printf 'lockfile_sha256=%s\n' "$LOCKFILE_SHA256"
+  printf 'config_sha256=%s\n' "$CONFIG_SHA256"
+  printf 'commands_sha256=%s\n' "$COMMANDS_SHA256"
+  printf 'postgres_binary_sha256=%s\n' "$POSTGRES_BINARY_SHA256"
+  printf 'mysql_binary_sha256=%s\n' "$MYSQL_BINARY_SHA256"
+  printf 'summarizer_binary_sha256=%s\n' "$SUMMARIZER_BINARY_SHA256"
+  printf 'postgres_image=%s\n' "$POSTGRES_IMAGE"
+  printf 'postgres_image_id=%s\n' "$POSTGRES_IMAGE_ID"
+  printf 'mysql_image=%s\n' "$MYSQL_IMAGE"
+  printf 'mysql_image_id=%s\n' "$MYSQL_IMAGE_ID"
+} > "$OUTPUT/manifest.txt"
+
+record_command "$SUMMARIZER_EXECUTABLE" \
+  --input "$RAW_RESULTS" \
+  --manifest "$OUTPUT/manifest.txt" \
+  --output-dir "$OUTPUT"
+record_command "$SERVICE_SUMMARIZER" \
+  --input "$RAW_SERVICE_RESULTS" \
+  --manifest "$OUTPUT/manifest.txt" \
+  --output-dir "$OUTPUT"
+
+{
+  printf 'status=complete\n'
+  printf 'completed_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} > "$OUTPUT/run-state.txt"
+printf 'MySQL/PostgreSQL comparison complete: %s/report.md\n' "$OUTPUT"

--- a/scripts/run_mysql_postgres_comparison.sh
+++ b/scripts/run_mysql_postgres_comparison.sh
@@ -172,8 +172,10 @@ CONFIG_SHA256="$(sha256_file "$OUTPUT/config.txt")"
 } > "$OUTPUT/machine.txt"
 
 if [[ "${BENCH_SKIP_BUILD:-0}" != 1 ]]; then
-  "$CARGO_BIN" build --release --manifest-path "$MANIFEST" 2>&1 | tee "$OUTPUT/build.log"
-  "$CARGO_BIN" tree --manifest-path "$MANIFEST" > "$OUTPUT/dependencies.txt"
+  "$CARGO_BIN" build --release --no-default-features --bins \
+    --manifest-path "$MANIFEST" 2>&1 | tee "$OUTPUT/build.log"
+  "$CARGO_BIN" tree --no-default-features --manifest-path "$MANIFEST" \
+    > "$OUTPUT/dependencies.txt"
 fi
 [[ "$("$GIT_BIN" -C "$REPO_ROOT" rev-parse HEAD)" == "$REVISION" ]] \
   || fail "HEAD changed during benchmark build"

--- a/scripts/run_mysql_postgres_service_matrix.sh
+++ b/scripts/run_mysql_postgres_service_matrix.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DRIVER="$SCRIPT_DIR/run_mysql_postgres_comparison.sh"
+SUMMARIZER="$SCRIPT_DIR/summarize_mysql_postgres_service_matrix.py"
+OUTPUT="${BENCH_OUT:-$REPO_ROOT/performance-results/mysql-postgres-service-$(date -u +%Y%m%dT%H%M%SZ)}"
+CLIENTS="${BENCH_CLIENTS:-1,8,32}"
+POOL_SIZES="${BENCH_POOL_SIZES:-4,16}"
+RECORDS="${BENCH_RECORDS:-100000}"
+CHANGES="${BENCH_CHANGES:-1000}"
+SAMPLES="${BENCH_SAMPLES:-10000}"
+
+[[ ! -e "$OUTPUT" ]] || {
+  printf 'refusing to overwrite service matrix output: %s\n' "$OUTPUT" >&2
+  exit 2
+}
+mkdir -p "$OUTPUT/cells"
+
+IFS=',' read -r -a client_values <<< "$CLIENTS"
+IFS=',' read -r -a pool_values <<< "$POOL_SIZES"
+first=true
+for clients in "${client_values[@]}"; do
+  for pool_size in "${pool_values[@]}"; do
+    [[ "$clients" =~ ^[1-9][0-9]*$ && "$pool_size" =~ ^[1-9][0-9]*$ ]] || {
+      printf 'BENCH_CLIENTS and BENCH_POOL_SIZES must contain positive integers\n' >&2
+      exit 2
+    }
+    cell="$OUTPUT/cells/clients-${clients}-pool-${pool_size}"
+    if [[ "$first" == true ]]; then
+      skip_build="${BENCH_SKIP_BUILD:-0}"
+      first=false
+    else
+      skip_build=1
+    fi
+    BENCH_OUT="$cell" \
+    BENCH_RECORDS="$RECORDS" \
+    BENCH_CHANGES="$CHANGES" \
+    BENCH_SAMPLES="$SAMPLES" \
+    BENCH_CONCURRENCY="$clients" \
+    BENCH_POOL_SIZE="$pool_size" \
+    BENCH_SKIP_BUILD="$skip_build" \
+      "$DRIVER"
+  done
+done
+
+python3 "$SUMMARIZER" --input "$OUTPUT/cells" --output "$OUTPUT"
+printf 'MySQL/PostgreSQL service matrix complete: %s/report.md\n' "$OUTPUT"

--- a/scripts/summarize_mysql_postgres_service.py
+++ b/scripts/summarize_mysql_postgres_service.py
@@ -207,7 +207,9 @@ def main() -> None:
     if csv_path.exists() or report_path.exists():
         raise ValueError("refusing to overwrite service comparison output")
     with csv_path.open("x", newline="") as handle:
-        writer = csv.DictWriter(handle, fieldnames=summaries[0].keys())
+        writer = csv.DictWriter(
+            handle, fieldnames=summaries[0].keys(), lineterminator="\n"
+        )
         writer.writeheader()
         writer.writerows(summaries)
     report_path.write_text(report(summaries, values))

--- a/scripts/summarize_mysql_postgres_service.py
+++ b/scripts/summarize_mysql_postgres_service.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import math
+import pathlib
+import statistics
+
+
+OPERATIONS = ("batch_put", "batch_get", "concurrent_get", "contended_root_cas")
+RESAMPLES = 10_000
+SEED = 0x243F6A8885A308D3
+
+
+def manifest(path: pathlib.Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in path.read_text().splitlines():
+        key, separator, value = line.partition("=")
+        if not separator or key in values:
+            raise ValueError(f"invalid manifest line: {line}")
+        values[key] = value
+    required = {
+        "status": "complete",
+        "resumed": "false",
+        "dirty": "false",
+        "backend_a": "postgres",
+        "backend_b": "mysql",
+    }
+    for key, expected in required.items():
+        if values.get(key) != expected:
+            raise ValueError(f"manifest {key} must be {expected}")
+    if int(values["repetitions"]) < 7:
+        raise ValueError("service comparison requires at least seven repetitions")
+    return values
+
+
+def load(path: pathlib.Path, values: dict[str, str]) -> list[dict[str, str]]:
+    with path.open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    expected_count = int(values["repetitions"]) * len(OPERATIONS) * 2
+    if len(rows) != expected_count:
+        raise ValueError(f"service matrix has {len(rows)} rows, expected {expected_count}")
+    indexed: dict[tuple[str, str, int], dict[str, str]] = {}
+    for row in rows:
+        if (
+            row["schema"] != "sql-service-comparison-v1"
+            or row["run_id"] != values["run_id"]
+            or row["revision"] != values["revision"]
+            or row["tree_hash"] != values["tree_hash"]
+            or row["validated"] != "true"
+            or row["error"]
+        ):
+            raise ValueError("service row provenance or validation differs")
+        backend = row["backend"]
+        if backend not in ("postgres", "mysql"):
+            raise ValueError(f"unexpected service backend: {backend}")
+        if row["binary_sha256"] != values[f"{backend}_binary_sha256"]:
+            raise ValueError(f"{backend} service binary identity differs")
+        key = (backend, row["operation"], int(row["repetition"]))
+        if key in indexed:
+            raise ValueError(f"duplicate service row: {key}")
+        for field in ("total_ns", "ops_per_sec", "p50_ns", "p95_ns", "p99_ns", "p999_ns", "max_ns"):
+            number = float(row[field])
+            if not math.isfinite(number) or number <= 0:
+                raise ValueError(f"invalid service measurement {field}")
+        indexed[key] = row
+    return rows
+
+
+def splitmix64(value: int) -> int:
+    value = (value + 0x9E3779B97F4A7C15) & ((1 << 64) - 1)
+    mixed = value
+    mixed = ((mixed ^ (mixed >> 30)) * 0xBF58476D1CE4E5B9) & ((1 << 64) - 1)
+    mixed = ((mixed ^ (mixed >> 27)) * 0x94D049BB133111EB) & ((1 << 64) - 1)
+    return mixed ^ (mixed >> 31)
+
+
+def percentile(values: list[float], quantile: float) -> float:
+    ordered = sorted(values)
+    rank = max(1, math.ceil(quantile * len(ordered)))
+    return ordered[min(rank - 1, len(ordered) - 1)]
+
+
+def bootstrap_ratio(first: list[float], second: list[float], seed: int) -> tuple[float, float]:
+    state = seed
+    ratios = []
+    for _ in range(RESAMPLES):
+        a = []
+        b = []
+        for _ in first:
+            state = splitmix64(state)
+            index = state % len(first)
+            a.append(first[index])
+            b.append(second[index])
+        ratios.append(statistics.median(b) / statistics.median(a))
+    return percentile(ratios, 0.025), percentile(ratios, 0.975)
+
+
+def summarize(rows: list[dict[str, str]], repetitions: int) -> list[dict[str, str]]:
+    indexed = {
+        (row["backend"], row["operation"], int(row["repetition"])): row for row in rows
+    }
+    summaries = []
+    for operation_index, operation in enumerate(OPERATIONS):
+        postgres = []
+        mysql = []
+        postgres_p99 = []
+        mysql_p99 = []
+        reference = None
+        for repetition in range(1, repetitions + 1):
+            pg = indexed[("postgres", operation, repetition)]
+            my = indexed[("mysql", operation, repetition)]
+            identity_fields = (
+                "clients",
+                "pool_size",
+                "adapter_batch_items",
+                "logical_operations",
+                "applied",
+                "conflicts",
+            )
+            if any(pg[field] != my[field] for field in identity_fields):
+                raise ValueError(f"{operation} repetition {repetition} differs between backends")
+            identity = tuple(pg[field] for field in identity_fields)
+            if reference is not None and identity != reference:
+                raise ValueError(f"{operation} configuration changed between repetitions")
+            reference = identity
+            postgres.append(float(pg["total_ns"]))
+            mysql.append(float(my["total_ns"]))
+            postgres_p99.append(float(pg["p99_ns"]))
+            mysql_p99.append(float(my["p99_ns"]))
+        pg_median = statistics.median(postgres)
+        my_median = statistics.median(mysql)
+        ratio = my_median / pg_median
+        low, high = bootstrap_ratio(postgres, mysql, SEED ^ operation_index)
+        if low > 1 and ratio > 1.05:
+            winner = "postgres"
+        elif high < 1 and ratio < 1 / 1.05:
+            winner = "mysql"
+        else:
+            winner = "inconclusive"
+        summaries.append(
+            {
+                "operation": operation,
+                "clients": reference[0],
+                "pool_size": reference[1],
+                "adapter_batch_items": reference[2],
+                "logical_operations": reference[3],
+                "postgres_median_ms": f"{pg_median / 1_000_000:.6f}",
+                "postgres_ops_per_sec": f"{float(reference[3]) * 1_000_000_000 / pg_median:.6f}",
+                "postgres_p99_ms": f"{statistics.median(postgres_p99) / 1_000_000:.6f}",
+                "mysql_median_ms": f"{my_median / 1_000_000:.6f}",
+                "mysql_ops_per_sec": f"{float(reference[3]) * 1_000_000_000 / my_median:.6f}",
+                "mysql_p99_ms": f"{statistics.median(mysql_p99) / 1_000_000:.6f}",
+                "mysql_to_postgres_latency": f"{ratio:.9f}",
+                "ratio_ci_low": f"{low:.9f}",
+                "ratio_ci_high": f"{high:.9f}",
+                "winner": winner,
+            }
+        )
+    return summaries
+
+
+def report(rows: list[dict[str, str]], values: dict[str, str]) -> str:
+    lines = [
+        "# PostgreSQL vs MySQL adapter service comparison",
+        "",
+        f"Environment class: `{values.get('environment_class', 'controlled_local')}`. "
+        f"Results use {values['repetitions']} measured repetitions.",
+        "",
+        "| Operation | Logical ops | PostgreSQL median | PostgreSQL ops/s | "
+        "PostgreSQL p99 | MySQL median | MySQL ops/s | MySQL p99 | "
+        "MySQL/PG 95% CI | Result |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for row in rows:
+        lines.append(
+            "| {operation} | {logical_operations} | {postgres_median_ms} ms | "
+            "{postgres_ops_per_sec} | {postgres_p99_ms} ms | {mysql_median_ms} ms | "
+            "{mysql_ops_per_sec} | {mysql_p99_ms} ms | {ratio_ci_low}–"
+            "{ratio_ci_high} | {winner} |".format(**row)
+        )
+    lines.extend(
+        [
+            "",
+            "Batch rows measure one bounded public batch. Concurrent-get and "
+            "contended-root-CAS p99 values are request-level latency. Exactly one "
+            "CAS contender must win each repetition.",
+            "",
+            "Winner claims require a paired bootstrap 95% interval excluding "
+            "parity and a median latency effect above 5%.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=pathlib.Path, required=True)
+    parser.add_argument("--manifest", type=pathlib.Path, required=True)
+    parser.add_argument("--output-dir", type=pathlib.Path, required=True)
+    args = parser.parse_args()
+    values = manifest(args.manifest)
+    rows = load(args.input, values)
+    summaries = summarize(rows, int(values["repetitions"]))
+    csv_path = args.output_dir / "service-comparison.csv"
+    report_path = args.output_dir / "service-report.md"
+    if csv_path.exists() or report_path.exists():
+        raise ValueError("refusing to overwrite service comparison output")
+    with csv_path.open("x", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=summaries[0].keys())
+        writer.writeheader()
+        writer.writerows(summaries)
+    report_path.write_text(report(summaries, values))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/summarize_mysql_postgres_service_matrix.py
+++ b/scripts/summarize_mysql_postgres_service_matrix.py
@@ -85,7 +85,9 @@ def main() -> None:
     if output.exists() or (args.output / "report.md").exists():
         raise ValueError("refusing to overwrite service matrix summary")
     with output.open("w", newline="") as handle:
-        writer = csv.DictWriter(handle, fieldnames=rows[0].keys())
+        writer = csv.DictWriter(
+            handle, fieldnames=rows[0].keys(), lineterminator="\n"
+        )
         writer.writeheader()
         writer.writerows(rows)
     (args.output / "report.md").write_text(report)

--- a/scripts/summarize_mysql_postgres_service_matrix.py
+++ b/scripts/summarize_mysql_postgres_service_matrix.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import pathlib
+import re
+
+
+CELL = re.compile(r"clients-(?P<clients>[1-9][0-9]*)-pool-(?P<pool>[1-9][0-9]*)$")
+
+
+def load_rows(root: pathlib.Path) -> list[dict[str, str]]:
+    rows = []
+    for path in sorted(root.glob("*/service-comparison.csv")):
+        match = CELL.fullmatch(path.parent.name)
+        if not match:
+            raise ValueError(f"unexpected service cell directory: {path.parent.name}")
+        with path.open(newline="") as handle:
+            matches = list(csv.DictReader(handle))
+        if len(matches) != 4:
+            raise ValueError(f"{path} must contain four service operation rows")
+        for row in matches:
+            row["clients"] = match.group("clients")
+            row["pool_size"] = match.group("pool")
+            rows.append(row)
+    if not rows:
+        raise ValueError("service matrix contains no completed cells")
+    return rows
+
+
+def render(rows: list[dict[str, str]]) -> str:
+    lines = [
+        "# MySQL vs PostgreSQL service saturation",
+        "",
+        "Each cell runs byte-identical adapter workloads with one excluded "
+        "warmup and at least seven measured repetitions. Concurrent-get and "
+        "contended-root-CAS p99 are request-level tail latency.",
+        "",
+        "| Clients | Pool | Operation | PostgreSQL ops/s | PostgreSQL p99 | MySQL ops/s | "
+        "MySQL p99 | MySQL/PG latency CI | Result |",
+        "|---:|---:|---|---:|---:|---:|---:|---:|---|",
+    ]
+    for row in sorted(
+        rows,
+        key=lambda item: (
+            int(item["clients"]),
+            int(item["pool_size"]),
+            item["operation"],
+        ),
+    ):
+        lines.append(
+            "| {clients} | {pool_size} | {operation} | {pg_ops:.2f} | {pg_p99:.2f} ms | "
+            "{my_ops:.2f} | {my_p99:.2f} ms | {low:.3f}–{high:.3f} | "
+            "{winner} |".format(
+                clients=row["clients"],
+                pool_size=row["pool_size"],
+                operation=row["operation"],
+                pg_ops=float(row["postgres_ops_per_sec"]),
+                pg_p99=float(row["postgres_p99_ms"]),
+                my_ops=float(row["mysql_ops_per_sec"]),
+                my_p99=float(row["mysql_p99_ms"]),
+                low=float(row["ratio_ci_low"]),
+                high=float(row["ratio_ci_high"]),
+                winner=row["winner"].replace("_", " "),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "These local-container results show adapter and pool behavior on the "
+            "captured host. They are not universal production capacity claims.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=pathlib.Path, required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    args = parser.parse_args()
+    rows = load_rows(args.input)
+    report = render(rows)
+    output = args.output / "service-matrix.csv"
+    if output.exists() or (args.output / "report.md").exists():
+        raise ValueError("refusing to overwrite service matrix summary")
+    with output.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+    (args.output / "report.md").write_text(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_run_mysql_postgres_comparison.py
+++ b/scripts/tests/test_run_mysql_postgres_comparison.py
@@ -77,6 +77,8 @@ class SqlComparisonDriverTests(unittest.TestCase):
         self.assertIn("environment_class=controlled_local\n", manifest)
         self.assertIn("backend_a=postgres\n", manifest)
         self.assertIn("backend_b=mysql\n", manifest)
+        commands = (self.root / "result" / "measurement-commands.txt").read_text()
+        self.assertTrue(all(line == line.rstrip() for line in commands.splitlines()))
 
     def test_external_mode_requires_acknowledgement(self):
         result = self.run_driver(BENCH_MODE="external")

--- a/scripts/tests/test_run_mysql_postgres_comparison.py
+++ b/scripts/tests/test_run_mysql_postgres_comparison.py
@@ -1,0 +1,179 @@
+import os
+import pathlib
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = pathlib.Path(__file__).parents[2]
+DRIVER = ROOT / "scripts" / "run_mysql_postgres_comparison.sh"
+
+
+class SqlComparisonDriverTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temp.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.log = self.root / "commands.log"
+        self._write_fakes()
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def run_driver(self, **overrides):
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{self.bin}:{env['PATH']}",
+                "BENCH_OUT": str(self.root / "result"),
+                "BENCH_RECORDS": "100",
+                "BENCH_CHANGES": "10",
+                "BENCH_SAMPLES": "10",
+                "BENCH_RUNS": "7",
+                "BENCH_SKIP_BUILD": "1",
+                "BENCH_SKIP_IMAGE_PULL": "1",
+                "BENCH_POSTGRES_EXECUTABLE": str(self.bin / "postgres-runner"),
+                "BENCH_MYSQL_EXECUTABLE": str(self.bin / "mysql-runner"),
+                "BENCH_SUMMARIZER_EXECUTABLE": str(self.bin / "summarizer"),
+                "BENCH_SERVICE_SUMMARIZER": str(self.bin / "service-summarizer"),
+                "BENCH_GIT_BIN": str(self.bin / "git"),
+                "BENCH_DOCKER_BIN": str(self.bin / "docker"),
+                "FAKE_LOG": str(self.log),
+            }
+        )
+        env.update(overrides)
+        return subprocess.run(
+            [str(DRIVER)],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_local_run_alternates_backends_and_records_pair(self):
+        result = self.run_driver()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        runners = [
+            line
+            for line in self.log.read_text().splitlines()
+            if line.startswith(("prolly-backend-postgres ", "prolly-backend-mysql "))
+            and "--suite end-to-end" in line
+        ]
+        self.assertEqual(len(runners), 16)
+        measured = runners[2:]
+        for repetition in range(1, 8):
+            expected = (
+                ["prolly-backend-postgres", "prolly-backend-mysql"]
+                if repetition % 2
+                else ["prolly-backend-mysql", "prolly-backend-postgres"]
+            )
+            pair = measured[(repetition - 1) * 2 : repetition * 2]
+            self.assertEqual([line.split()[0] for line in pair], expected)
+        manifest = (self.root / "result" / "manifest.txt").read_text()
+        self.assertIn("environment_class=controlled_local\n", manifest)
+        self.assertIn("backend_a=postgres\n", manifest)
+        self.assertIn("backend_b=mysql\n", manifest)
+
+    def test_external_mode_requires_acknowledgement(self):
+        result = self.run_driver(BENCH_MODE="external")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("BENCH_EXTERNAL_RESET_ACK", result.stderr)
+
+    def test_external_commands_redact_credentials(self):
+        result = self.run_driver(
+            BENCH_MODE="external",
+            BENCH_EXTERNAL_RESET_ACK="I_UNDERSTAND_BENCHMARK_DATA_WILL_BE_DELETED",
+            BENCH_EXTERNAL_POSTGRES_IDENTITY="postgres-16-managed",
+            BENCH_EXTERNAL_MYSQL_IDENTITY="mysql-8-managed",
+            PROLLY_BACKEND_POSTGRES_URL="postgres://admin:secret@db.example/prolly",
+            PROLLY_BACKEND_MYSQL_URL="mysql://admin:secret@db.example/prolly",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        commands = (self.root / "result" / "measurement-commands.txt").read_text()
+        self.assertNotIn("admin", commands)
+        self.assertNotIn("secret", commands)
+        self.assertIn("REDACTED", commands)
+
+    def _write_fakes(self):
+        self._script(
+            "git",
+            """
+            if [[ "$*" == *"status --porcelain --untracked-files=no"* ]]; then
+              exit 0
+            elif [[ "$*" == *"rev-parse HEAD^{tree}"* ]]; then
+              printf '%040d\n' 0 | tr 0 b
+            elif [[ "$*" == *"rev-parse HEAD"* ]]; then
+              printf '%040d\n' 0 | tr 0 a
+            else
+              exit 2
+            fi
+            """,
+        )
+        self._script(
+            "docker",
+            """
+            printf 'docker %s\n' "$*" >> "$FAKE_LOG"
+            if [[ "$*" == *"image inspect"* ]]; then
+              printf 'sha256:%064d\n' 0
+            elif [[ "$*" == *"inspect --format"* ]]; then
+              printf 'healthy\n'
+            elif [[ "$1" == "info" ]]; then
+              printf 'docker_server=fake cpus=8 memory=16000000000\n'
+            fi
+            """,
+        )
+        runner = """
+            name="$(basename "$0")"
+            printf '%s %s\n' "$name" "$*" >> "$FAKE_LOG"
+            output=""
+            while (($#)); do
+              case "$1" in
+                --output) output="$2"; shift 2 ;;
+                *) shift ;;
+              esac
+            done
+            mkdir -p "$(dirname "$output")"
+            printf 'header\nrow\n' > "$output"
+        """
+        self._script("postgres-runner", runner)
+        self._script("mysql-runner", runner)
+        self._script(
+            "summarizer",
+            """
+            printf 'summarizer %s\n' "$*" >> "$FAKE_LOG"
+            output=""
+            while (($#)); do
+              if [[ "$1" == "--output-dir" ]]; then output="$2"; shift 2; else shift; fi
+            done
+            printf 'summary\n' > "$output/comparison.csv"
+            printf 'report\n' > "$output/report.md"
+            """,
+        )
+        self._script(
+            "service-summarizer",
+            """
+            output=""
+            while (($#)); do
+              if [[ "$1" == "--output-dir" ]]; then output="$2"; shift 2; else shift; fi
+            done
+            printf 'service summary\n' > "$output/service-comparison.csv"
+            printf 'service report\n' > "$output/service-report.md"
+            """,
+        )
+
+    def _script(self, name, body):
+        path = self.bin / name
+        path.write_text(
+            "#!/usr/bin/env bash\nset -euo pipefail\n"
+            + textwrap.dedent(body).strip()
+            + "\n"
+        )
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/stores/prolly-store-mysql/README.md
+++ b/stores/prolly-store-mysql/README.md
@@ -33,10 +33,43 @@ state and DynamoDB/Cosmos/Spanner for cloud-native managed scale.
 - `prolly_nodes(cid VARBINARY(32) PRIMARY KEY, node LONGBLOB NOT NULL)`
 - `prolly_hints(namespace VARBINARY(255), key VARBINARY(255), value LONGBLOB)`
 - `prolly_roots(name VARBINARY(255) PRIMARY KEY, manifest LONGBLOB NOT NULL)`
+- `prolly_root_locks(name VARBINARY(255) PRIMARY KEY)`
 
 Nodes are content-addressed by CID. Named roots store serialized root manifests
 and are the stable durable handles for branches, checkpoints, and application
-heads.
+heads. The lock table contains no application data; it makes both absent and
+existing root names safely lockable during concurrent publication.
+
+## Performance tuning
+
+Batch reads, writes, deletes, and transactional publications use bounded
+set-based SQL. Ordered reads reconstruct the requested order, including
+duplicates and missing CIDs. A multi-chunk public batch uses one transaction and
+rolls back completely if any chunk fails.
+
+The adapter defaults to 1,000 items per SQL batch. Configure it independently
+from the SQLx connection-pool size:
+
+```rust
+use std::num::NonZeroUsize;
+
+use prolly_store_mysql::{MySqlBackend, MySqlBackendOptions};
+use sqlx::mysql::MySqlPoolOptions;
+
+async fn tuned_backend(url: &str) -> Result<MySqlBackend, sqlx::Error> {
+    let pool = MySqlPoolOptions::new()
+        .max_connections(32)
+        .connect(url)
+        .await?;
+    let options = MySqlBackendOptions::new(NonZeroUsize::new(2_000).unwrap());
+    Ok(MySqlBackend::new_with_options(pool, options))
+}
+```
+
+Larger batches reduce round trips but increase statement size and transaction
+work. Pool size controls concurrent requests; it does not change the batch
+limit. Benchmark both together for the deployment workload instead of assuming
+that the largest values are fastest.
 
 ## Setup
 
@@ -164,6 +197,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 - `initialize_schema` is idempotent.
 - Strict commits validate named-root preconditions and apply node and root
   writes in one MySQL transaction.
+- Root mutations acquire persistent lock identities in lexical order, preventing
+  absent-root races and reducing multi-root deadlock risk.
 - MySQL key length limits matter for named roots and hint keys; use compact
   binary or slash-separated names rather than large serialized metadata in the
   name itself.
@@ -194,6 +229,14 @@ cargo test --manifest-path stores/prolly-store-mysql/Cargo.toml
 
 Run it against a disposable database or schema. The adapter tables are shared by
 every client using that database.
+
+The repository also provides reproducible MySQL/PostgreSQL end-to-end and
+service comparisons:
+
+```bash
+scripts/run_mysql_postgres_comparison.sh
+scripts/run_mysql_postgres_service_matrix.sh
+```
 
 See the [`prolly-map` API documentation](https://docs.rs/prolly-map) for the
 async map, transaction, diff, and merge APIs used with this backend.

--- a/stores/prolly-store-mysql/src/lib.rs
+++ b/stores/prolly-store-mysql/src/lib.rs
@@ -7,7 +7,10 @@ pub use prolly::{
 
 /// MySQL adapter entry point.
 pub mod mysql {
-    use sqlx::{MySqlPool, Row};
+    use std::collections::{BTreeMap, BTreeSet, HashMap};
+    use std::num::NonZeroUsize;
+
+    use sqlx::{MySql, MySqlConnection, MySqlPool, QueryBuilder, Row};
 
     use crate::{
         RemoteBatchOp, RemoteManifestUpdate, RemoteNamedRoot, RemoteRootCondition, RemoteRootWrite,
@@ -17,26 +20,72 @@ pub mod mysql {
     /// Store adapter for MySQL-backed prolly nodes and roots.
     pub type MySqlStore = crate::RemoteProllyStore<MySqlBackend>;
 
+    /// MySQL adapter tuning that does not change stored data.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct MySqlBackendOptions {
+        max_batch_items: NonZeroUsize,
+    }
+
+    impl MySqlBackendOptions {
+        /// Create options with the maximum number of items sent in one SQL batch.
+        pub const fn new(max_batch_items: NonZeroUsize) -> Self {
+            Self { max_batch_items }
+        }
+
+        /// Maximum number of items sent in one SQL batch.
+        pub const fn max_batch_items(self) -> usize {
+            self.max_batch_items.get()
+        }
+    }
+
+    impl Default for MySqlBackendOptions {
+        fn default() -> Self {
+            Self::new(NonZeroUsize::new(1_000).expect("1000 is nonzero"))
+        }
+    }
+
     /// SQLx-backed MySQL backend.
     #[derive(Clone, Debug)]
     pub struct MySqlBackend {
         pool: MySqlPool,
+        options: MySqlBackendOptions,
     }
 
     impl MySqlBackend {
         /// Create a backend from an existing SQLx pool.
         pub fn new(pool: MySqlPool) -> Self {
-            Self { pool }
+            Self::new_with_options(pool, MySqlBackendOptions::default())
+        }
+
+        /// Create a backend from an existing SQLx pool and adapter options.
+        pub fn new_with_options(pool: MySqlPool, options: MySqlBackendOptions) -> Self {
+            Self { pool, options }
         }
 
         /// Connect to MySQL using `database_url`.
         pub async fn connect(database_url: &str) -> Result<Self, sqlx::Error> {
-            Ok(Self::new(MySqlPool::connect(database_url).await?))
+            Self::connect_with_options(database_url, MySqlBackendOptions::default()).await
+        }
+
+        /// Connect to MySQL using `database_url` and adapter options.
+        pub async fn connect_with_options(
+            database_url: &str,
+            options: MySqlBackendOptions,
+        ) -> Result<Self, sqlx::Error> {
+            Ok(Self::new_with_options(
+                MySqlPool::connect(database_url).await?,
+                options,
+            ))
         }
 
         /// Borrow the underlying pool.
         pub fn pool(&self) -> &MySqlPool {
             &self.pool
+        }
+
+        /// Return this backend's adapter options.
+        pub const fn options(&self) -> MySqlBackendOptions {
+            self.options
         }
 
         /// Create the required tables if they do not already exist.
@@ -79,28 +128,31 @@ pub mod mysql {
         }
 
         async fn batch_nodes(&self, ops: &[RemoteBatchOp<'_>]) -> Result<(), Self::Error> {
-            let mut tx = self.pool.begin().await?;
+            if ops.is_empty() {
+                return Ok(());
+            }
+            let mut final_ops = HashMap::<&[u8], Option<&[u8]>>::with_capacity(ops.len());
             for op in ops {
                 match op {
                     RemoteBatchOp::Upsert { key, value } => {
-                        sqlx::query(
-                            "\
-                            INSERT INTO prolly_nodes (cid, node) VALUES (?, ?) \
-                            ON DUPLICATE KEY UPDATE node = VALUES(node)",
-                        )
-                        .bind(*key)
-                        .bind(*value)
-                        .execute(&mut *tx)
-                        .await?;
+                        final_ops.insert(key, Some(value));
                     }
                     RemoteBatchOp::Delete { key } => {
-                        sqlx::query("DELETE FROM prolly_nodes WHERE cid = ?")
-                            .bind(*key)
-                            .execute(&mut *tx)
-                            .await?;
+                        final_ops.insert(key, None);
                     }
                 }
             }
+            let deletes = final_ops
+                .iter()
+                .filter_map(|(key, value)| value.is_none().then_some(*key))
+                .collect::<Vec<_>>();
+            let upserts = final_ops
+                .iter()
+                .filter_map(|(key, value)| value.map(|value| (*key, value)))
+                .collect::<Vec<_>>();
+            let mut tx = self.pool.begin().await?;
+            delete_node_chunks(&mut tx, &deletes, self.options.max_batch_items()).await?;
+            upsert_node_chunks(&mut tx, &upserts, self.options.max_batch_items()).await?;
             tx.commit().await
         }
 
@@ -108,26 +160,41 @@ pub mod mysql {
             &self,
             keys: &[&[u8]],
         ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
+            if keys.is_empty() {
+                return Ok(Vec::new());
+            }
             let mut values = Vec::with_capacity(keys.len());
-            for key in keys {
-                values.push(self.get_node(key).await?);
+            for chunk in keys.chunks(safe_batch_items(self.options.max_batch_items(), 1)) {
+                let mut builder =
+                    QueryBuilder::<MySql>::new("SELECT cid, node FROM prolly_nodes WHERE cid IN (");
+                {
+                    let mut separated = builder.separated(", ");
+                    for key in chunk {
+                        separated.push_bind(*key);
+                    }
+                }
+                builder.push(")");
+                let rows = builder.build().fetch_all(&self.pool).await?;
+                let mut by_cid = HashMap::with_capacity(rows.len());
+                for row in rows {
+                    by_cid.insert(
+                        row.try_get::<Vec<u8>, _>("cid")?,
+                        row.try_get::<Vec<u8>, _>("node")?,
+                    );
+                }
+                values.extend(chunk.iter().map(|key| by_cid.get(*key).cloned()));
             }
             Ok(values)
         }
 
         async fn batch_put_nodes(&self, entries: &[(&[u8], &[u8])]) -> Result<(), Self::Error> {
-            let mut tx = self.pool.begin().await?;
-            for (key, value) in entries {
-                sqlx::query(
-                    "\
-                    INSERT INTO prolly_nodes (cid, node) VALUES (?, ?) \
-                    ON DUPLICATE KEY UPDATE node = VALUES(node)",
-                )
-                .bind(*key)
-                .bind(*value)
-                .execute(&mut *tx)
-                .await?;
+            if entries.is_empty() {
+                return Ok(());
             }
+            let entries = deduplicate_entries(entries);
+            let entries = entries.into_iter().collect::<Vec<_>>();
+            let mut tx = self.pool.begin().await?;
+            upsert_node_chunks(&mut tx, &entries, self.options.max_batch_items()).await?;
             tx.commit().await
         }
 
@@ -186,18 +253,10 @@ pub mod mysql {
             key: &[u8],
             value: &[u8],
         ) -> Result<(), Self::Error> {
+            let entries = deduplicate_entries(entries);
+            let entries = entries.into_iter().collect::<Vec<_>>();
             let mut tx = self.pool.begin().await?;
-            for (key, value) in entries {
-                sqlx::query(
-                    "\
-                    INSERT INTO prolly_nodes (cid, node) VALUES (?, ?) \
-                    ON DUPLICATE KEY UPDATE node = VALUES(node)",
-                )
-                .bind(*key)
-                .bind(*value)
-                .execute(&mut *tx)
-                .await?;
-            }
+            upsert_node_chunks(&mut tx, &entries, self.options.max_batch_items()).await?;
             sqlx::query(
                 "\
                 INSERT INTO prolly_hints (namespace, `key`, value) VALUES (?, ?, ?) \
@@ -221,24 +280,18 @@ pub mod mysql {
         }
 
         async fn put_root_manifest(&self, name: &[u8], manifest: &[u8]) -> Result<(), Self::Error> {
-            sqlx::query(
-                "\
-                INSERT INTO prolly_roots (name, manifest) VALUES (?, ?) \
-                ON DUPLICATE KEY UPDATE manifest = VALUES(manifest)",
-            )
-            .bind(name)
-            .bind(manifest)
-            .execute(&self.pool)
-            .await?;
-            Ok(())
+            let mut tx = self.pool.begin().await?;
+            lock_root_names(&mut tx, &[name.to_vec()], self.options.max_batch_items()).await?;
+            upsert_root_chunks(&mut tx, &[(name, manifest)], self.options.max_batch_items())
+                .await?;
+            tx.commit().await
         }
 
         async fn delete_root_manifest(&self, name: &[u8]) -> Result<(), Self::Error> {
-            sqlx::query("DELETE FROM prolly_roots WHERE name = ?")
-                .bind(name)
-                .execute(&self.pool)
-                .await?;
-            Ok(())
+            let mut tx = self.pool.begin().await?;
+            lock_root_names(&mut tx, &[name.to_vec()], self.options.max_batch_items()).await?;
+            delete_root_chunks(&mut tx, &[name], self.options.max_batch_items()).await?;
+            tx.commit().await
         }
 
         async fn compare_and_swap_root_manifest(
@@ -248,59 +301,34 @@ pub mod mysql {
             new: Option<&[u8]>,
         ) -> Result<RemoteManifestUpdate, Self::Error> {
             let mut tx = self.pool.begin().await?;
-            let applied = match (expected, new) {
-                (None, Some(manifest)) => {
-                    sqlx::query("INSERT IGNORE INTO prolly_roots (name, manifest) VALUES (?, ?)")
-                        .bind(name)
-                        .bind(manifest)
-                        .execute(&mut *tx)
-                        .await?
-                        .rows_affected()
-                        == 1
-                }
-                (Some(expected), Some(manifest)) => {
-                    sqlx::query(
-                        "UPDATE prolly_roots SET manifest = ? WHERE name = ? AND manifest = ?",
-                    )
-                    .bind(manifest)
-                    .bind(name)
-                    .bind(expected)
-                    .execute(&mut *tx)
-                    .await?
-                    .rows_affected()
-                        == 1
-                }
-                (Some(expected), None) => {
-                    sqlx::query("DELETE FROM prolly_roots WHERE name = ? AND manifest = ?")
-                        .bind(name)
-                        .bind(expected)
-                        .execute(&mut *tx)
-                        .await?
-                        .rows_affected()
-                        == 1
-                }
-                (None, None) => {
-                    sqlx::query("SELECT manifest FROM prolly_roots WHERE name = ? FOR UPDATE")
-                        .bind(name)
-                        .fetch_optional(&mut *tx)
-                        .await?
-                        .is_none()
-                }
-            };
-
-            if applied {
-                tx.commit().await?;
-                return Ok(RemoteManifestUpdate::Applied);
-            }
-
+            lock_root_names(&mut tx, &[name.to_vec()], self.options.max_batch_items()).await?;
             let current = sqlx::query("SELECT manifest FROM prolly_roots WHERE name = ?")
                 .bind(name)
                 .fetch_optional(&mut *tx)
                 .await?
                 .map(|row| row.try_get("manifest"))
                 .transpose()?;
-            tx.rollback().await?;
-            Ok(RemoteManifestUpdate::Conflict { current })
+            if current.as_deref() != expected {
+                tx.rollback().await?;
+                return Ok(RemoteManifestUpdate::Conflict { current });
+            }
+
+            match new {
+                Some(manifest) => {
+                    upsert_root_chunks(
+                        &mut tx,
+                        &[(name, manifest)],
+                        self.options.max_batch_items(),
+                    )
+                    .await?;
+                }
+                None => {
+                    delete_root_chunks(&mut tx, &[name], self.options.max_batch_items()).await?;
+                }
+            }
+
+            tx.commit().await?;
+            Ok(RemoteManifestUpdate::Applied)
         }
 
         async fn list_root_manifests(&self) -> Result<Vec<RemoteNamedRoot>, Self::Error> {
@@ -327,16 +355,17 @@ pub mod mysql {
             root_conditions: &[RemoteRootCondition],
             root_writes: &[RemoteRootWrite],
         ) -> Result<RemoteTransactionUpdate, Self::Error> {
+            if node_writes.is_empty() && root_conditions.is_empty() && root_writes.is_empty() {
+                return Ok(RemoteTransactionUpdate::Applied);
+            }
             let mut tx = self.pool.begin().await?;
+            let root_names = root_names(root_conditions, root_writes);
+            lock_root_names(&mut tx, &root_names, self.options.max_batch_items()).await?;
+            let current_roots =
+                read_root_manifests(&mut tx, &root_names, self.options.max_batch_items()).await?;
 
             for condition in root_conditions {
-                let current =
-                    sqlx::query("SELECT manifest FROM prolly_roots WHERE name = ? FOR UPDATE")
-                        .bind(&condition.name)
-                        .fetch_optional(&mut *tx)
-                        .await?
-                        .map(|row| row.try_get("manifest"))
-                        .transpose()?;
+                let current = current_roots.get(&condition.name).cloned().unwrap_or(None);
                 if current != condition.expected {
                     tx.rollback().await?;
                     return Ok(RemoteTransactionUpdate::Conflict(
@@ -349,53 +378,213 @@ pub mod mysql {
                 }
             }
 
+            let mut final_nodes = HashMap::<&[u8], Option<&[u8]>>::with_capacity(node_writes.len());
             for write in node_writes {
                 match write {
                     RemoteBatchOp::Upsert { key, value } => {
-                        sqlx::query(
-                            "\
-                            INSERT INTO prolly_nodes (cid, node) VALUES (?, ?) \
-                            ON DUPLICATE KEY UPDATE node = VALUES(node)",
-                        )
-                        .bind(*key)
-                        .bind(*value)
-                        .execute(&mut *tx)
-                        .await?;
+                        final_nodes.insert(key, Some(value));
                     }
                     RemoteBatchOp::Delete { key } => {
-                        sqlx::query("DELETE FROM prolly_nodes WHERE cid = ?")
-                            .bind(*key)
-                            .execute(&mut *tx)
-                            .await?;
+                        final_nodes.insert(key, None);
                     }
                 }
             }
+            let node_deletes = final_nodes
+                .iter()
+                .filter_map(|(key, value)| value.is_none().then_some(*key))
+                .collect::<Vec<_>>();
+            let node_upserts = final_nodes
+                .iter()
+                .filter_map(|(key, value)| value.map(|value| (*key, value)))
+                .collect::<Vec<_>>();
+            delete_node_chunks(&mut tx, &node_deletes, self.options.max_batch_items()).await?;
+            upsert_node_chunks(&mut tx, &node_upserts, self.options.max_batch_items()).await?;
 
+            let mut final_roots = BTreeMap::<Vec<u8>, Option<Vec<u8>>>::new();
             for write in root_writes {
                 match write {
                     RemoteRootWrite::Put { name, manifest } => {
-                        sqlx::query(
-                            "\
-                            INSERT INTO prolly_roots (name, manifest) VALUES (?, ?) \
-                            ON DUPLICATE KEY UPDATE manifest = VALUES(manifest)",
-                        )
-                        .bind(name)
-                        .bind(manifest)
-                        .execute(&mut *tx)
-                        .await?;
+                        final_roots.insert(name.clone(), Some(manifest.clone()));
                     }
                     RemoteRootWrite::Delete { name } => {
-                        sqlx::query("DELETE FROM prolly_roots WHERE name = ?")
-                            .bind(name)
-                            .execute(&mut *tx)
-                            .await?;
+                        final_roots.insert(name.clone(), None);
                     }
                 }
             }
+            let root_deletes = final_roots
+                .iter()
+                .filter_map(|(name, manifest)| manifest.is_none().then_some(name.as_slice()))
+                .collect::<Vec<_>>();
+            let root_upserts = final_roots
+                .iter()
+                .filter_map(|(name, manifest)| {
+                    manifest
+                        .as_deref()
+                        .map(|manifest| (name.as_slice(), manifest))
+                })
+                .collect::<Vec<_>>();
+            delete_root_chunks(&mut tx, &root_deletes, self.options.max_batch_items()).await?;
+            upsert_root_chunks(&mut tx, &root_upserts, self.options.max_batch_items()).await?;
 
             tx.commit().await?;
             Ok(RemoteTransactionUpdate::Applied)
         }
+    }
+
+    const MYSQL_MAX_PARAMETERS: usize = 65_535;
+
+    fn safe_batch_items(configured: usize, parameters_per_item: usize) -> usize {
+        configured
+            .min(MYSQL_MAX_PARAMETERS / parameters_per_item)
+            .max(1)
+    }
+
+    fn deduplicate_entries<'a>(entries: &[(&'a [u8], &'a [u8])]) -> HashMap<&'a [u8], &'a [u8]> {
+        entries.iter().copied().collect()
+    }
+
+    async fn upsert_node_chunks(
+        connection: &mut MySqlConnection,
+        entries: &[(&[u8], &[u8])],
+        max_batch_items: usize,
+    ) -> Result<(), sqlx::Error> {
+        for chunk in entries.chunks(safe_batch_items(max_batch_items, 2)) {
+            let mut builder = QueryBuilder::<MySql>::new("INSERT INTO prolly_nodes (cid, node) ");
+            builder.push_values(chunk, |mut row, (key, value)| {
+                row.push_bind(*key).push_bind(*value);
+            });
+            builder.push(" ON DUPLICATE KEY UPDATE node = VALUES(node)");
+            builder.build().execute(&mut *connection).await?;
+        }
+        Ok(())
+    }
+
+    async fn delete_node_chunks(
+        connection: &mut MySqlConnection,
+        keys: &[&[u8]],
+        max_batch_items: usize,
+    ) -> Result<(), sqlx::Error> {
+        for chunk in keys.chunks(safe_batch_items(max_batch_items, 1)) {
+            let mut builder = QueryBuilder::<MySql>::new("DELETE FROM prolly_nodes WHERE cid IN (");
+            {
+                let mut separated = builder.separated(", ");
+                for key in chunk {
+                    separated.push_bind(*key);
+                }
+            }
+            builder.push(")");
+            builder.build().execute(&mut *connection).await?;
+        }
+        Ok(())
+    }
+
+    async fn upsert_root_chunks(
+        connection: &mut MySqlConnection,
+        entries: &[(&[u8], &[u8])],
+        max_batch_items: usize,
+    ) -> Result<(), sqlx::Error> {
+        for chunk in entries.chunks(safe_batch_items(max_batch_items, 2)) {
+            let mut builder =
+                QueryBuilder::<MySql>::new("INSERT INTO prolly_roots (name, manifest) ");
+            builder.push_values(chunk, |mut row, (name, manifest)| {
+                row.push_bind(*name).push_bind(*manifest);
+            });
+            builder.push(" ON DUPLICATE KEY UPDATE manifest = VALUES(manifest)");
+            builder.build().execute(&mut *connection).await?;
+        }
+        Ok(())
+    }
+
+    async fn delete_root_chunks(
+        connection: &mut MySqlConnection,
+        names: &[&[u8]],
+        max_batch_items: usize,
+    ) -> Result<(), sqlx::Error> {
+        for chunk in names.chunks(safe_batch_items(max_batch_items, 1)) {
+            let mut builder =
+                QueryBuilder::<MySql>::new("DELETE FROM prolly_roots WHERE name IN (");
+            {
+                let mut separated = builder.separated(", ");
+                for name in chunk {
+                    separated.push_bind(*name);
+                }
+            }
+            builder.push(")");
+            builder.build().execute(&mut *connection).await?;
+        }
+        Ok(())
+    }
+
+    fn root_names(conditions: &[RemoteRootCondition], writes: &[RemoteRootWrite]) -> Vec<Vec<u8>> {
+        let mut names = BTreeSet::new();
+        names.extend(conditions.iter().map(|condition| condition.name.clone()));
+        names.extend(writes.iter().map(|write| match write {
+            RemoteRootWrite::Put { name, .. } | RemoteRootWrite::Delete { name } => name.clone(),
+        }));
+        names.into_iter().collect()
+    }
+
+    async fn lock_root_names(
+        connection: &mut MySqlConnection,
+        names: &[Vec<u8>],
+        max_batch_items: usize,
+    ) -> Result<(), sqlx::Error> {
+        if names.is_empty() {
+            return Ok(());
+        }
+        for chunk in names.chunks(safe_batch_items(max_batch_items, 1)) {
+            let mut builder = QueryBuilder::<MySql>::new("INSERT INTO prolly_root_locks (name) ");
+            builder.push_values(chunk, |mut row, name| {
+                row.push_bind(name);
+            });
+            builder.push(" ON DUPLICATE KEY UPDATE name = VALUES(name)");
+            builder.build().execute(&mut *connection).await?;
+        }
+        for chunk in names.chunks(safe_batch_items(max_batch_items, 1)) {
+            let mut builder =
+                QueryBuilder::<MySql>::new("SELECT name FROM prolly_root_locks WHERE name IN (");
+            {
+                let mut separated = builder.separated(", ");
+                for name in chunk {
+                    separated.push_bind(name);
+                }
+            }
+            builder.push(") ORDER BY name FOR UPDATE");
+            builder.build().fetch_all(&mut *connection).await?;
+        }
+        Ok(())
+    }
+
+    async fn read_root_manifests(
+        connection: &mut MySqlConnection,
+        names: &[Vec<u8>],
+        max_batch_items: usize,
+    ) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, sqlx::Error> {
+        let mut manifests = names
+            .iter()
+            .cloned()
+            .map(|name| (name, None))
+            .collect::<BTreeMap<_, _>>();
+        for chunk in names.chunks(safe_batch_items(max_batch_items, 1)) {
+            let mut builder = QueryBuilder::<MySql>::new(
+                "SELECT name, manifest FROM prolly_roots WHERE name IN (",
+            );
+            {
+                let mut separated = builder.separated(", ");
+                for name in chunk {
+                    separated.push_bind(name);
+                }
+            }
+            builder.push(")");
+            let rows = builder.build().fetch_all(&mut *connection).await?;
+            for row in rows {
+                manifests.insert(
+                    row.try_get::<Vec<u8>, _>("name")?,
+                    Some(row.try_get::<Vec<u8>, _>("manifest")?),
+                );
+            }
+        }
+        Ok(manifests)
     }
 
     async fn execute_statements(pool: &MySqlPool, sql: &str) -> Result<(), sqlx::Error> {
@@ -424,6 +613,9 @@ CREATE TABLE IF NOT EXISTS prolly_hints (
 CREATE TABLE IF NOT EXISTS prolly_roots (
   name VARBINARY(255) PRIMARY KEY,
   manifest LONGBLOB NOT NULL
+);
+CREATE TABLE IF NOT EXISTS prolly_root_locks (
+  name VARBINARY(255) PRIMARY KEY
 );";
 }
 

--- a/stores/prolly-store-mysql/tests/mysql_backend.rs
+++ b/stores/prolly-store-mysql/tests/mysql_backend.rs
@@ -20,14 +20,149 @@ fn mysql_backend_satisfies_remote_backend_contract_when_url_is_set() {
 
     runtime().block_on(async {
         use prolly::remote_conformance::assert_remote_backend_contract;
-        use prolly_store_mysql::MySqlBackend;
-
         let backend = MySqlBackend::connect(&database_url).await.unwrap();
         backend.initialize_schema().await.unwrap();
         clear_mysql(backend.pool()).await.unwrap();
         assert_remote_backend_contract(&backend).await;
         clear_mysql(backend.pool()).await.unwrap();
     });
+}
+
+#[test]
+fn mysql_options_are_additive_and_default_to_bounded_batches() {
+    assert_eq!(MySqlBackendOptions::default().max_batch_items(), 1_000);
+    let options = MySqlBackendOptions::new(NonZeroUsize::new(7).unwrap());
+    assert_eq!(options.max_batch_items(), 7);
+}
+
+#[test]
+fn mysql_set_based_batches_and_root_locking_work_when_url_is_set() {
+    let Some(database_url) = env_var("PROLLY_STORE_MYSQL_URL", "PROLLY_ADAPTERS_MYSQL_URL") else {
+        return;
+    };
+
+    runtime().block_on(async {
+        let pool = MySqlPoolOptions::new()
+            .max_connections(1)
+            .connect(&database_url)
+            .await
+            .unwrap();
+        let options = MySqlBackendOptions::new(NonZeroUsize::new(2).unwrap());
+        let backend = MySqlBackend::new_with_options(pool, options);
+        backend.initialize_schema().await.unwrap();
+        clear_mysql(backend.pool()).await.unwrap();
+
+        let before = session_counter(backend.pool(), "Com_insert").await;
+        let entries = (0_u8..5)
+            .map(|id| (vec![id; 32], vec![id; 8]))
+            .collect::<Vec<_>>();
+        let borrowed = entries
+            .iter()
+            .map(|(key, value)| (key.as_slice(), value.as_slice()))
+            .collect::<Vec<_>>();
+        backend.batch_put_nodes(&borrowed).await.unwrap();
+        let after = session_counter(backend.pool(), "Com_insert").await;
+        assert_eq!(after - before, 3);
+
+        let missing = vec![99; 32];
+        let requested = [
+            entries[4].0.as_slice(),
+            missing.as_slice(),
+            entries[1].0.as_slice(),
+            entries[4].0.as_slice(),
+            entries[0].0.as_slice(),
+        ];
+        let values = backend.batch_get_nodes_ordered(&requested).await.unwrap();
+        assert_eq!(
+            values,
+            vec![
+                Some(entries[4].1.clone()),
+                None,
+                Some(entries[1].1.clone()),
+                Some(entries[4].1.clone()),
+                Some(entries[0].1.clone()),
+            ]
+        );
+
+        let concurrent_pool = MySqlPoolOptions::new()
+            .max_connections(16)
+            .connect(&database_url)
+            .await
+            .unwrap();
+        let concurrent_backend = MySqlBackend::new_with_options(concurrent_pool, options);
+        let mut contenders = tokio::task::JoinSet::new();
+        for id in 0_u8..16 {
+            let backend = concurrent_backend.clone();
+            contenders.spawn(async move {
+                backend
+                    .compare_and_swap_root_manifest(b"main", None, Some(&[id]))
+                    .await
+                    .unwrap()
+            });
+        }
+        let mut applied = 0;
+        let mut conflicts = 0;
+        while let Some(result) = contenders.join_next().await {
+            match result.unwrap() {
+                RemoteManifestUpdate::Applied => applied += 1,
+                RemoteManifestUpdate::Conflict { .. } => conflicts += 1,
+            }
+        }
+        assert_eq!((applied, conflicts), (1, 15));
+        clear_mysql(concurrent_backend.pool()).await.unwrap();
+    });
+}
+
+#[test]
+fn mysql_multichunk_batch_rolls_back_when_a_later_chunk_fails() {
+    let Some(database_url) = env_var("PROLLY_STORE_MYSQL_URL", "PROLLY_ADAPTERS_MYSQL_URL") else {
+        return;
+    };
+
+    runtime().block_on(async {
+        let backend = MySqlBackend::connect_with_options(
+            &database_url,
+            MySqlBackendOptions::new(NonZeroUsize::new(2).unwrap()),
+        )
+        .await
+        .unwrap();
+        backend.initialize_schema().await.unwrap();
+        clear_mysql(backend.pool()).await.unwrap();
+
+        let entries = [
+            (vec![1; 32], vec![1]),
+            (vec![2; 32], vec![2]),
+            (vec![0xff; 33], vec![3]),
+        ];
+        let borrowed = entries
+            .iter()
+            .map(|(key, value)| (key.as_slice(), value.as_slice()))
+            .collect::<Vec<_>>();
+        assert!(backend.batch_put_nodes(&borrowed).await.is_err());
+        assert_eq!(
+            backend
+                .batch_get_nodes_ordered(
+                    &entries
+                        .iter()
+                        .map(|(key, _)| key.as_slice())
+                        .collect::<Vec<_>>()
+                )
+                .await
+                .unwrap(),
+            vec![None, None, None]
+        );
+
+        clear_mysql(backend.pool()).await.unwrap();
+    });
+}
+
+async fn session_counter(pool: &sqlx::MySqlPool, name: &str) -> u64 {
+    let row = sqlx::query("SHOW SESSION STATUS WHERE Variable_name = ?")
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    row.try_get::<String, _>("Value").unwrap().parse().unwrap()
 }
 
 async fn clear_mysql(pool: &sqlx::MySqlPool) -> Result<(), sqlx::Error> {
@@ -40,5 +175,14 @@ async fn clear_mysql(pool: &sqlx::MySqlPool) -> Result<(), sqlx::Error> {
     sqlx::query("DELETE FROM prolly_nodes")
         .execute(pool)
         .await?;
+    sqlx::query("DELETE FROM prolly_root_locks")
+        .execute(pool)
+        .await?;
     Ok(())
 }
+use std::num::NonZeroUsize;
+
+use prolly_store_mysql::{
+    MySqlBackend, MySqlBackendOptions, RemoteManifestUpdate, RemoteStoreBackend,
+};
+use sqlx::{mysql::MySqlPoolOptions, Row};

--- a/stores/prolly-store-mysql/tests/mysql_backend.rs
+++ b/stores/prolly-store-mysql/tests/mysql_backend.rs
@@ -12,11 +12,18 @@ fn env_var(primary: &str, legacy: &str) -> Option<String> {
         .ok()
 }
 
+fn database_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    MYSQL_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 #[test]
 fn mysql_backend_satisfies_remote_backend_contract_when_url_is_set() {
     let Some(database_url) = env_var("PROLLY_STORE_MYSQL_URL", "PROLLY_ADAPTERS_MYSQL_URL") else {
         return;
     };
+    let _database_guard = database_test_guard();
 
     runtime().block_on(async {
         use prolly::remote_conformance::assert_remote_backend_contract;
@@ -40,6 +47,7 @@ fn mysql_set_based_batches_and_root_locking_work_when_url_is_set() {
     let Some(database_url) = env_var("PROLLY_STORE_MYSQL_URL", "PROLLY_ADAPTERS_MYSQL_URL") else {
         return;
     };
+    let _database_guard = database_test_guard();
 
     runtime().block_on(async {
         let pool = MySqlPoolOptions::new()
@@ -118,6 +126,7 @@ fn mysql_multichunk_batch_rolls_back_when_a_later_chunk_fails() {
     let Some(database_url) = env_var("PROLLY_STORE_MYSQL_URL", "PROLLY_ADAPTERS_MYSQL_URL") else {
         return;
     };
+    let _database_guard = database_test_guard();
 
     runtime().block_on(async {
         let backend = MySqlBackend::connect_with_options(
@@ -186,3 +195,5 @@ use prolly_store_mysql::{
     MySqlBackend, MySqlBackendOptions, RemoteManifestUpdate, RemoteStoreBackend,
 };
 use sqlx::{mysql::MySqlPoolOptions, Row};
+
+static MYSQL_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());


### PR DESCRIPTION
## Summary

- replace per-node MySQL adapter operations with bounded set-based reads and transactional chunked writes
- add configurable adapter batching and concurrency-safe, deadlock-ordered root CAS locking
- add a Rust MySQL/PostgreSQL comparison runner covering end-to-end VCS and adapter-service workloads
- add pinned local Docker orchestration, guarded external managed-service URL support, provenance capture, credential redaction, and pool/concurrency matrix tooling
- preserve the existing PostgreSQL/DynamoDB comparison while feature-gating AWS-only dependencies for SQL builds

## Why

Large Prolly deployments need predictable statement counts, bounded database parameters, correct root updates under contention, and a repeatable way to distinguish adapter costs from complete version-control workload costs. The previous MySQL adapter issued work item-by-item and lacked an authoritative comparison workflow against PostgreSQL.

## Local comparison

A controlled 100k-record run with seven alternating repetitions found PostgreSQL decisively faster for initial build and sequential query. Batch, concurrent-query, diff, merge, adapter batch put/get, and concurrent get were statistically inconclusive. PostgreSQL was materially faster for contended root CAS. These are local-container results, not universal managed-service capacity claims.

## Validation

- `cargo test --manifest-path benchmarks/backend-comparison/Cargo.toml --no-default-features` — 16 passed
- strict Clippy for the comparison crate and MySQL adapter
- 8 orchestration tests passed
- 4 live Docker-backed MySQL integration tests passed, including chunking, rollback, ordered reads, and 16-way root contention
- full local Docker harness smoke completed with 85 end-to-end evidence rows and 57 service evidence rows
