### PR TITLE
Harden secondary indexes with an industrial atomic foundation

### DIFF
--- a/docs/superpowers/plans/2026-07-28-secondary-index-industrial-foundation-hard-cutover.md
+++ b/docs/superpowers/plans/2026-07-28-secondary-index-industrial-foundation-hard-cutover.md
@@ -1,0 +1,735 @@
+# Secondary Index Industrial Foundation Hard-Cutover Implementation Plan
+
+> **Execution style:** Implementation-first with context. Implement the production
+> boundary in each task, then add focused verification and commit the completed
+> tranche. Do not use a TDD red/green loop.
+
+**Goal:** Replace the secondary-index multi-root coordinator with one canonical
+collection-state root, bounded operations, exact store capabilities, measured
+observability, and release-blocking production evidence.
+
+**Architecture:** Source and index trees remain immutable content-addressed
+prolly trees. One `IndexedCollectionState` tree contains the current and
+retained snapshot records, descriptors, active selections, and pins; one named
+root CAS is the only visibility transition. Queries, mutations, maintenance,
+transfer, and GC operate from one pinned state and consume typed finite
+budgets.
+
+**Tech stack:** Rust 2021, Rust 1.81, existing `Prolly`, `Store`,
+`ManifestStore`, `ManifestStoreScan`, `serde`, `serde_cbor`, and portable
+UniFFI bindings. Add no dependency unless an existing primitive cannot meet a
+release-blocking invariant.
+
+**Design:** `docs/superpowers/specs/2026-07-28-secondary-index-industrial-foundation-hard-cutover-design.md`
+
+## Global Constraints
+
+- This is a hard cutover. Do not add old-format readers, dual publication,
+  migration shims, compatibility aliases, or suffix-named replacement APIs.
+- Keep canonical public names versionless.
+- Do not release an intermediate commit from this branch.
+- Preserve the physical secondary-index entry grammar `(term, primary_key)` and
+  the existing `KeysOnly`, `Include`, and `All` semantics.
+- Every production operation has finite memory, work, retry, and elapsed
+  limits.
+- `FileNodeStore` and `MemStore` are verification-profile stores, not
+  production-profile stores.
+- Default errors, metrics, and traces contain no indexed application data.
+- Physical work metrics must originate at the builder, workspace, iterator, or
+  store boundary.
+- Preserve unrelated working-tree changes, especially changes under
+  `stores/prolly-store-mysql/` and unrelated plan files.
+- Use `apply_patch` for edits and stage only files belonging to the current
+  task.
+
+## Implementation Context
+
+The current implementation is concentrated in five files:
+
+- `src/prolly/secondary_index/storage.rs` persists the multi-root catalog,
+  control, checkpoint, descriptor, and physical index records.
+- `src/prolly/secondary_index/coordinator.rs` opens independent heads, validates
+  them, derives mutations, publishes multi-root transactions, and implements
+  lifecycle operations.
+- `src/prolly/secondary_index/snapshot.rs` opens historical component roots and
+  implements query, page, cursor, projection, and source-join behavior.
+- `src/prolly/secondary_index/bundle.rs` materializes transfer bundles and
+  verifies/imports them.
+- `src/prolly/secondary_index/definition.rs` owns runtime extractors,
+  descriptors' semantic limits, and generation history.
+
+The implementation should split by stable responsibility instead of expanding
+the 2,000-line coordinator:
+
+```text
+src/prolly/secondary_index/
+  budget.rs        typed budgets and accounting
+  bundle.rs        bounded streaming transfer
+  coordinator.rs   public IndexedMap facade and retry orchestration
+  definition.rs    runtime extractors and semantic record limits
+  lifecycle.rs     build, replace, repair, verify, retention, pins, health
+  metrics.rs       operation-local measured observations
+  publication.rs   one-root load, barrier, and CAS protocol
+  query.rs         bounded scans, pages, cursors, and source joins
+  snapshot.rs      immutable snapshot handles
+  state.rs         canonical persisted state/snapshot/descriptor records
+  workspace.rs     bounded sorted runs and spill abstraction
+```
+
+Keep a file combined when its implementation remains small; the responsibility
+boundaries and exported interfaces are mandatory, not the exact line count.
+
+---
+
+### Task 1: Canonical persisted state and hard-cutover fixtures
+
+**Context:** All later work depends on one deterministic representation of the
+collection state. Build this representation before changing publication.
+
+**Files:**
+
+- Create: `src/prolly/secondary_index/state.rs`
+- Modify: `src/prolly/secondary_index/mod.rs`
+- Modify: `src/lib.rs`
+- Modify: `tests/conformance_fixtures.rs`
+- Modify: `conformance/prolly-fixtures.v1.json`
+- Modify: `conformance/README.md`
+- Remove during this task: obsolete secondary-index fixture entries that
+  encode catalog, control, checkpoint, or component-head state
+
+**Interfaces produced:**
+
+- `indexed_collection_root_name(source_map_id: &[u8]) -> Vec<u8>`
+- `IndexedCollectionState`
+- `IndexedSnapshotRecord`
+- `IndexedSnapshotId`
+- `SourceSnapshotRef`
+- `IndexSnapshotRef`
+- `IndexDescriptor`
+- `CollectionIndexPolicy`
+- `SnapshotPin`
+- Canonical `to_bytes`, `from_bytes`, state-tree encode/decode, and
+  `validate_closure` operations
+
+**Implementation:**
+
+- [ ] Define the canonical root grammar
+  `\0prolly/indexed-collection/<hex-source-map-id>/state`; reject empty and
+  malformed source IDs consistently with existing map-ID rules.
+- [ ] Move descriptor persistence from `SecondaryIndexDescriptor` into
+  `IndexDescriptor`; retain name, generation, extractor identity, projection,
+  semantic limits, and content fingerprint.
+- [ ] Implement canonical state keys for format, source ID, collection policy,
+  head, snapshots, descriptors, active selections, retired descriptors, and
+  pins exactly as specified.
+- [ ] Encode snapshot index references sorted by name and exclude runtime
+  tuning and timestamps from content identity.
+- [ ] Make decoding fail closed on unsupported format, malformed keys,
+  duplicate logical records, absent head, wrong source ID, missing
+  descriptors, descriptor-fingerprint mismatch, and unsorted index references.
+- [ ] Replace crate-root exports for old catalog/control/checkpoint persisted
+  records with the canonical state records.
+- [ ] Replace secondary-index conformance fixtures with canonical state,
+  snapshot, descriptor, root-name, and physical index vectors.
+
+**Verification:**
+
+- [ ] Add round-trip, trailing-byte, wrong-format, duplicate, missing-reference,
+  fingerprint-mismatch, and canonical-order cases in
+  `tests/conformance_fixtures.rs` and state module tests.
+- [ ] Run `cargo test --test conformance_fixtures`.
+- [ ] Run `cargo test secondary_index::state`.
+- [ ] Run `cargo check --all-targets`.
+
+**Commit:** `refactor(index): define canonical collection state`
+
+---
+
+### Task 2: Exact indexed-store profiles and shared conformance
+
+**Context:** `supports_transactions() -> bool` is not an adequate production
+contract. Secondary indexes need immutable writes, one root CAS, visibility
+confirmation, and GC safety; they no longer need a multi-root transaction.
+
+**Files:**
+
+- Create: `src/prolly/secondary_index/publication.rs`
+- Modify: `src/prolly/secondary_index/mod.rs`
+- Modify: `src/prolly/store/memory.rs`
+- Modify: `src/prolly/store/file.rs`
+- Modify: `stores/prolly-store-test/src/lib.rs`
+- Modify as supported:
+  `stores/prolly-store-{pglite,redb,rocksdb,slatedb,sqlite}/src/lib.rs`
+- Modify: `tests/store_conformance.rs`
+- Modify: `tests/file_node_store.rs`
+
+**Interfaces produced:**
+
+- `IndexedStoreProfile::{Verification, Production(ProductionCapabilities)}`
+- `ProductionCapabilities` with coordination scope, visibility, durable
+  acknowledgement, GC enumeration, and lease/quiescence declarations
+- `IndexedStore: Store + ManifestStore`
+- `IndexedStore::indexed_store_profile`
+- `IndexedStore::confirm_indexed_publication`
+- Shared `assert_verification_indexed_store` and
+  `assert_production_indexed_store` conformance entry points in
+  `prolly-store-test`
+
+**Implementation:**
+
+- [ ] Add the exact profile and capability types without changing the general
+  `TransactionalStore` contract used by unrelated multi-map APIs.
+- [ ] Implement verification profiles for `MemStore` and `FileNodeStore`.
+  `FileNodeStore` must never construct a production capability value.
+- [ ] Add the publication confirmation hook used after immutable writes and
+  before root CAS; verification stores may perform deterministic read-back.
+- [ ] Audit each currently transactional adapter. Implement a production
+  profile only when its native CAS, visibility, reopen, and durability
+  semantics are explicit and testable; otherwise implement verification or
+  leave secondary indexes unsupported.
+- [ ] Make conformance results name the tested profile so a verification run
+  cannot be presented as production certification.
+
+**Verification:**
+
+- [ ] Exercise CAS success/conflict across separate handles for every declared
+  production adapter.
+- [ ] Add an independent-process CAS case for at least SQLite or redb.
+- [ ] Assert that `FileNodeStore` and `MemStore` are rejected when
+  `IndexedMap::open_production` is requested.
+- [ ] Run `cargo test --test store_conformance --test file_node_store`.
+- [ ] Run the conformance suites in each adapter that declares production
+  support.
+
+**Commit:** `feat(index): require exact store publication profiles`
+
+---
+
+### Task 3: One-root state loading and publication engine
+
+**Context:** This task removes the mixed-root read problem and establishes the
+only legal visibility transition. Keep mutation semantics out until the
+publication engine itself is complete.
+
+**Files:**
+
+- Modify: `src/prolly/secondary_index/publication.rs`
+- Rewrite relevant sections: `src/prolly/secondary_index/coordinator.rs`
+- Modify: `src/prolly/secondary_index/snapshot.rs`
+- Modify: `src/prolly/secondary_index/mod.rs`
+- Modify: `tests/secondary_index.rs`
+- Modify: `tests/node_publication.rs`
+
+**Interfaces produced:**
+
+- `LoadedIndexedState<S>` containing the observed manifest, state tree, decoded
+  state, head record, and immutable source/index handles
+- `IndexedPublication<S>` containing expected and candidate state roots plus
+  measured publication statistics
+- `IndexedMap::open_verification`
+- `IndexedMap::open_production`
+- Internal `load_indexed_state`, `prepare_publication`,
+  `confirm_candidate_objects`, and `compare_and_swap_collection`
+
+**Implementation:**
+
+- [ ] Make open load exactly one collection manifest and decode one immutable
+  state closure; remove sequential source/control/catalog head selection.
+- [ ] Implement empty collection creation as immutable state construction plus
+  `expected=None` root CAS.
+- [ ] Implement the common publication sequence: derive candidate objects,
+  publish nodes, confirm visibility, write candidate state, CAS the single
+  root, and classify the result.
+- [ ] Make CAS retries reload the entire state, rederive the candidate, honor
+  cancellation/deadline/backoff, and return structured exhaustion.
+- [ ] Open public snapshots exclusively from one `LoadedIndexedState`.
+- [ ] Reject known obsolete managed-index markers with
+  `index.format_unsupported`; do not decode them.
+- [ ] Route managed-source mutation exclusively through `IndexedMap`; remove
+  reliance on the old control-root write fence.
+
+**Verification:**
+
+- [ ] Replace the current two-writer test with barrier-controlled state-load,
+  node-publication, and CAS interleavings.
+- [ ] Verify that a reader at every barrier observes exactly the old or new
+  snapshot.
+- [ ] Inject conflict and failure before/after confirmation and CAS; assert
+  that only one complete state is visible.
+- [ ] Run the concurrency test repeatedly with a fixed scheduler/interleaving,
+  not probabilistic shell repetition.
+- [ ] Run `cargo test --test secondary_index --test node_publication`.
+
+**Commit:** `refactor(index): publish through one collection root`
+
+---
+
+### Task 4: Incremental mutation on canonical snapshots
+
+**Context:** Preserve the good incremental delta mechanics while changing
+their authority and allocation discipline.
+
+**Files:**
+
+- Create: `src/prolly/secondary_index/budget.rs`
+- Modify: `src/prolly/secondary_index/definition.rs`
+- Modify: `src/prolly/secondary_index/coordinator.rs`
+- Modify: `src/prolly/secondary_index/state.rs`
+- Modify: `tests/secondary_index.rs`
+- Modify: `tests/node_publication.rs`
+
+**Interfaces produced:**
+
+- `MutationBudget`
+- `BudgetCounter` with checked `charge_*` methods
+- Canonical `SecondaryIndexRegistry` lookup by
+  `(name, descriptor_fingerprint)`
+- `IndexedMapEditor` and `IndexedMapUpdate` using collection-state CAS
+
+**Implementation:**
+
+- [ ] Separate semantic per-record descriptor limits from operational mutation
+  limits; remove inert `max_indexes` and build fields from descriptor limits.
+- [ ] Admit input record and byte counts before last-write-wins normalization.
+- [ ] Batch-read old source values from the pinned source tree, derive old/new
+  emissions, skip unchanged emissions, and apply one sorted delta per changed
+  index.
+- [ ] Charge term, projection, derived-entry, total-byte, and accounted-memory
+  limits before retaining each derived item.
+- [ ] Charge `All` amplification as checked
+  `canonical_term_count * source_value_bytes` before cloning source values.
+- [ ] Enforce collection `max_active_indexes` before allocating per-index
+  mutation state.
+- [ ] Create a new `IndexedSnapshotRecord` and candidate state, then activate
+  both through the Task 3 publication engine.
+- [ ] Store runtime definitions by exact descriptor fingerprint and retain all
+  generations required by the handle.
+
+**Verification:**
+
+- [ ] Adapt the 100-seed incremental-versus-rebuild oracle to canonical states.
+- [ ] Cover exact-limit and one-past-limit input, fanout, projection,
+  transaction, memory, retry, and elapsed boundaries.
+- [ ] Verify extractor failure, cancellation, budget exhaustion, and CAS
+  exhaustion publish no visible state.
+- [ ] Add a three-generation replacement/history registry case.
+- [ ] Run `cargo test --test secondary_index`.
+
+**Commit:** `feat(index): maintain canonical snapshots within budgets`
+
+---
+
+### Task 5: Bounded query API and tamper-proof cursors
+
+**Context:** The current page machinery is reusable, but eager collectors and
+unvalidated continuation keys are not production-safe.
+
+**Files:**
+
+- Create: `src/prolly/secondary_index/query.rs`
+- Modify: `src/prolly/secondary_index/snapshot.rs`
+- Modify: `src/prolly/secondary_index/budget.rs`
+- Modify: `src/prolly/secondary_index/mod.rs`
+- Modify: `src/lib.rs`
+- Modify: `tests/secondary_index.rs`
+- Modify: `bindings/uniffi/src/domain/indexed.rs`
+- Modify: `bindings/api/secondary-index-snapshot-reconciliation.json`
+
+**Interfaces produced:**
+
+- `QueryBudget`
+- `SecondaryIndexQuery`
+- Bounded exact, prefix, range, projected, primary-key, and source-record page
+  methods
+- Visitor methods returning consumed budget and completion state
+- Cursor envelope bound to collection state, snapshot, descriptor, query kind,
+  direction, logical bounds, and physical continuation key
+
+**Implementation:**
+
+- [ ] Move physical-bound computation, scan accounting, source joins, cursor
+  validation, and page construction into `query.rs`.
+- [ ] Remove unbudgeted eager collectors from the Rust and binding production
+  surfaces.
+- [ ] Reject zero/invalid budgets and page requests larger than
+  `QueryBudget.page_entries` before allocation.
+- [ ] Account returned entries/bytes, scanned entries, source fetches, memory,
+  cancellation, and elapsed time during iteration.
+- [ ] Keep source joins ordered and batch them by both entry count and bytes.
+- [ ] Decode a cursor continuation key and prove it matches the index and
+  logical request and lies inside the physical bounds.
+- [ ] Resume forward scans strictly after the key while retaining both bounds;
+  resume reverse scans strictly before it while retaining both bounds.
+
+**Verification:**
+
+- [ ] Cover exact, prefix, bounded/unbounded range, both directions, zero
+  results, all projection modes, and multi-page source joins.
+- [ ] Mutate every cursor identity field and use physical keys before/after the
+  permitted range; every case must fail before scanning.
+- [ ] Request `usize::MAX` page size and verify bounded rejection without
+  allocation.
+- [ ] Demonstrate constant bounded page memory as matching cardinality grows.
+- [ ] Run Rust query tests and the portable snapshot reconciliation suite.
+
+**Commit:** `feat(index): enforce bounded snapshot queries`
+
+---
+
+### Task 6: Spillable build, replacement, repair, and verification
+
+**Context:** Maintenance must be bounded independently of index cardinality.
+Online/resumable build is intentionally excluded.
+
+**Files:**
+
+- Create: `src/prolly/secondary_index/workspace.rs`
+- Create: `src/prolly/secondary_index/lifecycle.rs`
+- Modify: `src/prolly/secondary_index/budget.rs`
+- Modify: `src/prolly/secondary_index/coordinator.rs`
+- Modify: `src/prolly/secondary_index/mod.rs`
+- Modify: `tests/secondary_index.rs`
+- Create: `tests/secondary_index_resources.rs`
+
+**Interfaces produced:**
+
+- `MaintenanceBudget`
+- `IndexBuildWorkspace`
+- `IndexRunWriter` and `IndexRunReader`
+- Verification memory workspace for bounded tests
+- Native temporary-directory workspace for approved non-WASM deployments
+- `IndexVerification::{Complete, BudgetStopped}`
+
+**Implementation:**
+
+- [ ] Scan the pinned source snapshot in bounded pages and emit canonical
+  physical entries into memory-bounded sorted runs.
+- [ ] Spill a run before the next entry would exceed the memory budget; charge
+  spill bytes and run count before writing.
+- [ ] Merge runs with bounded fan-in into `SortedBatchBuilder`, preserving exact
+  canonical ordering and duplicate handling.
+- [ ] Reuse this engine for ensure/build, replacement, repair, and logical
+  verification.
+- [ ] Validate root, entry count, descriptor fingerprint, and source snapshot
+  identity before activation.
+- [ ] Publish activation only through the collection CAS; delete temporary runs
+  after success, failure, conflict, and cancellation.
+- [ ] When no spill workspace is available, reject work that exceeds the
+  finite in-memory maintenance budget.
+
+**Verification:**
+
+- [ ] Compare spillable roots with clean in-memory canonical roots across run
+  sizes, merge fan-in, projections, and input cardinalities.
+- [ ] Inject failure and cancellation during source page, spill, merge,
+  validation, and activation boundaries; assert no visible partial activation.
+- [ ] Prove accounted peak memory remains bounded as source size grows.
+- [ ] Verify exact-boundary and one-past memory, spill-byte, run-count,
+  merge-fan-in, source-entry, finding, retry, and elapsed limits.
+- [ ] Run `cargo test --test secondary_index --test secondary_index_resources`.
+
+**Commit:** `feat(index): add bounded spillable maintenance`
+
+---
+
+### Task 7: Bounded transfer, retention, pins, GC, and health
+
+**Context:** These operations must traverse one state closure and must not
+materialize untrusted or complete datasets before budget checks.
+
+**Files:**
+
+- Rewrite: `src/prolly/secondary_index/bundle.rs`
+- Modify: `src/prolly/secondary_index/lifecycle.rs`
+- Modify: `src/prolly/secondary_index/budget.rs`
+- Modify: `src/prolly/secondary_index/state.rs`
+- Modify: `tests/secondary_index.rs`
+- Modify: `tests/gc.rs`
+- Modify: `tests/mixed_format_gc.rs`
+- Modify: `bindings/uniffi/src/domain/indexed.rs`
+
+**Interfaces produced:**
+
+- `TransferBudget`
+- Streaming bundle encoder/decoder and verifier
+- `SnapshotPinGuard` plus explicit durable pin operations
+- State-rooted retention, GC planning, and health results
+- Health fields for store profile, closure status, pin/lease safety, and
+  consumed budget
+
+**Implementation:**
+
+- [ ] Reject bundle envelope size before decode and charge every retained node,
+  encoded/decoded byte, and verification unit incrementally.
+- [ ] Verify CIDs, canonical records, exact reachability, ownership,
+  descriptors, and selected snapshot without constructing a duplicate full
+  `MemStore`.
+- [ ] Stream export in deterministic reachability order under
+  `TransferBudget`.
+- [ ] Implement retention and pins as candidate state changes activated by one
+  collection CAS.
+- [ ] Mark GC from one pinned state closure, including head, retained
+  snapshots, descriptors, and pins.
+- [ ] Require lease, pin, grace-period, or explicit-quiescence proof before a
+  production sweep; otherwise return `index.gc_unsafe`.
+- [ ] Implement bounded structural `health()` and distinguish it from complete
+  logical verification.
+
+**Verification:**
+
+- [ ] Feed oversized, truncated, duplicate, corrupt, unreachable, and
+  zero-index bundles and verify rejection at the earliest bounded stage.
+- [ ] Inject import failure before/after state write and CAS.
+- [ ] Interleave reader pins, retention, publication, and GC; reachable content
+  must survive every schedule.
+- [ ] Verify production GC refuses unsafe adapters while verification GC can
+  run under explicit quiescence.
+- [ ] Run `cargo test --test secondary_index --test gc --test mixed_format_gc`.
+
+**Commit:** `feat(index): bound transfer retention and garbage collection`
+
+---
+
+### Task 8: Structured errors, measured metrics, and binding parity
+
+**Context:** Operators and bindings need stable recovery semantics and truthful
+physical work data before the subsystem can be certified.
+
+**Files:**
+
+- Create: `src/prolly/secondary_index/metrics.rs`
+- Modify: `src/prolly/error.rs`
+- Modify all files under `src/prolly/secondary_index/` that construct errors or
+  observations
+- Modify: `src/lib.rs`
+- Modify: `bindings/uniffi/src/lib.rs`
+- Modify: `bindings/uniffi/src/domain/indexed.rs`
+- Modify: `bindings/api/indexed-map-reconciliation.json`
+- Modify: `bindings/api/secondary-index-snapshot-reconciliation.json`
+- Modify binding parity tests under `bindings/*/test` or their existing
+  language-specific test locations
+
+**Interfaces produced:**
+
+- `IndexErrorCode`
+- `RetryAdvice::{Never, RetryFreshState, RetryAfter}`
+- Structured safe error fields and sensitive opt-in diagnostics
+- `IndexedOperationStats` with physical node/byte, query, mutation, spill,
+  verification, CAS, and latency fields
+- Binding records that preserve error code, retry advice, budgets, and metrics
+
+**Implementation:**
+
+- [ ] Map every specified error code to an explicit Rust variant and portable
+  binding representation.
+- [ ] Redact primary keys, terms, source/projection values, bounds, physical
+  cursor keys, and extractor text from default formatting and causal output.
+- [ ] Add operation-local metrics collectors fed by actual tree builder, store,
+  iterator, and workspace statistics.
+- [ ] Delete or rename logical counters currently labeled as physical node
+  writes.
+- [ ] Propagate typed budgets and completion/budget-stopped results through
+  UniFFI and all reconciled language surfaces.
+- [ ] Keep labels bounded and free of application data.
+
+**Verification:**
+
+- [ ] Snapshot default error strings for every index error class and assert
+  sensitive sentinel values are absent.
+- [ ] Verify retry advice for CAS conflict, transient store failure, invalid
+  definition, budget exhaustion, corruption, and cancellation.
+- [ ] Cross-check reported physical node/byte counts against store observer
+  deltas for mutation, query, build, and transfer fixtures.
+- [ ] Run UniFFI generation and every supported portable parity suite listed in
+  `bindings/VERIFICATION.md`.
+- [ ] Run strict Clippy for the core and binding crates.
+
+**Commit:** `feat(index): expose structured errors and measured metrics`
+
+---
+
+### Task 9: Remove the obsolete architecture and update public guidance
+
+**Context:** The cutover is incomplete while old catalog/control/component-head
+paths remain callable or documented.
+
+**Files:**
+
+- Delete obsolete contents from:
+  `src/prolly/secondary_index/storage.rs`
+- Modify: `src/prolly/secondary_index/mod.rs`
+- Modify: `src/lib.rs`
+- Modify: `src/prolly/transaction.rs` only where secondary indexes no longer
+  require multi-root transactions
+- Rewrite secondary-index portions: `README.md`
+- Rewrite: `docs/secondary-index-design.md`
+- Modify: `examples/secondary_index.rs`
+- Modify: `bindings/VERIFICATION.md`
+- Remove obsolete fixture and reconciliation entries repository-wide
+
+**Implementation:**
+
+- [ ] Delete catalog map IDs, control roots, hidden mutable index heads,
+  checkpoint records, indexed head records, and their public helpers.
+- [ ] Delete the old `validate_state` mixed-head logic and multi-root indexed
+  transaction publication path.
+- [ ] Remove unbounded eager query APIs, inert limits, old health transaction
+  flags, misleading metrics, and generic binding fallbacks.
+- [ ] Rename retained canonical types without compatibility aliases.
+- [ ] Update the example and documentation to show one-root publication,
+  verification/production profiles, budgets, pins, and spill workspace.
+- [ ] Document `FileNodeStore` as verification-only and list the adapters that
+  actually passed production conformance.
+- [ ] Add repository checks that reject old root-name constants and suffix
+  replacement terminology in the secondary-index implementation.
+
+**Verification:**
+
+- [ ] Use `rg` to prove obsolete root names, catalog/control helpers, public
+  aliases, and multi-root coordinator calls are absent.
+- [ ] Run `cargo check --all-targets`.
+- [ ] Run `cargo test --doc`.
+- [ ] Build and run `examples/secondary_index.rs`.
+- [ ] Generate docs with warnings denied.
+
+**Commit:** `refactor(index): complete canonical hard cutover`
+
+---
+
+### Task 10: Deterministic release harness, benchmark, and tracked CI
+
+**Context:** The implementation is not industrial until the claimed properties
+are continuously demonstrated.
+
+**Files:**
+
+- Create: `tests/secondary_index_faults.rs`
+- Create: `tests/secondary_index_concurrency.rs`
+- Extend: `tests/secondary_index_resources.rs`
+- Rewrite: `benches/prolly_secondary_index_bench.rs`
+- Create: `scripts/run-secondary-index-bench.sh`
+- Create: `scripts/summarize-secondary-index-bench.sh`
+- Create: `.github/workflows/secondary-index-required.yml`
+- Create: `.github/workflows/secondary-index-scheduled.yml`
+- Modify: `Cargo.toml`
+- Modify: `README.md`
+- Modify: `bindings/VERIFICATION.md`
+
+**Implementation:**
+
+- [ ] Add a deterministic fault store that can stop before/after each node
+  publication, confirmation, state write, root CAS, spill operation, and bundle
+  stage and can reopen its durable image.
+- [ ] Add barrier-controlled concurrent operation scenarios for mutation,
+  activation, replacement, repair, retention, pins, readers, and GC.
+- [ ] Replace the one-shot benchmark with isolated repeated fixtures,
+  warm/cold modes, p50/p95/p99, declared provenance, and measured node/byte,
+  memory, spill, and conflict data.
+- [ ] Correct throughput denominators to use the number of records or operations
+  actually measured.
+- [ ] Add bounded PR smoke, required correctness/conformance/binding jobs, and
+  scheduled extended model/fuzz/crash/1M/10M performance jobs.
+- [ ] Make regression classification require minimum samples plus both
+  absolute and relative thresholds.
+
+**Verification:**
+
+- [ ] Demonstrate each injected failure reopens to the complete old or new
+  state.
+- [ ] Run the deterministic concurrency matrix without probabilistic retries.
+- [ ] Run the resource suite at increasing cardinalities and compare peak
+  accounted memory against fixed budgets.
+- [ ] Run the benchmark smoke twice and validate its result schema and
+  provenance.
+- [ ] Validate both workflow files locally where supported and ensure all
+  invoked commands exist.
+
+**Commit:** `test(index): gate industrial secondary index guarantees`
+
+---
+
+### Task 11: Final cutover audit and release evidence
+
+**Context:** This is the only release gate. Do not call the work complete based
+on individual task tests.
+
+**Files:**
+
+- Create: `docs/secondary-index-release-evidence.md`
+- Modify only defects found by the final audit in files already owned by Tasks
+  1–10
+
+**Implementation and verification:**
+
+- [ ] Map every acceptance criterion in the approved design to a passing test,
+  conformance result, benchmark result, or repository-absence check.
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `cargo check --all-targets`.
+- [ ] Run `cargo clippy --all-targets -- -D warnings`.
+- [ ] Run the complete core test and documentation suite.
+- [ ] Run canonical fixtures, deterministic concurrency/fault/resource suites,
+  and every declared production store-conformance suite.
+- [ ] Run portable binding generation and parity suites.
+- [ ] Run sanitizer and bounded fuzz smoke campaigns.
+- [ ] Run the secondary-index benchmark smoke and retain its provenance and
+  classification.
+- [ ] Audit public APIs for any production operation without finite budgets.
+- [ ] Audit default error and metric output with sensitive sentinel data.
+- [ ] Audit the repository for obsolete layout readers, roots, aliases,
+  misleading metrics, and suffix-named replacement architecture.
+- [ ] Record exact commands, revisions, adapter profiles, outcomes, known
+  limitations, and scheduled evidence links in
+  `docs/secondary-index-release-evidence.md`.
+- [ ] Stop and fix any failed criterion; do not mark a partial matrix as
+  release-ready.
+
+**Commit:** `docs: record secondary index release evidence`
+
+## Dependency and Review Order
+
+```text
+Task 1 canonical format
+  -> Task 2 store profiles
+  -> Task 3 publication engine
+  -> Task 4 mutation
+  -> Task 5 query
+  -> Task 6 maintenance
+  -> Task 7 transfer/lifecycle/GC
+  -> Task 8 errors/metrics/bindings
+  -> Task 9 hard-cutover cleanup
+  -> Task 10 release harness and CI
+  -> Task 11 final evidence
+```
+
+Tasks 5 and 6 may be developed in parallel after Task 4 if they modify
+separate modules. Tasks 7 and 8 may be developed in parallel after Tasks 5 and
+6 stabilize. Tasks 9–11 remain sequential because they define the final public
+surface and release claim.
+
+## Acceptance-Criteria Coverage
+
+| Design requirement | Owning tasks |
+|---|---|
+| One authoritative root and CAS | 1, 3 |
+| Old-or-new concurrency/crash behavior | 3, 10 |
+| Exact production store contract | 2 |
+| `FileNodeStore` verification-only | 2, 9 |
+| Bounded queries and cursor integrity | 5 |
+| Bounded maintenance and spill | 6 |
+| Preallocation mutation amplification | 4 |
+| Bounded bundle decode/export | 7 |
+| Historical extractor generations | 4 |
+| Finite retry/time/memory/work budgets | 4–7 |
+| Structured redacted errors | 8 |
+| Measured physical metrics | 8 |
+| Safe retention, pins, leases, and GC | 7 |
+| Fault/resource/conformance/performance gates | 10, 11 |
+| No compatibility or suffix architecture | 1, 9, 11 |
+
+## Execution Handoff
+
+Execute this plan in order on the existing hard-cutover branch. Use one
+reviewable commit per task, run each task's focused verification before its
+commit, and reserve the full repository matrix for Task 11. Keep a compact
+implementation log in the task checkboxes; do not introduce a second planning
+layer.

