### PR TITLE
Harden Cosmos DB and Spanner adapters with reproducible benchmarks

### DIFF
--- a/benchmarks/BACKEND_COMPARISON.md
+++ b/benchmarks/BACKEND_COMPARISON.md
@@ -52,6 +52,48 @@ The SQL result directory adds:
 - `service-comparison.csv`: paired service statistics
 - `service-report.md`: batch, concurrent-read, and root-contention comparison
 
+## Spanner vs PostgreSQL
+
+Run the reproducible local comparison with pinned Cloud Spanner emulator and
+PostgreSQL containers:
+
+```bash
+./scripts/run_spanner_postgres_comparison.sh
+```
+
+The driver uses the same seeded public Prolly and adapter service workloads,
+validation digests, excluded warm-up, seven-or-more alternating repetitions,
+median/MAD/CV statistics, and paired bootstrap confidence intervals as the
+other backend comparisons. Each backend gets a freshly recreated service for
+every invocation.
+
+Tune a local comparison with `BENCH_RECORDS`, `BENCH_VALUE_BYTES`,
+`BENCH_CHANGES`, `BENCH_SAMPLES`, `BENCH_CONCURRENCY`, `BENCH_POOL_SIZE`,
+`BENCH_ADAPTER_BATCH_ITEMS`, and `BENCH_RUNS`.
+
+Managed PostgreSQL and Cloud Spanner are supported through disposable
+benchmark databases:
+
+```bash
+BENCH_MODE=external \
+BENCH_EXTERNAL_RESET_ACK=I_UNDERSTAND_BENCHMARK_DATA_WILL_BE_DELETED \
+BENCH_EXTERNAL_POSTGRES_IDENTITY='provider/postgres/version/config' \
+BENCH_EXTERNAL_SPANNER_IDENTITY='project/instance/config/nodes/region' \
+PROLLY_BACKEND_POSTGRES_URL='postgres://…' \
+PROLLY_BACKEND_SPANNER_DATABASE='projects/…/instances/…/databases/…' \
+./scripts/run_spanner_postgres_comparison.sh
+```
+
+External mode uses Application Default Credentials for Spanner and deletes all
+rows in the three Prolly tables before each invocation. Use only isolated,
+disposable databases.
+
+The local emulator is useful for deterministic adapter correctness and
+regression measurements, but it serializes read-write transactions and does
+not model production Spanner latency, replication, scaling, IAM, or cost.
+Therefore local results compare adapter paths under emulation; they are not a
+managed-service performance claim.
+
 ## PostgreSQL vs DynamoDB Local
 
 The backend comparison runs byte-identical public Prolly operations against fresh local PostgreSQL and DynamoDB Local containers. It validates complete logical outcomes after timing and refuses incomplete, dirty, resumed, or mismatched evidence.

--- a/benchmarks/backend-comparison/Cargo.toml
+++ b/benchmarks/backend-comparison/Cargo.toml
@@ -10,16 +10,19 @@ publish = false
 [features]
 default = ["dynamodb"]
 dynamodb = ["dep:aws-sdk-dynamodb", "dep:prolly-store-dynamodb"]
+spanner = ["dep:google-cloud-spanner", "dep:prolly-store-spanner"]
 
 [dependencies]
 aws-sdk-dynamodb = { version = "=1.73.0", optional = true }
 csv = "1.3"
 futures-util = "0.3"
+google-cloud-spanner = { package = "gcloud-spanner", version = "=1.8.1", optional = true }
 prolly = { package = "prolly-map", path = "../..", features = ["async-store"] }
 prolly-backend-workload-contract = { path = "../backend-workload-contract" }
 prolly-store-dynamodb = { path = "../../stores/prolly-store-dynamodb", optional = true }
 prolly-store-mysql = { path = "../../stores/prolly-store-mysql" }
 prolly-store-postgres = { path = "../../stores/prolly-store-postgres" }
+prolly-store-spanner = { path = "../../stores/prolly-store-spanner", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 sqlx = { version = "0.8", default-features = false, features = ["mysql", "postgres", "runtime-tokio"] }
 tokio = { version = "1.45", features = ["macros", "rt-multi-thread", "time"] }
@@ -47,7 +50,17 @@ required-features = ["dynamodb"]
 name = "prolly-backend-summarize"
 path = "src/bin/summarize.rs"
 
+[[bin]]
+name = "prolly-backend-spanner"
+path = "src/bin/spanner.rs"
+required-features = ["spanner"]
+
 [[test]]
 name = "dynamodb_smoke"
 path = "tests/dynamodb_smoke.rs"
 required-features = ["dynamodb"]
+
+[[test]]
+name = "spanner_smoke"
+path = "tests/spanner_smoke.rs"
+required-features = ["spanner"]

--- a/benchmarks/backend-comparison/docker-compose.yml
+++ b/benchmarks/backend-comparison/docker-compose.yml
@@ -40,6 +40,12 @@ services:
     ports:
       - "127.0.0.1:${PROLLY_BACKEND_DYNAMODB_PORT:-58000}:8000"
 
+  spanner:
+    image: gcr.io/cloud-spanner-emulator/emulator@sha256:ad54472fe7b161b9214f7f816f304b649a4779e348229c375ac067f5ed5a6422
+    ports:
+      - "127.0.0.1:${PROLLY_BACKEND_SPANNER_GRPC_PORT:-59010}:9010"
+      - "127.0.0.1:${PROLLY_BACKEND_SPANNER_REST_PORT:-59020}:9020"
+
 volumes:
   postgres-data:
   mysql-data:

--- a/benchmarks/backend-comparison/src/adapters.rs
+++ b/benchmarks/backend-comparison/src/adapters.rs
@@ -8,6 +8,8 @@ use prolly_backend_workload_contract::Workload;
 use prolly_store_dynamodb::DynamoDbBackend;
 use prolly_store_mysql::{MySqlBackend, MySqlBackendOptions};
 use prolly_store_postgres::{PostgresBackend, PostgresBackendOptions};
+#[cfg(feature = "spanner")]
+use prolly_store_spanner::{SpannerBackend, SpannerBackendOptions};
 use sqlx::mysql::MySqlPoolOptions;
 use sqlx::postgres::PgPoolOptions;
 
@@ -127,6 +129,67 @@ pub async fn run_mysql_service(
             .map_err(|error| format!("failed to clear MySQL table {table}: {error}"))?;
     }
     run_service_workload(backend, config).await
+}
+
+#[cfg(feature = "spanner")]
+async fn connect_spanner(config: &RunConfig, database: &str) -> Result<SpannerBackend, String> {
+    use google_cloud_spanner::client::ClientConfig;
+
+    let mut client_config = ClientConfig::default();
+    if std::env::var_os("SPANNER_EMULATOR_HOST").is_none() {
+        client_config = client_config
+            .with_auth()
+            .await
+            .map_err(|error| format!("failed to configure Spanner authentication: {error}"))?;
+    }
+    SpannerBackend::connect_with_options(
+        database,
+        client_config,
+        SpannerBackendOptions::default()
+            .with_batch_read_items(config.adapter_batch_items)
+            .with_read_parallelism(config.workload.concurrency),
+    )
+    .await
+    .map_err(|error| format!("failed to connect to Spanner: {error}"))
+}
+
+#[cfg(feature = "spanner")]
+async fn clear_spanner(backend: &SpannerBackend) -> Result<(), String> {
+    use google_cloud_spanner::key::all_keys;
+    use google_cloud_spanner::mutation::delete;
+
+    backend
+        .client()
+        .apply(vec![
+            delete("ProllyHints", all_keys()),
+            delete("ProllyRoots", all_keys()),
+            delete("ProllyNodes", all_keys()),
+        ])
+        .await
+        .map(|_| ())
+        .map_err(|error| format!("failed to clear Spanner benchmark state: {error}"))
+}
+
+#[cfg(feature = "spanner")]
+pub async fn run_spanner(config: &RunConfig, database: &str) -> Result<Vec<EvidenceRow>, String> {
+    let backend = connect_spanner(config, database).await?;
+    clear_spanner(&backend).await?;
+    let workload = Workload::generate(config.workload)?;
+    let result = run_workload(RemoteProllyStore::new(backend.clone()), config, &workload).await;
+    backend.client().clone().close().await;
+    result
+}
+
+#[cfg(feature = "spanner")]
+pub async fn run_spanner_service(
+    config: &RunConfig,
+    database: &str,
+) -> Result<Vec<ServiceEvidenceRow>, String> {
+    let backend = connect_spanner(config, database).await?;
+    clear_spanner(&backend).await?;
+    let result = run_service_workload(backend.clone(), config).await;
+    backend.client().clone().close().await;
+    result
 }
 
 #[cfg(feature = "dynamodb")]

--- a/benchmarks/backend-comparison/src/bin/spanner.rs
+++ b/benchmarks/backend-comparison/src/bin/spanner.rs
@@ -1,0 +1,29 @@
+use prolly_backend_comparison::{
+    parse_binary_args, run_spanner, run_spanner_service, write_rows_new, write_service_rows_new,
+    Backend, ConnectionConfig, Suite,
+};
+
+#[tokio::main]
+async fn main() {
+    if let Err(error) = run().await {
+        eprintln!("Spanner comparison failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), String> {
+    let config = parse_binary_args(Backend::Spanner, std::env::args().collect())?;
+    let ConnectionConfig::Spanner { database } = &config.connection else {
+        return Err("Spanner binary received a non-Spanner connection".to_string());
+    };
+    match config.suite {
+        Suite::EndToEnd => {
+            let rows = run_spanner(&config.run, database).await?;
+            write_rows_new(&config.run.output, &rows)
+        }
+        Suite::Service => {
+            let rows = run_spanner_service(&config.run, database).await?;
+            write_service_rows_new(&config.run.output, &rows)
+        }
+    }
+}

--- a/benchmarks/backend-comparison/src/cli.rs
+++ b/benchmarks/backend-comparison/src/cli.rs
@@ -19,6 +19,7 @@ pub enum ConnectionConfig {
     Postgres { url: String },
     MySql { url: String },
     DynamoDb(DynamoDbConnection),
+    Spanner { database: String },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -96,6 +97,7 @@ pub fn parse_binary_args(backend: Backend, values: Vec<String>) -> Result<Binary
         Backend::Postgres => "postgres://prolly:prolly@127.0.0.1:55433/prolly",
         Backend::MySql => "mysql://prolly:prolly@127.0.0.1:53307/prolly",
         Backend::DynamoDbLocal => "",
+        Backend::Spanner => "",
     }
     .to_string();
     let mut dynamodb = DynamoDbConnection {
@@ -106,6 +108,7 @@ pub fn parse_binary_args(backend: Backend, values: Vec<String>) -> Result<Binary
         batch_write_parallelism: 16,
         scan_parallelism: 8,
     };
+    let mut spanner_database = String::new();
 
     let mut index = 1;
     while index < values.len() {
@@ -144,6 +147,7 @@ pub fn parse_binary_args(backend: Backend, values: Vec<String>) -> Result<Binary
                 dynamodb.batch_write_parallelism = number(&value(&mut index)?, flag)?
             }
             "--scan-parallelism" => dynamodb.scan_parallelism = number(&value(&mut index)?, flag)?,
+            "--database" => spanner_database = value(&mut index)?,
             "--help" | "-h" => return Err(usage(backend).to_string()),
             _ => return Err(format!("unknown option for {backend}: {flag}")),
         }
@@ -184,9 +188,17 @@ pub fn parse_binary_args(backend: Backend, values: Vec<String>) -> Result<Binary
             }
             ConnectionConfig::DynamoDb(dynamodb)
         }
+        Backend::Spanner => {
+            if spanner_database.is_empty() {
+                return Err("Spanner database resource name must be set".to_string());
+            }
+            ConnectionConfig::Spanner {
+                database: spanner_database,
+            }
+        }
     };
     if backend == Backend::DynamoDbLocal && suite == Suite::Service {
-        return Err("the service suite supports MySQL and PostgreSQL".to_string());
+        return Err("the service suite supports MySQL, PostgreSQL, and Spanner".to_string());
     }
     Ok(BinaryConfig {
         run,
@@ -238,6 +250,9 @@ fn usage(backend: Backend) -> &'static str {
         }
         Backend::DynamoDbLocal => {
             "usage: prolly-backend-dynamodb --output PATH --run-id ID --repetition N --revision SHA --tree-hash SHA --binary-sha256 SHA --records N --value-bytes N --changes N --samples N --concurrency N --seed N [--endpoint URL] [--table NAME] [--read-parallelism N] [--batch-get-parallelism N] [--batch-write-parallelism N] [--scan-parallelism N]"
+        }
+        Backend::Spanner => {
+            "usage: prolly-backend-spanner --output PATH --run-id ID --repetition N --revision SHA --tree-hash SHA --binary-sha256 SHA --records N --value-bytes N --changes N --samples N --concurrency N --seed N --database RESOURCE [--adapter-batch-items N]"
         }
     }
 }
@@ -315,5 +330,54 @@ mod tests {
                 url: "postgres://local".to_string()
             }
         );
+    }
+
+    #[test]
+    fn spanner_arguments_require_and_preserve_database_resource() {
+        let mut args = vec![
+            "runner".to_string(),
+            "--output".to_string(),
+            "row.csv".to_string(),
+            "--run-id".to_string(),
+            "run-1".to_string(),
+            "--repetition".to_string(),
+            "3".to_string(),
+            "--revision".to_string(),
+            "a".repeat(40),
+            "--tree-hash".to_string(),
+            "b".repeat(40),
+            "--binary-sha256".to_string(),
+            "c".repeat(64),
+            "--records".to_string(),
+            "100".to_string(),
+            "--value-bytes".to_string(),
+            "27".to_string(),
+            "--changes".to_string(),
+            "10".to_string(),
+            "--samples".to_string(),
+            "8".to_string(),
+            "--concurrency".to_string(),
+            "4".to_string(),
+            "--seed".to_string(),
+            "0x6a09e667f3bcc909".to_string(),
+        ];
+        assert!(parse_binary_args(Backend::Spanner, args.clone())
+            .unwrap_err()
+            .contains("database resource"));
+
+        args.extend([
+            "--database".to_string(),
+            "projects/p/instances/i/databases/d".to_string(),
+            "--suite".to_string(),
+            "service".to_string(),
+        ]);
+        let parsed = parse_binary_args(Backend::Spanner, args).unwrap();
+        assert_eq!(
+            parsed.connection,
+            ConnectionConfig::Spanner {
+                database: "projects/p/instances/i/databases/d".to_string()
+            }
+        );
+        assert_eq!(parsed.suite, Suite::Service);
     }
 }

--- a/benchmarks/backend-comparison/src/evidence.rs
+++ b/benchmarks/backend-comparison/src/evidence.rs
@@ -17,6 +17,7 @@ pub enum Backend {
     #[serde(rename = "mysql")]
     MySql,
     DynamoDbLocal,
+    Spanner,
 }
 
 impl Backend {
@@ -25,6 +26,7 @@ impl Backend {
             Self::Postgres => "postgres",
             Self::MySql => "mysql",
             Self::DynamoDbLocal => "dynamodb_local",
+            Self::Spanner => "spanner",
         }
     }
 }
@@ -43,6 +45,7 @@ impl FromStr for Backend {
             "postgres" => Ok(Self::Postgres),
             "mysql" => Ok(Self::MySql),
             "dynamodb_local" | "dynamodb" => Ok(Self::DynamoDbLocal),
+            "spanner" => Ok(Self::Spanner),
             _ => Err(format!("unsupported backend: {value}")),
         }
     }

--- a/benchmarks/backend-comparison/src/lib.rs
+++ b/benchmarks/backend-comparison/src/lib.rs
@@ -10,6 +10,8 @@ pub mod summary;
 #[cfg(feature = "dynamodb")]
 pub use adapters::run_dynamodb;
 pub use adapters::{run_mysql, run_mysql_service, run_postgres, run_postgres_service};
+#[cfg(feature = "spanner")]
+pub use adapters::{run_spanner, run_spanner_service};
 pub use cli::{
     parse_binary_args, BinaryConfig, ConnectionConfig, DynamoDbConnection, RunConfig, Suite,
 };

--- a/benchmarks/backend-comparison/src/summary.rs
+++ b/benchmarks/backend-comparison/src/summary.rs
@@ -590,6 +590,7 @@ fn manifest_prefix(backend: Backend) -> &'static str {
         Backend::Postgres => "postgres",
         Backend::MySql => "mysql",
         Backend::DynamoDbLocal => "dynamodb",
+        Backend::Spanner => "spanner",
     }
 }
 
@@ -606,6 +607,7 @@ fn backend_label(backend: Backend) -> &'static str {
         Backend::Postgres => "PostgreSQL",
         Backend::MySql => "MySQL",
         Backend::DynamoDbLocal => "DynamoDB Local",
+        Backend::Spanner => "Spanner",
     }
 }
 
@@ -624,6 +626,9 @@ fn backend_limitation(backend: Backend) -> &'static str {
         }
         Backend::Postgres | Backend::MySql => {
             "- Local SQL container measurements compare captured adapter and service configurations, not every production deployment."
+        }
+        Backend::Spanner => {
+            "- The Spanner emulator serializes read-write transactions and does not model production latency, scaling, replication, IAM, or query planning."
         }
     }
 }

--- a/benchmarks/backend-comparison/tests/spanner_smoke.rs
+++ b/benchmarks/backend-comparison/tests/spanner_smoke.rs
@@ -1,0 +1,34 @@
+use std::path::PathBuf;
+
+use prolly_backend_comparison::{run_spanner, Backend, RunConfig};
+use prolly_backend_workload_contract::{WorkloadSpec, DEFAULT_SEED};
+
+#[tokio::test]
+#[ignore = "requires PROLLY_BACKEND_SPANNER_TEST_DATABASE"]
+async fn spanner_executes_the_common_comparison() {
+    let database = std::env::var("PROLLY_BACKEND_SPANNER_TEST_DATABASE").unwrap();
+    let config = RunConfig {
+        backend: Backend::Spanner,
+        output: PathBuf::from("unused.csv"),
+        run_id: "spanner-smoke".to_string(),
+        repetition: 1,
+        revision: "a".repeat(40),
+        tree_hash: "b".repeat(40),
+        binary_sha256: "c".repeat(64),
+        pool_size: 4,
+        adapter_batch_items: 7,
+        workload: WorkloadSpec {
+            records: 100,
+            value_bytes: 27,
+            changes: 10,
+            samples: 10,
+            concurrency: 4,
+            seed: DEFAULT_SEED,
+        },
+    };
+
+    let rows = run_spanner(&config, &database).await.unwrap();
+    assert_eq!(rows.len(), 6);
+    assert!(rows.iter().all(|row| row.backend == Backend::Spanner));
+    assert!(rows.iter().all(|row| row.validated));
+}

--- a/benchmarks/cosmos-spanner-comparison/Cargo.lock
+++ b/benchmarks/cosmos-spanner-comparison/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,15 +26,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atoi"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,18 +36,6 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "aws-credential-types"
-version = "1.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "zeroize",
-]
 
 [[package]]
 name = "aws-lc-rs"
