### PR TITLE
perf: harden and accelerate the Redis adapter

### DIFF
--- a/benchmarks/redis-scale/Cargo.lock
+++ b/benchmarks/redis-scale/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "prolly-map"
-version = "0.4.0"
+version = "0.5.1"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "prolly-store-redis"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "prolly-map",
  "redis",

--- a/benchmarks/redis-scale/src/model.rs
+++ b/benchmarks/redis-scale/src/model.rs
@@ -147,7 +147,7 @@ impl RunConfig {
             revision,
             dirty,
             sizes: FULL_SIZES.to_vec(),
-            runs: 3,
+            runs: 7,
             operations: Operation::ALL.to_vec(),
             patterns: Pattern::ALL.to_vec(),
             changes: None,

--- a/benchmarks/redis-scale/src/model.rs
+++ b/benchmarks/redis-scale/src/model.rs
@@ -11,6 +11,7 @@ pub const FULL_SIZES: &[usize] = &[1_000_000];
 #[serde(rename_all = "snake_case")]
 pub enum Operation {
     Build,
+    BackendBatch,
     Put,
     Batch,
     GetCold,
@@ -23,7 +24,8 @@ pub enum Operation {
 }
 
 impl Operation {
-    pub const ALL: [Self; 9] = [
+    pub const ALL: [Self; 10] = [
+        Self::BackendBatch,
         Self::Put,
         Self::Batch,
         Self::GetCold,
@@ -38,6 +40,7 @@ impl Operation {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Build => "build",
+            Self::BackendBatch => "backend_batch",
             Self::Put => "put",
             Self::Batch => "batch",
             Self::GetCold => "get_cold",
@@ -57,6 +60,7 @@ impl FromStr for Operation {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "build" => Ok(Self::Build),
+            "backend_batch" => Ok(Self::BackendBatch),
             "put" => Ok(Self::Put),
             "batch" => Ok(Self::Batch),
             "get_cold" => Ok(Self::GetCold),
@@ -265,7 +269,9 @@ impl CellSpec {
     pub fn logical_operations(&self) -> usize {
         match self.operation {
             Operation::Put => 1,
-            Operation::Batch | Operation::Diff | Operation::Merge => self.changes,
+            Operation::BackendBatch | Operation::Batch | Operation::Diff | Operation::Merge => {
+                self.changes
+            }
             Operation::GetCold | Operation::GetWarm | Operation::Query | Operation::Scan => {
                 self.read_samples
             }

--- a/benchmarks/redis-scale/src/redis_runner.rs
+++ b/benchmarks/redis-scale/src/redis_runner.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 
 use prolly::{
     AsyncProlly, AsyncSortedBatchBuilder, Config, Diff, Mutation, ProllyMetricsSnapshot,
-    RemoteProllyStore, Tree, TreeStats,
+    RemoteProllyStore, RemoteStoreBackend, Tree, TreeStats,
 };
 use prolly_store_redis::redis::{RedisBackend, RedisStore};
 
@@ -105,6 +105,7 @@ pub async fn run_cell(spec: &CellSpec, layout: &FixtureLayout) -> Result<RawRow,
 
     let outcome = match spec.operation {
         Operation::Build => return Err("build is measured by build_fixture".to_string()),
+        Operation::BackendBatch => run_backend_batch(store.clone(), &base, spec).await?,
         Operation::Put => run_put(store.clone(), &base, spec).await?,
         Operation::Batch => run_batch(store.clone(), &base, spec).await?,
         Operation::GetCold | Operation::GetWarm => {
@@ -181,6 +182,67 @@ pub async fn run_cell(spec: &CellSpec, layout: &FixtureLayout) -> Result<RawRow,
         &redis,
         namespace_keys,
     ))
+}
+
+async fn run_backend_batch(
+    store: RedisStore,
+    base: &Tree,
+    spec: &CellSpec,
+) -> Result<Outcome, String> {
+    let ids = mutation_ids(spec.pattern, spec.records, spec.changes, 1);
+    let keys = ids
+        .iter()
+        .copied()
+        .map(backend_benchmark_key)
+        .collect::<Vec<_>>();
+    let values = ids
+        .iter()
+        .copied()
+        .map(|id| value(id, 1))
+        .collect::<Vec<_>>();
+    let entries = keys
+        .iter()
+        .zip(&values)
+        .map(|(key, value)| (key.as_slice(), value.as_slice()))
+        .collect::<Vec<_>>();
+
+    let started = Instant::now();
+    store
+        .backend()
+        .batch_put_nodes(&entries)
+        .await
+        .map_err(|error| format!("backend batch failed: {error}"))?;
+    let total_ns = started.elapsed().as_nanos().max(1);
+
+    let requested = keys.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    let observed = store
+        .backend()
+        .batch_get_nodes_ordered(&requested)
+        .await
+        .map_err(|error| format!("backend batch validation failed: {error}"))?;
+    for (index, (actual, expected)) in observed.into_iter().zip(values.iter()).enumerate() {
+        if actual.as_deref() != Some(expected.as_slice()) {
+            return Err(format!(
+                "backend batch validation returned the wrong value at index {index}"
+            ));
+        }
+    }
+
+    Ok(Outcome {
+        tree: base.clone(),
+        changed_values: BTreeMap::new(),
+        observed_items: entries.len(),
+        total_ns,
+        latencies: Vec::new(),
+        metrics: ProllyMetricsSnapshot::default(),
+    })
+}
+
+fn backend_benchmark_key(id: usize) -> Vec<u8> {
+    let mut key = vec![0_u8; 32];
+    key[..8].copy_from_slice(b"adapter:");
+    key[24..].copy_from_slice(&(id as u64).to_be_bytes());
+    key
 }
 
 struct Outcome {

--- a/benchmarks/redis-scale/tests/matrix.rs
+++ b/benchmarks/redis-scale/tests/matrix.rs
@@ -6,7 +6,7 @@ fn full_matrix_has_seven_fixtures_and_complete_cells() {
     let config = RunConfig::full("results".into(), "revision".into(), false);
     let plan = enumerate_matrix(&config);
     assert_eq!(plan.fixtures.len(), 7);
-    assert_eq!(plan.cells.len(), 175);
+    assert_eq!(plan.cells.len(), 196);
 
     let cells = enumerate_cells(&config, 1_000_000, 1);
     for operation in Operation::ALL {
@@ -27,7 +27,7 @@ fn full_matrix_has_seven_fixtures_and_complete_cells() {
 fn smoke_matrix_uses_single_put_and_separate_read_and_change_counts() {
     let config = RunConfig::smoke("smoke".into());
     let cells = enumerate_cells(&config, 100, 1);
-    assert_eq!(cells.len(), 25);
+    assert_eq!(cells.len(), 28);
     for cell in cells {
         assert_eq!(cell.changes, 10);
         assert_eq!(cell.read_samples, 10);

--- a/benchmarks/redis-scale/tests/matrix.rs
+++ b/benchmarks/redis-scale/tests/matrix.rs
@@ -2,11 +2,11 @@ use prolly_redis_scale_bench::harness::enumerate_matrix;
 use prolly_redis_scale_bench::model::{enumerate_cells, Operation, Pattern, RunConfig};
 
 #[test]
-fn full_matrix_has_three_fixtures_and_complete_cells() {
+fn full_matrix_has_seven_fixtures_and_complete_cells() {
     let config = RunConfig::full("results".into(), "revision".into(), false);
     let plan = enumerate_matrix(&config);
-    assert_eq!(plan.fixtures.len(), 3);
-    assert_eq!(plan.cells.len(), 75);
+    assert_eq!(plan.fixtures.len(), 7);
+    assert_eq!(plan.cells.len(), 175);
 
     let cells = enumerate_cells(&config, 1_000_000, 1);
     for operation in Operation::ALL {

--- a/benchmarks/redis-scale/tests/model_cli.rs
+++ b/benchmarks/redis-scale/tests/model_cli.rs
@@ -14,7 +14,7 @@ fn full_profile_freezes_the_one_million_baseline() {
     );
     assert_eq!(config.redis_url, "redis://127.0.0.1:6379/");
     assert_eq!(config.sizes, vec![1_000_000]);
-    assert_eq!(config.runs, 3);
+    assert_eq!(config.runs, 7);
     assert_eq!(config.changes, None);
     assert_eq!(config.read_samples, 10_000);
     assert_eq!(config.operations, Operation::ALL);

--- a/docs/redis-scale-benchmark.md
+++ b/docs/redis-scale-benchmark.md
@@ -1,6 +1,9 @@
 # Redis prolly scale benchmark
 
-This benchmark establishes a reproducible Redis baseline for the prolly tree's build, point put, batch mutation, cold and warm point get, batched query, bounded and full scan, diff, and three-way merge operations.
+This benchmark establishes a reproducible Redis baseline for the Redis backend's
+native batch write and the prolly tree's build, point put, batch mutation, cold
+and warm point get, batched query, bounded and full scan, diff, and three-way
+merge operations.
 
 ## Baseline contract
 
@@ -8,6 +11,10 @@ This benchmark establishes a reproducible Redis baseline for the prolly tree's b
 - Append, random, and clustered key patterns are covered. Full scan runs once per repetition because its key pattern does not change the workload.
 - Keys are 24 bytes and values are 100 bytes. The random seed, change semantics, and matrix are frozen in `run-manifest.txt`.
 - Each repetition builds one source Redis namespace. Every measured cell receives a server-side `COPY` clone under a unique namespace. Clone, cleanup, branch setup, validation, publication, persistence checks, and statistics are outside the timed interval.
+- `backend_batch` times `RedisBackend::batch_put_nodes` directly with 32-byte
+  synthetic CIDs and 100-byte values, then validates every value outside the
+  timed interval. It isolates adapter command encoding and Redis durability from
+  Prolly tree computation.
 
 ## Strong durability
 

--- a/docs/redis-scale-benchmark.md
+++ b/docs/redis-scale-benchmark.md
@@ -4,7 +4,7 @@ This benchmark establishes a reproducible Redis baseline for the prolly tree's b
 
 ## Baseline contract
 
-- The default full profile builds 1,000,000 deterministic records, applies 300,000 changes (30%), performs 10,000 reads or bounded-scan rows, and runs three independent repetitions.
+- The default full profile builds 1,000,000 deterministic records, applies 300,000 changes (30%), performs 10,000 reads or bounded-scan rows, and runs seven independent repetitions.
 - Append, random, and clustered key patterns are covered. Full scan runs once per repetition because its key pattern does not change the workload.
 - Keys are 24 bytes and values are 100 bytes. The random seed, change semantics, and matrix are frozen in `run-manifest.txt`.
 - Each repetition builds one source Redis namespace. Every measured cell receives a server-side `COPY` clone under a unique namespace. Clone, cleanup, branch setup, validation, publication, persistence checks, and statistics are outside the timed interval.

--- a/docs/redis-scale-benchmark.md
+++ b/docs/redis-scale-benchmark.md
@@ -27,7 +27,7 @@ scripts/run_redis_scale_benchmark.sh --profile full \
   --output performance-results/redis/baseline
 ```
 
-The runner chooses an unused localhost port, verifies Redis readiness, builds a release binary, records source and binary checksums, captures Docker/image/configuration/system provenance, and removes its container and volume after the run. Set `REDIS_BENCH_KEEP_CONTAINER=1` or `REDIS_BENCH_KEEP_FIXTURES=1` only for debugging.
+The runner chooses an unused localhost port, verifies Redis readiness, builds a release binary, records source and binary checksums, captures Docker/image/configuration/system provenance, and removes its container and volume after the run. It fingerprints the tracked source revision and binary diff before the build, then verifies that fingerprint after the build, dependency capture, and benchmark execution. It fails instead of publishing mixed-revision evidence if a shared checkout changes mid-run. Set `REDIS_BENCH_KEEP_CONTAINER=1` or `REDIS_BENCH_KEEP_FIXTURES=1` only for debugging.
 
 The full output belongs under `performance-results/redis/baseline`. `raw-results.csv` contains one validated row per cell and repetition, `fixture-results.csv` contains build measurements, `summary.csv` contains medians, and `report.md` is the human-readable baseline.
 

--- a/scripts/run_redis_scale_benchmark.sh
+++ b/scripts/run_redis_scale_benchmark.sh
@@ -36,7 +36,7 @@ case "$PROFILE" in
     ;;
   full)
     SIZES="${REDIS_BENCH_SIZES:-1000000}"
-    RUNS="${REDIS_BENCH_RUNS:-3}"
+    RUNS="${REDIS_BENCH_RUNS:-7}"
     CHANGES="${REDIS_BENCH_CHANGES:-auto}"
     READ_SAMPLES="${REDIS_BENCH_READ_SAMPLES:-10000}"
     MIN_FREE_GB="${REDIS_BENCH_MIN_FREE_GB:-3}"
@@ -90,7 +90,7 @@ fi
 REDIS_URL="redis://127.0.0.1:$REDIS_PORT/"
 
 REVISION="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || printf unknown)"
-if [[ -n "$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null || true)" ]]; then
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain --untracked-files=no 2>/dev/null || true)" ]]; then
   DIRTY=true
   DIRTY_ARG=--dirty
 else

--- a/scripts/run_redis_scale_benchmark.sh
+++ b/scripts/run_redis_scale_benchmark.sh
@@ -90,7 +90,11 @@ fi
 REDIS_URL="redis://127.0.0.1:$REDIS_PORT/"
 
 REVISION="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || printf unknown)"
-if [[ -n "$(git -C "$REPO_ROOT" status --porcelain --untracked-files=no 2>/dev/null || true)" ]]; then
+SOURCE_DIFF_SHA256="$(
+  git -C "$REPO_ROOT" diff --binary HEAD | shasum -a 256 | awk '{print $1}'
+)"
+TRACKED_STATUS="$(git -C "$REPO_ROOT" status --porcelain --untracked-files=no 2>/dev/null || true)"
+if [[ -n "$TRACKED_STATUS" ]]; then
   DIRTY=true
   DIRTY_ARG=--dirty
 else
@@ -98,6 +102,24 @@ else
   DIRTY_ARG=--clean
 fi
 STARTED_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+assert_source_stable() {
+  local checkpoint="$1"
+  local current_revision
+  local current_diff_sha256
+  current_revision="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || printf unknown)"
+  current_diff_sha256="$(
+    git -C "$REPO_ROOT" diff --binary HEAD | shasum -a 256 | awk '{print $1}'
+  )"
+  if [[ "$current_revision" != "$REVISION" || "$current_diff_sha256" != "$SOURCE_DIFF_SHA256" ]]; then
+    printf 'tracked benchmark source changed during %s; refusing mixed-revision evidence\n' \
+      "$checkpoint" >&2
+    printf 'start revision=%s diff_sha256=%s\n' "$REVISION" "$SOURCE_DIFF_SHA256" >&2
+    printf 'current revision=%s diff_sha256=%s\n' \
+      "$current_revision" "$current_diff_sha256" >&2
+    exit 1
+  fi
+}
 
 {
   printf 'captured_utc=%s\n' "$STARTED_UTC"
@@ -128,8 +150,10 @@ if [[ "${REDIS_BENCH_SKIP_BUILD:-0}" != 1 ]]; then
   CARGO_INCREMENTAL=0 cargo build --release --manifest-path "$MANIFEST" \
     2>&1 | tee "$OUTPUT/build.log"
 fi
+assert_source_stable "release build"
 cargo tree --manifest-path "$MANIFEST" > "$OUTPUT/dependencies.txt"
 cargo tree --manifest-path "$MANIFEST" -e features > "$OUTPUT/dependency-features.txt"
+assert_source_stable "dependency capture"
 
 if [[ -n "${REDIS_BENCH_EXECUTABLE:-}" ]]; then
   EXECUTABLE="$REDIS_BENCH_EXECUTABLE"
@@ -177,6 +201,7 @@ fi
 } > "$OUTPUT/driver-provenance.txt"
 
 "$EXECUTABLE" "${ARGS[@]}" 2>&1 | tee "$OUTPUT/run.log"
+assert_source_stable "benchmark execution"
 docker exec "$CONTAINER_ID" redis-cli INFO memory persistence > "$OUTPUT/redis-info-after.txt"
 printf 'ended_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$OUTPUT/driver-provenance.txt"
 

--- a/scripts/run_redis_scale_benchmark.sh
+++ b/scripts/run_redis_scale_benchmark.sh
@@ -47,7 +47,7 @@ case "$PROFILE" in
     ;;
 esac
 
-OPERATIONS="${REDIS_BENCH_OPERATIONS:-put,batch,get_cold,get_warm,query,scan,full_scan,diff,merge}"
+OPERATIONS="${REDIS_BENCH_OPERATIONS:-backend_batch,put,batch,get_cold,get_warm,query,scan,full_scan,diff,merge}"
 PATTERNS="${REDIS_BENCH_PATTERNS:-append,random,clustered}"
 TOKIO_WORKERS="${REDIS_BENCH_TOKIO_WORKERS:-4}"
 PROJECT="prolly-redis-bench-$$"

--- a/stores/prolly-store-redis/README.md
+++ b/stores/prolly-store-redis/README.md
@@ -164,7 +164,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 `RedisBackend::connect` creates separate multiplexed physical connections for
 latency-sensitive roots/CAS operations and bulk node traffic. Batch reads and
 writes are bounded by both item count and approximate payload size, so large
-publishes do not become one unbounded Redis request. Multi-command writes still
+publishes do not become one unbounded multi-key command. Multi-command writes still
 use `MULTI`/`EXEC` to preserve whole-batch atomicity.
 
 Use `RedisBackendOptions` when service latency, payload sizes, or managed Redis
@@ -200,11 +200,11 @@ path discovery for append-heavy workloads. Disable this extra hint write with
 synchronous value-reclamation stalls caused by large `DEL` cleanup commands.
 It remains an administrative/test operation, not a request-path primitive.
 
-The adapter targets standalone Redis, Sentinel-backed endpoints exposed as one
-Redis URL, and compatible managed-service URLs. Redis Cluster requires all keys
-in a Lua script or multi-key command to share a hash slot; the default key
-layout does not promise that. Do not point this adapter at a sharded Redis
-Cluster endpoint until a deliberate hash-tag/partitioning strategy is chosen.
+The adapter targets standalone Redis primary endpoints and compatible
+managed-service URLs. Redis Cluster requires all keys in a Lua script or
+multi-key command to share a hash slot; the default key layout does not promise
+that. Do not point this adapter at a sharded Redis Cluster endpoint until a
+deliberate hash-tag/partitioning strategy is chosen.
 
 ## Transactions and durability
 

--- a/stores/prolly-store-redis/README.md
+++ b/stores/prolly-store-redis/README.md
@@ -34,8 +34,8 @@ The adapter stores three logical families under a configurable binary key prefix
 - `root:` named root manifests for durable branch/checkpoint names.
 - `hint:` optional traversal hints, such as the append rightmost-path hint.
 
-Redis operations used by the adapter include `GET`, `SET`, `DEL`, `MGET`,
-`SCAN`, and pipelined writes.
+Redis operations used by the adapter include `GET`, `SET`, `DEL`, bounded
+`MGET`/`MSET`, `SCAN`, `UNLINK`, and atomic pipelined writes.
 
 ## Setup
 
@@ -158,6 +158,53 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
+
+## Performance and operational tuning
+
+`RedisBackend::connect` creates separate multiplexed physical connections for
+latency-sensitive roots/CAS operations and bulk node traffic. Batch reads and
+writes are bounded by both item count and approximate payload size, so large
+publishes do not become one unbounded Redis request. Multi-command writes still
+use `MULTI`/`EXEC` to preserve whole-batch atomicity.
+
+Use `RedisBackendOptions` when service latency, payload sizes, or managed Redis
+limits require explicit tuning:
+
+```rust
+use std::time::Duration;
+use prolly_store_redis::{RedisBackend, RedisBackendOptions};
+
+async fn connect() -> Result<RedisBackend, Box<dyn std::error::Error>> {
+    let options = RedisBackendOptions::default()
+        .with_max_batch_items(512)
+        .with_max_batch_bytes(4 * 1024 * 1024)
+        .with_read_parallelism(32)
+        .with_scan_count(2048)
+        .with_response_timeout(Duration::from_secs(2))
+        .with_connection_timeout(Duration::from_secs(2));
+
+    Ok(RedisBackend::connect_with_options(
+        "redis://127.0.0.1:56379/",
+        options,
+    )
+    .await?)
+}
+```
+
+The defaults cap each multi-key command at 1,024 items and approximately 8 MiB.
+They also maintain persisted rightmost-path hints, which avoid repeated remote
+path discovery for append-heavy workloads. Disable this extra hint write with
+`with_rightmost_path_hints(false)` when the workload is not append-oriented.
+
+`clear_namespace` uses incremental `SCAN` plus chunked `UNLINK`, avoiding the
+synchronous value-reclamation stalls caused by large `DEL` cleanup commands.
+It remains an administrative/test operation, not a request-path primitive.
+
+The adapter targets standalone Redis, Sentinel-backed endpoints exposed as one
+Redis URL, and compatible managed-service URLs. Redis Cluster requires all keys
+in a Lua script or multi-key command to share a hash slot; the default key
+layout does not promise that. Do not point this adapter at a sharded Redis
+Cluster endpoint until a deliberate hash-tag/partitioning strategy is chosen.
 
 ## Transactions and durability
 

--- a/stores/prolly-store-redis/src/lib.rs
+++ b/stores/prolly-store-redis/src/lib.rs
@@ -7,6 +7,8 @@ pub use prolly::{
 
 /// Redis adapter entry point.
 pub mod redis {
+    use std::{collections::HashSet, ops::Range, sync::LazyLock, time::Duration};
+
     use redis_client::{ErrorKind, RedisError, Script, Value};
 
     use crate::{
@@ -23,16 +25,140 @@ pub mod redis {
     /// Redis-backed prolly node/root backend.
     #[derive(Clone)]
     pub struct RedisBackend {
-        connection: redis_client::aio::ConnectionManager,
+        control_connection: redis_client::aio::ConnectionManager,
+        bulk_connection: redis_client::aio::ConnectionManager,
         key_prefix: Vec<u8>,
+        options: RedisBackendOptions,
+    }
+
+    /// Operational limits and connection settings for [`RedisBackend`].
+    ///
+    /// Bounded multi-key commands avoid oversized request buffers and long
+    /// single-threaded Redis stalls. Connections created by
+    /// [`RedisBackend::connect_with_options`] also apply the configured
+    /// timeouts.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub struct RedisBackendOptions {
+        max_batch_items: usize,
+        max_batch_bytes: usize,
         read_parallelism: usize,
+        scan_count: usize,
+        delete_chunk_size: usize,
+        response_timeout: Option<Duration>,
+        connection_timeout: Option<Duration>,
+        rightmost_path_hints: bool,
+    }
+
+    impl Default for RedisBackendOptions {
+        fn default() -> Self {
+            Self {
+                max_batch_items: DEFAULT_MAX_BATCH_ITEMS,
+                max_batch_bytes: DEFAULT_MAX_BATCH_BYTES,
+                read_parallelism: DEFAULT_READ_PARALLELISM,
+                scan_count: DEFAULT_SCAN_COUNT,
+                delete_chunk_size: DEFAULT_DELETE_CHUNK_SIZE,
+                response_timeout: None,
+                connection_timeout: None,
+                rightmost_path_hints: true,
+            }
+        }
+    }
+
+    impl RedisBackendOptions {
+        /// Limit the number of items encoded in one Redis multi-key command.
+        pub fn with_max_batch_items(mut self, max_batch_items: usize) -> Self {
+            self.max_batch_items = max_batch_items.max(1);
+            self
+        }
+
+        /// Limit the approximate key/value payload in one multi-key command.
+        pub fn with_max_batch_bytes(mut self, max_batch_bytes: usize) -> Self {
+            self.max_batch_bytes = max_batch_bytes.max(1);
+            self
+        }
+
+        /// Set the read parallelism advertised to async prolly traversals.
+        pub fn with_read_parallelism(mut self, read_parallelism: usize) -> Self {
+            self.read_parallelism = read_parallelism.max(1);
+            self
+        }
+
+        /// Set the approximate number of keys requested from each `SCAN`.
+        pub fn with_scan_count(mut self, scan_count: usize) -> Self {
+            self.scan_count = scan_count.max(1);
+            self
+        }
+
+        /// Set the maximum number of keys passed to each namespace cleanup.
+        pub fn with_delete_chunk_size(mut self, delete_chunk_size: usize) -> Self {
+            self.delete_chunk_size = delete_chunk_size.max(1);
+            self
+        }
+
+        /// Set the maximum time to await a Redis response.
+        pub fn with_response_timeout(mut self, response_timeout: Duration) -> Self {
+            self.response_timeout = Some(response_timeout);
+            self
+        }
+
+        /// Set the maximum time for each Redis connection attempt.
+        pub fn with_connection_timeout(mut self, connection_timeout: Duration) -> Self {
+            self.connection_timeout = Some(connection_timeout);
+            self
+        }
+
+        /// Enable or disable persisted rightmost-path hints for append-heavy writes.
+        pub fn with_rightmost_path_hints(mut self, enabled: bool) -> Self {
+            self.rightmost_path_hints = enabled;
+            self
+        }
+
+        /// Maximum items encoded in one Redis multi-key command.
+        pub fn max_batch_items(&self) -> usize {
+            self.max_batch_items
+        }
+
+        /// Approximate maximum payload encoded in one Redis multi-key command.
+        pub fn max_batch_bytes(&self) -> usize {
+            self.max_batch_bytes
+        }
+
+        /// Read parallelism advertised to async prolly traversals.
+        pub fn read_parallelism(&self) -> usize {
+            self.read_parallelism
+        }
+
+        /// Approximate number of keys requested from each `SCAN`.
+        pub fn scan_count(&self) -> usize {
+            self.scan_count
+        }
+
+        /// Maximum keys passed to each namespace cleanup command.
+        pub fn delete_chunk_size(&self) -> usize {
+            self.delete_chunk_size
+        }
+
+        /// Configured Redis response timeout.
+        pub fn response_timeout(&self) -> Option<Duration> {
+            self.response_timeout
+        }
+
+        /// Configured Redis connection timeout.
+        pub fn connection_timeout(&self) -> Option<Duration> {
+            self.connection_timeout
+        }
+
+        /// Whether append-heavy writes maintain rightmost-path hints.
+        pub fn rightmost_path_hints(&self) -> bool {
+            self.rightmost_path_hints
+        }
     }
 
     impl std::fmt::Debug for RedisBackend {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.debug_struct("RedisBackend")
                 .field("key_prefix", &self.key_prefix)
-                .field("read_parallelism", &self.read_parallelism)
+                .field("options", &self.options)
                 .finish_non_exhaustive()
         }
     }
@@ -40,27 +166,82 @@ pub mod redis {
     impl RedisBackend {
         /// Create a backend from an existing Redis connection manager.
         pub fn new(connection: redis_client::aio::ConnectionManager) -> Self {
-            Self {
+            Self::new_with_options(
+                connection.clone(),
                 connection,
+                RedisBackendOptions::default(),
+            )
+        }
+
+        /// Create a backend with separate control and bulk connection managers.
+        ///
+        /// Supplying distinct managers prevents large scans and multi-key
+        /// commands from queueing latency-sensitive root operations behind
+        /// them on the same physical connection.
+        pub fn new_with_options(
+            control_connection: redis_client::aio::ConnectionManager,
+            bulk_connection: redis_client::aio::ConnectionManager,
+            options: RedisBackendOptions,
+        ) -> Self {
+            Self {
+                control_connection,
+                bulk_connection,
                 key_prefix: DEFAULT_KEY_PREFIX.to_vec(),
-                read_parallelism: DEFAULT_READ_PARALLELISM,
+                options,
             }
         }
 
         /// Connect to Redis using `redis_url`.
         pub async fn connect(redis_url: &str) -> Result<Self, RedisError> {
+            Self::connect_with_options(redis_url, RedisBackendOptions::default()).await
+        }
+
+        /// Connect to Redis using `redis_url` and explicit operational options.
+        pub async fn connect_with_options(
+            redis_url: &str,
+            options: RedisBackendOptions,
+        ) -> Result<Self, RedisError> {
             let client = redis_client::Client::open(redis_url)?;
-            Self::from_client(client).await
+            Self::from_client_with_options(client, options).await
         }
 
         /// Create a backend from an existing Redis client.
         pub async fn from_client(client: redis_client::Client) -> Result<Self, RedisError> {
-            Ok(Self::new(client.get_connection_manager().await?))
+            Self::from_client_with_options(client, RedisBackendOptions::default()).await
+        }
+
+        /// Create a backend from a Redis client and explicit operational options.
+        pub async fn from_client_with_options(
+            client: redis_client::Client,
+            options: RedisBackendOptions,
+        ) -> Result<Self, RedisError> {
+            let connection_config = connection_manager_config(&options);
+            let control_connection = client
+                .get_connection_manager_with_config(connection_config.clone())
+                .await?;
+            let bulk_connection = client
+                .get_connection_manager_with_config(connection_config)
+                .await?;
+            Ok(Self::new_with_options(
+                control_connection,
+                bulk_connection,
+                options,
+            ))
         }
 
         /// Borrow the underlying connection manager.
         pub fn connection(&self) -> &redis_client::aio::ConnectionManager {
-            &self.connection
+            &self.control_connection
+        }
+
+        /// Borrow the connection manager used for scans and multi-key commands.
+        pub fn bulk_connection(&self) -> &redis_client::aio::ConnectionManager {
+            &self.bulk_connection
+        }
+
+        /// Return this backend's operational options.
+        pub fn options(&self) -> &RedisBackendOptions {
+            &self.options
         }
 
         /// Return the namespace prefix prepended to all Redis keys.
@@ -78,7 +259,7 @@ pub mod redis {
 
         /// Set the read parallelism advertised to async prolly traversals.
         pub fn with_read_parallelism(mut self, read_parallelism: usize) -> Self {
-            self.read_parallelism = read_parallelism.max(1);
+            self.options.read_parallelism = read_parallelism.max(1);
             self
         }
 
@@ -133,7 +314,7 @@ pub mod redis {
         }
 
         async fn scan_keys(&self, pattern: &[u8]) -> Result<Vec<Vec<u8>>, RedisError> {
-            let mut connection = self.connection.clone();
+            let mut connection = self.bulk_connection.clone();
             let mut cursor = 0_u64;
             let mut keys = Vec::new();
 
@@ -143,7 +324,7 @@ pub mod redis {
                     .arg("MATCH")
                     .arg(pattern)
                     .arg("COUNT")
-                    .arg(SCAN_COUNT)
+                    .arg(self.options.scan_count)
                     .query_async(&mut connection)
                     .await?;
                 keys.extend(batch);
@@ -161,9 +342,9 @@ pub mod redis {
                 return Ok(());
             }
 
-            let mut connection = self.connection.clone();
-            for chunk in keys.chunks(DELETE_CHUNK_SIZE) {
-                let mut command = redis_client::cmd("DEL");
+            let mut connection = self.bulk_connection.clone();
+            for chunk in keys.chunks(self.options.delete_chunk_size) {
+                let mut command = redis_client::cmd("UNLINK");
                 for key in chunk {
                     command.arg(key.as_slice());
                 }
@@ -171,13 +352,43 @@ pub mod redis {
             }
             Ok(())
         }
+
+        fn command_ranges<F>(&self, len: usize, item_bytes: F) -> Vec<Range<usize>>
+        where
+            F: Fn(usize) -> usize,
+        {
+            bounded_ranges(
+                len,
+                self.options.max_batch_items,
+                self.options.max_batch_bytes,
+                item_bytes,
+            )
+        }
+
+        async fn mget_raw_keys(
+            &self,
+            keys: &[Vec<u8>],
+        ) -> Result<Vec<Option<Vec<u8>>>, RedisError> {
+            let ranges = self.command_ranges(keys.len(), |index| keys[index].len());
+            let mut values = Vec::with_capacity(keys.len());
+            let mut connection = self.bulk_connection.clone();
+            for range in ranges {
+                let mut command = redis_client::cmd("MGET");
+                for key in &keys[range] {
+                    command.arg(key.as_slice());
+                }
+                let mut chunk: Vec<Option<Vec<u8>>> = command.query_async(&mut connection).await?;
+                values.append(&mut chunk);
+            }
+            Ok(values)
+        }
     }
 
     impl RemoteStoreBackend for RedisBackend {
         type Error = RedisError;
 
         async fn get_node(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
-            let mut connection = self.connection.clone();
+            let mut connection = self.bulk_connection.clone();
             redis_client::cmd("GET")
                 .arg(self.node_key(key))
                 .query_async(&mut connection)
@@ -185,7 +396,7 @@ pub mod redis {
         }
 
         async fn put_node(&self, key: &[u8], value: &[u8]) -> Result<(), Self::Error> {
-            let mut connection = self.connection.clone();
+            let mut connection = self.bulk_connection.clone();
             redis_client::cmd("SET")
                 .arg(self.node_key(key))
                 .arg(value)
@@ -194,7 +405,7 @@ pub mod redis {
         }
 
         async fn delete_node(&self, key: &[u8]) -> Result<(), Self::Error> {
-            let mut connection = self.connection.clone();
+            let mut connection = self.bulk_connection.clone();
             redis_client::cmd("DEL")
                 .arg(self.node_key(key))
                 .query_async::<()>(&mut connection)
@@ -206,24 +417,78 @@ pub mod redis {
                 return Ok(());
             }
 
-            let mut pipeline = redis_client::pipe();
-            pipeline.atomic();
-            for op in ops {
-                match op {
-                    RemoteBatchOp::Upsert { key, value } => {
-                        pipeline
-                            .cmd("SET")
-                            .arg(self.node_key(key))
-                            .arg(*value)
-                            .ignore();
-                    }
-                    RemoteBatchOp::Delete { key } => {
-                        pipeline.cmd("DEL").arg(self.node_key(key)).ignore();
-                    }
+            // Redis applies commands in a transaction sequentially. Coalescing
+            // duplicate keys to the final operation preserves that behavior
+            // while avoiding redundant writes.
+            let mut seen = HashSet::with_capacity(ops.len());
+            let mut effective = Vec::with_capacity(ops.len());
+            for op in ops.iter().rev() {
+                let key = match op {
+                    RemoteBatchOp::Upsert { key, .. } | RemoteBatchOp::Delete { key } => *key,
+                };
+                if seen.insert(key) {
+                    effective.push(op);
                 }
             }
+            effective.reverse();
 
-            let mut connection = self.connection.clone();
+            let upserts = effective
+                .iter()
+                .filter_map(|op| match op {
+                    RemoteBatchOp::Upsert { key, value } => Some((*key, *value)),
+                    RemoteBatchOp::Delete { .. } => None,
+                })
+                .collect::<Vec<_>>();
+            let deletes = effective
+                .iter()
+                .filter_map(|op| match op {
+                    RemoteBatchOp::Delete { key } => Some(*key),
+                    RemoteBatchOp::Upsert { .. } => None,
+                })
+                .collect::<Vec<_>>();
+            let upsert_ranges = self.command_ranges(upserts.len(), |index| {
+                self.key_prefix.len()
+                    + NODE_FAMILY.len()
+                    + upserts[index].0.len()
+                    + upserts[index].1.len()
+            });
+            let delete_ranges = self.command_ranges(deletes.len(), |index| {
+                self.key_prefix.len() + NODE_FAMILY.len() + deletes[index].len()
+            });
+
+            let mut connection = self.bulk_connection.clone();
+            if upsert_ranges.len() == 1 && delete_ranges.is_empty() {
+                let mut command = redis_client::cmd("MSET");
+                for (key, value) in &upserts[upsert_ranges[0].clone()] {
+                    command.arg(self.node_key(key)).arg(*value);
+                }
+                return command.query_async::<()>(&mut connection).await;
+            }
+            if delete_ranges.len() == 1 && upsert_ranges.is_empty() {
+                let mut command = redis_client::cmd("DEL");
+                for key in &deletes[delete_ranges[0].clone()] {
+                    command.arg(self.node_key(key));
+                }
+                return command.query_async::<()>(&mut connection).await;
+            }
+
+            let mut pipeline = redis_client::pipe();
+            pipeline.atomic();
+            for range in upsert_ranges {
+                let command = pipeline.cmd("MSET");
+                for (key, value) in &upserts[range] {
+                    command.arg(self.node_key(key)).arg(*value);
+                }
+                command.ignore();
+            }
+            for range in delete_ranges {
+                let command = pipeline.cmd("DEL");
+                for key in &deletes[range] {
+                    command.arg(self.node_key(key));
+                }
+                command.ignore();
+            }
+
             pipeline.query_async::<()>(&mut connection).await
         }
 
@@ -231,17 +496,11 @@ pub mod redis {
             &self,
             keys: &[&[u8]],
         ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
-            if keys.is_empty() {
-                return Ok(Vec::new());
-            }
-
-            let mut command = redis_client::cmd("MGET");
-            for key in keys {
-                command.arg(self.node_key(key));
-            }
-
-            let mut connection = self.connection.clone();
-            command.query_async(&mut connection).await
+            let redis_keys = keys
+                .iter()
+                .map(|key| self.node_key(key))
+                .collect::<Vec<_>>();
+            self.mget_raw_keys(&redis_keys).await
         }
 
         async fn batch_put_nodes(&self, entries: &[(&[u8], &[u8])]) -> Result<(), Self::Error> {
@@ -249,17 +508,30 @@ pub mod redis {
                 return Ok(());
             }
 
-            let mut pipeline = redis_client::pipe();
-            pipeline.atomic();
-            for (key, value) in entries {
-                pipeline
-                    .cmd("SET")
-                    .arg(self.node_key(key))
-                    .arg(*value)
-                    .ignore();
+            let ranges = self.command_ranges(entries.len(), |index| {
+                self.key_prefix.len()
+                    + NODE_FAMILY.len()
+                    + entries[index].0.len()
+                    + entries[index].1.len()
+            });
+            let mut connection = self.bulk_connection.clone();
+            if ranges.len() == 1 {
+                let mut command = redis_client::cmd("MSET");
+                for (key, value) in entries {
+                    command.arg(self.node_key(key)).arg(*value);
+                }
+                return command.query_async::<()>(&mut connection).await;
             }
 
-            let mut connection = self.connection.clone();
+            let mut pipeline = redis_client::pipe();
+            pipeline.atomic();
+            for range in ranges {
+                let command = pipeline.cmd("MSET");
+                for (key, value) in &entries[range] {
+                    command.arg(self.node_key(key)).arg(*value);
+                }
+                command.ignore();
+            }
             pipeline.query_async::<()>(&mut connection).await
         }
 
@@ -285,11 +557,15 @@ pub mod redis {
         }
 
         fn read_parallelism(&self) -> usize {
-            self.read_parallelism
+            self.options.read_parallelism
         }
 
         fn supports_hints(&self) -> bool {
             true
+        }
+
+        fn prefers_rightmost_path_hints(&self) -> bool {
+            self.options.rightmost_path_hints
         }
 
         async fn get_hint(
@@ -297,7 +573,7 @@ pub mod redis {
             namespace: &[u8],
             key: &[u8],
         ) -> Result<Option<Vec<u8>>, Self::Error> {
-            let mut connection = self.connection.clone();
+            let mut connection = self.control_connection.clone();
             redis_client::cmd("GET")
                 .arg(self.hint_key(namespace, key))
                 .query_async(&mut connection)
@@ -310,7 +586,7 @@ pub mod redis {
             key: &[u8],
             value: &[u8],
         ) -> Result<(), Self::Error> {
-            let mut connection = self.connection.clone();
+            let mut connection = self.control_connection.clone();
             redis_client::cmd("SET")
                 .arg(self.hint_key(namespace, key))
                 .arg(value)
@@ -325,14 +601,20 @@ pub mod redis {
             key: &[u8],
             value: &[u8],
         ) -> Result<(), Self::Error> {
+            let ranges = self.command_ranges(entries.len(), |index| {
+                self.key_prefix.len()
+                    + NODE_FAMILY.len()
+                    + entries[index].0.len()
+                    + entries[index].1.len()
+            });
             let mut pipeline = redis_client::pipe();
             pipeline.atomic();
-            for (key, value) in entries {
-                pipeline
-                    .cmd("SET")
-                    .arg(self.node_key(key))
-                    .arg(*value)
-                    .ignore();
+            for range in ranges {
+                let command = pipeline.cmd("MSET");
+                for (key, value) in &entries[range] {
+                    command.arg(self.node_key(key)).arg(*value);
+                }
+                command.ignore();
             }
             pipeline
                 .cmd("SET")
@@ -340,12 +622,12 @@ pub mod redis {
                 .arg(value)
                 .ignore();
 
-            let mut connection = self.connection.clone();
+            let mut connection = self.bulk_connection.clone();
             pipeline.query_async::<()>(&mut connection).await
         }
 
         async fn get_root_manifest(&self, name: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
-            let mut connection = self.connection.clone();
+            let mut connection = self.control_connection.clone();
             redis_client::cmd("GET")
                 .arg(self.root_key(name))
                 .query_async(&mut connection)
@@ -353,7 +635,7 @@ pub mod redis {
         }
 
         async fn put_root_manifest(&self, name: &[u8], manifest: &[u8]) -> Result<(), Self::Error> {
-            let mut connection = self.connection.clone();
+            let mut connection = self.control_connection.clone();
             redis_client::cmd("SET")
                 .arg(self.root_key(name))
                 .arg(manifest)
@@ -362,7 +644,7 @@ pub mod redis {
         }
 
         async fn delete_root_manifest(&self, name: &[u8]) -> Result<(), Self::Error> {
-            let mut connection = self.connection.clone();
+            let mut connection = self.control_connection.clone();
             redis_client::cmd("DEL")
                 .arg(self.root_key(name))
                 .query_async::<()>(&mut connection)
@@ -375,8 +657,7 @@ pub mod redis {
             expected: Option<&[u8]>,
             new: Option<&[u8]>,
         ) -> Result<RemoteManifestUpdate, Self::Error> {
-            let script = Script::new(ROOT_CAS_LUA);
-            let mut invocation = script.prepare_invoke();
+            let mut invocation = ROOT_CAS_SCRIPT.prepare_invoke();
             invocation
                 .key(self.root_key(name))
                 .arg(if expected.is_some() { b"1" } else { b"0" }.as_slice())
@@ -384,7 +665,7 @@ pub mod redis {
                 .arg(if new.is_some() { b"1" } else { b"0" }.as_slice())
                 .arg(new.unwrap_or_default());
 
-            let mut connection = self.connection.clone();
+            let mut connection = self.control_connection.clone();
             let response: Value = invocation.invoke_async(&mut connection).await?;
             parse_root_cas_response(response)
         }
@@ -400,13 +681,18 @@ pub mod redis {
                 .collect::<Vec<_>>();
             names.sort();
 
-            let mut roots = Vec::with_capacity(names.len());
-            for name in names {
-                if let Some(manifest) = self.get_root_manifest(&name).await? {
-                    roots.push(RemoteNamedRoot::new(name, manifest));
-                }
-            }
-            Ok(roots)
+            let redis_keys = names
+                .iter()
+                .map(|name| self.root_key(name))
+                .collect::<Vec<_>>();
+            let manifests = self.mget_raw_keys(&redis_keys).await?;
+            Ok(names
+                .into_iter()
+                .zip(manifests)
+                .filter_map(|(name, manifest)| {
+                    manifest.map(|manifest| RemoteNamedRoot::new(name, manifest))
+                })
+                .collect())
         }
 
         fn supports_transactions(&self) -> bool {
@@ -419,8 +705,7 @@ pub mod redis {
             root_conditions: &[RemoteRootCondition],
             root_writes: &[RemoteRootWrite],
         ) -> Result<RemoteTransactionUpdate, Self::Error> {
-            let script = Script::new(TRANSACTION_COMMIT_LUA);
-            let mut invocation = script.prepare_invoke();
+            let mut invocation = TRANSACTION_COMMIT_SCRIPT.prepare_invoke();
             for condition in root_conditions {
                 invocation.key(self.root_key(&condition.name));
             }
@@ -476,10 +761,51 @@ pub mod redis {
                 }
             }
 
-            let mut connection = self.connection.clone();
+            let mut connection = self.control_connection.clone();
             let response: Value = invocation.invoke_async(&mut connection).await?;
             parse_transaction_response(response, root_conditions)
         }
+    }
+
+    fn connection_manager_config(
+        options: &RedisBackendOptions,
+    ) -> redis_client::aio::ConnectionManagerConfig {
+        let mut config = redis_client::aio::ConnectionManagerConfig::new();
+        if let Some(timeout) = options.response_timeout {
+            config = config.set_response_timeout(timeout);
+        }
+        if let Some(timeout) = options.connection_timeout {
+            config = config.set_connection_timeout(timeout);
+        }
+        config
+    }
+
+    fn bounded_ranges<F>(
+        len: usize,
+        max_items: usize,
+        max_bytes: usize,
+        item_bytes: F,
+    ) -> Vec<Range<usize>>
+    where
+        F: Fn(usize) -> usize,
+    {
+        let mut ranges = Vec::new();
+        let mut start = 0;
+        while start < len {
+            let mut end = start;
+            let mut bytes = 0usize;
+            while end < len && end - start < max_items {
+                let next_bytes = item_bytes(end);
+                if end > start && bytes.saturating_add(next_bytes) > max_bytes {
+                    break;
+                }
+                bytes = bytes.saturating_add(next_bytes);
+                end += 1;
+            }
+            ranges.push(start..end);
+            start = end;
+        }
+        ranges
     }
 
     fn parse_root_cas_response(response: Value) -> Result<RemoteManifestUpdate, RedisError> {
@@ -572,8 +898,10 @@ pub mod redis {
 
     const DEFAULT_KEY_PREFIX: &[u8] = b"prolly:";
     const DEFAULT_READ_PARALLELISM: usize = 16;
-    const SCAN_COUNT: usize = 1024;
-    const DELETE_CHUNK_SIZE: usize = 512;
+    const DEFAULT_MAX_BATCH_ITEMS: usize = 1024;
+    const DEFAULT_MAX_BATCH_BYTES: usize = 8 * 1024 * 1024;
+    const DEFAULT_SCAN_COUNT: usize = 1024;
+    const DEFAULT_DELETE_CHUNK_SIZE: usize = 512;
 
     const NODE_FAMILY: &[u8] = b"node:";
     const ROOT_FAMILY: &[u8] = b"root:";
@@ -585,6 +913,10 @@ pub mod redis {
     pub const ROOT_KEY_PREFIX: &str = "prolly:root:";
     /// Recommended key prefix for hints.
     pub const HINT_KEY_PREFIX: &str = "prolly:hint:";
+
+    static ROOT_CAS_SCRIPT: LazyLock<Script> = LazyLock::new(|| Script::new(ROOT_CAS_LUA));
+    static TRANSACTION_COMMIT_SCRIPT: LazyLock<Script> =
+        LazyLock::new(|| Script::new(TRANSACTION_COMMIT_LUA));
 
     const ROOT_CAS_LUA: &str = r#"
 local current = redis.call('GET', KEYS[1])
@@ -669,6 +1001,53 @@ end
 
 return {1, 0, false}
 "#;
+
+    #[cfg(test)]
+    mod tests {
+        use super::{bounded_ranges, RedisBackendOptions};
+
+        #[test]
+        fn default_options_are_bounded_and_enable_append_hints() {
+            let options = RedisBackendOptions::default();
+            assert_eq!(options.max_batch_items(), 1024);
+            assert_eq!(options.max_batch_bytes(), 8 * 1024 * 1024);
+            assert_eq!(options.read_parallelism(), 16);
+            assert_eq!(options.scan_count(), 1024);
+            assert_eq!(options.delete_chunk_size(), 512);
+            assert!(options.rightmost_path_hints());
+            assert_eq!(options.response_timeout(), None);
+            assert_eq!(options.connection_timeout(), None);
+        }
+
+        #[test]
+        fn bounded_ranges_respect_item_and_byte_limits() {
+            let sizes = [2, 3, 7, 1, 1];
+            assert_eq!(
+                bounded_ranges(sizes.len(), 3, 5, |index| sizes[index]),
+                vec![0..2, 2..3, 3..5]
+            );
+        }
+
+        #[test]
+        fn bounded_ranges_make_progress_for_one_oversized_item() {
+            assert_eq!(bounded_ranges(2, 10, 1, |_| 100), vec![0..1, 1..2]);
+        }
+
+        #[test]
+        fn zero_option_limits_are_clamped() {
+            let options = RedisBackendOptions::default()
+                .with_max_batch_items(0)
+                .with_max_batch_bytes(0)
+                .with_read_parallelism(0)
+                .with_scan_count(0)
+                .with_delete_chunk_size(0);
+            assert_eq!(options.max_batch_items(), 1);
+            assert_eq!(options.max_batch_bytes(), 1);
+            assert_eq!(options.read_parallelism(), 1);
+            assert_eq!(options.scan_count(), 1);
+            assert_eq!(options.delete_chunk_size(), 1);
+        }
+    }
 }
 
 pub use redis::*;

--- a/stores/prolly-store-redis/tests/redis_backend.rs
+++ b/stores/prolly-store-redis/tests/redis_backend.rs
@@ -14,6 +14,17 @@ fn env_var(primary: &str, legacy: &str) -> Option<String> {
         .ok()
 }
 
+fn unique_prefix(label: &str) -> Vec<u8> {
+    format!(
+        "prolly:test:{label}:{}:",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    )
+    .into_bytes()
+}
+
 #[test]
 fn redis_backend_satisfies_remote_backend_contract_when_url_is_set() {
     let Some(redis_url) = env_var("PROLLY_STORE_REDIS_URL", "PROLLY_ADAPTERS_REDIS_URL") else {
@@ -24,20 +35,151 @@ fn redis_backend_satisfies_remote_backend_contract_when_url_is_set() {
         use prolly::remote_conformance::assert_remote_backend_contract;
         use prolly_store_redis::RedisBackend;
 
-        let prefix = format!(
-            "prolly:test:{}:",
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        );
         let backend = RedisBackend::connect(&redis_url)
             .await
             .unwrap()
-            .with_key_prefix(prefix.into_bytes());
+            .with_key_prefix(unique_prefix("contract"));
 
         backend.clear_namespace().await.unwrap();
         assert_remote_backend_contract(&backend).await;
         backend.clear_namespace().await.unwrap();
+    });
+}
+
+#[test]
+fn redis_backend_bounds_bulk_commands_and_preserves_semantics_when_url_is_set() {
+    let Some(redis_url) = env_var("PROLLY_STORE_REDIS_URL", "PROLLY_ADAPTERS_REDIS_URL") else {
+        return;
+    };
+
+    runtime().block_on(async {
+        use std::time::Duration;
+
+        use prolly::{RemoteBatchOp, RemoteRootWrite, RemoteStoreBackend, RemoteTransactionUpdate};
+        use prolly_store_redis::{RedisBackend, RedisBackendOptions};
+
+        let options = RedisBackendOptions::default()
+            .with_max_batch_items(2)
+            .with_max_batch_bytes(64)
+            .with_scan_count(1)
+            .with_delete_chunk_size(1)
+            .with_read_parallelism(3)
+            .with_response_timeout(Duration::from_secs(5))
+            .with_connection_timeout(Duration::from_secs(5));
+        let backend = RedisBackend::connect_with_options(&redis_url, options)
+            .await
+            .unwrap()
+            .with_key_prefix(unique_prefix("bounded"));
+
+        assert_eq!(backend.options().max_batch_items(), 2);
+        assert_eq!(backend.read_parallelism(), 3);
+        assert!(backend.prefers_rightmost_path_hints());
+
+        let mut control = backend.connection().clone();
+        let mut bulk = backend.bulk_connection().clone();
+        let control_id: i64 = redis_client::cmd("CLIENT")
+            .arg("ID")
+            .query_async(&mut control)
+            .await
+            .unwrap();
+        let bulk_id: i64 = redis_client::cmd("CLIENT")
+            .arg("ID")
+            .query_async(&mut bulk)
+            .await
+            .unwrap();
+        assert_ne!(control_id, bulk_id);
+
+        let entries = [
+            (b"a".as_slice(), b"one".as_slice()),
+            (b"b".as_slice(), b"two".as_slice()),
+            (b"c".as_slice(), b"three".as_slice()),
+            (b"d".as_slice(), b"four".as_slice()),
+            (b"e".as_slice(), b"five".as_slice()),
+        ];
+        backend.batch_put_nodes(&entries).await.unwrap();
+        let keys = [
+            b"e".as_slice(),
+            b"missing".as_slice(),
+            b"a".as_slice(),
+            b"c".as_slice(),
+            b"b".as_slice(),
+        ];
+        assert_eq!(
+            backend.batch_get_nodes_ordered(&keys).await.unwrap(),
+            vec![
+                Some(b"five".to_vec()),
+                None,
+                Some(b"one".to_vec()),
+                Some(b"three".to_vec()),
+                Some(b"two".to_vec()),
+            ]
+        );
+
+        backend
+            .batch_nodes(&[
+                RemoteBatchOp::Upsert {
+                    key: b"a",
+                    value: b"stale",
+                },
+                RemoteBatchOp::Delete { key: b"a" },
+                RemoteBatchOp::Delete { key: b"b" },
+                RemoteBatchOp::Upsert {
+                    key: b"b",
+                    value: b"latest",
+                },
+            ])
+            .await
+            .unwrap();
+        assert_eq!(backend.get_node(b"a").await.unwrap(), None);
+        assert_eq!(
+            backend.get_node(b"b").await.unwrap(),
+            Some(b"latest".to_vec())
+        );
+
+        for index in (0..5).rev() {
+            backend
+                .put_root_manifest(
+                    format!("root-{index}").as_bytes(),
+                    format!("manifest-{index}").as_bytes(),
+                )
+                .await
+                .unwrap();
+        }
+        let roots = backend.list_root_manifests().await.unwrap();
+        assert_eq!(
+            roots
+                .iter()
+                .map(|root| root.name.as_slice())
+                .collect::<Vec<_>>(),
+            vec![
+                b"root-0".as_slice(),
+                b"root-1".as_slice(),
+                b"root-2".as_slice(),
+                b"root-3".as_slice(),
+                b"root-4".as_slice(),
+            ]
+        );
+
+        assert_eq!(
+            backend
+                .commit_transaction(
+                    &[RemoteBatchOp::Upsert {
+                        key: b"transaction-node",
+                        value: b"value",
+                    }],
+                    &[],
+                    &[RemoteRootWrite::Put {
+                        name: b"transaction-root".to_vec(),
+                        manifest: b"manifest".to_vec(),
+                    }],
+                )
+                .await
+                .unwrap(),
+            RemoteTransactionUpdate::Applied
+        );
+
+        backend.clear_namespace().await.unwrap();
+        assert!(backend.list_node_cids().await.unwrap().is_empty());
+        assert!(backend.list_root_manifests().await.unwrap().is_empty());
     });
 }

--- a/stores/prolly-store-redis/tests/redis_backend.rs
+++ b/stores/prolly-store-redis/tests/redis_backend.rs
@@ -32,7 +32,9 @@ fn redis_backend_satisfies_remote_backend_contract_when_url_is_set() {
     };
 
     runtime().block_on(async {
-        use prolly::remote_conformance::assert_remote_backend_contract;
+        use prolly::remote_conformance::{
+            assert_remote_backend_contract, assert_remote_backend_transaction_contract,
+        };
         use prolly_store_redis::RedisBackend;
 
         let backend = RedisBackend::connect(&redis_url)
@@ -42,6 +44,7 @@ fn redis_backend_satisfies_remote_backend_contract_when_url_is_set() {
 
         backend.clear_namespace().await.unwrap();
         assert_remote_backend_contract(&backend).await;
+        assert_remote_backend_transaction_contract(&backend).await;
         backend.clear_namespace().await.unwrap();
     });
 }
@@ -55,7 +58,10 @@ fn redis_backend_bounds_bulk_commands_and_preserves_semantics_when_url_is_set() 
     runtime().block_on(async {
         use std::time::Duration;
 
-        use prolly::{RemoteBatchOp, RemoteRootWrite, RemoteStoreBackend, RemoteTransactionUpdate};
+        use prolly::{
+            RemoteBatchOp, RemoteManifestUpdate, RemoteRootWrite, RemoteStoreBackend,
+            RemoteTransactionUpdate,
+        };
         use prolly_store_redis::{RedisBackend, RedisBackendOptions};
 
         let options = RedisBackendOptions::default()
@@ -159,6 +165,32 @@ fn redis_backend_bounds_bulk_commands_and_preserves_semantics_when_url_is_set() 
                 b"root-4".as_slice(),
             ]
         );
+
+        let mut contenders = Vec::new();
+        for index in 0..32 {
+            let contender = backend.clone();
+            contenders.push(tokio::spawn(async move {
+                contender
+                    .compare_and_swap_root_manifest(
+                        b"contended-root",
+                        None,
+                        Some(format!("contender-{index}").as_bytes()),
+                    )
+                    .await
+                    .unwrap()
+            }));
+        }
+        let mut applied = 0;
+        let mut conflicts = 0;
+        for contender in contenders {
+            match contender.await.unwrap() {
+                RemoteManifestUpdate::Applied => applied += 1,
+                RemoteManifestUpdate::Conflict { current: Some(_) } => conflicts += 1,
+                other => panic!("unexpected contended CAS result: {other:?}"),
+            }
+        }
+        assert_eq!(applied, 1);
+        assert_eq!(conflicts, 31);
 
         assert_eq!(
             backend


### PR DESCRIPTION
## Summary

- add configurable Redis batch bounds, scan/cleanup limits, traversal parallelism, and connection/response timeouts
- isolate latency-sensitive root/CAS traffic from bulk node traffic with separate connection managers
- aggregate node writes with bounded `MSET`, bound ordered `MGET`, cache Lua scripts, batch root loading, and use chunked `UNLINK` cleanup
- enable persisted rightmost-path hints by default with an opt-out
- preserve whole-batch atomicity and last-write-wins behavior for duplicate mixed operations
- add direct `backend_batch` scale coverage and fail benchmark runs if tracked source changes mid-run
- expand live Redis coverage for bounded commands, transactions, and 32-way CAS contention
- document tuning and the explicit Redis Cluster limitation

## Performance

Focused local Docker comparison using Redis 7.4.2, 100,000 base records, 30,000 writes, seven independent repetitions, and AOF `appendfsync always`:

| Workload | Before | After | Change |
|---|---:|---:|---:|
| Direct adapter append batch | 321,625 ops/s | 464,705 ops/s | +44.49% |
| Direct adapter random batch | 301,410 ops/s | 464,487 ops/s | +54.10% |
| Direct adapter clustered batch | 310,904 ops/s | 461,293 ops/s | +48.37% |
| End-to-end Prolly append batch | 560,666 ops/s | 618,011 ops/s | +10.23% |
| End-to-end Prolly random batch | 116,640 ops/s | 124,260 ops/s | +6.53% |
| End-to-end Prolly clustered batch | 327,054 ops/s | 322,551 ops/s | -1.38% |

The clustered end-to-end movement overlaps the observed run spread and is treated as neutral rather than a confirmed regression. Each evidence run records a clean Git revision and frozen workload manifest.

## Validation

- live Redis unit and integration tests, including common and transaction conformance
- 32-way contended CAS test: one applied update and 31 conflicts
- Redis adapter doctests
- nine Redis scale harness tests
- clippy with warnings denied for the adapter and benchmark crates
- shell syntax, whitespace, and clean tracked-worktree checks

## Compatibility

The adapter supports standalone Redis primary endpoints and compatible managed-service URLs. The current key layout does not guarantee a shared hash slot, so sharded Redis Cluster endpoints remain explicitly unsupported.