--- a/docs/superpowers/specs/2026-07-28-secondary-index-industrial-foundation-hard-cutover-design.md
+++ b/docs/superpowers/specs/2026-07-28-secondary-index-industrial-foundation-hard-cutover-design.md
@@ -1,6 +1,6 @@
 # Secondary Index Industrial Foundation Hard-Cutover Design
 
-**Status:** Approved in design review; pending written-spec review
+**Status:** Approved
 
 **Date:** 2026-07-28
 

--- a/docs/superpowers/specs/2026-07-28-secondary-index-industrial-foundation-hard-cutover-design.md
+++ b/docs/superpowers/specs/2026-07-28-secondary-index-industrial-foundation-hard-cutover-design.md
@@ -1,0 +1,757 @@
+# Secondary Index Industrial Foundation Hard-Cutover Design
+
+**Status:** Approved in design review; pending written-spec review
+
+**Date:** 2026-07-28
+
+**Scope:** Replace the current secondary-index coordination architecture with
+one canonical, production-grade foundation. This is a hard cutover. It does
+not preserve the current storage layout or public compatibility surfaces.
+
+## Summary
+
+The current secondary-index implementation has a strong logical model but does
+not meet the required production bar. Its source, hidden-index, catalog, and
+control heads are read and published independently. That permits transient
+mixed observations under concurrency and requires a backend to provide a
+crash-atomic transaction across several mutable roots. Its query, build,
+verification, and transfer paths also contain work that is not bounded before
+allocation.
+
+This design replaces that coordination model. One immutable
+`IndexedCollectionState`, selected by one authoritative root compare-and-swap,
+is the only visibility point for a managed source and all of its secondary
+indexes. Source and index trees remain immutable, content-addressed prolly
+trees. Writers upload candidate objects first and make them visible with one
+CAS. Readers load one state root and therefore observe one complete indexed
+snapshot.
+
+Every production operation receives a finite, typed budget. Index builds use
+bounded sorted runs and an injected spill workspace instead of collecting the
+complete index in memory. Queries are page- or visitor-based and validate
+cursor positions against their logical and physical bounds. Errors are
+structured and redacted. Metrics report measured physical work. Deterministic
+concurrency, failure-injection, resource, store-conformance, and scale tests
+become release gates.
+
+The first delivery is an industrial foundation only. Unique indexes, typed
+composite terms, query composition, deferred maintenance, and resumable online
+builds are deliberately deferred.
+
+## Canonical Cutover Policy
+
+There is one secondary-index architecture and one supported persisted format
+at a time.
+
+- Public types and persisted records use canonical names such as
+  `IndexedCollectionState`, `IndexedSnapshot`, and `IndexDescriptor`.
+- Mutable root names contain no `v2`, `v3`, generation suffix, or compatibility
+  namespace.
+- A release supports exactly one secondary-index format discriminator.
+- An incompatible future change replaces the supported discriminator, types,
+  fixtures, and implementation in one hard cutover.
+- The implementation does not dual-read, dual-write, auto-migrate, or retain
+  a legacy compatibility mode.
+- Opening a store that contains a known obsolete managed-index marker fails
+  with `index.format_unsupported`; it never creates a second authoritative
+  collection beside obsolete roots.
+- Data required across a cutover must be exported or rebuilt before installing
+  the cutover release. The new release does not decode the old index format.
+
+This document supersedes the foundation portion and suffix-based naming in
+`2026-07-14-secondary-index-production-improvements-design.md`. Later feature
+directions in that document remain proposals, not part of this delivery.
+
+## Goals
+
+1. Make one root CAS the sole linearization point for every visible
+   secondary-index state change.
+2. Guarantee that a reader observes a complete old or complete new indexed
+   snapshot, never mixed source, index, descriptor, or retention state.
+3. Require only immutable content writes, declared visibility semantics, and
+   one atomic named-root CAS from a production store.
+4. Bound memory, result size, scans, source fetches, spill space, retries, and
+   elapsed time for every production operation.
+5. Preserve canonical, deterministic source and index roots.
+6. Retain every extractor generation required by a current or retained
+   snapshot.
+7. Expose stable, retry-aware, redacted errors in Rust and all portable
+   bindings.
+8. Measure physical node, byte, retry, spill, and latency work accurately.
+9. Make concurrency, crash/reopen, corruption, resource, and performance
+   evidence mandatory release gates.
+10. Keep the secondary-index subsystem store-neutral and independent of a SQL
+    planner.
+
+## Non-Goals
+
+This delivery does not add:
+
+- unique indexes;
+- typed composite terms or a new term codec;
+- intersection, union, query planning, or statistics-based selection;
+- deferred or asynchronously maintained indexes;
+- resumable online builds or build catch-up under concurrent writes;
+- indexed merge, rollback, or portable query proofs;
+- a production-grade `FileNodeStore`;
+- an old-format migration reader;
+- compatibility aliases for removed APIs or record types.
+
+Synchronous build, replace, repair, and verification operations may retry a
+conflicting final activation, but they are not guaranteed to complete under a
+continuous write rate.
+
+## Release-Blocking Invariants
+
+1. The collection root is the only mutable visibility reference for a managed
+   indexed collection.
+2. A visible state references exactly one source tree and exactly one tree and
+   descriptor for every active index.
+3. All objects referenced by a candidate state are readable under the active
+   store profile before its root CAS is attempted.
+4. Failed and conflicting CAS operations do not change visible collection
+   state.
+5. An indexed snapshot ID changes when its source root, any index root, any
+   selected descriptor, or canonical snapshot metadata changes.
+6. A query cursor cannot widen or change its original logical request.
+7. No production API allocates in proportion to an unbounded result set,
+   complete source, complete index, or untrusted transfer payload.
+8. Every configured limit is enforced before the allocation or amplification
+   it is intended to bound.
+9. A runtime extractor must match the exact persisted descriptor fingerprint
+   used by the selected snapshot.
+10. Default errors and telemetry never contain primary keys, terms, source
+    values, projections, query bounds, or extractor-provided text.
+11. Physical node and byte metrics come from builders, workspaces, and stores;
+    they are never inferred from logical map counts.
+12. Garbage collection cannot remove content reachable from the current,
+    retained, explicitly pinned, or safely leased snapshots.
+
+## Persistence Architecture
+
+### Authoritative Root
+
+Each indexed collection owns one reserved mutable root:
+
+```text
+\0prolly/indexed-collection/<hex-source-map-id>/state
+```
+
+The value is the root CID of the canonical `IndexedCollectionState` tree. It is
+the only mutable head for the source map, its indexes, its descriptor history,
+and its retained snapshots.
+
+There are no independently authoritative source, hidden-index, catalog, or
+control heads. A component tree may be cached by CID, but a cache or helper
+root is never a source of truth.
+
+### Collection State
+
+The state tree uses this canonical logical key grammar:
+
+```text
+meta/format                         -> supported format discriminator
+meta/source-map-id                  -> exact application source-map ID
+meta/collection-policy              -> canonical CollectionIndexPolicy
+head                                -> IndexedSnapshotId
+snapshots/<snapshot-id>             -> IndexedSnapshot
+descriptors/<name>/<fingerprint>    -> IndexDescriptor
+active/<name>                       -> descriptor fingerprint
+retired/<name>/<fingerprint>        -> RetirementRecord
+pins/<pin-id>                       -> SnapshotPin
+```
+
+Entries are length-delimited and sorted by encoded key. Canonical decoding
+rejects malformed keys, unknown record kinds, duplicate logical entries, an
+unsupported format discriminator, a mismatched source-map ID, a head absent
+from `snapshots/`, and references to absent or fingerprint-mismatched
+descriptors.
+
+`CollectionIndexPolicy` stores semantic collection rules required to interpret
+the state, including `max_active_indexes`. Per-operation execution budgets are
+runtime policy and are not persisted.
+
+The head snapshot must remain in `snapshots/`. A descriptor referenced by the
+head, a retained snapshot, or a pin must remain in `descriptors/`. Retirement
+removes a descriptor from `active/`; it does not remove descriptor history
+still required by a retained snapshot.
+
+### Indexed Snapshot
+
+An `IndexedSnapshot` is a canonical content-addressed record with the
+equivalent shape:
+
+```rust
+struct IndexedSnapshot {
+    source_map_id: Vec<u8>,
+    parent: Option<IndexedSnapshotId>,
+    source: SourceSnapshotRef,
+    indexes: Vec<IndexSnapshotRef>,
+}
+
+struct SourceSnapshotRef {
+    tree: PersistedTreeRef,
+    entry_count: u64,
+}
+
+struct IndexSnapshotRef {
+    name: Vec<u8>,
+    descriptor_fingerprint: Cid,
+    tree: PersistedTreeRef,
+    entry_count: u64,
+}
+
+struct PersistedTreeRef {
+    root: Cid,
+    format: TreeFormat,
+}
+```
+
+Index references are sorted by name. Runtime cache settings, prefetch policy,
+worker count, timestamps used only for telemetry, and other nondeterministic
+data are excluded. `IndexedSnapshotId` is the CID of the canonical snapshot
+record.
+
+The parent is history metadata. Read correctness depends only on the exact
+tree and descriptor references in the selected snapshot.
+
+### Descriptor and Extractor Identity
+
+`IndexDescriptor` contains the logical name, generation, extractor identity,
+projection mode, semantic record-shape limits, and canonical fingerprint.
+Runtime extractors are registered by `(name, descriptor_fingerprint)`, not
+only by name.
+
+The registry retains all registered generations required by the current
+handle. Opening a snapshot that references a descriptor for which no exact
+runtime extractor is registered returns `index.extractor_missing`; it never
+substitutes another generation.
+
+Changing extractor behavior requires a new extractor identity and descriptor
+fingerprint. The engine cannot prove arbitrary callback determinism, but it
+fails closed when persisted and runtime identity differ.
+
+## Store Capability Contract
+
+Store support is described by an exact profile rather than
+`supports_transactions() -> bool`.
+
+### Production Profile
+
+A production store must provide and pass conformance for:
+
+1. Idempotent content-addressed immutable writes with CID validation.
+2. Declared read-after-write or publication-barrier semantics.
+3. Atomic compare-and-swap for one named collection root.
+4. CAS correctness across independent handles and processes.
+5. Durable acknowledgement semantics documented by the adapter.
+6. Consistent root reopen after an acknowledged CAS.
+7. Enumerability or an adapter-specific mechanism required for safe GC.
+8. Lease, pin, or operational-quiescence integration required by its GC
+   profile.
+
+Runtime probes can disprove these properties. Claims about physical power-loss
+durability also require the underlying database or provider contract.
+
+### Verification Profile
+
+A verification store may exercise tree construction, query semantics, CAS
+conflicts, fixtures, and local reopen behavior without claiming production
+durability or coordination.
+
+`FileNodeStore` belongs to this profile. Its current local transaction behavior
+may remain for verification, but it cannot satisfy or report the production
+profile. The secondary-index documentation and capability API state this
+directly.
+
+## Publication Protocol
+
+Every mutation, index activation, replacement, repair, retention change, pin
+change, and verified import follows the same protocol:
+
+1. Read the collection root once, obtaining `expected_state_root`.
+2. Load and validate that immutable `IndexedCollectionState`.
+3. Resolve the selected `IndexedSnapshot` and exact runtime descriptors.
+4. Derive candidate source, index, descriptor, retention, and snapshot
+   changes under the operation budget.
+5. Write all candidate immutable nodes and records.
+6. Complete the store's required publication barrier or read-back checks.
+7. Build and write the candidate collection-state tree.
+8. CAS the collection root from `expected_state_root` to
+   `candidate_state_root`.
+9. Return success only after the CAS acknowledgement.
+
+The successful CAS is the linearization point.
+
+Failure before CAS leaves the old state visible. A conflict leaves the winning
+state visible and the losing candidate unreachable. A successful CAS followed
+by client disconnect leaves the new state visible; retry is idempotent when
+the desired content already matches the observed state.
+
+Only classified transient store failures and CAS conflicts are retried.
+Retries always reload the complete state and rederive the candidate. They are
+bounded by attempts, elapsed time, cancellation, and backoff.
+
+### Reads
+
+A normal read loads the collection root once and opens the selected immutable
+snapshot. It does not reread mutable component heads.
+
+Historical reads select an `IndexedSnapshotId` retained by the loaded state,
+then open its exact source, index, and descriptor references. Retention removal
+is observed on the next independent state load; an already protected snapshot
+remains valid through its pin or lease.
+
+### Managed Source Ownership
+
+A managed source tree has no independently mutable `VersionedMap` head. Public
+source writes go through `IndexedMap` and the collection CAS. Snapshot APIs may
+expose read-only source trees by immutable reference.
+
+Opening a raw mutable map for a managed source ID fails with
+`index.managed_source`. The cutover deletes the old control-root fence and
+hidden-map publication mechanism rather than maintaining them as mirrors.
+
+## Bounded Execution
+
+### Budget Types
+
+Execution limits are separated by responsibility:
+
+```text
+MutationBudget
+  input_records
+  input_bytes
+  derived_entries
+  derived_bytes
+  accounted_memory_bytes
+  cas_attempts
+  elapsed
+
+QueryBudget
+  page_entries
+  returned_entries
+  returned_bytes
+  scanned_entries
+  source_fetches
+  accounted_memory_bytes
+  elapsed
+
+MaintenanceBudget
+  source_entries
+  derived_entries
+  verification_findings
+  accounted_memory_bytes
+  spill_bytes
+  spill_runs
+  merge_fan_in
+  cas_attempts
+  elapsed
+
+TransferBudget
+  encoded_bytes
+  nodes
+  decoded_bytes
+  verification_work
+  accounted_memory_bytes
+  elapsed
+```
+
+All production defaults are finite and nonzero. Callers may select stricter
+values. Values whose arithmetic overflows or cannot be represented by an
+adapter fail validation before work begins. The cutover preserves the current
+finite semantic descriptor defaults unless a limit moves to the appropriate
+operation budget:
+
+| Semantic limit | Default |
+|---|---:|
+| Encoded term bytes | 4 KiB |
+| Projection bytes per emission | 64 KiB |
+| Source value bytes for `All` | 1 MiB |
+| Emissions per source record | 1,024 |
+| Derived projection bytes per source record | 1 MiB |
+| Active indexes per collection | 32 |
+
+Operational default values are centralized in one production profile and one
+verification profile. A default cannot be unbounded. Benchmarks may override
+budgets explicitly but do not alter production defaults.
+
+### Mutation
+
+Mutation input is normalized only after input-record and input-byte admission.
+Last-write-wins deduplication remains canonical.
+
+For each source record, the engine:
+
+1. validates source and descriptor semantic limits;
+2. extracts and canonicalizes terms within the emissions budget;
+3. computes checked amplification before cloning projections;
+4. charges `All` projection bytes as
+   `canonical_term_count * source_value_bytes`;
+5. rejects the record before allocating derived buffers when a limit would be
+   exceeded.
+
+The coordinator checks `max_active_indexes` before descriptor activation and
+before allocating multi-index mutation state. Transaction-level derived entry,
+byte, and memory budgets are charged as candidate deltas are created, not
+after a complete delta map exists.
+
+### Query
+
+Production query primitives are bounded pages and streaming visitors. Exact,
+prefix, range, primary-key, projection, and source-record queries do not expose
+an unbudgeted collector.
+
+Before allocating a result buffer, the engine rejects a requested page size
+larger than `QueryBudget.page_entries`. Iteration stops at the first returned,
+scanned, fetched, byte, memory, cancellation, or elapsed limit. Source joins
+use batches bounded by both entry count and encoded bytes.
+
+A cursor binds:
+
+- collection state and indexed snapshot IDs;
+- index name and descriptor fingerprint;
+- direction;
+- logical query kind and logical bounds;
+- physical continuation key.
+
+Cursor validation decodes the continuation key, proves it belongs to the
+selected index and logical request, and checks it lies within the computed
+physical bounds. Forward resume retains both physical bounds and continues
+strictly after the key. Reverse resume retains both bounds and continues
+strictly before it. A cursor mismatch returns an error before scanning.
+
+### Build, Replace, Repair, and Verification
+
+These operations never collect the complete derived index in a `BTreeMap`.
+They use:
+
+1. a bounded page scan of one pinned source snapshot;
+2. memory-bounded sorted runs;
+3. an injected `IndexBuildWorkspace` for spill files or store-backed runs;
+4. a bounded k-way merge into `SortedBatchBuilder`;
+5. root, count, descriptor, and canonical-order validation;
+6. collection-root CAS activation.
+
+The workspace accounts for memory, bytes, run count, and merge fan-in.
+Temporary runs are namespaced by operation and cleaned after success, failure,
+or cancellation. Orphan cleanup after process death is adapter policy and
+must be safe to repeat.
+
+An environment without an approved spill workspace may build only an index
+that fits its finite memory budget. Crossing memory or spill limits returns
+`index.budget_exceeded` and publishes nothing.
+
+Verification streams the source and selected index under a
+`MaintenanceBudget`. Its result states whether it completed or stopped at a
+budget boundary. A partial verification is never reported as complete.
+
+### Bundles
+
+Bundle import rejects the encoded envelope size before decoding. Streaming
+decode charges nodes, encoded bytes, decoded bytes, verification work, and
+accounted memory before retaining each item.
+
+Verification checks content IDs, canonical records, exact reachability,
+source/index ownership, descriptor fingerprints, and the selected source
+state without constructing a duplicate full-size `MemStore`. Publication
+occurs only after complete validation through the collection CAS.
+
+Export streams reachable content under `TransferBudget`; it does not first
+collect the complete node set into an unbounded vector.
+
+## Errors and Retry Policy
+
+Every secondary-index error exposes:
+
+- a stable code;
+- operation category;
+- retry advice: `Never`, `RetryFreshState`, or `RetryAfter`;
+- safe structured fields;
+- an optional bounded causal chain.
+
+Required codes include:
+
+```text
+index.format_unsupported
+index.managed_source
+index.store_capability
+index.definition_invalid
+index.definition_mismatch
+index.extractor_missing
+index.extraction_failed
+index.budget_exceeded
+index.deadline_exceeded
+index.cancelled
+index.cas_conflict
+index.retry_exhausted
+index.cursor_mismatch
+index.snapshot_not_retained
+index.corruption
+index.bundle_invalid
+index.gc_unsafe
+```
+
+Default text, metrics, and traces exclude primary keys, terms, source values,
+projections, logical bounds, physical cursor keys, and extractor-provided
+messages. Safe context uses counts, limit dimensions, bounded operator-assigned
+names, and content hashes. An explicitly sensitive diagnostic API may return
+raw application data; portable errors do not.
+
+Bindings preserve code, category, retry advice, and structured safe fields.
+They do not collapse secondary-index errors into `Internal`.
+
+## Observability
+
+Operation-local statistics are collected from tree builders, stores, query
+iterators, and spill workspaces. Required observations include:
+
+- source, index, state, and spill nodes read, reused, written, and uploaded;
+- bytes read, written, decoded, returned, and spilled;
+- source records scanned and fetched;
+- extracted, canonicalized, inserted, removed, and deduplicated entries;
+- source and projection amplification bytes;
+- CAS attempts, conflicts, retries, backoff, and latency;
+- query pages, scanned entries, returned entries, and early termination;
+- build run count, merge fan-in, merge passes, and peak accounted memory;
+- verification coverage, findings, and completeness;
+- retained and pinned snapshots and GC-reclaimed nodes and bytes;
+- terminal error code and total operation latency.
+
+Metrics named `*_nodes_written` report physical nodes written. Logical
+publication counts use distinct names. No counter is incremented by assuming
+that one logical map change equals one physical node.
+
+Labels use bounded collection/index names or hashes. Application data is never
+a metric label.
+
+## Retention, Pins, and Garbage Collection
+
+Retention changes are collection-state CAS operations. The candidate state
+must keep:
+
+- the head snapshot;
+- snapshots selected by retention policy;
+- explicitly pinned snapshots;
+- every descriptor and immutable tree referenced by those snapshots.
+
+GC marks from one pinned collection state and traverses its complete content
+closure. It does not combine roots observed at different times.
+
+Unpublished objects and objects removed by retention are swept only after the
+configured grace interval. Long-lived readers must hold a collection pin or a
+store-provided lease. A production GC operation fails with `index.gc_unsafe`
+when the adapter cannot prove a safe lease, pin, grace-period, or explicit
+quiescence policy.
+
+## Health and Verification
+
+`health()` is a bounded structural check. It loads one collection state and
+verifies format, ownership, snapshot closure, descriptors, referenced roots,
+counts that can be checked without a full scan, store profile, and GC safety.
+
+`verify_index()` is a bounded logical rederivation against one immutable source
+snapshot. It reports:
+
+- descriptor and snapshot identity;
+- entries compared;
+- source entries scanned;
+- mismatch counts by safe category;
+- consumed budget;
+- `Complete` or `BudgetStopped`.
+
+Queries fail closed on missing or corrupt referenced content. Repair builds a
+new candidate from the immutable source snapshot and activates it only by the
+collection CAS.
+
+## Verification and Release Gates
+
+### Model and Property Tests
+
+- Incremental maintenance equals a clean rebuild across inserts, updates,
+  deletes, sparse output, duplicate terms, all projections, and multiple
+  active indexes.
+- Canonical roots are invariant across input order, batch shape, retry count,
+  and supported worker counts.
+- Every retained snapshot matches a reference multimap.
+- Cursor pages neither duplicate, skip, nor escape the logical request.
+- Replacement through at least three extractor generations preserves exact
+  historical reopening.
+
+The fast deterministic seed set runs on every change. An extended scheduled
+campaign increases seeds and dataset shapes without changing the oracle.
+
+### Deterministic Concurrency
+
+Tests place barriers around every state load, candidate build, object
+publication, read-back, and root-CAS boundary. They cover:
+
+- concurrent source mutations;
+- mutation versus index activation, replacement, repair, retention, and pin;
+- reader versus writer and reader versus GC;
+- CAS success, conflict, retry, exhaustion, and cancellation;
+- independent handles and processes where supported.
+
+The existing mixed source/catalog observation failure becomes a regression
+test proving that the new architecture can expose only complete old or new
+snapshots.
+
+### Failure Injection
+
+Inject returned failure, cancellation, or simulated crash:
+
+- before, during, and after immutable source/index/state writes;
+- before and after the publication barrier;
+- immediately before and after root CAS;
+- after successful CAS but before success reaches the caller;
+- during every sorted-run spill and merge pass;
+- during bundle decode, verification, and publication;
+- during retention, pin, repair, and GC planning.
+
+Reopen must expose the complete old or new state. No accepted outcome contains
+a mixed source/index snapshot or a root referencing unavailable content.
+
+### Store Conformance
+
+Every production adapter runs one shared suite proving the production-profile
+properties. At least one test uses independent handles and one uses independent
+processes. Verification-profile stores run a separately named suite that
+cannot produce a production capability result.
+
+### Resource Tests
+
+- Accounted peak memory stays within the operation budget plus documented
+  constant adapter overhead as dataset cardinality grows.
+- Query allocation is rejected before scan when the requested page exceeds its
+  budget.
+- Builds spill at deterministic thresholds and fail before crossing memory,
+  run-count, merge-fan-in, or spill-byte limits.
+- `All` and multi-valued amplification is rejected before projection cloning.
+- Bundle decode rejects oversized input before complete materialization.
+- Every integer limit receives zero, maximum representable, overflow, exact
+  boundary, and one-past-boundary coverage.
+- Budget exhaustion, deadline, and cancellation publish nothing.
+
+### Performance and Scale
+
+Benchmarks use repeated samples, isolated fixtures, declared hardware and
+backend provenance, and warm/cold separation. Reports include p50, p95, and
+p99 latency together with memory, physical node I/O, bytes, spill work, and CAS
+conflicts.
+
+Required fixtures cover:
+
+- source-only mutation and one, several, and maximum active indexes;
+- insert, update-with-same-terms, update-with-new-terms, and delete;
+- exact, prefix, bounded range, projection, and source-record pages;
+- cold and warm build, replace, repair, and verification;
+- retention and GC;
+- conflict-free and contended publication.
+
+Tracked CI runs a bounded smoke profile. Scheduled CI runs declared production
+adapters at 1 million and 10 million source records. A performance gate uses
+both relative and absolute thresholds, a minimum sample count, and stored
+baseline provenance. One-shot measurements and logical node estimates cannot
+pass or fail a release.
+
+### Required CI
+
+The tracked required workflow runs:
+
+- formatting;
+- `cargo check --all-targets`;
+- strict Clippy;
+- unit, integration, and documentation tests;
+- canonical fixture verification;
+- deterministic concurrency and failure matrices;
+- production and verification store-conformance suites;
+- portable binding error, budget, cursor, and metrics parity;
+- sanitizer and bounded fuzz smoke jobs;
+- benchmark smoke and regression classification.
+
+Extended fuzz, model, scale, and crash campaigns run on a published schedule
+and block release when unresolved.
+
+## Hard-Cutover Delivery Order
+
+The implementation lands as one architectural cutover branch but is reviewed
+in dependency order:
+
+1. **Canonical format and store contract**
+   - introduce the canonical state/snapshot/descriptor records;
+   - introduce production and verification store profiles;
+   - add conformance and canonical-format fixtures.
+2. **Single-root coordinator**
+   - implement state loading, reads, publication, retries, retention, pins, and
+     managed-source ownership;
+   - delete multi-root source/index/catalog/control publication.
+3. **Correct bounded query surface**
+   - replace eager production collectors;
+   - enforce query budgets and validate cursor continuation keys.
+4. **Bounded mutation and maintenance**
+   - enforce preallocation amplification accounting;
+   - implement spillable build, replace, repair, and verification.
+5. **Bounded transfer, GC, and health**
+   - stream bundle processing;
+   - implement state-rooted retention, safe pins/leases, GC, and structural
+     health.
+6. **Errors, metrics, and binding parity**
+   - replace generic error mapping and logical node counters;
+   - propagate typed budgets and measured observations.
+7. **Release evidence**
+   - add deterministic fault/concurrency/resource gates;
+   - replace the secondary-index benchmark harness;
+   - add tracked required CI and scheduled scale campaigns.
+8. **Cutover cleanup**
+   - delete obsolete layouts, types, helpers, tests, fixtures, docs, and
+     compatibility terminology;
+   - verify repository-wide absence of old root names and multi-root paths.
+
+No intermediate commit from this branch is released as a supported library.
+The release occurs only after the final cutover gates pass.
+
+## Acceptance Criteria
+
+The industrial foundation is complete only when all statements below are
+proved:
+
+1. Strict publication has exactly one mutable visibility root and one CAS
+   linearization point.
+2. Concurrent and crash/reopen tests expose a complete old or new indexed
+   snapshot, never a mixed state.
+3. A production adapter needs no multi-root transaction and passes the exact
+   single-root conformance suite.
+4. `FileNodeStore` is classified and documented as verification-only.
+5. Query memory is bounded by declared work and result budgets regardless of
+   total matches.
+6. Build, replace, repair, and verification memory is bounded independently of
+   source and index size, with bounded spill behavior.
+7. Mutation amplification and bundle decoding are rejected before unsafe
+   allocation.
+8. Tampered cursors cannot change or widen the original request.
+9. Historical snapshots reopen the exact registered extractor fingerprint
+   across at least three replacements.
+10. Every production operation has finite attempts, elapsed time, memory, and
+    relevant work limits.
+11. Errors are stable, retry-aware, binding-preserved, and redacted by
+    default.
+12. Metrics report measured physical node and byte work.
+13. Retention and GC cannot remove current, retained, pinned, or safely leased
+    snapshot content.
+14. The deterministic fault, concurrency, resource, conformance, binding, and
+    performance release gates pass.
+15. The repository contains one canonical secondary-index architecture, no
+    suffix-named replacement architecture, and no compatibility reader for the
+    removed layout.
+
+## Final Recommendation
+
+Replace the multi-root coordinator rather than incrementally hardening it.
+Keep the existing immutable prolly-tree mechanics and strict synchronous index
+semantics, but select every complete indexed snapshot through one canonical
+collection root.
+
+Deliver atomic visibility, bounded execution, exact error and metric contracts,
+and mandatory release evidence before expanding index semantics. This fixes
+the production boundary first and leaves one coherent architecture on which
+later features can be built through deliberate hard cutovers.