@@ -89,304 +62,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-runtime"
-version = "1.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
-dependencies = [
- "aws-credential-types",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "bytes-utils",
- "fastrand",
- "http 1.4.2",
- "http-body 1.1.0",
- "percent-encoding",
- "pin-project-lite",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "aws-sdk-dynamodb"
-version = "1.73.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d954f3581bd7254f42bbaa3a21dfd99d40a14d82a324d2012b8f3ea0d15f12b"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http 0.62.6",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sigv4"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-http 0.63.6",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "form_urlencoded",
- "hex",
- "hmac 0.13.0",
- "http 0.2.12",
- "http 1.4.2",
- "percent-encoding",
- "sha2 0.11.0",
- "time",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-async"
-version = "1.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.62.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http 1.4.2",
- "http-body 0.4.6",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.63.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "futures-util",
- "http 1.4.2",
- "http-body 1.1.0",
- "http-body-util",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http-client"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "h2 0.3.27",
- "h2 0.4.15",
- "http 0.2.12",
- "http 1.4.2",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper 1.11.0",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.9",
- "hyper-util",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls 0.23.42",
- "rustls-native-certs",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.26.4",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.61.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
-dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-observability"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
-dependencies = [
- "aws-smithy-runtime-api",
-]
-
-[[package]]
-name = "aws-smithy-runtime"
-version = "1.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-http-client",
- "aws-smithy-observability",
- "aws-smithy-runtime-api",
- "aws-smithy-schema",
- "aws-smithy-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.2",
- "http-body 0.4.6",
- "http-body 1.1.0",
- "http-body-util",
- "pin-project-lite",
- "pin-utils",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api-macros",
- "aws-smithy-types",
- "bytes",
- "http 0.2.12",
- "http 1.4.2",
- "pin-project-lite",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "aws-smithy-schema"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "http 1.4.2",
-]
-
-[[package]]
-name = "aws-smithy-types"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
-dependencies = [
- "base64-simd",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http 1.4.2",
- "http-body 0.4.6",
- "http-body 1.1.0",
- "http-body-util",
- "itoa",
- "num-integer",
- "pin-project-lite",
- "pin-utils",
- "ryu",
- "serde",
- "time",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "aws-types"
-version = "1.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-schema",
- "aws-smithy-types",
- "rustc_version",
- "tracing",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
-dependencies = [
- "outref",
- "vsimd",
-]
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bigdecimal"
@@ -407,9 +86,6 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "block-buffer"
@@ -421,41 +97,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
-
-[[package]]
-name = "bytes-utils"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
-dependencies = [
- "bytes",
- "either",
-]
 
 [[package]]
 name = "cc"
@@ -502,12 +153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmov"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,27 +161,6 @@ dependencies = [
  "bytes",
  "memchr",
 ]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -573,21 +197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,15 +225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,56 +241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "ctutils"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-dependencies = [
- "cmov",
-]
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,40 +252,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "const-oid 0.9.6",
- "crypto-common 0.1.7",
+ "block-buffer",
+ "crypto-common",
  "subtle",
 ]
 
 [[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.1",
- "const-oid 0.10.2",
- "crypto-common 0.2.2",
- "ctutils",
-]
-
-[[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
-
-[[package]]
-name = "dotenvy"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dunce"
@@ -748,9 +279,6 @@ name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "encoding_rs"
@@ -766,44 +294,6 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "etcetera"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
-dependencies = [
- "cfg-if",
- "home",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -828,12 +318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,7 +339,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -863,23 +346,6 @@ name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
-
-[[package]]
-name = "futures-intrusive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
-dependencies = [
- "futures-core",
- "lock_api",
- "parking_lot",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
@@ -911,11 +377,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -931,7 +394,7 @@ dependencies = [
  "gcloud-metadata",
  "home",
  "jsonwebtoken",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror",
@@ -948,7 +411,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558634081d1cf458d1bc0166f69475a80f445b5b991f162028b293a38307059d"
 dependencies = [
- "http 1.4.2",
+ "http",
  "thiserror",
  "token-source",
  "tokio",
@@ -988,7 +451,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd3152612316be627be52fe9ca72331eb48425059b3a6a700e7adde223e061d5"
 dependencies = [
- "reqwest",
+ "reqwest 0.13.4",
  "thiserror",
  "tokio",
 ]
@@ -1055,25 +518,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
@@ -1083,7 +527,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -1099,35 +543,9 @@ checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1136,30 +554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
-dependencies = [
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -1173,34 +573,12 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -1210,7 +588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http",
 ]
 
 [[package]]
@@ -1221,8 +599,8 @@ checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
- "http-body 1.1.0",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1239,39 +617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hybrid-array"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
 name = "hyper"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,9 +626,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
- "http 1.4.2",
- "http-body 1.1.0",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1294,33 +639,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
- "hyper 1.11.0",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.42",
- "rustls-native-certs",
+ "rustls",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1329,7 +659,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.11.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1346,14 +676,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
- "http-body 1.1.0",
- "hyper 1.11.0",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1469,7 +799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1582,15 +912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,24 +931,6 @@ checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "libredox"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.9.0",
-]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1655,16 +958,6 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
 
 [[package]]
 name = "memchr"
@@ -1719,22 +1012,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.7",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,23 +1027,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1780,18 +1046,6 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "outref"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1811,7 +1065,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -1824,15 +1078,6 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -1868,43 +1113,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "potential_utf"
@@ -1922,15 +1134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,31 +1143,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "prolly-backend-comparison"
+name = "prolly-cosmos-spanner-comparison"
 version = "0.0.0"
 dependencies = [
- "aws-sdk-dynamodb",
- "csv",
- "futures-util",
  "gcloud-spanner",
- "prolly-backend-workload-contract",
  "prolly-map",
- "prolly-store-dynamodb",
- "prolly-store-mysql",
- "prolly-store-postgres",
+ "prolly-store-cosmosdb",
  "prolly-store-spanner",
- "serde",
- "sqlx",
- "tempfile",
+ "reqwest 0.12.28",
+ "serde_json",
  "tokio",
-]
-
-[[package]]
-name = "prolly-backend-workload-contract"
-version = "0.0.0"
-dependencies = [
- "serde",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1978,47 +1166,26 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "xxhash-rust",
 ]
 
 [[package]]
-name = "prolly-store-dynamodb"
-version = "0.4.0"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-sdk-dynamodb",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-http-client",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-runtime-api-macros",
- "aws-smithy-schema",
- "aws-smithy-types",
- "aws-types",
- "futures-util",
- "prolly-map",
- "tokio",
-]
-
-[[package]]
-name = "prolly-store-mysql"
+name = "prolly-store-cosmosdb"
 version = "0.3.0"
 dependencies = [
+ "base64",
+ "futures-util",
+ "hex",
+ "hmac",
+ "httpdate",
+ "percent-encoding",
  "prolly-map",
- "sqlx",
-]
-
-[[package]]
-name = "prolly-store-postgres"
-version = "0.4.0"
-dependencies = [
- "prolly-map",
- "sqlx",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
 ]
 
 [[package]]
@@ -2076,8 +1243,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.42",
- "socket2 0.6.5",
+ "rustls",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -2094,11 +1261,11 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand 0.10.2",
+ "rand",
  "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls 0.23.42",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror",
@@ -2116,7 +1283,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -2138,17 +1305,6 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
@@ -2156,16 +1312,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2222,19 +1368,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.9.0"
+name = "reqwest"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "bitflags",
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
 ]
-
-[[package]]
-name = "regex-lite"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "reqwest"
@@ -2246,11 +1415,11 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
- "http 1.4.2",
- "http-body 1.1.0",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.11.0",
- "hyper-rustls 0.27.9",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -2258,7 +1427,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.42",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -2266,7 +1435,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2291,26 +1460,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2326,41 +1475,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -2398,10 +1523,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.42",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -2413,16 +1538,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -2471,16 +1586,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "security-framework"
@@ -2577,17 +1682,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2595,19 +1689,8 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "digest",
  "sha2-asm",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
 ]
 
 [[package]]
@@ -2631,7 +1714,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2680,19 +1762,6 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -2705,199 +1774,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
-name = "sqlx"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
-dependencies = [
- "sqlx-core",
- "sqlx-macros",
- "sqlx-mysql",
- "sqlx-postgres",
-]
-
-[[package]]
-name = "sqlx-core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
-dependencies = [
- "base64",
- "bytes",
- "crc",
- "crossbeam-queue",
- "either",
- "event-listener",
- "futures-core",
- "futures-intrusive",
- "futures-io",
- "futures-util",
- "hashbrown 0.15.5",
- "hashlink",
- "indexmap",
- "log",
- "memchr",
- "once_cell",
- "percent-encoding",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "smallvec",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "sqlx-macros"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
-dependencies = [
- "proc-macro2",
- "quote",
- "sqlx-core",
- "sqlx-macros-core",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "sqlx-macros-core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
-dependencies = [
- "dotenvy",
- "either",
- "heck",
- "hex",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "sqlx-core",
- "sqlx-mysql",
- "sqlx-postgres",
- "syn 2.0.119",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "sqlx-mysql"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
-dependencies = [
- "atoi",
- "base64",
- "bitflags",
- "byteorder",
- "bytes",
- "crc",
- "digest 0.10.7",
- "dotenvy",
- "either",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-util",
- "generic-array",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "itoa",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "percent-encoding",
- "rand 0.8.7",
- "rsa",
- "serde",
- "sha1",
- "sha2 0.10.9",
- "smallvec",
- "sqlx-core",
- "stringprep",
- "thiserror",
- "tracing",
- "whoami",
-]
-
-[[package]]
-name = "sqlx-postgres"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
-dependencies = [
- "atoi",
- "base64",
- "bitflags",
- "byteorder",
- "crc",
- "dotenvy",
- "etcetera",
- "futures-channel",
- "futures-core",
- "futures-util",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "home",
- "itoa",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "rand 0.8.7",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "smallvec",
- "sqlx-core",
- "stringprep",
- "thiserror",
- "tracing",
- "whoami",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "stringprep"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
- "unicode-properties",
-]
 
 [[package]]
 name = "subtle"
@@ -2945,19 +1825,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.3",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3055,20 +1922,20 @@ dependencies = [
  "mio",
  "parking_lot",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3083,21 +1950,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.42",
+ "rustls",
  "tokio",
 ]
 
@@ -3136,17 +1993,17 @@ dependencies = [
  "base64",
  "bytes",
  "flate2",
- "http 1.4.2",
- "http-body 1.1.0",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.11.0",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -3194,8 +2051,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.2",
- "http-body 1.1.0",
+ "http",
+ "http-body",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -3221,7 +2078,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3260,31 +2116,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "untrusted"
@@ -3323,26 +2158,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "uuid"
-version = "1.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -3368,12 +2187,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3469,16 +2282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "whoami"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3495,20 +2298,11 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3522,40 +2316,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3565,21 +2338,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3595,21 +2356,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3619,21 +2368,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3674,26 +2411,6 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]

--- a/benchmarks/cosmos-spanner-comparison/Cargo.toml
+++ b/benchmarks/cosmos-spanner-comparison/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "prolly-cosmos-spanner-comparison"
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.81"
+publish = false
+
+[workspace]
+
+[dependencies]
+google-cloud-spanner = { package = "gcloud-spanner", version = "=1.8.1" }
+prolly = { package = "prolly-map", path = "../..", features = ["async-store"] }
+prolly-store-cosmosdb = { path = "../../stores/prolly-store-cosmosdb" }
+prolly-store-spanner = { path = "../../stores/prolly-store-spanner" }
+reqwest = { version = "0.12.24", default-features = false, features = ["rustls-tls"] }
+serde_json = "1.0"
+tokio = { version = "1.45", features = ["macros", "rt-multi-thread", "time"] }
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/benchmarks/cosmos-spanner-comparison/README.md
+++ b/benchmarks/cosmos-spanner-comparison/README.md
@@ -1,0 +1,35 @@
+# Cosmos DB / Spanner adapter comparison
+
+This Rust benchmark exercises the `RemoteStoreBackend` operations used by
+prolly: batch node publication, ordered batch reads, and named-root
+compare-and-swap. It is intended for repeatable adapter regression detection,
+not for claiming cloud-service capacity from emulator timings.
+
+Run both credential-free Docker emulators, conformance tests, contention tests,
+and the comparison:
+
+```bash
+scripts/run-cosmos-spanner-comparison.sh
+```
+
+Results are written beneath `performance-results/cosmos-spanner-*`. Configure
+the workload with:
+
+```bash
+export PROLLY_CLOUD_BENCH_ITEMS=1000
+export PROLLY_CLOUD_BENCH_VALUE_BYTES=1024
+export PROLLY_CLOUD_BENCH_CAS_ITERATIONS=100
+export PROLLY_CLOUD_BENCH_CONCURRENCY=16
+```
+
+To use managed services, supply all four `PROLLY_STORE_COSMOS_*` values and
+`PROLLY_STORE_SPANNER_DATABASE`; normal application-default Spanner
+authentication is used when `SPANNER_EMULATOR_HOST` is absent. Use isolated
+test resources because the Spanner conformance suite clears the three adapter
+tables.
+
+Emulators verify correctness, batching, request counts, contention behavior,
+and relative regressions on one machine. They do not reproduce production RU
+accounting, multi-region latency, autoscaling, replication, IAM, or Spanner
+query planning. Repeat candidate configurations against isolated managed
+resources before production sizing.

--- a/benchmarks/cosmos-spanner-comparison/src/main.rs
+++ b/benchmarks/cosmos-spanner-comparison/src/main.rs
@@ -1,0 +1,202 @@
+use std::env;
+use std::error::Error;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use prolly::{RemoteBatchOp, RemoteManifestUpdate, RemoteStoreBackend};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let provider = env::args()
+        .nth(1)
+        .ok_or("usage: benchmark <cosmos|spanner>")?;
+    let items = env::var("PROLLY_CLOUD_BENCH_ITEMS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(1_000usize)
+        .max(1);
+    let value_bytes = env::var("PROLLY_CLOUD_BENCH_VALUE_BYTES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(1_024usize)
+        .max(1);
+    let cas_iterations = env::var("PROLLY_CLOUD_BENCH_CAS_ITERATIONS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(100usize)
+        .max(1);
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .as_nanos()
+        .to_be_bytes();
+    let keys = benchmark_keys(items, nonce);
+    let values = benchmark_values(items, value_bytes);
+
+    match provider.as_str() {
+        "cosmos" => {
+            use prolly_store_cosmosdb::{CosmosDbBackend, CosmosDbBackendOptions};
+
+            let endpoint = required_env("PROLLY_STORE_COSMOS_ENDPOINT")?;
+            let key = required_env("PROLLY_STORE_COSMOS_KEY")?;
+            let database = required_env("PROLLY_STORE_COSMOS_DATABASE")?;
+            let container = required_env("PROLLY_STORE_COSMOS_CONTAINER")?;
+            let options = CosmosDbBackendOptions::default().with_max_concurrency(
+                env::var("PROLLY_CLOUD_BENCH_CONCURRENCY")
+                    .ok()
+                    .and_then(|value| value.parse().ok())
+                    .unwrap_or(16),
+            );
+            let prefix = format!("prolly:bench:{}:", hex_string(&nonce)).into_bytes();
+            let backend = CosmosDbBackend::with_http_client_and_options(
+                reqwest::Client::new(),
+                endpoint,
+                &key,
+                database,
+                container,
+                options,
+            )?
+            .with_key_prefix(prefix);
+            let result = run_workload("cosmos", &backend, &keys, &values, cas_iterations).await?;
+            let metrics = backend.metrics();
+            println!(
+                "{}",
+                serde_json::json!({
+                    "provider": "cosmos",
+                    "items": items,
+                    "value_bytes": value_bytes,
+                    "cas_iterations": cas_iterations,
+                    "batch_put_ms": result.batch_put_ms,
+                    "batch_get_ms": result.batch_get_ms,
+                    "cas_ms": result.cas_ms,
+                    "requests": metrics.requests,
+                    "retries": metrics.retries,
+                    "request_charge": metrics.request_charge,
+                })
+            );
+            backend.clear_namespace().await?;
+        }
+        "spanner" => {
+            use google_cloud_spanner::client::ClientConfig;
+            use prolly_store_spanner::{SpannerBackend, SpannerBackendOptions};
+
+            let database = required_env("PROLLY_STORE_SPANNER_DATABASE")?;
+            let mut config = ClientConfig::default();
+            if env::var_os("SPANNER_EMULATOR_HOST").is_none() {
+                config = config.with_auth().await?;
+            }
+            let options = SpannerBackendOptions::default().with_batch_read_items(
+                env::var("PROLLY_CLOUD_BENCH_BATCH_READ_ITEMS")
+                    .ok()
+                    .and_then(|value| value.parse().ok())
+                    .unwrap_or(5_000),
+            );
+            let backend = SpannerBackend::connect_with_options(&database, config, options).await?;
+            let result = run_workload("spanner", &backend, &keys, &values, cas_iterations).await?;
+            println!(
+                "{}",
+                serde_json::json!({
+                    "provider": "spanner",
+                    "items": items,
+                    "value_bytes": value_bytes,
+                    "cas_iterations": cas_iterations,
+                    "batch_put_ms": result.batch_put_ms,
+                    "batch_get_ms": result.batch_get_ms,
+                    "cas_ms": result.cas_ms,
+                })
+            );
+            backend.client().clone().close().await;
+        }
+        _ => return Err(format!("unknown provider {provider:?}; use cosmos or spanner").into()),
+    }
+    Ok(())
+}
+
+struct WorkloadResult {
+    batch_put_ms: f64,
+    batch_get_ms: f64,
+    cas_ms: f64,
+}
+
+async fn run_workload<B: RemoteStoreBackend>(
+    provider: &str,
+    backend: &B,
+    keys: &[Vec<u8>],
+    values: &[Vec<u8>],
+    cas_iterations: usize,
+) -> Result<WorkloadResult, B::Error> {
+    let entries = keys
+        .iter()
+        .zip(values)
+        .map(|(key, value)| (key.as_slice(), value.as_slice()))
+        .collect::<Vec<_>>();
+    let started = Instant::now();
+    backend.batch_put_nodes(&entries).await?;
+    let batch_put_ms = elapsed_ms(started);
+
+    let key_refs = keys.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    let started = Instant::now();
+    let fetched = backend.batch_get_nodes_ordered(&key_refs).await?;
+    let batch_get_ms = elapsed_ms(started);
+    assert_eq!(fetched.len(), values.len());
+    for (actual, expected) in fetched.iter().zip(values) {
+        assert_eq!(actual.as_deref(), Some(expected.as_slice()));
+    }
+
+    let root_name = format!("benchmark/{provider}").into_bytes();
+    let mut expected = None;
+    let started = Instant::now();
+    for iteration in 0..cas_iterations {
+        let next = (iteration as u64).to_be_bytes();
+        let update = backend
+            .compare_and_swap_root_manifest(&root_name, expected.as_deref(), Some(next.as_slice()))
+            .await?;
+        assert_eq!(update, RemoteManifestUpdate::Applied);
+        expected = Some(next.to_vec());
+    }
+    let cas_ms = elapsed_ms(started);
+
+    let deletes = keys
+        .iter()
+        .map(|key| RemoteBatchOp::Delete {
+            key: key.as_slice(),
+        })
+        .collect::<Vec<_>>();
+    backend.batch_nodes(&deletes).await?;
+    backend
+        .compare_and_swap_root_manifest(&root_name, expected.as_deref(), None)
+        .await?;
+
+    Ok(WorkloadResult {
+        batch_put_ms,
+        batch_get_ms,
+        cas_ms,
+    })
+}
+
+fn benchmark_keys(items: usize, nonce: [u8; 16]) -> Vec<Vec<u8>> {
+    (0..items)
+        .map(|index| {
+            let mut key = vec![0u8; 32];
+            key[..16].copy_from_slice(&nonce);
+            key[24..].copy_from_slice(&(index as u64).to_be_bytes());
+            key
+        })
+        .collect()
+}
+
+fn benchmark_values(items: usize, value_bytes: usize) -> Vec<Vec<u8>> {
+    (0..items)
+        .map(|index| vec![(index % 251) as u8; value_bytes])
+        .collect()
+}
+
+fn required_env(name: &str) -> Result<String, Box<dyn Error>> {
+    env::var(name).map_err(|_| format!("{name} must be set").into())
+}
+
+fn elapsed_ms(started: Instant) -> f64 {
+    started.elapsed().as_secs_f64() * 1_000.0
+}
+
+fn hex_string(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}

--- a/docker-compose.store-services.yml
+++ b/docker-compose.store-services.yml
@@ -1,8 +1,21 @@
 name: prolly-store-services
 
 services:
+  cosmosdb:
+    image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator@sha256:a8b93e25520e999d867ed3949e7de7f4ff3ddab23ca95fa6f90230de5dd9729b
+    environment:
+      ENABLE_EXPLORER: "false"
+      ENABLE_INIT_DATA: "true"
+      ENABLE_TELEMETRY: "false"
+      PROTOCOL: "http"
+    ports:
+      - "${PROLLY_STORE_COSMOS_PORT:-58081}:8081"
+      - "${PROLLY_STORE_COSMOS_HEALTH_PORT:-58080}:8080"
+    volumes:
+      - "./stores/prolly-store-cosmosdb/tests/emulator-init:/init:ro"
+
   spanner:
-    image: gcr.io/cloud-spanner-emulator/emulator:latest
+    image: gcr.io/cloud-spanner-emulator/emulator@sha256:ad54472fe7b161b9214f7f816f304b649a4779e348229c375ac067f5ed5a6422
     ports:
       - "${PROLLY_STORE_SPANNER_GRPC_PORT:-9010}:9010"
       - "${PROLLY_STORE_SPANNER_REST_PORT:-9020}:9020"

--- a/scripts/run-cosmos-spanner-comparison.sh
+++ b/scripts/run-cosmos-spanner-comparison.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker-compose.store-services.yml"
+PROJECT_NAME="${PROLLY_CLOUD_COMPOSE_PROJECT:-prolly-cosmos-spanner-comparison}"
+COSMOS_PORT="${PROLLY_STORE_COSMOS_PORT:-58081}"
+COSMOS_HEALTH_PORT="${PROLLY_STORE_COSMOS_HEALTH_PORT:-58080}"
+SPANNER_GRPC_PORT="${PROLLY_STORE_SPANNER_GRPC_PORT:-9010}"
+SPANNER_REST_PORT="${PROLLY_STORE_SPANNER_REST_PORT:-9020}"
+OUTPUT="${PROLLY_CLOUD_BENCH_OUTPUT:-$ROOT_DIR/performance-results/cosmos-spanner-$(date -u +%Y%m%dT%H%M%SZ)}"
+LOCAL_COSMOS=0
+LOCAL_SPANNER=0
+
+compose() {
+  docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" "$@"
+}
+
+cleanup() {
+  if [[ "${KEEP_PROLLY_CLOUD_SERVICES:-0}" != "1" ]] &&
+    ((LOCAL_COSMOS == 1 || LOCAL_SPANNER == 1)); then
+    compose down -v >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+wait_for_url() {
+  local name="$1"
+  local url="$2"
+  for _ in $(seq 1 180); do
+    if curl --silent --fail "$url" >/dev/null 2>&1; then
+      printf '%s is ready\n' "$name"
+      return 0
+    fi
+    sleep 1
+  done
+  printf '%s did not become ready: %s\n' "$name" "$url" >&2
+  compose ps >&2 || true
+  return 1
+}
+
+wait_for_tcp() {
+  local name="$1"
+  local port="$2"
+  for _ in $(seq 1 120); do
+    if (echo >"/dev/tcp/127.0.0.1/$port") >/dev/null 2>&1; then
+      printf '%s is listening on port %s\n' "$name" "$port"
+      return 0
+    fi
+    sleep 1
+  done
+  printf '%s did not start on port %s\n' "$name" "$port" >&2
+  return 1
+}
+
+wait_for_cosmos_init() {
+  for _ in $(seq 1 120); do
+    if compose logs --no-color cosmosdb 2>/dev/null |
+      grep -q "All initialization scripts processed successfully"; then
+      printf 'Cosmos DB emulator schema is ready\n'
+      return 0
+    fi
+    sleep 1
+  done
+  printf 'Cosmos DB initialization did not complete\n' >&2
+  compose logs cosmosdb >&2 || true
+  return 1
+}
+
+services=()
+if [[ -z "${PROLLY_STORE_COSMOS_ENDPOINT:-}" ]]; then
+  LOCAL_COSMOS=1
+  services+=(cosmosdb)
+fi
+if [[ -z "${PROLLY_STORE_SPANNER_DATABASE:-}" ]]; then
+  LOCAL_SPANNER=1
+  services+=(spanner)
+fi
+
+if ((${#services[@]} > 0)); then
+  export PROLLY_STORE_COSMOS_PORT="$COSMOS_PORT"
+  export PROLLY_STORE_COSMOS_HEALTH_PORT="$COSMOS_HEALTH_PORT"
+  export PROLLY_STORE_SPANNER_GRPC_PORT="$SPANNER_GRPC_PORT"
+  export PROLLY_STORE_SPANNER_REST_PORT="$SPANNER_REST_PORT"
+  compose up -d "${services[@]}"
+fi
+
+if ((LOCAL_COSMOS == 1)); then
+  wait_for_url "Cosmos DB emulator" "http://127.0.0.1:$COSMOS_HEALTH_PORT/ready"
+  wait_for_cosmos_init
+  export PROLLY_STORE_COSMOS_ENDPOINT="http://127.0.0.1:$COSMOS_PORT"
+  export PROLLY_STORE_COSMOS_KEY="C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+  export PROLLY_STORE_COSMOS_DATABASE="prolly"
+  export PROLLY_STORE_COSMOS_CONTAINER="prolly_store"
+else
+  : "${PROLLY_STORE_COSMOS_KEY:?managed Cosmos comparison requires PROLLY_STORE_COSMOS_KEY}"
+  : "${PROLLY_STORE_COSMOS_DATABASE:?managed Cosmos comparison requires PROLLY_STORE_COSMOS_DATABASE}"
+  : "${PROLLY_STORE_COSMOS_CONTAINER:?managed Cosmos comparison requires PROLLY_STORE_COSMOS_CONTAINER}"
+fi
+
+if ((LOCAL_SPANNER == 1)); then
+  wait_for_tcp "Spanner emulator" "$SPANNER_GRPC_PORT"
+  spanner_rest="http://127.0.0.1:$SPANNER_REST_PORT"
+  curl --silent --fail-with-body \
+    -H "content-type: application/json" \
+    -X POST "$spanner_rest/v1/projects/prolly-local/instances" \
+    --data-binary '{
+      "instanceId": "prolly-instance",
+      "instance": {
+        "config": "projects/prolly-local/instanceConfigs/emulator-config",
+        "displayName": "Prolly Local",
+        "nodeCount": 1
+      }
+    }' >/dev/null
+  curl --silent --fail-with-body \
+    -H "content-type: application/json" \
+    -X POST "$spanner_rest/v1/projects/prolly-local/instances/prolly-instance/databases" \
+    --data-binary '{
+      "createStatement": "CREATE DATABASE `prolly`",
+      "extraStatements": [
+        "CREATE TABLE ProllyNodes (Cid BYTES(32) NOT NULL, Node BYTES(MAX) NOT NULL) PRIMARY KEY (Cid)",
+        "CREATE TABLE ProllyHints (Namespace BYTES(MAX) NOT NULL, HintKey BYTES(MAX) NOT NULL, Value BYTES(MAX) NOT NULL) PRIMARY KEY (Namespace, HintKey)",
+        "CREATE TABLE ProllyRoots (Name BYTES(MAX) NOT NULL, Manifest BYTES(MAX) NOT NULL) PRIMARY KEY (Name)"
+      ]
+    }' >/dev/null
+  wait_for_url \
+    "Spanner test database" \
+    "$spanner_rest/v1/projects/prolly-local/instances/prolly-instance/databases/prolly"
+  export SPANNER_EMULATOR_HOST="127.0.0.1:$SPANNER_GRPC_PORT"
+  export PROLLY_STORE_SPANNER_DATABASE="projects/prolly-local/instances/prolly-instance/databases/prolly"
+elif [[ -z "${PROLLY_STORE_SPANNER_AUTH:-}" ]]; then
+  export PROLLY_STORE_SPANNER_AUTH=1
+fi
+
+mkdir -p "$OUTPUT"
+{
+  printf 'captured_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf 'git_revision=%s\n' "$(git -C "$ROOT_DIR" rev-parse HEAD)"
+  rustc --version
+  cargo --version
+  docker --version 2>/dev/null || true
+  if ((LOCAL_COSMOS == 1)); then
+    compose images cosmosdb
+  fi
+  if ((LOCAL_SPANNER == 1)); then
+    compose images spanner
+  fi
+} >"$OUTPUT/environment.txt"
+
+cargo test --manifest-path "$ROOT_DIR/stores/prolly-store-cosmosdb/Cargo.toml" \
+  2>&1 | tee "$OUTPUT/cosmos-conformance.log"
+cargo test --manifest-path "$ROOT_DIR/stores/prolly-store-spanner/Cargo.toml" \
+  2>&1 | tee "$OUTPUT/spanner-conformance.log"
+
+cargo run --release \
+  --manifest-path "$ROOT_DIR/benchmarks/cosmos-spanner-comparison/Cargo.toml" \
+  -- cosmos | tee "$OUTPUT/cosmos.json"
+cargo run --release \
+  --manifest-path "$ROOT_DIR/benchmarks/cosmos-spanner-comparison/Cargo.toml" \
+  -- spanner | tee "$OUTPUT/spanner.json"
+
+printf 'comparison artifacts: %s\n' "$OUTPUT"

--- a/scripts/run_spanner_postgres_comparison.sh
+++ b/scripts/run_spanner_postgres_comparison.sh
@@ -1,0 +1,494 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MANIFEST="$REPO_ROOT/benchmarks/backend-comparison/Cargo.toml"
+LOCKFILE="$REPO_ROOT/benchmarks/backend-comparison/Cargo.lock"
+COMPOSE_FILE="$REPO_ROOT/benchmarks/backend-comparison/docker-compose.yml"
+OUTPUT="${BENCH_OUT:-$REPO_ROOT/performance-results/spanner-postgres-$(date -u +%Y%m%dT%H%M%SZ)}"
+MODE="${BENCH_MODE:-local}"
+RECORDS="${BENCH_RECORDS:-10000}"
+VALUE_BYTES="${BENCH_VALUE_BYTES:-128}"
+CHANGES="${BENCH_CHANGES:-1000}"
+SAMPLES="${BENCH_SAMPLES:-1000}"
+CONCURRENCY="${BENCH_CONCURRENCY:-16}"
+POOL_SIZE="${BENCH_POOL_SIZE:-16}"
+ADAPTER_BATCH_ITEMS="${BENCH_ADAPTER_BATCH_ITEMS:-1000}"
+RUNS="${BENCH_RUNS:-7}"
+SEED="${BENCH_SEED:-0x6a09e667f3bcc909}"
+POSTGRES_PORT="${PROLLY_BACKEND_POSTGRES_PORT:-55433}"
+SPANNER_GRPC_PORT="${PROLLY_BACKEND_SPANNER_GRPC_PORT:-59010}"
+SPANNER_REST_PORT="${PROLLY_BACKEND_SPANNER_REST_PORT:-59020}"
+POSTGRES_URL="${PROLLY_BACKEND_POSTGRES_URL:-postgres://prolly:prolly@127.0.0.1:${POSTGRES_PORT}/prolly}"
+SPANNER_DATABASE="${PROLLY_BACKEND_SPANNER_DATABASE:-projects/prolly-local/instances/prolly-instance/databases/prolly}"
+POSTGRES_IMAGE="postgres@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777"
+SPANNER_IMAGE="gcr.io/cloud-spanner-emulator/emulator@sha256:ad54472fe7b161b9214f7f816f304b649a4779e348229c375ac067f5ed5a6422"
+POSTGRES_PROJECT="prolly-spanner-postgres-postgres"
+SPANNER_PROJECT="prolly-spanner-postgres-spanner"
+GIT_BIN="${BENCH_GIT_BIN:-git}"
+DOCKER_BIN="${BENCH_DOCKER_BIN:-docker}"
+CARGO_BIN="${BENCH_CARGO_BIN:-cargo}"
+CURL_BIN="${BENCH_CURL_BIN:-curl}"
+SHASUM_BIN="${BENCH_SHASUM_BIN:-shasum}"
+MEASUREMENT_COMMANDS=""
+RUN_STARTED=false
+
+compose() {
+  local project="$1"
+  shift
+  "$DOCKER_BIN" compose -p "$project" -f "$COMPOSE_FILE" "$@"
+}
+
+cleanup() {
+  if [[ "$MODE" == local ]]; then
+    compose "$POSTGRES_PROJECT" down -v >/dev/null 2>&1 || true
+    compose "$SPANNER_PROJECT" down -v >/dev/null 2>&1 || true
+  fi
+}
+
+finish() {
+  local code=$?
+  trap - EXIT
+  cleanup
+  if [[ "$code" != 0 && "$RUN_STARTED" == true && -d "$OUTPUT" ]]; then
+    {
+      printf 'status=failed\n'
+      printf 'exit_code=%s\n' "$code"
+      printf 'failed_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    } >"$OUTPUT/failure.txt"
+  fi
+  exit "$code"
+}
+trap finish EXIT
+
+fail() {
+  printf '%s\n' "$*" >&2
+  exit 2
+}
+
+is_positive_integer() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+sha256_file() {
+  "$SHASUM_BIN" -a 256 "$1" | awk '{print $1}'
+}
+
+redact_url() {
+  printf '%s' "$1" | sed -E 's#(://)[^/@]+@#\1REDACTED@#'
+}
+
+write_shell_command() {
+  local separator=""
+  local value
+  for value in "$@"; do
+    printf '%s' "$separator"
+    printf '%q' "$value"
+    separator=" "
+  done
+  printf '\n'
+}
+
+record_command() {
+  write_shell_command "$@" >>"$MEASUREMENT_COMMANDS"
+  "$@"
+}
+
+record_runner_command() {
+  local -a actual=("$@")
+  local -a redacted=()
+  local redact_next=false
+  local value
+  for value in "${actual[@]}"; do
+    if [[ "$redact_next" == true ]]; then
+      redacted+=("$(redact_url "$value")")
+      redact_next=false
+    else
+      redacted+=("$value")
+      [[ "$value" == --url ]] && redact_next=true
+    fi
+  done
+  write_shell_command "${redacted[@]}" >>"$MEASUREMENT_COMMANDS"
+  "${actual[@]}"
+}
+
+wait_for_postgres() {
+  local consecutive_ready=0
+  for _ in $(seq 1 120); do
+    local health
+    health="$("$DOCKER_BIN" inspect --format '{{.State.Health.Status}}' \
+      "$POSTGRES_PROJECT-postgres-1" 2>/dev/null || true)"
+    if [[ "$health" == healthy ]] &&
+      "$DOCKER_BIN" exec "$POSTGRES_PROJECT-postgres-1" \
+        psql -U prolly -d prolly -tAc "SELECT 1" 2>/dev/null |
+        tr -d '[:space:]' | grep -qx 1; then
+      consecutive_ready=$((consecutive_ready + 1))
+      [[ "$consecutive_ready" -ge 3 ]] && return 0
+    else
+      consecutive_ready=0
+    fi
+    sleep 1
+  done
+  compose "$POSTGRES_PROJECT" logs postgres >&2 || true
+  return 1
+}
+
+wait_for_spanner() {
+  for _ in $(seq 1 120); do
+    if (echo >"/dev/tcp/127.0.0.1/$SPANNER_GRPC_PORT") >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  compose "$SPANNER_PROJECT" logs spanner >&2 || true
+  return 1
+}
+
+initialize_spanner() {
+  local endpoint="http://127.0.0.1:$SPANNER_REST_PORT"
+  local instance_ready=false
+  local database_ready=false
+  for _ in $(seq 1 60); do
+    if "$CURL_BIN" --silent --fail-with-body \
+      -H "content-type: application/json" \
+      -X POST "$endpoint/v1/projects/prolly-local/instances" \
+      --data-binary '{
+        "instanceId": "prolly-instance",
+        "instance": {
+          "config": "projects/prolly-local/instanceConfigs/emulator-config",
+          "displayName": "Prolly Local",
+          "nodeCount": 1
+        }
+      }' >/dev/null 2>&1; then
+      instance_ready=true
+      break
+    fi
+    sleep 1
+  done
+  [[ "$instance_ready" == true ]] || return 1
+  for _ in $(seq 1 60); do
+    if "$CURL_BIN" --silent --fail-with-body \
+      -H "content-type: application/json" \
+      -X POST "$endpoint/v1/projects/prolly-local/instances/prolly-instance/databases" \
+      --data-binary '{
+        "createStatement": "CREATE DATABASE `prolly`",
+        "extraStatements": [
+          "CREATE TABLE ProllyNodes (Cid BYTES(32) NOT NULL, Node BYTES(MAX) NOT NULL) PRIMARY KEY (Cid)",
+          "CREATE TABLE ProllyHints (Namespace BYTES(MAX) NOT NULL, HintKey BYTES(MAX) NOT NULL, Value BYTES(MAX) NOT NULL) PRIMARY KEY (Namespace, HintKey)",
+          "CREATE TABLE ProllyRoots (Name BYTES(MAX) NOT NULL, Manifest BYTES(MAX) NOT NULL) PRIMARY KEY (Name)"
+        ]
+      }' >/dev/null 2>&1; then
+      database_ready=true
+      break
+    fi
+    sleep 1
+  done
+  [[ "$database_ready" == true ]] || return 1
+  for _ in $(seq 1 60); do
+    if "$CURL_BIN" --silent --fail \
+      "$endpoint/v1/projects/prolly-local/instances/prolly-instance/databases/prolly" \
+      >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+[[ "$MODE" == local || "$MODE" == external ]] ||
+  fail "BENCH_MODE must be local or external"
+if [[ "$MODE" == external ]]; then
+  [[ "${BENCH_EXTERNAL_RESET_ACK:-}" == "I_UNDERSTAND_BENCHMARK_DATA_WILL_BE_DELETED" ]] ||
+    fail "external mode requires BENCH_EXTERNAL_RESET_ACK=I_UNDERSTAND_BENCHMARK_DATA_WILL_BE_DELETED"
+  [[ -n "${BENCH_EXTERNAL_POSTGRES_IDENTITY:-}" ]] ||
+    fail "external mode requires BENCH_EXTERNAL_POSTGRES_IDENTITY"
+  [[ -n "${BENCH_EXTERNAL_SPANNER_IDENTITY:-}" ]] ||
+    fail "external mode requires BENCH_EXTERNAL_SPANNER_IDENTITY"
+  [[ -n "${PROLLY_BACKEND_POSTGRES_URL:-}" ]] ||
+    fail "external mode requires PROLLY_BACKEND_POSTGRES_URL"
+  [[ -n "${PROLLY_BACKEND_SPANNER_DATABASE:-}" ]] ||
+    fail "external mode requires PROLLY_BACKEND_SPANNER_DATABASE"
+fi
+[[ ! -e "$OUTPUT" ]] || fail "refusing to overwrite comparison output: $OUTPUT"
+for pair in \
+  "BENCH_RECORDS:$RECORDS" \
+  "BENCH_VALUE_BYTES:$VALUE_BYTES" \
+  "BENCH_CHANGES:$CHANGES" \
+  "BENCH_SAMPLES:$SAMPLES" \
+  "BENCH_CONCURRENCY:$CONCURRENCY" \
+  "BENCH_POOL_SIZE:$POOL_SIZE" \
+  "BENCH_ADAPTER_BATCH_ITEMS:$ADAPTER_BATCH_ITEMS" \
+  "BENCH_RUNS:$RUNS"; do
+  name="${pair%%:*}"
+  value="${pair#*:}"
+  is_positive_integer "$value" || fail "$name must be a positive integer"
+done
+((RUNS >= 7)) || fail "BENCH_RUNS must be at least 7"
+((CHANGES % 2 == 0)) || fail "BENCH_CHANGES must be even"
+((CHANGES <= RECORDS)) || fail "BENCH_CHANGES cannot exceed BENCH_RECORDS"
+((SAMPLES <= RECORDS)) || fail "BENCH_SAMPLES cannot exceed BENCH_RECORDS"
+
+REVISION="$("$GIT_BIN" -C "$REPO_ROOT" rev-parse HEAD)"
+TREE_HASH="$("$GIT_BIN" -C "$REPO_ROOT" rev-parse 'HEAD^{tree}')"
+[[ "$REVISION" =~ ^[0-9a-f]{40}$ ]] || fail "HEAD is not a committed Git revision"
+[[ "$TREE_HASH" =~ ^[0-9a-f]{40}$ ]] || fail "HEAD tree hash is invalid"
+[[ -z "$("$GIT_BIN" -C "$REPO_ROOT" status --porcelain --untracked-files=no)" ]] ||
+  fail "tracked worktree must be clean before comparison"
+
+mkdir -p "$OUTPUT/bin" "$OUTPUT/invocations" "$OUTPUT/warmup"
+RUN_STARTED=true
+MEASUREMENT_COMMANDS="$OUTPUT/measurement-commands.txt"
+: >"$MEASUREMENT_COMMANDS"
+RUN_ID="spanner-postgres-${REVISION:0:12}-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+
+{
+  printf 'environment_class=%s\n' "$([[ "$MODE" == local ]] && printf controlled_local || printf external)"
+  printf 'records=%s\n' "$RECORDS"
+  printf 'value_bytes=%s\n' "$VALUE_BYTES"
+  printf 'changes=%s\n' "$CHANGES"
+  printf 'samples=%s\n' "$SAMPLES"
+  printf 'concurrency=%s\n' "$CONCURRENCY"
+  printf 'pool_size=%s\n' "$POOL_SIZE"
+  printf 'adapter_batch_items=%s\n' "$ADAPTER_BATCH_ITEMS"
+  printf 'repetitions=%s\n' "$RUNS"
+  printf 'seed=%s\n' "$SEED"
+} >"$OUTPUT/config.txt"
+CONFIG_SHA256="$(sha256_file "$OUTPUT/config.txt")"
+
+{
+  printf 'captured_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  uname -a
+  rustc --version
+  "$CARGO_BIN" --version
+  if [[ "$MODE" == local ]]; then
+    "$DOCKER_BIN" info --format \
+      'docker_server={{.ServerVersion}} os={{.OperatingSystem}} cpus={{.NCPU}} memory={{.MemTotal}}'
+  else
+    printf 'external_postgres_identity=%s\n' "$BENCH_EXTERNAL_POSTGRES_IDENTITY"
+    printf 'external_spanner_identity=%s\n' "$BENCH_EXTERNAL_SPANNER_IDENTITY"
+  fi
+} >"$OUTPUT/machine.txt"
+
+if [[ "${BENCH_SKIP_BUILD:-0}" != 1 ]]; then
+  "$CARGO_BIN" build --release --no-default-features --features spanner --bins \
+    --manifest-path "$MANIFEST" 2>&1 | tee "$OUTPUT/build.log"
+  "$CARGO_BIN" tree --no-default-features --features spanner \
+    --manifest-path "$MANIFEST" >"$OUTPUT/dependencies.txt"
+fi
+[[ "$("$GIT_BIN" -C "$REPO_ROOT" rev-parse HEAD)" == "$REVISION" ]] ||
+  fail "HEAD changed during benchmark build"
+[[ -z "$("$GIT_BIN" -C "$REPO_ROOT" status --porcelain --untracked-files=no)" ]] ||
+  fail "tracked worktree changed during benchmark build"
+LOCKFILE_SHA256="$(sha256_file "$LOCKFILE")"
+
+POSTGRES_SOURCE="${BENCH_POSTGRES_EXECUTABLE:-$REPO_ROOT/benchmarks/backend-comparison/target/release/prolly-backend-postgres}"
+SPANNER_SOURCE="${BENCH_SPANNER_EXECUTABLE:-$REPO_ROOT/benchmarks/backend-comparison/target/release/prolly-backend-spanner}"
+SUMMARIZER_SOURCE="${BENCH_SUMMARIZER_EXECUTABLE:-$REPO_ROOT/benchmarks/backend-comparison/target/release/prolly-backend-summarize}"
+SERVICE_SUMMARIZER="${BENCH_SERVICE_SUMMARIZER:-$SCRIPT_DIR/summarize_mysql_postgres_service.py}"
+for executable in "$POSTGRES_SOURCE" "$SPANNER_SOURCE" "$SUMMARIZER_SOURCE"; do
+  [[ -x "$executable" ]] ||
+    fail "benchmark executable is missing or not executable: $executable"
+done
+cp "$POSTGRES_SOURCE" "$OUTPUT/bin/prolly-backend-postgres"
+cp "$SPANNER_SOURCE" "$OUTPUT/bin/prolly-backend-spanner"
+cp "$SUMMARIZER_SOURCE" "$OUTPUT/bin/prolly-backend-summarize"
+POSTGRES_EXECUTABLE="$OUTPUT/bin/prolly-backend-postgres"
+SPANNER_EXECUTABLE="$OUTPUT/bin/prolly-backend-spanner"
+SUMMARIZER_EXECUTABLE="$OUTPUT/bin/prolly-backend-summarize"
+POSTGRES_BINARY_SHA256="$(sha256_file "$POSTGRES_EXECUTABLE")"
+SPANNER_BINARY_SHA256="$(sha256_file "$SPANNER_EXECUTABLE")"
+SUMMARIZER_BINARY_SHA256="$(sha256_file "$SUMMARIZER_EXECUTABLE")"
+{
+  printf '%s  %s\n' "$POSTGRES_BINARY_SHA256" "bin/prolly-backend-postgres"
+  printf '%s  %s\n' "$SPANNER_BINARY_SHA256" "bin/prolly-backend-spanner"
+  printf '%s  %s\n' "$SUMMARIZER_BINARY_SHA256" "bin/prolly-backend-summarize"
+} >"$OUTPUT/binaries.sha256"
+
+if [[ "$MODE" == local ]]; then
+  if [[ "${BENCH_SKIP_IMAGE_PULL:-0}" != 1 ]]; then
+    {
+      "$DOCKER_BIN" pull "$POSTGRES_IMAGE"
+      "$DOCKER_BIN" pull "$SPANNER_IMAGE"
+    } >"$OUTPUT/image-pull.log"
+  fi
+  POSTGRES_IMAGE_ID="$("$DOCKER_BIN" image inspect "$POSTGRES_IMAGE" --format '{{.Id}}')"
+  SPANNER_IMAGE_ID="$("$DOCKER_BIN" image inspect "$SPANNER_IMAGE" --format '{{.Id}}')"
+else
+  POSTGRES_IMAGE="external"
+  SPANNER_IMAGE="external"
+  POSTGRES_IMAGE_ID="$BENCH_EXTERNAL_POSTGRES_IDENTITY"
+  SPANNER_IMAGE_ID="$BENCH_EXTERNAL_SPANNER_IDENTITY"
+fi
+[[ -n "$POSTGRES_IMAGE_ID" && -n "$SPANNER_IMAGE_ID" ]] ||
+  fail "service identities are unavailable"
+{
+  printf 'postgres_image=%s\n' "$POSTGRES_IMAGE"
+  printf 'postgres_image_id=%s\n' "$POSTGRES_IMAGE_ID"
+  printf 'spanner_image=%s\n' "$SPANNER_IMAGE"
+  printf 'spanner_image_id=%s\n' "$SPANNER_IMAGE_ID"
+} >"$OUTPUT/images.txt"
+
+run_backend() {
+  local backend="$1"
+  local repetition="$2"
+  local output="$3"
+  local service_output="$4"
+  local invocation_run_id="$5"
+  local executable binary_sha256
+  local -a connection_args environment_args
+
+  if [[ "$backend" == postgres ]]; then
+    executable="$POSTGRES_EXECUTABLE"
+    binary_sha256="$POSTGRES_BINARY_SHA256"
+    connection_args=(--url "$POSTGRES_URL")
+    environment_args=(env)
+    if [[ "$MODE" == local ]]; then
+      record_command "$DOCKER_BIN" compose -p "$POSTGRES_PROJECT" \
+        -f "$COMPOSE_FILE" down -v
+      record_command env PROLLY_BACKEND_POSTGRES_PORT="$POSTGRES_PORT" \
+        "$DOCKER_BIN" compose -p "$POSTGRES_PROJECT" -f "$COMPOSE_FILE" up -d postgres
+      wait_for_postgres
+    fi
+  else
+    executable="$SPANNER_EXECUTABLE"
+    binary_sha256="$SPANNER_BINARY_SHA256"
+    connection_args=(--database "$SPANNER_DATABASE")
+    if [[ "$MODE" == local ]]; then
+      environment_args=(env "SPANNER_EMULATOR_HOST=127.0.0.1:$SPANNER_GRPC_PORT")
+      record_command "$DOCKER_BIN" compose -p "$SPANNER_PROJECT" \
+        -f "$COMPOSE_FILE" down -v
+      record_command env \
+        PROLLY_BACKEND_SPANNER_GRPC_PORT="$SPANNER_GRPC_PORT" \
+        PROLLY_BACKEND_SPANNER_REST_PORT="$SPANNER_REST_PORT" \
+        "$DOCKER_BIN" compose -p "$SPANNER_PROJECT" -f "$COMPOSE_FILE" up -d spanner
+      wait_for_spanner
+      initialize_spanner
+    else
+      environment_args=(env -u SPANNER_EMULATOR_HOST)
+    fi
+  fi
+
+  local -a common_args=(
+    --run-id "$invocation_run_id"
+    --repetition "$repetition"
+    --revision "$REVISION"
+    --tree-hash "$TREE_HASH"
+    --binary-sha256 "$binary_sha256"
+    --records "$RECORDS"
+    --value-bytes "$VALUE_BYTES"
+    --changes "$CHANGES"
+    --samples "$SAMPLES"
+    --concurrency "$CONCURRENCY"
+    --pool-size "$POOL_SIZE"
+    --adapter-batch-items "$ADAPTER_BATCH_ITEMS"
+    --seed "$SEED"
+  )
+  record_runner_command "${environment_args[@]}" "$executable" \
+    --output "$output" "${common_args[@]}" "${connection_args[@]}" --suite end-to-end
+  record_runner_command "${environment_args[@]}" "$executable" \
+    --output "$service_output" "${common_args[@]}" "${connection_args[@]}" --suite service
+
+  if [[ "$MODE" == local ]]; then
+    if [[ "$backend" == postgres ]]; then
+      record_command "$DOCKER_BIN" compose -p "$POSTGRES_PROJECT" \
+        -f "$COMPOSE_FILE" down -v
+    else
+      record_command "$DOCKER_BIN" compose -p "$SPANNER_PROJECT" \
+        -f "$COMPOSE_FILE" down -v
+    fi
+  fi
+}
+
+run_backend postgres 1 "$OUTPUT/warmup/postgres.csv" \
+  "$OUTPUT/warmup/postgres-service.csv" "$RUN_ID-warmup-postgres"
+run_backend spanner 1 "$OUTPUT/warmup/spanner.csv" \
+  "$OUTPUT/warmup/spanner-service.csv" "$RUN_ID-warmup-spanner"
+
+measured_files=()
+measured_service_files=()
+for repetition in $(seq 1 "$RUNS"); do
+  if ((repetition % 2 == 1)); then
+    order=(postgres spanner)
+  else
+    order=(spanner postgres)
+  fi
+  for backend in "${order[@]}"; do
+    file="$OUTPUT/invocations/${repetition}-${backend}.csv"
+    service_file="$OUTPUT/invocations/${repetition}-${backend}-service.csv"
+    run_backend "$backend" "$repetition" "$file" "$service_file" "$RUN_ID"
+    measured_files+=("$file")
+    measured_service_files+=("$service_file")
+  done
+done
+
+combine_csv() {
+  local destination="$1"
+  shift
+  local first=true
+  local header=""
+  local file current_header
+  for file in "$@"; do
+    current_header="$(head -n 1 "$file")"
+    if [[ "$first" == true ]]; then
+      cp "$file" "$destination"
+      header="$current_header"
+      first=false
+    else
+      [[ "$current_header" == "$header" ]] ||
+        fail "evidence headers differ: $file"
+      tail -n +2 "$file" >>"$destination"
+    fi
+  done
+}
+
+RAW_RESULTS="$OUTPUT/raw-results.csv"
+RAW_SERVICE_RESULTS="$OUTPUT/raw-service-results.csv"
+combine_csv "$RAW_RESULTS" "${measured_files[@]}"
+combine_csv "$RAW_SERVICE_RESULTS" "${measured_service_files[@]}"
+
+write_shell_command "$SUMMARIZER_EXECUTABLE" \
+  --input "$RAW_RESULTS" --manifest "$OUTPUT/manifest.txt" --output-dir "$OUTPUT" \
+  >>"$MEASUREMENT_COMMANDS"
+write_shell_command "$SERVICE_SUMMARIZER" \
+  --input "$RAW_SERVICE_RESULTS" --manifest "$OUTPUT/manifest.txt" --output-dir "$OUTPUT" \
+  >>"$MEASUREMENT_COMMANDS"
+COMMANDS_SHA256="$(sha256_file "$MEASUREMENT_COMMANDS")"
+{
+  printf 'schema=backend-comparison-manifest-v1\n'
+  printf 'status=complete\n'
+  printf 'resumed=false\n'
+  printf 'dirty=false\n'
+  printf 'environment_class=%s\n' "$([[ "$MODE" == local ]] && printf controlled_local || printf external)"
+  printf 'backend_a=postgres\n'
+  printf 'backend_b=spanner\n'
+  printf 'run_id=%s\n' "$RUN_ID"
+  printf 'revision=%s\n' "$REVISION"
+  printf 'tree_hash=%s\n' "$TREE_HASH"
+  printf 'contract_version=backend-workload-v1\n'
+  printf 'timed_scope_version=public-prolly-operation-v1\n'
+  printf 'result_schema=backend-comparison-v1\n'
+  printf 'repetitions=%s\n' "$RUNS"
+  printf 'lockfile_sha256=%s\n' "$LOCKFILE_SHA256"
+  printf 'config_sha256=%s\n' "$CONFIG_SHA256"
+  printf 'commands_sha256=%s\n' "$COMMANDS_SHA256"
+  printf 'postgres_binary_sha256=%s\n' "$POSTGRES_BINARY_SHA256"
+  printf 'spanner_binary_sha256=%s\n' "$SPANNER_BINARY_SHA256"
+  printf 'summarizer_binary_sha256=%s\n' "$SUMMARIZER_BINARY_SHA256"
+  printf 'postgres_image=%s\n' "$POSTGRES_IMAGE"
+  printf 'postgres_image_id=%s\n' "$POSTGRES_IMAGE_ID"
+  printf 'spanner_image=%s\n' "$SPANNER_IMAGE"
+  printf 'spanner_image_id=%s\n' "$SPANNER_IMAGE_ID"
+} >"$OUTPUT/manifest.txt"
+
+"$SUMMARIZER_EXECUTABLE" \
+  --input "$RAW_RESULTS" --manifest "$OUTPUT/manifest.txt" --output-dir "$OUTPUT"
+"$SERVICE_SUMMARIZER" \
+  --input "$RAW_SERVICE_RESULTS" --manifest "$OUTPUT/manifest.txt" --output-dir "$OUTPUT"
+[[ "$(sha256_file "$MEASUREMENT_COMMANDS")" == "$COMMANDS_SHA256" ]] ||
+  fail "measurement command provenance changed after the manifest was sealed"
+{
+  printf 'status=complete\n'
+  printf 'completed_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} >"$OUTPUT/run-state.txt"
+printf 'Spanner/PostgreSQL comparison complete: %s/report.md\n' "$OUTPUT"

--- a/scripts/summarize_mysql_postgres_service.py
+++ b/scripts/summarize_mysql_postgres_service.py
@@ -22,14 +22,16 @@ def manifest(path: pathlib.Path) -> dict[str, str]:
         "status": "complete",
         "resumed": "false",
         "dirty": "false",
-        "backend_a": "postgres",
-        "backend_b": "mysql",
     }
     for key, expected in required.items():
         if values.get(key) != expected:
             raise ValueError(f"manifest {key} must be {expected}")
     if int(values["repetitions"]) < 7:
         raise ValueError("service comparison requires at least seven repetitions")
+    if not values.get("backend_a") or not values.get("backend_b"):
+        raise ValueError("service comparison requires two declared backends")
+    if values["backend_a"] == values["backend_b"]:
+        raise ValueError("service comparison backends must differ")
     return values
 
 
@@ -51,7 +53,7 @@ def load(path: pathlib.Path, values: dict[str, str]) -> list[dict[str, str]]:
         ):
             raise ValueError("service row provenance or validation differs")
         backend = row["backend"]
-        if backend not in ("postgres", "mysql"):
+        if backend not in (values["backend_a"], values["backend_b"]):
             raise ValueError(f"unexpected service backend: {backend}")
         if row["binary_sha256"] != values[f"{backend}_binary_sha256"]:
             raise ValueError(f"{backend} service binary identity differs")
@@ -95,20 +97,22 @@ def bootstrap_ratio(first: list[float], second: list[float], seed: int) -> tuple
     return percentile(ratios, 0.025), percentile(ratios, 0.975)
 
 
-def summarize(rows: list[dict[str, str]], repetitions: int) -> list[dict[str, str]]:
+def summarize(
+    rows: list[dict[str, str]], repetitions: int, backend_a: str, backend_b: str
+) -> list[dict[str, str]]:
     indexed = {
         (row["backend"], row["operation"], int(row["repetition"])): row for row in rows
     }
     summaries = []
     for operation_index, operation in enumerate(OPERATIONS):
-        postgres = []
-        mysql = []
-        postgres_p99 = []
-        mysql_p99 = []
+        first_samples = []
+        second_samples = []
+        first_p99 = []
+        second_p99 = []
         reference = None
         for repetition in range(1, repetitions + 1):
-            pg = indexed[("postgres", operation, repetition)]
-            my = indexed[("mysql", operation, repetition)]
+            first = indexed[(backend_a, operation, repetition)]
+            second = indexed[(backend_b, operation, repetition)]
             identity_fields = (
                 "clients",
                 "pool_size",
@@ -117,24 +121,24 @@ def summarize(rows: list[dict[str, str]], repetitions: int) -> list[dict[str, st
                 "applied",
                 "conflicts",
             )
-            if any(pg[field] != my[field] for field in identity_fields):
+            if any(first[field] != second[field] for field in identity_fields):
                 raise ValueError(f"{operation} repetition {repetition} differs between backends")
-            identity = tuple(pg[field] for field in identity_fields)
+            identity = tuple(first[field] for field in identity_fields)
             if reference is not None and identity != reference:
                 raise ValueError(f"{operation} configuration changed between repetitions")
             reference = identity
-            postgres.append(float(pg["total_ns"]))
-            mysql.append(float(my["total_ns"]))
-            postgres_p99.append(float(pg["p99_ns"]))
-            mysql_p99.append(float(my["p99_ns"]))
-        pg_median = statistics.median(postgres)
-        my_median = statistics.median(mysql)
-        ratio = my_median / pg_median
-        low, high = bootstrap_ratio(postgres, mysql, SEED ^ operation_index)
+            first_samples.append(float(first["total_ns"]))
+            second_samples.append(float(second["total_ns"]))
+            first_p99.append(float(first["p99_ns"]))
+            second_p99.append(float(second["p99_ns"]))
+        first_median = statistics.median(first_samples)
+        second_median = statistics.median(second_samples)
+        ratio = second_median / first_median
+        low, high = bootstrap_ratio(first_samples, second_samples, SEED ^ operation_index)
         if low > 1 and ratio > 1.05:
-            winner = "postgres"
+            winner = backend_a
         elif high < 1 and ratio < 1 / 1.05:
-            winner = "mysql"
+            winner = backend_b
         else:
             winner = "inconclusive"
         summaries.append(
@@ -144,13 +148,13 @@ def summarize(rows: list[dict[str, str]], repetitions: int) -> list[dict[str, st
                 "pool_size": reference[1],
                 "adapter_batch_items": reference[2],
                 "logical_operations": reference[3],
-                "postgres_median_ms": f"{pg_median / 1_000_000:.6f}",
-                "postgres_ops_per_sec": f"{float(reference[3]) * 1_000_000_000 / pg_median:.6f}",
-                "postgres_p99_ms": f"{statistics.median(postgres_p99) / 1_000_000:.6f}",
-                "mysql_median_ms": f"{my_median / 1_000_000:.6f}",
-                "mysql_ops_per_sec": f"{float(reference[3]) * 1_000_000_000 / my_median:.6f}",
-                "mysql_p99_ms": f"{statistics.median(mysql_p99) / 1_000_000:.6f}",
-                "mysql_to_postgres_latency": f"{ratio:.9f}",
+                f"{backend_a}_median_ms": f"{first_median / 1_000_000:.6f}",
+                f"{backend_a}_ops_per_sec": f"{float(reference[3]) * 1_000_000_000 / first_median:.6f}",
+                f"{backend_a}_p99_ms": f"{statistics.median(first_p99) / 1_000_000:.6f}",
+                f"{backend_b}_median_ms": f"{second_median / 1_000_000:.6f}",
+                f"{backend_b}_ops_per_sec": f"{float(reference[3]) * 1_000_000_000 / second_median:.6f}",
+                f"{backend_b}_p99_ms": f"{statistics.median(second_p99) / 1_000_000:.6f}",
+                f"{backend_b}_to_{backend_a}_latency": f"{ratio:.9f}",
                 "ratio_ci_low": f"{low:.9f}",
                 "ratio_ci_high": f"{high:.9f}",
                 "winner": winner,
@@ -160,23 +164,41 @@ def summarize(rows: list[dict[str, str]], repetitions: int) -> list[dict[str, st
 
 
 def report(rows: list[dict[str, str]], values: dict[str, str]) -> str:
+    backend_a = values["backend_a"]
+    backend_b = values["backend_b"]
+    labels = {
+        "postgres": "PostgreSQL",
+        "mysql": "MySQL",
+        "spanner": "Spanner",
+        "dynamodb_local": "DynamoDB Local",
+    }
+    first_label = labels.get(backend_a, backend_a)
+    second_label = labels.get(backend_b, backend_b)
     lines = [
-        "# PostgreSQL vs MySQL adapter service comparison",
+        f"# {first_label} vs {second_label} adapter service comparison",
         "",
         f"Environment class: `{values.get('environment_class', 'controlled_local')}`. "
         f"Results use {values['repetitions']} measured repetitions.",
         "",
-        "| Operation | Logical ops | PostgreSQL median | PostgreSQL ops/s | "
-        "PostgreSQL p99 | MySQL median | MySQL ops/s | MySQL p99 | "
-        "MySQL/PG 95% CI | Result |",
+        f"| Operation | Logical ops | {first_label} median | {first_label} ops/s | "
+        f"{first_label} p99 | {second_label} median | {second_label} ops/s | "
+        f"{second_label} p99 | {second_label}/{first_label} 95% CI | Result |",
         "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|",
     ]
     for row in rows:
         lines.append(
-            "| {operation} | {logical_operations} | {postgres_median_ms} ms | "
-            "{postgres_ops_per_sec} | {postgres_p99_ms} ms | {mysql_median_ms} ms | "
-            "{mysql_ops_per_sec} | {mysql_p99_ms} ms | {ratio_ci_low}–"
-            "{ratio_ci_high} | {winner} |".format(**row)
+            "| {operation} | {logical_operations} | {first_median_ms} ms | "
+            "{first_ops_per_sec} | {first_p99_ms} ms | {second_median_ms} ms | "
+            "{second_ops_per_sec} | {second_p99_ms} ms | {ratio_ci_low}–"
+            "{ratio_ci_high} | {winner} |".format(
+                first_median_ms=row[f"{backend_a}_median_ms"],
+                first_ops_per_sec=row[f"{backend_a}_ops_per_sec"],
+                first_p99_ms=row[f"{backend_a}_p99_ms"],
+                second_median_ms=row[f"{backend_b}_median_ms"],
+                second_ops_per_sec=row[f"{backend_b}_ops_per_sec"],
+                second_p99_ms=row[f"{backend_b}_p99_ms"],
+                **row,
+            )
         )
     lines.extend(
         [
@@ -201,7 +223,12 @@ def main() -> None:
     args = parser.parse_args()
     values = manifest(args.manifest)
     rows = load(args.input, values)
-    summaries = summarize(rows, int(values["repetitions"]))
+    summaries = summarize(
+        rows,
+        int(values["repetitions"]),
+        values["backend_a"],
+        values["backend_b"],
+    )
     csv_path = args.output_dir / "service-comparison.csv"
     report_path = args.output_dir / "service-report.md"
     if csv_path.exists() or report_path.exists():

--- a/stores/prolly-store-cosmosdb/Cargo.toml
+++ b/stores/prolly-store-cosmosdb/Cargo.toml
@@ -21,12 +21,14 @@ base64 = "0.22.1"
 hex = "0.4"
 hmac = "0.12.1"
 httpdate = "1.0.3"
+futures-util = "0.3"
 percent-encoding = "2.3.2"
 prolly = { package = "prolly-map", path = "../..", version = "0.5.0", features = ["async-store"] }
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
+tokio = { version = "1.45", features = ["time"] }
 
 [dev-dependencies]
 tokio = { version = "1.45", features = ["rt-multi-thread", "time"] }

--- a/stores/prolly-store-cosmosdb/README.md
+++ b/stores/prolly-store-cosmosdb/README.md
@@ -119,8 +119,10 @@ root conditions and applies staged node/root writes atomically; if a root change
 since the transaction read it, the commit returns a conflict and Cosmos rolls the
 batch back.
 
-Cosmos DB limits one transactional batch to a single partition key and up to 100
-operations. Large transactions should be split by the caller.
+Cosmos DB limits one transactional batch to a single partition key, 100
+operations, and a 2 MiB request payload. The adapter validates strict
+transactions against both limits and automatically divides non-transactional
+node publication into valid batches.
 
 ## Diff and merge
 
@@ -171,8 +173,13 @@ async fn run(backend: CosmosDbBackend) -> Result<(), Box<dyn std::error::Error>>
 - Use `with_key_prefix` for tenant, environment, and test isolation.
 - `clear_namespace` queries each `kind` partition and deletes matching prefixed
   documents. It is intended for isolated tests, not broad production cleanup.
-- Batch methods are implemented as ordered REST calls. Size RU/s and retry
-  policy around your production workload.
+- Node publication uses native atomic transactional batches. Ordered batch
+  reads issue bounded concurrent point reads and reconstruct request order.
+- Throttled and transient responses honor `x-ms-retry-after-ms` with a bounded
+  retry budget. `CosmosDbBackendOptions` controls concurrency, query pages,
+  retries, and hint maintenance.
+- `CosmosDbBackend::metrics()` reports requests, retries, and observed request
+  charge without requiring a metrics SDK.
 - Root compare-and-swap uses document ETags.
 
 ## Running the example
@@ -201,6 +208,19 @@ cargo test --manifest-path stores/prolly-store-cosmosdb/Cargo.toml
 
 Use a dedicated container or key prefix for integration tests. The test suite
 creates isolated records but still consumes provisioned request units.
+
+For a credential-free local Cosmos/Spanner conformance and performance
+comparison, run:
+
+```bash
+scripts/run-cosmos-spanner-comparison.sh
+```
+
+The script starts the Linux vNext Cosmos emulator and the Spanner emulator,
+creates their schemas, runs transaction/contention conformance, and records the
+same Rust adapter workload for both. If the `PROLLY_STORE_COSMOS_*` and
+`PROLLY_STORE_SPANNER_DATABASE` variables are already supplied, it uses those
+managed services instead.
 
 See the [`prolly-map` API documentation](https://docs.rs/prolly-map) for the
 async map, transaction, diff, and merge APIs used with this backend.

--- a/stores/prolly-store-cosmosdb/examples/basic_usage.rs
+++ b/stores/prolly-store-cosmosdb/examples/basic_usage.rs
@@ -63,13 +63,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
     let resolver: Resolver = Box::new(|conflict| {
         let mut value = conflict.left.clone().unwrap_or_default();
         value.extend_from_slice(b"+");
-        value.extend_from_slice(
-            conflict
-                .right
-                .as_ref()
-                .map(Vec::as_slice)
-                .unwrap_or_default(),
-        );
+        value.extend_from_slice(conflict.right.as_deref().unwrap_or_default());
         Resolution::value(value)
     });
     let resolved = prolly

--- a/stores/prolly-store-cosmosdb/src/lib.rs
+++ b/stores/prolly-store-cosmosdb/src/lib.rs
@@ -10,10 +10,13 @@ pub mod cosmosdb {
     use std::collections::{HashMap, HashSet};
     use std::error::Error as StdError;
     use std::fmt;
-    use std::time::SystemTime;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+    use std::time::{Duration, SystemTime};
 
     use base64::engine::general_purpose::STANDARD as BASE64;
     use base64::Engine as _;
+    use futures_util::stream::{self, StreamExt, TryStreamExt};
     use hmac::{Hmac, Mac};
     use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
     use reqwest::{Method, StatusCode};
@@ -34,7 +37,7 @@ pub mod cosmosdb {
     /// all documents for one backend instance under a single `kind` partition
     /// value so Cosmos DB transactional batches can atomically commit nodes and
     /// roots together. The logical document family lives in `family`.
-    #[derive(Clone, Debug)]
+    #[derive(Clone)]
     pub struct CosmosDbBackend {
         http: reqwest::Client,
         endpoint: String,
@@ -44,7 +47,107 @@ pub mod cosmosdb {
         container_link: String,
         key_prefix: Vec<u8>,
         partition_key: String,
-        read_parallelism: usize,
+        options: CosmosDbBackendOptions,
+        metrics: Arc<CosmosDbMetrics>,
+    }
+
+    impl fmt::Debug for CosmosDbBackend {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("CosmosDbBackend")
+                .field("endpoint", &self.endpoint)
+                .field("database_id", &self.database_id)
+                .field("container_id", &self.container_id)
+                .field("key_prefix", &self.key_prefix)
+                .field("partition_key", &self.partition_key)
+                .field("options", &self.options)
+                .finish_non_exhaustive()
+        }
+    }
+
+    /// Performance and retry controls for the Cosmos DB REST backend.
+    #[derive(Clone, Debug)]
+    pub struct CosmosDbBackendOptions {
+        /// Maximum in-flight point reads in a batch.
+        pub max_concurrency: usize,
+        /// Maximum in-flight reads advertised to prolly traversal paths.
+        pub read_parallelism: usize,
+        /// Number of retry attempts after the initial request.
+        pub max_retries: usize,
+        /// Maximum cumulative server-requested retry delay.
+        pub max_retry_wait: Duration,
+        /// Maximum documents requested per query page.
+        pub query_page_size: usize,
+        /// Maintain rightmost-path hints for append-heavy maps.
+        pub rightmost_path_hints: bool,
+    }
+
+    impl Default for CosmosDbBackendOptions {
+        fn default() -> Self {
+            Self {
+                max_concurrency: DEFAULT_MAX_CONCURRENCY,
+                read_parallelism: DEFAULT_READ_PARALLELISM,
+                max_retries: DEFAULT_MAX_RETRIES,
+                max_retry_wait: DEFAULT_MAX_RETRY_WAIT,
+                query_page_size: DEFAULT_QUERY_PAGE_SIZE,
+                rightmost_path_hints: true,
+            }
+        }
+    }
+
+    impl CosmosDbBackendOptions {
+        /// Set maximum in-flight point reads used by native batches.
+        pub fn with_max_concurrency(mut self, max_concurrency: usize) -> Self {
+            self.max_concurrency = max_concurrency.max(1);
+            self
+        }
+
+        /// Set maximum traversal read concurrency.
+        pub fn with_read_parallelism(mut self, read_parallelism: usize) -> Self {
+            self.read_parallelism = read_parallelism.max(1);
+            self
+        }
+
+        /// Set the number of retries for 429, 408, and 503 responses.
+        pub fn with_max_retries(mut self, max_retries: usize) -> Self {
+            self.max_retries = max_retries;
+            self
+        }
+
+        /// Bound cumulative backoff time for a request.
+        pub fn with_max_retry_wait(mut self, max_retry_wait: Duration) -> Self {
+            self.max_retry_wait = max_retry_wait;
+            self
+        }
+
+        /// Set the number of documents requested per query page.
+        pub fn with_query_page_size(mut self, query_page_size: usize) -> Self {
+            self.query_page_size = query_page_size.max(1);
+            self
+        }
+
+        /// Enable or disable rightmost-path hint maintenance.
+        pub fn with_rightmost_path_hints(mut self, enabled: bool) -> Self {
+            self.rightmost_path_hints = enabled;
+            self
+        }
+    }
+
+    #[derive(Default)]
+    struct CosmosDbMetrics {
+        requests: AtomicU64,
+        retries: AtomicU64,
+        request_charge_micros: AtomicU64,
+    }
+
+    /// A point-in-time snapshot of low-overhead Cosmos DB request metrics.
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
+    pub struct CosmosDbMetricsSnapshot {
+        /// Total HTTP responses received, including retry attempts.
+        pub requests: u64,
+        /// Total retry attempts triggered by throttling or transient status codes.
+        pub retries: u64,
+        /// Sum of `x-ms-request-charge` values observed on responses.
+        pub request_charge: f64,
     }
 
     impl CosmosDbBackend {
@@ -55,12 +158,13 @@ pub mod cosmosdb {
             database_id: impl Into<String>,
             container_id: impl Into<String>,
         ) -> Result<Self, CosmosDbBackendError> {
-            Self::with_http_client(
+            Self::with_http_client_and_options(
                 reqwest::Client::new(),
                 endpoint,
                 account_key,
                 database_id,
                 container_id,
+                CosmosDbBackendOptions::default(),
             )
         }
 
@@ -71,6 +175,25 @@ pub mod cosmosdb {
             account_key: &str,
             database_id: impl Into<String>,
             container_id: impl Into<String>,
+        ) -> Result<Self, CosmosDbBackendError> {
+            Self::with_http_client_and_options(
+                http,
+                endpoint,
+                account_key,
+                database_id,
+                container_id,
+                CosmosDbBackendOptions::default(),
+            )
+        }
+
+        /// Create a backend with a caller-provided client and performance controls.
+        pub fn with_http_client_and_options(
+            http: reqwest::Client,
+            endpoint: impl Into<String>,
+            account_key: &str,
+            database_id: impl Into<String>,
+            container_id: impl Into<String>,
+            options: CosmosDbBackendOptions,
         ) -> Result<Self, CosmosDbBackendError> {
             let database_id = database_id.into();
             let container_id = container_id.into();
@@ -91,7 +214,15 @@ pub mod cosmosdb {
                 container_link,
                 key_prefix: DEFAULT_KEY_PREFIX.to_vec(),
                 partition_key: DEFAULT_PARTITION_KEY.to_string(),
-                read_parallelism: DEFAULT_READ_PARALLELISM,
+                options: CosmosDbBackendOptions {
+                    max_concurrency: options.max_concurrency.max(1),
+                    read_parallelism: options.read_parallelism.max(1),
+                    max_retries: options.max_retries,
+                    max_retry_wait: options.max_retry_wait,
+                    query_page_size: options.query_page_size.max(1),
+                    rightmost_path_hints: options.rightmost_path_hints,
+                },
+                metrics: Arc::new(CosmosDbMetrics::default()),
             })
         }
 
@@ -137,8 +268,18 @@ pub mod cosmosdb {
 
         /// Set the read parallelism advertised to async prolly traversals.
         pub fn with_read_parallelism(mut self, read_parallelism: usize) -> Self {
-            self.read_parallelism = read_parallelism.max(1);
+            self.options.read_parallelism = read_parallelism.max(1);
             self
+        }
+
+        /// Return cumulative request, retry, and request-unit metrics.
+        pub fn metrics(&self) -> CosmosDbMetricsSnapshot {
+            CosmosDbMetricsSnapshot {
+                requests: self.metrics.requests.load(Ordering::Relaxed),
+                retries: self.metrics.retries.load(Ordering::Relaxed),
+                request_charge: self.metrics.request_charge_micros.load(Ordering::Relaxed) as f64
+                    / 1_000_000.0,
+            }
         }
 
         /// Delete every document under this backend's namespace prefix.
@@ -152,13 +293,29 @@ pub mod cosmosdb {
             }
 
             for kind in [NODE_KIND, ROOT_KIND, HINT_KIND] {
-                let docs = self.query_kind(kind).await?;
+                let docs = self.query_kind(kind, &self.key_prefix).await?;
+                let mut operations = Vec::with_capacity(docs.len());
                 for doc in docs {
                     let logical_key = doc.logical_key()?;
                     if logical_key.starts_with(&self.key_prefix) {
-                        self.delete_document(kind, &logical_key, None, true).await?;
+                        let etag = match doc.etag {
+                            Some(etag) => etag,
+                            None => {
+                                let Some(current) = self.read_document(kind, &logical_key).await?
+                                else {
+                                    continue;
+                                };
+                                current.etag
+                            }
+                        };
+                        operations.push(CosmosBatchOperation::delete(
+                            document_id(&logical_key),
+                            self.batch_partition_key(),
+                            Some(etag),
+                        ));
                     }
                 }
+                self.execute_upsert_batches(&operations).await?;
             }
 
             Ok(())
@@ -222,6 +379,61 @@ pub mod cosmosdb {
                 .header("x-ms-version", COSMOS_API_VERSION))
         }
 
+        async fn send_with_retry(
+            &self,
+            request: reqwest::RequestBuilder,
+        ) -> Result<reqwest::Response, CosmosDbBackendError> {
+            let template = request.try_clone();
+            let mut next = Some(request);
+            let mut retry_wait = Duration::ZERO;
+            let mut attempt = 0usize;
+
+            loop {
+                let response = next
+                    .take()
+                    .expect("Cosmos DB request is available")
+                    .send()
+                    .await
+                    .map_err(CosmosDbBackendError::Http)?;
+                self.record_response_metrics(&response);
+
+                if !is_retryable_status(response.status()) || attempt >= self.options.max_retries {
+                    return Ok(response);
+                }
+                let Some(template) = template
+                    .as_ref()
+                    .and_then(reqwest::RequestBuilder::try_clone)
+                else {
+                    return Ok(response);
+                };
+
+                let delay = retry_delay(&response, attempt);
+                if retry_wait.saturating_add(delay) > self.options.max_retry_wait {
+                    return Ok(response);
+                }
+                retry_wait += delay;
+                attempt += 1;
+                self.metrics.retries.fetch_add(1, Ordering::Relaxed);
+                tokio::time::sleep(delay).await;
+                next = Some(template);
+            }
+        }
+
+        fn record_response_metrics(&self, response: &reqwest::Response) {
+            self.metrics.requests.fetch_add(1, Ordering::Relaxed);
+            if let Some(charge) = response
+                .headers()
+                .get("x-ms-request-charge")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.parse::<f64>().ok())
+            {
+                self.metrics.request_charge_micros.fetch_add(
+                    (charge.max(0.0) * 1_000_000.0).round() as u64,
+                    Ordering::Relaxed,
+                );
+            }
+        }
+
         fn authorization_header(
             &self,
             method: &str,
@@ -251,12 +463,10 @@ pub mod cosmosdb {
         ) -> Result<Option<CosmosReadDocument>, CosmosDbBackendError> {
             let id = document_id(logical_key);
             let link = self.document_link(&id);
-            let response = self
+            let request = self
                 .authorized_request(Method::GET, DOCS_RESOURCE, &link, self.resource_url(&link))?
-                .header("x-ms-documentdb-partitionkey", self.partition_key_header())
-                .send()
-                .await
-                .map_err(CosmosDbBackendError::Http)?;
+                .header("x-ms-documentdb-partitionkey", self.partition_key_header());
+            let response = self.send_with_retry(request).await?;
 
             if response.status() == StatusCode::NOT_FOUND {
                 return Ok(None);
@@ -283,7 +493,7 @@ pub mod cosmosdb {
         ) -> Result<(), CosmosDbBackendError> {
             let doc = self.document(kind, logical_key, value);
             let link = self.feed_link();
-            let response = self
+            let request = self
                 .authorized_request(
                     Method::POST,
                     DOCS_RESOURCE,
@@ -293,10 +503,8 @@ pub mod cosmosdb {
                 .header("content-type", "application/json")
                 .header("x-ms-documentdb-partitionkey", self.partition_key_header())
                 .header("x-ms-documentdb-is-upsert", "True")
-                .json(&doc)
-                .send()
-                .await
-                .map_err(CosmosDbBackendError::Http)?;
+                .json(&doc);
+            let response = self.send_with_retry(request).await?;
             ensure_status(response).await?;
             Ok(())
         }
@@ -309,7 +517,7 @@ pub mod cosmosdb {
         ) -> Result<bool, CosmosDbBackendError> {
             let doc = self.document(kind, logical_key, value);
             let link = self.feed_link();
-            let response = self
+            let request = self
                 .authorized_request(
                     Method::POST,
                     DOCS_RESOURCE,
@@ -319,10 +527,8 @@ pub mod cosmosdb {
                 .header("content-type", "application/json")
                 .header("if-none-match", "*")
                 .header("x-ms-documentdb-partitionkey", self.partition_key_header())
-                .json(&doc)
-                .send()
-                .await
-                .map_err(CosmosDbBackendError::Http)?;
+                .json(&doc);
+            let response = self.send_with_retry(request).await?;
             if is_conflict_status(response.status()) {
                 return Ok(false);
             }
@@ -340,15 +546,13 @@ pub mod cosmosdb {
             let id = document_id(logical_key);
             let doc = self.document(kind, logical_key, value);
             let link = self.document_link(&id);
-            let response = self
+            let request = self
                 .authorized_request(Method::PUT, DOCS_RESOURCE, &link, self.resource_url(&link))?
                 .header("content-type", "application/json")
                 .header("if-match", etag)
                 .header("x-ms-documentdb-partitionkey", self.partition_key_header())
-                .json(&doc)
-                .send()
-                .await
-                .map_err(CosmosDbBackendError::Http)?;
+                .json(&doc);
+            let response = self.send_with_retry(request).await?;
             if is_conflict_status(response.status()) {
                 return Ok(false);
             }
@@ -377,7 +581,7 @@ pub mod cosmosdb {
                 request = request.header("if-match", etag);
             }
 
-            let response = request.send().await.map_err(CosmosDbBackendError::Http)?;
+            let response = self.send_with_retry(request).await?;
             if response.status() == StatusCode::NOT_FOUND && ignore_missing {
                 return Ok(true);
             }
@@ -391,6 +595,7 @@ pub mod cosmosdb {
         async fn query_kind(
             &self,
             kind: &'static str,
+            logical_prefix: &[u8],
         ) -> Result<Vec<CosmosProllyDocument>, CosmosDbBackendError> {
             let mut documents = Vec::new();
             let mut continuation = None;
@@ -398,10 +603,11 @@ pub mod cosmosdb {
             loop {
                 let link = self.feed_link();
                 let body = serde_json::json!({
-                    "query": "SELECT * FROM c WHERE c.kind = @kind AND c.family = @family",
+                    "query": "SELECT * FROM c WHERE c.kind = @kind AND c.family = @family AND STARTSWITH(c.key, @prefix)",
                     "parameters": [
                         { "name": "@kind", "value": self.partition_key },
-                        { "name": "@family", "value": kind }
+                        { "name": "@family", "value": kind },
+                        { "name": "@prefix", "value": hex::encode(logical_prefix) }
                     ]
                 });
                 let mut request = self
@@ -414,15 +620,16 @@ pub mod cosmosdb {
                     .header("content-type", "application/query+json")
                     .header("x-ms-documentdb-isquery", "True")
                     .header("x-ms-documentdb-partitionkey", self.partition_key_header())
-                    .header("x-ms-max-item-count", "100")
+                    .header(
+                        "x-ms-max-item-count",
+                        self.options.query_page_size.to_string(),
+                    )
                     .json(&body);
                 if let Some(token) = continuation.as_deref() {
                     request = request.header("x-ms-continuation", token);
                 }
 
-                let response =
-                    ensure_status(request.send().await.map_err(CosmosDbBackendError::Http)?)
-                        .await?;
+                let response = ensure_status(self.send_with_retry(request).await?).await?;
                 continuation = response
                     .headers()
                     .get("x-ms-continuation")
@@ -451,6 +658,72 @@ pub mod cosmosdb {
             CosmosProllyDocument::new(&self.partition_key, kind, logical_key, value)
         }
 
+        async fn batch_upsert_operations(
+            &self,
+            kind: &'static str,
+            entries: &[(&[u8], &[u8])],
+        ) -> Result<Vec<CosmosBatchOperation>, CosmosDbBackendError> {
+            let mut operations = stream::iter(entries.iter().enumerate())
+                .map(|(index, (logical_key, value))| async move {
+                    let operation = match self.read_document(kind, logical_key).await? {
+                        Some(current) if current.document.value_bytes()?.as_slice() == *value => {
+                            None
+                        }
+                        Some(current) => Some(CosmosBatchOperation::replace(
+                            document_id(logical_key),
+                            self.batch_partition_key(),
+                            current.etag,
+                            self.document(kind, logical_key, value),
+                        )),
+                        None => Some(CosmosBatchOperation::upsert(
+                            self.batch_partition_key(),
+                            self.document(kind, logical_key, value),
+                        )),
+                    };
+                    Ok::<_, CosmosDbBackendError>((index, operation))
+                })
+                .buffer_unordered(self.options.max_concurrency)
+                .try_collect::<Vec<_>>()
+                .await?;
+            operations.sort_unstable_by_key(|(index, _)| *index);
+            Ok(operations
+                .into_iter()
+                .filter_map(|(_, operation)| operation)
+                .collect())
+        }
+
+        async fn prepare_node_batch_operation(
+            &self,
+            key: &[u8],
+            value: Option<&[u8]>,
+        ) -> Result<Option<CosmosBatchOperation>, CosmosDbBackendError> {
+            let logical_key = self.node_key(key);
+            let current = self.read_document(NODE_KIND, &logical_key).await?;
+            match (value, current) {
+                (Some(value), Some(current))
+                    if current.document.value_bytes()?.as_slice() == value =>
+                {
+                    Ok(None)
+                }
+                (Some(value), Some(current)) => Ok(Some(CosmosBatchOperation::replace(
+                    document_id(&logical_key),
+                    self.batch_partition_key(),
+                    current.etag,
+                    self.document(NODE_KIND, &logical_key, value),
+                ))),
+                (Some(value), None) => Ok(Some(CosmosBatchOperation::upsert(
+                    self.batch_partition_key(),
+                    self.document(NODE_KIND, &logical_key, value),
+                ))),
+                (None, Some(current)) => Ok(Some(CosmosBatchOperation::delete(
+                    document_id(&logical_key),
+                    self.batch_partition_key(),
+                    Some(current.etag),
+                ))),
+                (None, None) => Ok(None),
+            }
+        }
+
         fn partition_key_header(&self) -> String {
             partition_key(&self.partition_key)
         }
@@ -463,8 +736,9 @@ pub mod cosmosdb {
             &self,
             operations: &[CosmosBatchOperation],
         ) -> Result<Vec<CosmosBatchOperationResponse>, CosmosDbBackendError> {
+            validate_transaction_batch(operations)?;
             let link = self.feed_link();
-            let response = self
+            let request = self
                 .authorized_request(
                     Method::POST,
                     DOCS_RESOURCE,
@@ -475,16 +749,53 @@ pub mod cosmosdb {
                 .header("x-ms-documentdb-partitionkey", self.partition_key_header())
                 .header("x-ms-cosmos-is-batch-request", "True")
                 .header("x-ms-cosmos-batch-atomic", "True")
-                .json(operations)
-                .send()
-                .await
-                .map_err(CosmosDbBackendError::Http)?;
+                .json(operations);
 
-            let response = ensure_status(response).await?;
+            let response = ensure_status(self.send_with_retry(request).await?).await?;
             response
                 .json::<Vec<CosmosBatchOperationResponse>>()
                 .await
                 .map_err(CosmosDbBackendError::Http)
+        }
+
+        async fn execute_checked_batch(
+            &self,
+            operations: &[CosmosBatchOperation],
+        ) -> Result<(), CosmosDbBackendError> {
+            if operations.is_empty() {
+                return Ok(());
+            }
+            let responses = self.execute_transaction_batch(operations).await?;
+            if responses.len() != operations.len()
+                || responses.iter().any(|response| !response.is_success())
+            {
+                return Err(batch_response_error(&responses));
+            }
+            Ok(())
+        }
+
+        async fn execute_upsert_batches(
+            &self,
+            operations: &[CosmosBatchOperation],
+        ) -> Result<(), CosmosDbBackendError> {
+            let mut start = 0;
+            while start < operations.len() {
+                let mut end = (start + COSMOS_BATCH_OPERATION_LIMIT).min(operations.len());
+                loop {
+                    match validate_transaction_batch(&operations[start..end]) {
+                        Ok(()) => break,
+                        Err(CosmosDbBackendError::TransactionPayloadTooLarge { .. })
+                            if end > start + 1 =>
+                        {
+                            end -= 1;
+                        }
+                        Err(err) => return Err(err),
+                    }
+                }
+                self.execute_checked_batch(&operations[start..end]).await?;
+                start = end;
+            }
+            Ok(())
         }
 
         async fn push_root_condition_operation(
@@ -705,37 +1016,67 @@ pub mod cosmosdb {
         }
 
         async fn batch_nodes(&self, ops: &[RemoteBatchOp<'_>]) -> Result<(), Self::Error> {
-            for op in ops {
+            let mut writes = HashMap::<Vec<u8>, (usize, Option<Vec<u8>>)>::with_capacity(ops.len());
+            for (index, op) in ops.iter().enumerate() {
                 match op {
-                    RemoteBatchOp::Upsert { key, value } => self.put_node(key, value).await?,
-                    RemoteBatchOp::Delete { key } => self.delete_node(key).await?,
+                    RemoteBatchOp::Upsert { key, value } => {
+                        writes.insert(key.to_vec(), (index, Some(value.to_vec())));
+                    }
+                    RemoteBatchOp::Delete { key } => {
+                        writes.insert(key.to_vec(), (index, None));
+                    }
                 }
             }
-            Ok(())
+
+            let mut writes = writes.into_iter().collect::<Vec<_>>();
+            writes.sort_unstable_by_key(|(_, (index, _))| *index);
+            let operations = stream::iter(writes)
+                .map(|(key, (_, value))| async move {
+                    self.prepare_node_batch_operation(&key, value.as_deref())
+                        .await
+                })
+                .buffered(self.options.max_concurrency)
+                .try_collect::<Vec<_>>()
+                .await?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+            self.execute_upsert_batches(&operations).await
         }
 
         async fn batch_get_nodes_ordered(
             &self,
             keys: &[&[u8]],
         ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
-            let mut values = Vec::with_capacity(keys.len());
-            for key in keys {
-                values.push(self.get_node(key).await?);
-            }
-            Ok(values)
+            let mut values = stream::iter(keys.iter().enumerate())
+                .map(|(index, key)| async move { Ok((index, self.get_node(key).await?)) })
+                .buffer_unordered(self.options.max_concurrency)
+                .try_collect::<Vec<(usize, Option<Vec<u8>>)>>()
+                .await?;
+            values.sort_unstable_by_key(|(index, _)| *index);
+            Ok(values.into_iter().map(|(_, value)| value).collect())
         }
 
         async fn batch_put_nodes(&self, entries: &[(&[u8], &[u8])]) -> Result<(), Self::Error> {
-            for (key, value) in entries {
-                self.put_node(key, value).await?;
-            }
-            Ok(())
+            let logical_entries = entries
+                .iter()
+                .map(|(key, value)| {
+                    let logical_key = self.node_key(key);
+                    (logical_key, value.to_vec())
+                })
+                .collect::<Vec<_>>();
+            let refs = logical_entries
+                .iter()
+                .map(|(key, value)| (key.as_slice(), value.as_slice()))
+                .collect::<Vec<_>>();
+            let operations = self.batch_upsert_operations(NODE_KIND, &refs).await?;
+            self.execute_upsert_batches(&operations).await
         }
 
         async fn list_node_cids(&self) -> Result<Vec<Vec<u8>>, Self::Error> {
             let prefix = self.family_prefix(NODE_FAMILY);
             let mut cids = self
-                .query_kind(NODE_KIND)
+                .query_kind(NODE_KIND, &prefix)
                 .await?
                 .into_iter()
                 .map(|doc| doc.logical_key())
@@ -752,11 +1093,19 @@ pub mod cosmosdb {
         }
 
         fn read_parallelism(&self) -> usize {
-            self.read_parallelism
+            self.options.read_parallelism
+        }
+
+        fn prefers_batch_reads(&self) -> bool {
+            true
         }
 
         fn supports_hints(&self) -> bool {
             true
+        }
+
+        fn prefers_rightmost_path_hints(&self) -> bool {
+            self.options.rightmost_path_hints
         }
 
         async fn get_hint(
@@ -787,8 +1136,30 @@ pub mod cosmosdb {
             key: &[u8],
             value: &[u8],
         ) -> Result<(), Self::Error> {
-            self.batch_put_nodes(entries).await?;
-            self.put_hint(namespace, key, value).await
+            let logical_entries = entries
+                .iter()
+                .map(|(key, value)| {
+                    let logical_key = self.node_key(key);
+                    (logical_key, value.to_vec())
+                })
+                .collect::<Vec<_>>();
+            let refs = logical_entries
+                .iter()
+                .map(|(key, value)| (key.as_slice(), value.as_slice()))
+                .collect::<Vec<_>>();
+            let mut operations = self.batch_upsert_operations(NODE_KIND, &refs).await?;
+            let hint_key = self.hint_key(namespace, key);
+            let mut hint_operations = self
+                .batch_upsert_operations(HINT_KIND, &[(hint_key.as_slice(), value)])
+                .await?;
+
+            if operations.len() < COSMOS_BATCH_OPERATION_LIMIT {
+                operations.append(&mut hint_operations);
+                self.execute_checked_batch(&operations).await
+            } else {
+                self.execute_upsert_batches(&operations).await?;
+                self.execute_checked_batch(&hint_operations).await
+            }
         }
 
         async fn get_root_manifest(&self, name: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
@@ -885,7 +1256,7 @@ pub mod cosmosdb {
         async fn list_root_manifests(&self) -> Result<Vec<RemoteNamedRoot>, Self::Error> {
             let prefix = self.family_prefix(ROOT_FAMILY);
             let mut roots = self
-                .query_kind(ROOT_KIND)
+                .query_kind(ROOT_KIND, &prefix)
                 .await?
                 .into_iter()
                 .filter_map(|doc| {
@@ -893,9 +1264,7 @@ pub mod cosmosdb {
                         Ok(key) => key,
                         Err(err) => return Some(Err(err)),
                     };
-                    let Some(name) = logical_key.strip_prefix(prefix.as_slice()) else {
-                        return None;
-                    };
+                    let name = logical_key.strip_prefix(prefix.as_slice())?;
                     let manifest = match doc.value_bytes() {
                         Ok(value) => value,
                         Err(err) => return Some(Err(err)),
@@ -923,7 +1292,7 @@ pub mod cosmosdb {
                 .collect::<HashMap<_, _>>();
             let written_roots = root_writes
                 .iter()
-                .map(|write| root_write_name(write))
+                .map(root_write_name)
                 .collect::<HashSet<_>>();
 
             let mut operations = Vec::new();
@@ -972,11 +1341,12 @@ pub mod cosmosdb {
                 match write {
                     RemoteBatchOp::Upsert { key, value } => {
                         let logical_key = self.node_key(key);
-                        operations.push(CosmosBatchOperation::upsert(
-                            self.batch_partition_key(),
-                            self.document(NODE_KIND, &logical_key, value),
-                        ));
-                        operation_conditions.push(None);
+                        let node_operations = self
+                            .batch_upsert_operations(NODE_KIND, &[(logical_key.as_slice(), value)])
+                            .await?;
+                        operation_conditions
+                            .extend(std::iter::repeat(None).take(node_operations.len()));
+                        operations.extend(node_operations);
                     }
                     RemoteBatchOp::Delete { key } => {
                         let logical_key = self.node_key(key);
@@ -1040,6 +1410,8 @@ pub mod cosmosdb {
         InvalidConfiguration(String),
         /// The staged transaction exceeds Cosmos DB transactional batch limits.
         TransactionTooLarge { operations: usize, limit: usize },
+        /// The serialized transactional batch exceeds Cosmos DB's payload limit.
+        TransactionPayloadTooLarge { bytes: usize, limit: usize },
         /// A root condition failed while building a transactional batch.
         RootConditionConflict(RemoteTransactionConflict),
     }
@@ -1061,6 +1433,10 @@ pub mod cosmosdb {
                 Self::TransactionTooLarge { operations, limit } => write!(
                     f,
                     "Cosmos DB transaction has {operations} operations, exceeding the limit of {limit}"
+                ),
+                Self::TransactionPayloadTooLarge { bytes, limit } => write!(
+                    f,
+                    "Cosmos DB transaction is {bytes} bytes, exceeding the limit of {limit} bytes"
                 ),
                 Self::RootConditionConflict(conflict) => write!(
                     f,
@@ -1091,6 +1467,8 @@ pub mod cosmosdb {
         family: Option<String>,
         key: String,
         value: String,
+        #[serde(default, rename = "_etag", skip_serializing_if = "Option::is_none")]
+        etag: Option<String>,
     }
 
     impl CosmosProllyDocument {
@@ -1106,6 +1484,7 @@ pub mod cosmosdb {
                 family: Some(family.to_string()),
                 key: hex::encode(logical_key),
                 value: BASE64.encode(value),
+                etag: None,
             }
         }
 
@@ -1259,6 +1638,12 @@ pub mod cosmosdb {
     }
 
     fn batch_response_error(responses: &[CosmosBatchOperationResponse]) -> CosmosDbBackendError {
+        if responses.is_empty() {
+            return CosmosDbBackendError::UnexpectedStatus {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                body: "Cosmos DB transactional batch returned no operation responses".to_string(),
+            };
+        }
         let (index, response) = responses
             .iter()
             .enumerate()
@@ -1276,10 +1661,60 @@ pub mod cosmosdb {
         CosmosDbBackendError::UnexpectedStatus {
             status,
             body: format!(
-                "Cosmos DB transactional batch operation {index} returned status {}; response={response:?}",
-                response.status_code
+                "Cosmos DB transactional batch operation {index} returned status {}; responses={responses:?}",
+                response.status_code,
             ),
         }
+    }
+
+    fn validate_transaction_batch(
+        operations: &[CosmosBatchOperation],
+    ) -> Result<(), CosmosDbBackendError> {
+        if operations.len() > COSMOS_BATCH_OPERATION_LIMIT {
+            return Err(CosmosDbBackendError::TransactionTooLarge {
+                operations: operations.len(),
+                limit: COSMOS_BATCH_OPERATION_LIMIT,
+            });
+        }
+        let payload_bytes = serde_json::to_vec(operations)
+            .map_err(|err| CosmosDbBackendError::InvalidConfiguration(err.to_string()))?
+            .len();
+        if payload_bytes > COSMOS_BATCH_PAYLOAD_LIMIT {
+            return Err(CosmosDbBackendError::TransactionPayloadTooLarge {
+                bytes: payload_bytes,
+                limit: COSMOS_BATCH_PAYLOAD_LIMIT,
+            });
+        }
+        Ok(())
+    }
+
+    fn is_retryable_status(status: StatusCode) -> bool {
+        matches!(
+            status,
+            StatusCode::TOO_MANY_REQUESTS
+                | StatusCode::REQUEST_TIMEOUT
+                | StatusCode::SERVICE_UNAVAILABLE
+        )
+    }
+
+    fn retry_delay(response: &reqwest::Response, attempt: usize) -> Duration {
+        if let Some(milliseconds) = response
+            .headers()
+            .get("x-ms-retry-after-ms")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<u64>().ok())
+        {
+            return Duration::from_millis(milliseconds);
+        }
+        if let Some(seconds) = response
+            .headers()
+            .get("retry-after")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<u64>().ok())
+        {
+            return Duration::from_secs(seconds);
+        }
+        Duration::from_millis(100u64.saturating_mul(1u64 << attempt.min(6)))
     }
 
     const COSMOS_API_VERSION: &str = "2018-12-31";
@@ -1288,7 +1723,12 @@ pub mod cosmosdb {
     const DEFAULT_KEY_PREFIX: &[u8] = b"prolly:";
     const DEFAULT_PARTITION_KEY: &str = "prolly";
     const DEFAULT_READ_PARALLELISM: usize = 16;
+    const DEFAULT_MAX_CONCURRENCY: usize = 16;
+    const DEFAULT_MAX_RETRIES: usize = 9;
+    const DEFAULT_MAX_RETRY_WAIT: Duration = Duration::from_secs(30);
+    const DEFAULT_QUERY_PAGE_SIZE: usize = 500;
     const COSMOS_BATCH_OPERATION_LIMIT: usize = 100;
+    const COSMOS_BATCH_PAYLOAD_LIMIT: usize = 2 * 1024 * 1024;
 
     const NODE_KIND: &str = "node";
     const ROOT_KIND: &str = "root";
@@ -1346,6 +1786,47 @@ pub mod cosmosdb {
                     }
                 })
             );
+        }
+
+        #[test]
+        fn transactional_batch_enforces_operation_and_payload_limits() {
+            let small = || {
+                CosmosBatchOperation::upsert(
+                    partition_key("prolly"),
+                    CosmosProllyDocument::new("prolly", NODE_KIND, b"node", b"value"),
+                )
+            };
+            let too_many = (0..=COSMOS_BATCH_OPERATION_LIMIT)
+                .map(|_| small())
+                .collect::<Vec<_>>();
+            assert!(matches!(
+                validate_transaction_batch(&too_many),
+                Err(CosmosDbBackendError::TransactionTooLarge { .. })
+            ));
+
+            let large = vec![CosmosBatchOperation::upsert(
+                partition_key("prolly"),
+                CosmosProllyDocument::new(
+                    "prolly",
+                    NODE_KIND,
+                    b"large-node",
+                    &vec![0; COSMOS_BATCH_PAYLOAD_LIMIT],
+                ),
+            )];
+            assert!(matches!(
+                validate_transaction_batch(&large),
+                Err(CosmosDbBackendError::TransactionPayloadTooLarge { .. })
+            ));
+        }
+
+        #[test]
+        fn production_defaults_enable_bounded_parallelism_and_retries() {
+            let options = CosmosDbBackendOptions::default();
+            assert_eq!(options.max_concurrency, 16);
+            assert_eq!(options.read_parallelism, 16);
+            assert_eq!(options.max_retries, 9);
+            assert_eq!(options.max_retry_wait, Duration::from_secs(30));
+            assert!(options.rightmost_path_hints);
         }
     }
 }

--- a/stores/prolly-store-cosmosdb/tests/cosmosdb_backend.rs
+++ b/stores/prolly-store-cosmosdb/tests/cosmosdb_backend.rs
@@ -49,6 +49,7 @@ fn cosmosdb_backend_satisfies_remote_backend_contract_when_env_is_set() {
         use prolly::remote_conformance::{
             assert_remote_backend_contract, assert_remote_backend_transaction_contract,
         };
+        use prolly::{RemoteManifestUpdate, RemoteStoreBackend};
         use prolly_store_cosmosdb::CosmosDbBackend;
 
         let backend = CosmosDbBackend::with_key(endpoint, &account_key, database, container)
@@ -58,6 +59,25 @@ fn cosmosdb_backend_satisfies_remote_backend_contract_when_env_is_set() {
         backend.clear_namespace().await.unwrap();
         assert_remote_backend_contract(&backend).await;
         assert_remote_backend_transaction_contract(&backend).await;
+
+        let mut contenders = tokio::task::JoinSet::new();
+        for contender in 0..16u8 {
+            let backend = backend.clone();
+            contenders.spawn(async move {
+                backend
+                    .compare_and_swap_root_manifest(b"contention/main", None, Some(&[contender]))
+                    .await
+                    .unwrap()
+            });
+        }
+        let mut applied = 0;
+        while let Some(result) = contenders.join_next().await {
+            if result.unwrap() == RemoteManifestUpdate::Applied {
+                applied += 1;
+            }
+        }
+        assert_eq!(applied, 1, "exactly one concurrent root CAS must win");
+
         backend.clear_namespace().await.unwrap();
     });
 }

--- a/stores/prolly-store-cosmosdb/tests/emulator-init/01-create-store.csh
+++ b/stores/prolly-store-cosmosdb/tests/emulator-init/01-create-store.csh
@@ -1,0 +1,2 @@
+mkdb prolly
+mkcon prolly_store /kind --database=prolly

--- a/stores/prolly-store-spanner/Cargo.toml
+++ b/stores/prolly-store-spanner/Cargo.toml
@@ -18,8 +18,10 @@ path = "src/lib.rs"
 
 [dependencies]
 google-cloud-googleapis = { package = "gcloud-googleapis", version = "1.3.0", features = ["spanner"] }
+google-cloud-gax = { package = "gcloud-gax", version = "1.4.0" }
 google-cloud-spanner = { package = "gcloud-spanner", version = "=1.8.1" }
 prolly = { package = "prolly-map", path = "../..", version = "0.5.0", features = ["async-store"] }
+tokio = { version = "1.45", features = ["time"] }
 
 [dev-dependencies]
 tokio = { version = "1.45", features = ["rt-multi-thread", "time"] }

--- a/stores/prolly-store-spanner/README.md
+++ b/stores/prolly-store-spanner/README.md
@@ -54,6 +54,7 @@ CREATE TABLE ProllyRoots (
 ```
 
 The same DDL is exposed as `SPANNER_SCHEMA`.
+It is also checked in as `schema.sql` for provisioning tools.
 
 ## Setup
 
@@ -159,6 +160,12 @@ async fn run(backend: SpannerBackend) -> Result<(), Box<dyn std::error::Error>> 
 - Strict commits validate named-root preconditions and apply node and root
   mutations in one Spanner read-write transaction.
 - `batch_put_nodes` is applied as Spanner mutations.
+- Point reads use Spanner's native key-read API rather than SQL. Ordered batch
+  reads coalesce keys into bounded streaming reads and reconstruct caller order.
+- Transactions read all named-root preconditions in one request. Retry closures
+  share immutable staged writes rather than cloning their payloads per attempt.
+- `SpannerBackendOptions` controls native batch-read size, traversal
+  parallelism, and rightmost-path hint maintenance.
 - There is no adapter-level key prefix. Use distinct named-root prefixes for
   tenants or environments, and isolate databases when you need full physical
   separation.
@@ -191,6 +198,18 @@ cargo test --manifest-path stores/prolly-store-spanner/Cargo.toml
 
 Use a dedicated test database or distinct named-root prefix. The adapter does
 not provide a backend-wide key prefix or cleanup helper.
+
+For a credential-free local Cosmos/Spanner conformance and performance
+comparison, run:
+
+```bash
+scripts/run-cosmos-spanner-comparison.sh
+```
+
+The script provisions both Docker emulators through their local APIs; neither
+`gcloud` nor cloud credentials are required. Existing
+`PROLLY_STORE_COSMOS_*` and `PROLLY_STORE_SPANNER_DATABASE` values select
+managed services instead.
 
 See the [`prolly-map` API documentation](https://docs.rs/prolly-map) for the
 async map, transaction, diff, and merge APIs used with this backend.

--- a/stores/prolly-store-spanner/examples/basic_usage.rs
+++ b/stores/prolly-store-spanner/examples/basic_usage.rs
@@ -68,13 +68,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
     let resolver: Resolver = Box::new(|conflict| {
         let mut value = conflict.left.clone().unwrap_or_default();
         value.extend_from_slice(b"+");
-        value.extend_from_slice(
-            conflict
-                .right
-                .as_ref()
-                .map(Vec::as_slice)
-                .unwrap_or_default(),
-        );
+        value.extend_from_slice(conflict.right.as_deref().unwrap_or_default());
         Resolution::value(value)
     });
     let resolved = prolly

--- a/stores/prolly-store-spanner/schema.sql
+++ b/stores/prolly-store-spanner/schema.sql
@@ -1,0 +1,15 @@
+CREATE TABLE ProllyNodes (
+  Cid BYTES(32) NOT NULL,
+  Node BYTES(MAX) NOT NULL
+) PRIMARY KEY (Cid);
+
+CREATE TABLE ProllyHints (
+  Namespace BYTES(MAX) NOT NULL,
+  HintKey BYTES(MAX) NOT NULL,
+  Value BYTES(MAX) NOT NULL
+) PRIMARY KEY (Namespace, HintKey);
+
+CREATE TABLE ProllyRoots (
+  Name BYTES(MAX) NOT NULL,
+  Manifest BYTES(MAX) NOT NULL
+) PRIMARY KEY (Name);

--- a/stores/prolly-store-spanner/src/lib.rs
+++ b/stores/prolly-store-spanner/src/lib.rs
@@ -7,6 +7,11 @@ pub use prolly::{
 
 /// Spanner adapter entry point.
 pub mod spanner {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use google_cloud_gax::grpc::Code;
     use google_cloud_googleapis::spanner::v1::Mutation;
     use google_cloud_spanner::client::{Client, ClientConfig, Error};
     use google_cloud_spanner::key::Key;
@@ -26,13 +31,63 @@ pub mod spanner {
     #[derive(Clone)]
     pub struct SpannerBackend {
         client: Client,
-        read_parallelism: usize,
+        options: SpannerBackendOptions,
+    }
+
+    /// Performance controls for the Spanner backend.
+    #[derive(Clone, Debug)]
+    pub struct SpannerBackendOptions {
+        /// Maximum in-flight reads used by prolly traversal paths.
+        pub read_parallelism: usize,
+        /// Maximum keys sent in one Spanner streaming-read request.
+        pub batch_read_items: usize,
+        /// Maintain rightmost-path hints for append-heavy maps.
+        pub rightmost_path_hints: bool,
+        /// Additional adapter retry attempts after the client exhausts an aborted transaction.
+        pub max_transaction_retries: usize,
+    }
+
+    impl Default for SpannerBackendOptions {
+        fn default() -> Self {
+            Self {
+                read_parallelism: DEFAULT_READ_PARALLELISM,
+                batch_read_items: DEFAULT_BATCH_READ_ITEMS,
+                rightmost_path_hints: true,
+                max_transaction_retries: DEFAULT_TRANSACTION_RETRIES,
+            }
+        }
+    }
+
+    impl SpannerBackendOptions {
+        /// Set maximum traversal read concurrency.
+        pub fn with_read_parallelism(mut self, read_parallelism: usize) -> Self {
+            self.read_parallelism = read_parallelism.max(1);
+            self
+        }
+
+        /// Set the maximum number of keys in a native batch read.
+        pub fn with_batch_read_items(mut self, batch_read_items: usize) -> Self {
+            self.batch_read_items = batch_read_items.max(1);
+            self
+        }
+
+        /// Enable or disable rightmost-path hint maintenance.
+        pub fn with_rightmost_path_hints(mut self, enabled: bool) -> Self {
+            self.rightmost_path_hints = enabled;
+            self
+        }
+
+        /// Set additional retry attempts for transactions aborted by contention.
+        pub fn with_max_transaction_retries(mut self, max_transaction_retries: usize) -> Self {
+            self.max_transaction_retries = max_transaction_retries;
+            self
+        }
     }
 
     impl std::fmt::Debug for SpannerBackend {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.debug_struct("SpannerBackend")
-                .field("read_parallelism", &self.read_parallelism)
+                .field("options", &self.options)
                 .finish_non_exhaustive()
         }
     }
@@ -40,15 +95,37 @@ pub mod spanner {
     impl SpannerBackend {
         /// Create a backend from an existing Spanner client.
         pub fn new(client: Client) -> Self {
+            Self::new_with_options(client, SpannerBackendOptions::default())
+        }
+
+        /// Create a backend from an existing client and explicit performance controls.
+        pub fn new_with_options(client: Client, options: SpannerBackendOptions) -> Self {
             Self {
                 client,
-                read_parallelism: DEFAULT_READ_PARALLELISM,
+                options: SpannerBackendOptions {
+                    read_parallelism: options.read_parallelism.max(1),
+                    batch_read_items: options.batch_read_items.max(1),
+                    rightmost_path_hints: options.rightmost_path_hints,
+                    max_transaction_retries: options.max_transaction_retries,
+                },
             }
         }
 
         /// Connect to a Spanner database resource name using a caller-provided config.
         pub async fn connect(database: &str, config: ClientConfig) -> Result<Self, Error> {
             Ok(Self::new(Client::new(database, config).await?))
+        }
+
+        /// Connect with explicit adapter performance controls.
+        pub async fn connect_with_options(
+            database: &str,
+            config: ClientConfig,
+            options: SpannerBackendOptions,
+        ) -> Result<Self, Error> {
+            Ok(Self::new_with_options(
+                Client::new(database, config).await?,
+                options,
+            ))
         }
 
         /// Borrow the underlying Spanner client.
@@ -58,18 +135,21 @@ pub mod spanner {
 
         /// Set the read parallelism advertised to async prolly traversals.
         pub fn with_read_parallelism(mut self, read_parallelism: usize) -> Self {
-            self.read_parallelism = read_parallelism.max(1);
+            self.options.read_parallelism = read_parallelism.max(1);
             self
         }
 
-        async fn query_one_value(
+        async fn read_one_value(
             &self,
-            statement: Statement,
+            table: &str,
+            key: Key,
             column: &str,
         ) -> Result<Option<Vec<u8>>, Error> {
             let mut tx = self.client.single().await?;
-            let mut rows = tx.query(statement).await.map_err(Error::from)?;
-            let row = rows.next().await.map_err(Error::from)?;
+            let row = tx
+                .read_row(table, &[column], key)
+                .await
+                .map_err(Error::from)?;
             row.map(|row| row.column_by_name(column).map_err(Error::from))
                 .transpose()
         }
@@ -93,9 +173,8 @@ pub mod spanner {
         type Error = Error;
 
         async fn get_node(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
-            let mut statement = Statement::new("SELECT Node FROM ProllyNodes WHERE Cid = @cid");
-            statement.add_param("cid", &key.to_vec());
-            self.query_one_value(statement, "Node").await
+            self.read_one_value(NODES_TABLE, Key::new(&key.to_vec()), "Node")
+                .await
         }
 
         async fn put_node(&self, key: &[u8], value: &[u8]) -> Result<(), Self::Error> {
@@ -127,11 +206,30 @@ pub mod spanner {
             &self,
             keys: &[&[u8]],
         ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
-            let mut values = Vec::with_capacity(keys.len());
-            for key in keys {
-                values.push(self.get_node(key).await?);
+            if keys.is_empty() {
+                return Ok(Vec::new());
             }
-            Ok(values)
+
+            let mut found = HashMap::with_capacity(keys.len());
+            for chunk in keys.chunks(self.options.batch_read_items) {
+                let key_set = chunk
+                    .iter()
+                    .map(|key| Key::new(&key.to_vec()))
+                    .collect::<Vec<_>>();
+                let mut tx = self.client.single().await?;
+                let mut rows = tx
+                    .read(NODES_TABLE, &["Cid", "Node"], key_set)
+                    .await
+                    .map_err(Error::from)?;
+                while let Some(row) = rows.next().await.map_err(Error::from)? {
+                    found.insert(
+                        row.column_by_name::<Vec<u8>>("Cid")?,
+                        row.column_by_name::<Vec<u8>>("Node")?,
+                    );
+                }
+            }
+
+            Ok(keys.iter().map(|key| found.get(*key).cloned()).collect())
         }
 
         async fn batch_put_nodes(&self, entries: &[(&[u8], &[u8])]) -> Result<(), Self::Error> {
@@ -154,11 +252,19 @@ pub mod spanner {
         }
 
         fn read_parallelism(&self) -> usize {
-            self.read_parallelism
+            self.options.read_parallelism
+        }
+
+        fn prefers_batch_reads(&self) -> bool {
+            true
         }
 
         fn supports_hints(&self) -> bool {
             true
+        }
+
+        fn prefers_rightmost_path_hints(&self) -> bool {
+            self.options.rightmost_path_hints
         }
 
         async fn get_hint(
@@ -166,12 +272,12 @@ pub mod spanner {
             namespace: &[u8],
             key: &[u8],
         ) -> Result<Option<Vec<u8>>, Self::Error> {
-            let mut statement = Statement::new(
-                "SELECT Value FROM ProllyHints WHERE Namespace = @namespace AND HintKey = @key",
-            );
-            statement.add_param("namespace", &namespace.to_vec());
-            statement.add_param("key", &key.to_vec());
-            self.query_one_value(statement, "Value").await
+            self.read_one_value(
+                HINTS_TABLE,
+                Key::composite(&[&namespace.to_vec(), &key.to_vec()]),
+                "Value",
+            )
+            .await
         }
 
         async fn put_hint(
@@ -202,10 +308,8 @@ pub mod spanner {
         }
 
         async fn get_root_manifest(&self, name: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
-            let mut statement =
-                Statement::new("SELECT Manifest FROM ProllyRoots WHERE Name = @name");
-            statement.add_param("name", &name.to_vec());
-            self.query_one_value(statement, "Manifest").await
+            self.read_one_value(ROOTS_TABLE, Key::new(&name.to_vec()), "Manifest")
+                .await
         }
 
         async fn put_root_manifest(&self, name: &[u8], manifest: &[u8]) -> Result<(), Self::Error> {
@@ -228,29 +332,44 @@ pub mod spanner {
             let name = name.to_vec();
             let expected = expected.map(<[u8]>::to_vec);
             let new = new.map(<[u8]>::to_vec);
-            let (_, update) = self
-                .client
-                .read_write_transaction(|tx| {
-                    let name = name.clone();
-                    let expected = expected.clone();
-                    let new = new.clone();
-                    Box::pin(async move {
-                        let current = read_root_in_transaction(tx, &name).await?;
-                        if current.as_deref() != expected.as_deref() {
-                            return Ok::<RemoteManifestUpdate, Error>(
-                                RemoteManifestUpdate::Conflict { current },
-                            );
-                        }
+            let mut outer_attempt = 0;
+            loop {
+                let result = self
+                    .client
+                    .read_write_transaction(|tx| {
+                        let name = name.clone();
+                        let expected = expected.clone();
+                        let new = new.clone();
+                        Box::pin(async move {
+                            let current = read_root_in_transaction(tx, &name).await?;
+                            if current.as_deref() != expected.as_deref() {
+                                return Ok::<RemoteManifestUpdate, Error>(
+                                    RemoteManifestUpdate::Conflict { current },
+                                );
+                            }
 
-                        match new {
-                            Some(manifest) => tx.buffer_write(vec![root_upsert(&name, &manifest)]),
-                            None => tx.buffer_write(vec![root_delete(&name)]),
-                        }
-                        Ok::<RemoteManifestUpdate, Error>(RemoteManifestUpdate::Applied)
+                            match new {
+                                Some(manifest) => {
+                                    tx.buffer_write(vec![root_upsert(&name, &manifest)])
+                                }
+                                None => tx.buffer_write(vec![root_delete(&name)]),
+                            }
+                            Ok::<RemoteManifestUpdate, Error>(RemoteManifestUpdate::Applied)
+                        })
                     })
-                })
-                .await?;
-            Ok(update)
+                    .await;
+                match result {
+                    Ok((_, update)) => return Ok(update),
+                    Err(err)
+                        if is_aborted(&err)
+                            && outer_attempt < self.options.max_transaction_retries =>
+                    {
+                        tokio::time::sleep(transaction_retry_delay(outer_attempt)).await;
+                        outer_attempt += 1;
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
         }
 
         async fn list_root_manifests(&self) -> Result<Vec<RemoteNamedRoot>, Self::Error> {
@@ -281,65 +400,92 @@ pub mod spanner {
             root_conditions: &[RemoteRootCondition],
             root_writes: &[RemoteRootWrite],
         ) -> Result<RemoteTransactionUpdate, Self::Error> {
-            let node_writes = node_writes
-                .iter()
-                .map(|write| match write {
-                    RemoteBatchOp::Upsert { key, value } => (true, key.to_vec(), value.to_vec()),
-                    RemoteBatchOp::Delete { key } => (false, key.to_vec(), Vec::new()),
-                })
-                .collect::<Vec<_>>();
-            let root_conditions = root_conditions.to_vec();
-            let root_writes = root_writes.to_vec();
-
-            let (_, update) = self
-                .client
-                .read_write_transaction(|tx| {
-                    let node_writes = node_writes.clone();
-                    let root_conditions = root_conditions.clone();
-                    let root_writes = root_writes.clone();
-                    Box::pin(async move {
-                        for condition in &root_conditions {
-                            let current = read_root_in_transaction(tx, &condition.name).await?;
-                            if current != condition.expected {
-                                return Ok::<RemoteTransactionUpdate, Error>(
-                                    RemoteTransactionUpdate::Conflict(
-                                        RemoteTransactionConflict::new(
-                                            condition.name.clone(),
-                                            condition.expected.clone(),
-                                            current,
-                                        ),
-                                    ),
-                                );
-                            }
+            let node_writes = Arc::new(
+                node_writes
+                    .iter()
+                    .map(|write| match write {
+                        RemoteBatchOp::Upsert { key, value } => {
+                            (true, key.to_vec(), value.to_vec())
                         }
-
-                        let mut mutations = Vec::new();
-                        for (is_upsert, key, value) in &node_writes {
-                            if *is_upsert {
-                                mutations.push(node_upsert(key, value));
-                            } else {
-                                mutations.push(node_delete(key));
-                            }
-                        }
-                        for write in &root_writes {
-                            match write {
-                                RemoteRootWrite::Put { name, manifest } => {
-                                    mutations.push(root_upsert(name, manifest));
-                                }
-                                RemoteRootWrite::Delete { name } => {
-                                    mutations.push(root_delete(name));
-                                }
-                            }
-                        }
-                        if !mutations.is_empty() {
-                            tx.buffer_write(mutations);
-                        }
-                        Ok::<RemoteTransactionUpdate, Error>(RemoteTransactionUpdate::Applied)
+                        RemoteBatchOp::Delete { key } => (false, key.to_vec(), Vec::new()),
                     })
-                })
-                .await?;
-            Ok(update)
+                    .collect::<Vec<_>>(),
+            );
+            let root_conditions = Arc::new(root_conditions.to_vec());
+            let root_writes = Arc::new(root_writes.to_vec());
+
+            let mut outer_attempt = 0;
+            loop {
+                let result = self
+                    .client
+                    .read_write_transaction(|tx| {
+                        let node_writes = Arc::clone(&node_writes);
+                        let root_conditions = Arc::clone(&root_conditions);
+                        let root_writes = Arc::clone(&root_writes);
+                        Box::pin(async move {
+                            let current_roots =
+                                read_roots_in_transaction(tx, &root_conditions).await?;
+                            for condition in root_conditions.iter() {
+                                let current = current_roots.get(&condition.name).cloned();
+                                if current != condition.expected {
+                                    return Ok::<RemoteTransactionUpdate, Error>(
+                                        RemoteTransactionUpdate::Conflict(
+                                            RemoteTransactionConflict::new(
+                                                condition.name.clone(),
+                                                condition.expected.clone(),
+                                                current,
+                                            ),
+                                        ),
+                                    );
+                                }
+                            }
+
+                            let mut mutations = Vec::new();
+                            for (is_upsert, key, value) in node_writes.iter() {
+                                if *is_upsert {
+                                    mutations.push(node_upsert(key, value));
+                                } else {
+                                    mutations.push(node_delete(key));
+                                }
+                            }
+                            for write in root_writes.iter() {
+                                match write {
+                                    RemoteRootWrite::Put { name, manifest } => {
+                                        mutations.push(root_upsert(name, manifest));
+                                    }
+                                    RemoteRootWrite::Delete { name } => {
+                                        mutations.push(root_delete(name));
+                                    }
+                                }
+                            }
+                            if !mutations.is_empty() {
+                                tx.buffer_write(mutations);
+                            }
+                            Ok::<RemoteTransactionUpdate, Error>(RemoteTransactionUpdate::Applied)
+                        })
+                    })
+                    .await;
+                match result {
+                    Ok((_, update)) => return Ok(update),
+                    Err(err)
+                        if is_aborted(&err)
+                            && outer_attempt < self.options.max_transaction_retries =>
+                    {
+                        tokio::time::sleep(transaction_retry_delay(outer_attempt)).await;
+                        outer_attempt += 1;
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
         }
+    }
+
+    fn is_aborted(error: &Error) -> bool {
+        matches!(error, Error::GRPC(status) if status.code() == Code::Aborted)
+    }
+
+    fn transaction_retry_delay(attempt: usize) -> Duration {
+        Duration::from_millis(10u64.saturating_mul(1u64 << attempt.min(5)))
     }
 
     async fn read_root_in_transaction(
@@ -353,6 +499,31 @@ pub mod spanner {
             .map_err(Error::from)?;
         row.map(|row| row.column_by_name("Manifest").map_err(Error::from))
             .transpose()
+    }
+
+    async fn read_roots_in_transaction(
+        tx: &mut ReadWriteTransaction,
+        conditions: &[RemoteRootCondition],
+    ) -> Result<HashMap<Vec<u8>, Vec<u8>>, Error> {
+        if conditions.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let keys = conditions
+            .iter()
+            .map(|condition| Key::new(&condition.name))
+            .collect::<Vec<_>>();
+        let mut rows = tx
+            .read(ROOTS_TABLE, &["Name", "Manifest"], keys)
+            .await
+            .map_err(Error::from)?;
+        let mut roots = HashMap::with_capacity(conditions.len());
+        while let Some(row) = rows.next().await.map_err(Error::from)? {
+            roots.insert(
+                row.column_by_name::<Vec<u8>>("Name")?,
+                row.column_by_name::<Vec<u8>>("Manifest")?,
+            );
+        }
+        Ok(roots)
     }
 
     fn node_upsert(key: &[u8], value: &[u8]) -> Mutation {
@@ -389,6 +560,8 @@ pub mod spanner {
     }
 
     const DEFAULT_READ_PARALLELISM: usize = 16;
+    const DEFAULT_BATCH_READ_ITEMS: usize = 5_000;
+    const DEFAULT_TRANSACTION_RETRIES: usize = 16;
     const NODES_TABLE: &str = "ProllyNodes";
     const HINTS_TABLE: &str = "ProllyHints";
     const ROOTS_TABLE: &str = "ProllyRoots";
@@ -408,6 +581,29 @@ CREATE TABLE ProllyRoots (
   Name BYTES(MAX) NOT NULL,
   Manifest BYTES(MAX) NOT NULL
 ) PRIMARY KEY (Name);";
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn production_defaults_enable_native_batch_reads_and_hints() {
+            let options = SpannerBackendOptions::default();
+            assert_eq!(options.read_parallelism, 16);
+            assert_eq!(options.batch_read_items, 5_000);
+            assert_eq!(options.max_transaction_retries, 16);
+            assert!(options.rightmost_path_hints);
+        }
+
+        #[test]
+        fn checked_in_schema_matches_exported_schema() {
+            let checked_in = include_str!("../schema.sql")
+                .split_whitespace()
+                .collect::<String>();
+            let exported = SPANNER_SCHEMA.split_whitespace().collect::<String>();
+            assert_eq!(checked_in, exported);
+        }
+    }
 }
 
 pub use spanner::*;

--- a/stores/prolly-store-spanner/tests/spanner_backend.rs
+++ b/stores/prolly-store-spanner/tests/spanner_backend.rs
@@ -23,8 +23,11 @@ fn spanner_backend_satisfies_remote_backend_contract_when_database_is_set() {
 
     runtime().block_on(async {
         use google_cloud_spanner::client::ClientConfig;
-        use prolly::remote_conformance::assert_remote_backend_contract;
-        use prolly_store_spanner::SpannerBackend;
+        use prolly::remote_conformance::{
+            assert_remote_backend_contract, assert_remote_backend_transaction_contract,
+        };
+        use prolly::{RemoteManifestUpdate, RemoteStoreBackend};
+        use prolly_store_spanner::{SpannerBackend, SpannerBackendOptions};
 
         let mut config = ClientConfig::default();
         if env_var("PROLLY_STORE_SPANNER_AUTH", "PROLLY_ADAPTERS_SPANNER_AUTH").is_some() {
@@ -34,6 +37,103 @@ fn spanner_backend_satisfies_remote_backend_contract_when_database_is_set() {
         let backend = SpannerBackend::connect(&database, config).await.unwrap();
         clear_spanner(backend.client()).await.unwrap();
         assert_remote_backend_contract(&backend).await;
+        assert_remote_backend_transaction_contract(&backend).await;
+
+        let mut contenders = tokio::task::JoinSet::new();
+        for contender in 0..32u8 {
+            let backend = backend.clone();
+            contenders.spawn(async move {
+                backend
+                    .compare_and_swap_root_manifest(b"contention/main", None, Some(&[contender]))
+                    .await
+                    .unwrap()
+            });
+        }
+        let mut applied = 0;
+        while let Some(result) = contenders.join_next().await {
+            if result.unwrap() == RemoteManifestUpdate::Applied {
+                applied += 1;
+            }
+        }
+        assert_eq!(applied, 1, "exactly one concurrent root CAS must win");
+
+        clear_spanner(backend.client()).await.unwrap();
+        let chunked_backend = SpannerBackend::new_with_options(
+            backend.client().clone(),
+            SpannerBackendOptions::default()
+                .with_batch_read_items(7)
+                .with_read_parallelism(4),
+        );
+        assert_eq!(chunked_backend.read_parallelism(), 4);
+        assert!(chunked_backend.prefers_batch_reads());
+
+        let keys = (0..257u32)
+            .map(|index| {
+                let mut key = [0u8; 32];
+                key[..4].copy_from_slice(&index.to_be_bytes());
+                key[4..8].copy_from_slice(&(index ^ 0xa5a5_5a5a).to_be_bytes());
+                key
+            })
+            .collect::<Vec<_>>();
+        let values = (0..keys.len())
+            .map(|index| {
+                let length = 48 + (index % 113);
+                (0..length)
+                    .map(|offset| ((index * 31 + offset * 17) & 0xff) as u8)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let entries = keys
+            .iter()
+            .zip(&values)
+            .map(|(key, value)| (key.as_slice(), value.as_slice()))
+            .collect::<Vec<_>>();
+        chunked_backend.batch_put_nodes(&entries).await.unwrap();
+        chunked_backend.batch_put_nodes(&[]).await.unwrap();
+        assert!(chunked_backend
+            .batch_get_nodes_ordered(&[])
+            .await
+            .unwrap()
+            .is_empty());
+
+        let missing = [0xff; 32];
+        let mut requested = keys
+            .iter()
+            .rev()
+            .map(<[u8; 32]>::as_slice)
+            .collect::<Vec<_>>();
+        requested.insert(3, keys[42].as_slice());
+        requested.insert(129, missing.as_slice());
+        requested.push(keys[42].as_slice());
+        let fetched = chunked_backend
+            .batch_get_nodes_ordered(&requested)
+            .await
+            .unwrap();
+        assert_eq!(fetched.len(), requested.len());
+        for (key, value) in requested.iter().zip(&fetched) {
+            let expected = keys
+                .iter()
+                .position(|candidate| candidate.as_slice() == *key)
+                .map(|index| values[index].clone());
+            assert_eq!(*value, expected);
+        }
+
+        let large_key = [0xfe; 32];
+        let large_value = vec![0x5a; 1024 * 1024];
+        chunked_backend
+            .put_node(&large_key, &large_value)
+            .await
+            .unwrap();
+        assert_eq!(
+            chunked_backend.get_node(&large_key).await.unwrap(),
+            Some(large_value)
+        );
+
+        let listed = chunked_backend.list_node_cids().await.unwrap();
+        assert_eq!(listed.len(), keys.len() + 1);
+        assert!(listed.windows(2).all(|pair| pair[0] < pair[1]));
+        assert!(listed.contains(&large_key.to_vec()));
+
         clear_spanner(backend.client()).await.unwrap();
         backend.client().clone().close().await;
     });


### PR DESCRIPTION
## Summary

- harden the Rust Cosmos DB adapter with configurable bounded reads, native transactional batches, payload-aware batching, retry telemetry, and emulator-compatible conditional writes
- harden the Rust Cloud Spanner adapter with native point/KeySet reads, configurable batching and read parallelism, transactional retry handling, and rightmost-path hints
- add pinned local Docker harnesses for Cosmos DB vs Spanner and Spanner vs PostgreSQL while supporting explicit managed-service endpoints
- extend the shared backend workload and fail-closed evidence summarizers to Spanner
- add boundary, ordering, large-value, transaction, and high-contention integration coverage
- document local reproduction, external destructive-run safeguards, and emulator limitations

## Why

The remote adapters need predictable batching, concurrency, contention handling, and reproducible performance evidence before they can support larger Prolly-backed version-control services. The new harnesses make adapter regressions testable without cloud credentials while retaining an explicit path to managed-service validation.

## Validation

- `cargo test --manifest-path benchmarks/backend-comparison/Cargo.toml --no-default-features --features spanner --all-targets`
- `cargo clippy --manifest-path benchmarks/backend-comparison/Cargo.toml --no-default-features --features spanner --all-targets -- -D warnings`
- `cargo clippy --manifest-path stores/prolly-store-spanner/Cargo.toml --all-targets -- -D warnings`
- live Spanner emulator conformance, including 257-key chunk boundaries, duplicate/missing ordered reads, a 1 MiB value, and 32-way root CAS contention
- live shared Spanner workload smoke test
- pinned local Cosmos DB/Spanner harness
- 15 alternating Spanner/PostgreSQL repetitions: 180/180 end-to-end rows and 120/120 service rows validated; binary, configuration, and command provenance hashes matched
- `python3 -m unittest scripts.tests.test_run_mysql_postgres_comparison`
- Rust formatting, shell syntax, Compose validation, and `git diff --check`

## Local comparison note

The pinned Spanner emulator won the 10k-record build and batch phases, while local PostgreSQL won query, concurrent query, diff, merge, and the service operations. These are adapter-regression measurements, not managed-service claims: the Spanner emulator serializes read-write transactions and does not model production latency, replication, scaling, IAM, or cost.