### PR DESCRIPTION
## Outcome

Implements the approved `2026-07-28-secondary-index-industrial-foundation-hard-cutover.md` plan for the industrial foundation: atomic architecture, bounded resources, correctness, observability, and rigorous release gates.

This is a hard cutover. It adds no compatibility reader, dual publication, migration shim, or suffix-named V2/V3 API.

## Architecture

- Replaces source/index/catalog/control publication with one canonical `IndexedCollectionState` root and one CAS linearization point.
- Makes snapshots content-addressed and binds private cursors to snapshot, source/state versions, descriptor, direction, bounds, and continuation.
- Fences raw source-head mutation after canonical indexed initialization.
- Introduces exact store profiles. SQLite is the only production-qualified adapter; `MemStore`, `FileNodeStore`, PGlite, redb, RocksDB, and SlateDB are verification-only.

## Industrial controls

- Finite typed budgets for mutation, query, maintenance/spill, transfer, retry, and elapsed work.
- Spillable bounded index construction and verification.
- Bounded bundle parsing/import/export, retention, durable pins, shared-store-safe GC, and structural health.
- Structured redacted errors, retry advice, and measured indexed-operation counters.
- Canonical API propagation through UniFFI, Node, WASM, Python, Ruby, Swift, Java, and Kotlin.

## Release gates

- Deterministic confirmation/CAS fault injection and barrier-controlled two-writer visibility tests.
- Bounded resource and 10,000-case malformed descriptor/cursor/bundle parser fuzz smoke.
- Required Rust, SQLite production-profile, binding parity, API-inventory, and hard-cutover CI.
- Scheduled release-mode, ASan, and 100,000-record repeated benchmark jobs.
- Exact local evidence and limitations: `docs/secondary-index-release-evidence.md`.

## Local validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`: 500 library tests, all integration suites, 74 doc tests
- Focused industrial gate: 41/41
- SQLite production profile/shared contract/separate-handle CAS: 3/3
- UniFFI 77/77; Node 60/60; WASM 34/34; Python 23/23; Ruby 22/22; targeted JVM portable parity passed
- Binding inventory: 3,052 operations
- PGlite, redb, RocksDB, and SlateDB all-target compilation passed with verification profiles
- Two independent five-sample benchmark smoke runs passed with every row semantically verified

## Release status

The implementation is complete for review. Merge and production release remain gated on the required PR workflow. Swift runtime parity requires a configured macOS/XCTest runner, and scheduled ASan/extended performance evidence must be attached before a production release.
