### PR TITLE
docs: add comprehensive IndexedMap usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ reflogs, patches, merge orchestration, sync planning, and repository-level GC.
   content-derived versions, pinned reads, proofs, comparison and merge,
   backup/sync, typed codecs, subscriptions, multi-map transactions, bounded
   history, and scoped GC.
-- A strict `IndexedMap` coordinator for runtime-defined, non-unique secondary
+- A strict [`IndexedMap`](docs/secondary-indexes.md) coordinator for
+  runtime-defined, non-unique secondary
   indexes with one-root atomic publication, finite operation budgets, sparse
   and multi-valued terms, `KeysOnly`/`Include`/`All` projections, exact
   historical snapshots, durable pins, safe GC, structured diagnostics, and
@@ -142,6 +143,9 @@ More copyable examples live in [`examples/`](examples/):
 - [`resolver.rs`](examples/resolver.rs): delete-aware merge resolvers.
 - [`secondary_index.rs`](examples/secondary_index.rs): declare, build, query,
   verify, replace, retain, export, and import strict `IndexedMap` indexes.
+- [`indexed_map_real_world.rs`](examples/indexed_map_real_world.rs): run 14
+  production-shaped patterns for status, customer, tenant, time, sparse,
+  multi-valued, covering, path, geospatial, text, and historical indexes.
 - [`materialized_view.rs`](examples/materialized_view.rs): derive and update a
   materialized view from source diffs, with source/view roots in manifests.
 - [`crdt_merge.rs`](examples/crdt_merge.rs): LWW, multi-value, delete/update,

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,9 +31,12 @@ tests described here.
 - [Object-Store VCS Design](object-store-vcs-design.md): technical design for
   direct object-store node/blob storage, distributed ref CAS, publish protocol,
   and GC for Git-like version-control systems.
-- [Versioned Secondary Indexes](secondary-index-design.md): technical design for
-  strict derived `VersionedMap`s, atomic source/index publication, historical
-  queries, lifecycle management, retention, backup, sync, and bindings.
+- [Build and Operate Secondary Indexes](secondary-indexes.md): comprehensive
+  `IndexedMap` guide with typed definitions, query shapes, projections,
+  resource budgets, lifecycle operations, and 14 real-world patterns.
+- [IndexedMap Secondary-Index Semantics](secondary-index-design.md): canonical
+  atomic-state, persisted-layout, cursor, retention, transfer, and
+  observability reference.
 - [prolly-vcs Design](prolly-vcs-design.md): proposed neutral high-level
   repository crate with a general backend-neutral `KvStore` substrate, commits,
   refs, reflogs, patches, merge orchestration, sync planning, GC policy, and an

--- a/docs/secondary-index-design.md
+++ b/docs/secondary-index-design.md
@@ -1,8 +1,12 @@
-# IndexedMap Secondary Indexes
+# `IndexedMap` secondary-index semantics
 
 `IndexedMap` is the synchronous secondary-index coordinator for one
 authoritative ordered collection. It supports sparse, non-unique and
 multi-valued indexes with `KeysOnly`, `Include`, and `All` projections.
+
+Start with [Build and operate secondary indexes with `IndexedMap`](secondary-indexes.md)
+for a self-contained application guide and 14 runnable real-world patterns.
+This page defines the lower-level persisted and operational semantics.
 
 This document describes the only supported persisted layout. There is no
 compatibility reader or suffix-named replacement format. A deployment using an

--- a/docs/secondary-indexes.md
+++ b/docs/secondary-indexes.md
@@ -1,0 +1,945 @@
+# Build and operate secondary indexes with `IndexedMap`
+
+`IndexedMap` maintains an authoritative byte-keyed collection and its ordered secondary indexes as one atomic state. This guide explains the complete application workflow: define deterministic extractors, activate indexes, mutate records, query current and historical snapshots, bound resources, observe health, verify correctness, replace definitions, transfer state, retain history, and operate garbage collection safely.
+
+## Decide whether `IndexedMap` fits your data
+
+Use `IndexedMap` when one source record can produce zero or more ordered lookup terms and every visible source version must agree with every visible index version.
+
+Good fits include:
+
+- Equality lookup, such as users by status or orders by customer
+- Ordered range lookup, such as tasks by state and due time
+- Sparse lookup, such as pending jobs or records with an optional field
+- Multi-valued lookup, such as tags, categories, and access-control memberships
+- Covering lookup with a deterministic summary projection
+- Historical lookup against retained source and index snapshots
+- Prefix candidate generation for paths, tokens, geohashes, and other ordered buckets
+
+Choose another abstraction when you need:
+
+- Enforced uniqueness: `IndexedMap` indexes are non-unique
+- Full SQL planning, joins, foreign keys, or constraints
+- Language-aware full-text ranking, stemming, typo tolerance, or relevance scoring
+- Exact geospatial predicates without application-side filtering
+- Approximate nearest-neighbor vector search: use `ProximityMap`
+- An independently updated derived system whose consistency may lag the source
+
+## Understand the collection model
+
+One indexed collection contains a source map, runtime index definitions, immutable snapshots, and one canonical collection root.
+
+Each visible snapshot selects:
+
+- One exact source tree
+- One exact tree for every active index
+- The descriptor fingerprint for each selected index generation
+- The parent snapshot used by retention and historical traversal
+
+A write stages every new immutable source, index, snapshot, and state node. One compare-and-swap (CAS) of the collection root makes the complete candidate visible. Readers observe the previous collection state or the next collection state, never a partially published mixture.
+
+The public constructor is:
+
+```rust
+let users = engine.indexed_map(b"users", index_registry()?)?;
+```
+
+There is no separate production constructor. The store and its deployment configuration determine durability, coordination, backup, and process-topology properties.
+
+## Add the crate and choose a store
+
+Add the package to `Cargo.toml`. Rust code imports the library as `prolly`.
+
+```toml
+[dependencies]
+prolly-map = "0.7"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+```
+
+`indexed_map` requires a synchronous store that implements `Store`, `ManifestStore`, and `IndexedStore`. `MemStore` works for tests and examples. Use a durable adapter and configure its durability guarantees for persistent deployments.
+
+```rust
+use prolly::{Config, MemStore, Prolly};
+use std::sync::Arc;
+
+let store = Arc::new(MemStore::new());
+let engine = Prolly::new(store, Config::default());
+# Ok::<(), prolly::Error>(())
+```
+
+You remain responsible for store credentials, durability mode, backups, multi-process coordination, and safe garbage-collection windows.
+
+## Define the source schema
+
+`IndexedMap` stores raw byte keys and values. Typed applications should choose one deterministic encoding and reject malformed records in every extractor.
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct User {
+    tenant_id: String,
+    status: String,
+    email: String,
+    tags: Vec<String>,
+}
+```
+
+An extractor receives the primary key and the exact stored source bytes. It returns zero or more `SecondaryIndexEntry` values, or it returns `SecondaryIndexError` and aborts the entire operation.
+
+## Define deterministic extractors
+
+Use `SecondaryIndex::non_unique` for a keys-only index. The callback returns one byte term for each logical membership.
+
+```rust
+use prolly::{SecondaryIndex, SecondaryIndexError};
+
+let by_status = SecondaryIndex::non_unique(
+    "by-status",
+    1,
+    "app.users.by-status/1",
+    |_key, value| {
+        let user: User = serde_json::from_slice(value)
+            .map_err(|_| SecondaryIndexError::new("invalid user JSON"))?;
+        Ok(vec![user.status.trim().to_lowercase().into_bytes()])
+    },
+)?;
+# Ok::<(), prolly::Error>(())
+```
+
+The four definition inputs have distinct roles:
+
+- **Name**: stable logical query name, such as `by-status`
+- **Generation**: monotonically increasing integer for semantic replacement
+- **Extractor ID**: application-controlled identity for extractor behavior
+- **Extractor**: runtime callback that derives terms and projections
+
+The descriptor fingerprint commits the source map ID, name, generation, extractor ID, projection, semantic limits, and physical layout. Callback machine code is not persisted.
+
+Every extractor must satisfy these rules:
+
+- Produce the same emissions for the same primary key and source bytes
+- Avoid time, randomness, network calls, environment state, and mutable globals
+- Avoid external side effects because conflict retries may run it again
+- Normalize text with a versioned, application-defined policy
+- Encode numeric fields so byte order matches application order
+- Return an error for malformed data instead of guessing
+- Stay within per-record term and projection limits
+
+Duplicate emissions of the same term and projection for one record collapse into one physical entry. Different projections for the same term and primary key fail with `ConflictingIndexProjection`.
+
+## Register definitions at open time
+
+A registry supplies the runtime definitions needed to open, query, mutate, verify, and retain a collection.
+
+```rust
+use prolly::SecondaryIndexRegistry;
+
+let registry = SecondaryIndexRegistry::new()
+    .register(by_status)?
+    .register(by_tag)?;
+let users = engine.indexed_map(b"users", registry)?;
+# Ok::<(), prolly::Error>(())
+```
+
+Register each logical name once. Reopening a persisted collection requires definitions whose fingerprints match its active descriptors. Historical snapshots also require the retained generation definitions they reference.
+
+## Activate an index
+
+Registering a definition makes its runtime behavior available. Call `ensure_index` to build and atomically activate the physical index.
+
+```rust
+let result = users.ensure_index(b"by-status")?;
+println!(
+    "generation={} entries={} attempts={}",
+    result.generation,
+    result.entries,
+    result.attempts
+);
+# Ok::<(), prolly::Error>(())
+```
+
+`ensure_index` is idempotent for an already active matching definition. A successful build selects the source version used for construction and publishes the index only with a matching canonical snapshot.
+
+Activate indexes before bulk loading an empty collection when you want every subsequent write to maintain them incrementally. You can also activate an index after loading source data; `ensure_index` then builds it from the selected source snapshot.
+
+## Write only through `IndexedMap`
+
+Once a map belongs to an indexed collection, route every head-changing mutation through its `IndexedMap`. Raw `VersionedMap` writes are fenced because they could bypass index maintenance.
+
+Use `put` and `delete` for one record:
+
+```rust
+let bytes = serde_json::to_vec(&user).unwrap();
+users.put(b"user-42", bytes)?;
+users.delete(b"user-17")?;
+# Ok::<(), prolly::Error>(())
+```
+
+Use `edit` or `apply` to amortize publication and update several records atomically:
+
+```rust
+users.edit(|edit| {
+    edit.put(b"user-42", updated_user_bytes);
+    edit.delete(b"user-17");
+})?;
+# Ok::<(), prolly::Error>(())
+```
+
+The coordinator normalizes repeated mutations for one primary key. It compares old and new extractor emissions, deletes stale physical entries, inserts changed entries, and skips unchanged emissions.
+
+Use `apply_if` for application-level optimistic concurrency:
+
+```rust
+use prolly::{IndexedMapUpdate, Mutation};
+
+let expected = users.snapshot()?.source_version().clone();
+let update = users.apply_if(
+    Some(&expected),
+    vec![Mutation::Upsert { key, val }],
+)?;
+assert!(matches!(update, IndexedMapUpdate::Applied { .. }));
+# Ok::<(), prolly::Error>(())
+```
+
+A conflict returns the current indexed version without publishing the candidate. Decide whether to reload, merge at the application layer, or retry with a fresh expected version.
+
+## Choose a projection mode
+
+Projection mode determines the value stored beside each physical `(term, primary_key)` key.
+
+| Mode | Stored index value | Best use | Cost |
+| --- | --- | --- | --- |
+| `KeysOnly` | No application payload | Fetch keys or resolve complete source records | Smallest index |
+| `Include` | Extractor-supplied bytes | Cover dashboards and list views | Duplicates selected fields |
+| `All` | Complete source value | Serve matching values without source fetches | Largest index and write amplification |
+
+`SecondaryIndex::non_unique` creates a `KeysOnly` definition. Use the builder for `Include` or `All`.
+
+```rust
+use prolly::{IndexProjection, SecondaryIndex, SecondaryIndexEntry};
+
+let covering = SecondaryIndex::builder(
+    "by-status-summary",
+    1,
+    "app.users.by-status-summary/1",
+)
+.projection(IndexProjection::Include)
+.extract(|_, value| {
+    let user = decode_user(value)?;
+    let summary = encode_summary(&user)?;
+    Ok(vec![SecondaryIndexEntry::included(user.status, summary)])
+})?;
+# Ok::<(), prolly::Error>(())
+```
+
+An `Include` extractor must emit `SecondaryIndexEntry::included`. `KeysOnly` and `All` extractors emit terms without custom projection bytes. `All` inserts the complete source value automatically.
+
+## Encode terms for byte ordering
+
+Secondary-index terms use raw lexicographic byte ordering. Your encoding determines equality, prefix grouping, and range order.
+
+Use these conventions:
+
+- UTF-8 normalized text for case-insensitive exact lookup
+- Unsigned integers encoded with `to_be_bytes()`
+- Signed integers and timestamps encoded with `KeyBuilder`
+- Composite terms encoded as ordered `KeyBuilder` segments
+- Canonical path segments without `.` or `..`
+- Versioned tokenization and normalization for text terms
+
+Do not concatenate variable-width fields with an ambiguous delimiter. `KeyBuilder` encodes segment boundaries and preserves numeric ordering.
+
+```rust
+use prolly::KeyBuilder;
+
+fn tenant_status(tenant: &str, status: &str) -> Vec<u8> {
+    KeyBuilder::new()
+        .push_str(tenant)
+        .push_str(status)
+        .finish()
+}
+```
+
+Keep normalization in one shared function used by both extractor definitions and query construction. A query encoded with a different normalization policy will return no match even when the human-readable values look equal.
+
+## Query one immutable snapshot
+
+Call `snapshot()` once for a logical read operation. Every source and index read through that handle belongs to the same canonical collection snapshot.
+
+```rust
+let snapshot = users.snapshot()?;
+let by_status = snapshot.index(b"by-status")?;
+let keys = by_status.primary_keys(b"active")?;
+# Ok::<(), prolly::Error>(())
+```
+
+Do not call `snapshot()` separately for related reads when they must agree. Concurrent writers may publish between calls.
+
+## Run exact, prefix, and range queries
+
+The three logical query shapes operate on terms before the primary-key tie-breaker.
+
+```rust
+let exact = index.exact(b"active")?;
+let prefix = index.prefix(b"data")?;
+let range = index.range(&start_term, Some(&end_term))?;
+# Ok::<(), prolly::Error>(())
+```
+
+Range bounds are start-inclusive and end-exclusive. Pass `None` for an unbounded end. Matching entries sort by term and then primary key.
+
+Use reverse methods when you need newest-first or highest-first results:
+
+```rust
+let page = index.range_reverse_page(
+    &start_term,
+    Some(&end_term),
+    None,
+    100,
+)?;
+# Ok::<(), prolly::Error>(())
+```
+
+Reverse traversal changes order, not logical bounds.
+
+## Choose keys, projections, or source records
+
+Select the lowest-cost result shape that contains the data you need.
+
+```rust
+let keys = index.primary_keys(b"active")?;
+let summaries = index.projected(b"active")?;
+let records = index.records(b"active")?;
+# Ok::<(), prolly::Error>(())
+```
+
+The methods return:
+
+- `primary_keys`: matching source keys only
+- `projected`: primary keys plus optional `Include` or `All` bytes
+- `records`: term, primary key, projection, and exact source value
+
+`records` performs bounded source fetches from the source tree selected by the same snapshot. A missing referenced source key is reported as `IndexSnapshotMismatch`, not silently ignored.
+
+## Stream results without collecting them
+
+Use scan callbacks when the complete result set should not reside in memory.
+
+```rust
+let visited = index.scan_exact(b"active", |matched| {
+    process(matched.primary_key, matched.projection);
+})?;
+println!("processed {visited} entries");
+# Ok::<(), prolly::Error>(())
+```
+
+The `scan_*_until` variants accept `ControlFlow` and stop after an application condition. Borrowed `SecondaryIndexMatchRef` and `IndexedSourceRecordRef` values remain valid only during the callback.
+
+## Paginate with snapshot-bound cursors
+
+Page methods return a `SecondaryIndexPage` with `matches` and an optional `next_cursor`.
+
+```rust
+let query = index.query(query_budget)?;
+let first = query.prefix_page(b"data", None, 100)?;
+let second = query.prefix_page(
+    b"data",
+    first.next_cursor.as_ref(),
+    100,
+)?;
+# Ok::<(), prolly::Error>(())
+```
+
+A cursor binds the snapshot, source version, state version, index name, index version, descriptor fingerprint, direction, bounds, and continuation key. Reusing it with another snapshot, direction, or bound returns `IndexCursorVersionMismatch`.
+
+Serialize a cursor only when your service must send it across a process boundary:
+
+```rust
+use prolly::SecondaryIndexCursor;
+
+let bytes = cursor.to_bytes()?;
+let restored = SecondaryIndexCursor::from_bytes(&bytes)?;
+# Ok::<(), prolly::Error>(())
+```
+
+Treat cursor bytes as opaque and untrusted. Decoding validates the envelope, while query execution validates its complete identity and physical continuation key.
+
+## Apply explicit query budgets
+
+Convenience queries use finite defaults. Create a query session when endpoint limits must differ from library defaults.
+
+```rust
+use prolly::QueryBudget;
+use std::time::Duration;
+
+let budget = QueryBudget {
+    max_page_entries: 250,
+    max_returned_entries: 1_000,
+    max_returned_bytes: 4 * 1024 * 1024,
+    max_scanned_entries: 10_000,
+    max_source_fetches: 250,
+    max_accounted_memory_bytes: 8 * 1024 * 1024,
+    max_elapsed: Duration::from_secs(2),
+};
+let query = index.query(budget)?;
+# Ok::<(), prolly::Error>(())
+```
+
+Reject page sizes above `max_page_entries` at your API boundary. A budget failure returns `IndexResourceLimitExceeded` and does not weaken snapshot consistency.
+
+## Use real-world index patterns
+
+The following patterns map common application access paths to deterministic term encodings. The runnable [`indexed_map_real_world.rs`](../examples/indexed_map_real_world.rs) example executes every pattern in this section.
+
+| Scenario | Emitted term | Query |
+| --- | --- | --- |
+| Users by status | Normalized status | Exact |
+| Orders by customer | Normalized customer ID | Exact |
+| Multi-tenant status | `(tenant, status)` segments | Exact or tenant prefix |
+| Tasks ordered by state and time | `(state, due_timestamp)` segments | Range or reverse range |
+| Tags and categories | One normalized term per tag | Exact |
+| Sparse pending jobs | Emit only for pending records | Exact pending state |
+| Access-control reverse lookup | One term per group or member | Exact group or member |
+| Email lookup | Normalized email | Exact, without uniqueness enforcement |
+| Covering dashboard | Status plus summary projection | `projected()` |
+| Expiration processing | Big-endian expiry timestamp | Range from minimum through cutoff |
+| Hierarchical paths | Canonical path segments | Prefix |
+| Geospatial buckets | Cell or geohash | Prefix or range, then application filtering |
+| Basic inverted text | One normalized token per document | Exact or token prefix |
+| Audit and history | Same index at a retained source version | `snapshot_at()` |
+
+### Index users by status
+
+Emit one normalized status term and query it exactly.
+
+```rust
+let by_status = SecondaryIndex::non_unique(
+    "by-status",
+    1,
+    "app.users.by-status/1",
+    |_, value| {
+        let user = decode_user(value)?;
+        Ok(vec![normalize(&user.status).into_bytes()])
+    },
+)?;
+```
+
+Status indexes work well for queues and administration filters. If one status has millions of records, paginate or stream instead of calling an unbounded convenience collector.
+
+### Index orders by customer
+
+Emit the customer ID from each order to support reverse lookup from a customer to their orders.
+
+```rust
+let by_customer = SecondaryIndex::non_unique(
+    "by-customer",
+    1,
+    "app.orders.by-customer/1",
+    |_, value| {
+        let order = decode_order(value)?;
+        Ok(vec![normalize(&order.customer_id).into_bytes()])
+    },
+)?;
+```
+
+Use a composite `(customer, created_at)` term when the application also needs chronological customer order history.
+
+### Isolate tenants in composite terms
+
+Place the tenant segment first. Exact lookup selects one tenant and status, while a tenant prefix returns every status for that tenant.
+
+```rust
+let term = KeyBuilder::new()
+    .push_str(&user.tenant_id)
+    .push_str(&user.status)
+    .finish();
+let tenant = KeyBuilder::new()
+    .push_str("tenant-42")
+    .finish();
+let all_tenant_entries = index.prefix(&tenant)?;
+# Ok::<(), prolly::Error>(())
+```
+
+The term order improves query locality but does not implement authorization. Validate tenant access before constructing the query and validate returned records when policy requires it.
+
+### Order tasks by state and due time
+
+Encode state first and an ordered timestamp second. Query a half-open time window within one state.
+
+```rust
+fn state_due(state: &str, due_ms: u64) -> Vec<u8> {
+    KeyBuilder::new()
+        .push_str(state)
+        .push_u64(due_ms)
+        .finish()
+}
+
+let start = state_due("pending", window_start_ms);
+let end = state_due("pending", window_end_ms);
+let due = index.range(&start, Some(&end))?;
+# Ok::<(), prolly::Error>(())
+```
+
+Use `range_reverse_page` to process the same window from the greatest timestamp downward.
+
+### Emit one term per tag or category
+
+A multi-valued extractor maps one source record to several physical entries.
+
+```rust
+|_, value| {
+    let user = decode_user(value)?;
+    Ok(user
+        .tags
+        .iter()
+        .map(|tag| normalize(tag).into_bytes())
+        .collect())
+}
+```
+
+Deduplicate normalized tags in the application when duplicate input should be rejected. The index canonicalizer collapses identical emissions, but preserving a validation error may better expose malformed source data.
+
+### Build a sparse pending-work index
+
+Return no term when a record should be absent from the index.
+
+```rust
+|_, value| {
+    let task = decode_task(value)?;
+    if task.state == "pending" {
+        Ok(vec![b"pending".to_vec()])
+    } else {
+        Ok(Vec::new())
+    }
+}
+```
+
+Sparse indexes reduce storage and query scanning when a small subset needs attention. Updating a task to `done` atomically removes its previous pending entry.
+
+### Reverse access-control memberships
+
+Emit one term for each group or member that can access a resource.
+
+```rust
+|_, value| {
+    let resource = decode_resource(value)?;
+    Ok(resource
+        .group_ids
+        .iter()
+        .map(|group| normalize(group).into_bytes())
+        .collect())
+}
+```
+
+An index accelerates candidate lookup but does not replace policy evaluation. Recheck deny rules, inheritance, expiry, and request context before granting access.
+
+### Normalize email without assuming uniqueness
+
+Normalize email identically during extraction and query construction.
+
+```rust
+let email_term = email.trim().to_lowercase().into_bytes();
+let matching_users = by_email.primary_keys(&email_term)?;
+# Ok::<(), prolly::Error>(())
+```
+
+`IndexedMap` does not reject a second primary key with the same term. Enforce uniqueness in an authoritative write protocol, or handle multiple matches explicitly.
+
+### Cover a dashboard with `Include`
+
+Store only the fields needed by the list view. This avoids source fetches and avoids duplicating the complete record.
+
+```rust
+let entry = SecondaryIndexEntry::included(
+    normalize(&user.status),
+    serde_json::to_vec(&UserSummary {
+        display_name: user.display_name,
+        plan: user.plan,
+    }).map_err(|_| SecondaryIndexError::new("summary encode failed"))?,
+);
+```
+
+Treat projection bytes as a schema with its own versioned extractor ID. Changing field encoding or meaning requires a greater generation and atomic replacement.
+
+### Process records by expiration time
+
+Encode an unsigned timestamp as eight big-endian bytes. Lexicographic order then matches numeric order.
+
+```rust
+let term = item.expires_at_ms.to_be_bytes().to_vec();
+let minimum = 0_u64.to_be_bytes();
+let cutoff_exclusive = cutoff_ms.saturating_add(1).to_be_bytes();
+let expired = index.range(&minimum, Some(&cutoff_exclusive))?;
+# Ok::<(), prolly::Error>(())
+```
+
+Use an end-exclusive cutoff directly when the application already models half-open time windows. Avoid `saturating_add(1)` if the maximum timestamp needs distinct handling.
+
+### Query hierarchical paths by prefix
+
+Split canonical paths into `KeyBuilder` segments. A parent term becomes the byte prefix for its descendants.
+
+```rust
+fn path_term(path: &str) -> Vec<u8> {
+    path.split('/')
+        .filter(|segment| !segment.is_empty())
+        .fold(KeyBuilder::new(), |key, segment| key.push_str(segment))
+        .finish()
+}
+
+let subtree = index.prefix(&path_term("/acme/projects"))?;
+# Ok::<(), prolly::Error>(())
+```
+
+Reject dot segments, ambiguous separators, invalid Unicode policy, and non-canonical aliases before storing the record.
+
+### Use geospatial cells as candidates
+
+Emit a geohash or another hierarchical cell ID. Query a cell prefix, decode projected records, then apply the exact spatial predicate.
+
+```rust
+let candidates = by_cell.prefix(b"c2b2")?;
+let inside = candidates
+    .iter()
+    .filter_map(|row| row.projection.as_deref())
+    .map(decode_place)
+    .filter(|place| bounding_box.contains(place))
+    .collect::<Vec<_>>();
+```
+
+Cell lookup can return false positives and miss neighbors if the application queries too few adjacent cells. Choose precision, neighbor expansion, and exact filtering from measured geographic workloads.
+
+### Build a basic inverted text index
+
+Tokenize, normalize, deduplicate, and emit each distinct token.
+
+```rust
+let terms = text
+    .split(|character: char| !character.is_alphanumeric())
+    .filter(|token| !token.is_empty())
+    .map(normalize)
+    .collect::<BTreeSet<_>>()
+    .into_iter()
+    .map(String::into_bytes)
+    .collect();
+```
+
+Exact token lookup implements boolean membership. Prefix lookup implements byte-prefix token candidates. This pattern does not implement relevance, positions, phrase matching, language-aware analysis, or typo correction.
+
+### Query retained history for audits
+
+Capture the source version from a canonical snapshot, retain it, and reopen it later.
+
+```rust
+let historical_version = users.snapshot()?.source_version().clone();
+let _pin = users.pin_snapshot(b"audit-export", &historical_version)?;
+
+users.put(b"user-42", updated_bytes)?;
+let historical = users.snapshot_at(&historical_version)?;
+let old_active = historical
+    .index(b"by-status")?
+    .primary_keys(b"active")?;
+# Ok::<(), prolly::Error>(())
+```
+
+The snapshot and every index it selects remain exact. Release the pin after the external audit no longer needs the version.
+
+## Retain and pin historical snapshots
+
+`keep_last(count)` retains the newest snapshot chain and always keeps at least the head. Durable pins add selected snapshots even when they fall outside that count.
+
+```rust
+let version = users.snapshot()?.source_version().clone();
+let pin = users.pin_snapshot(b"month-end-export", &version)?;
+users.keep_last(30)?;
+run_export(users.snapshot_at(&version)?)?;
+pin.release()?;
+# Ok::<(), prolly::Error>(())
+```
+
+Dropping a `SnapshotPinGuard` also attempts to release its pin. Call `release()` when the application must observe and handle release failure.
+
+Retaining a snapshot keeps its source tree, index trees, descriptors, and required state reachable. It does not keep arbitrary external resources referenced inside application values.
+
+## Replace an index definition
+
+Change extractor semantics by creating the same logical name with a strictly greater generation. Keep the extractor ID descriptive and versioned.
+
+```rust
+let generation_two = SecondaryIndex::non_unique(
+    "by-status",
+    2,
+    "app.users.by-status/2-unicode-normalization",
+    generation_two_extractor,
+)?;
+let result = users.replace_index(b"by-status", generation_two)?;
+assert!(result.activated);
+# Ok::<(), prolly::Error>(())
+```
+
+Replacement builds against one source snapshot and atomically publishes the new descriptor and tree. The previous generation becomes retired but remains available to retained snapshots.
+
+When reopening after replacement, construct the registry with `SecondaryIndexRegistry::replace` so it retains the prior runtime definition for historical snapshots:
+
+```rust
+let registry = SecondaryIndexRegistry::new()
+    .register(generation_one)?
+    .replace(generation_two)?;
+# Ok::<(), prolly::Error>(())
+```
+
+Do not reuse a generation or extractor ID after changing normalization, term encoding, projection encoding, limits, or meaning.
+
+Call `deactivate_index(name)` when new snapshots should stop maintaining and exposing an index. Deactivation atomically removes the index from the new head and retires its descriptor. Retained snapshots still select their exact historical index tree, so keep the corresponding runtime definition registered until retention no longer references it.
+
+## Use hard cutover for persisted format changes
+
+The current indexed-collection layout has one supported persisted format. There is no compatibility reader and no suffix-named `V2` or `V3` collection.
+
+For an incompatible persisted-format change:
+
+1. Stop writes or establish a source snapshot boundary
+2. Build or import into an empty destination using the new software
+3. Verify the complete destination snapshot and every index
+4. Switch readers and writers to the destination atomically at the deployment layer
+5. Keep the old deployment available for rollback until the cutover is accepted
+6. Retire the old deployment after the rollback window closes
+
+`Error::IndexFormatUnsupported` means the deployment must perform this hard cutover. Do not rename the old format or append a format suffix to avoid the migration decision.
+
+## Verify and repair index correctness
+
+`health()` performs structural closure checks and reports selected versions, active indexes, retained snapshots, and durable pins.
+
+```rust
+let health = users.health()?;
+assert!(health.closure_valid);
+for index in &health.active_indexes {
+    println!("{:?} generation={}", index.name, index.generation);
+}
+# Ok::<(), prolly::Error>(())
+```
+
+Health does not recompute extractor semantics. Use `verify_index` or `verify_all` for semantic qualification.
+
+```rust
+let source = users.snapshot()?.source_version().clone();
+for verification in users.verify_all(&source)? {
+    assert!(verification.is_valid());
+    assert!(verification.is_canonical());
+}
+# Ok::<(), prolly::Error>(())
+```
+
+Verification rebuilds expected index content under a finite maintenance budget and compares it with the selected physical tree. `is_valid()` checks entries and semantic differences. `is_canonical()` also checks deterministic root identity.
+
+`repair_index` can publish a rebuilt tree only for the current head snapshot. Investigate the cause before repair because deterministic extraction and atomic publication should prevent ordinary drift.
+
+## Export and import one canonical collection closure
+
+`export_current` creates a content-addressed bundle for the current canonical state and every reachable immutable node.
+
+```rust
+let bundle = users.export_current()?;
+let expected_digest = bundle.digest()?;
+let encoded = bundle.to_bytes()?;
+let decoded = prolly::IndexedSnapshotBundle::from_bytes(&encoded)?;
+assert_eq!(decoded.digest()?, expected_digest);
+# Ok::<(), prolly::Error>(())
+```
+
+Inspect and verify untrusted bytes under a `TransferBudget` before allocating deployment-specific resources. Import verifies hashes, records, reachability, ownership, runtime definitions, and the selected snapshot before publishing one destination root.
+
+```rust
+let replica = replica_engine.indexed_map(b"users", registry)?;
+replica.import_current(&decoded, None)?;
+# Ok::<(), prolly::Error>(())
+```
+
+Pass `None` only when the destination is logically empty. For an existing destination, pass its current source version as the compare-and-set expectation. Import does not merge two independently changed heads, so establish an application-level source of truth before transfer.
+
+## Bound mutation and maintenance work
+
+All indexed operations have finite defaults. Override budgets from measured endpoint and maintenance objectives.
+
+| Budget | Bounds |
+| --- | --- |
+| `MutationBudget` | Input records and bytes, derived entries and bytes, accounted memory, CAS attempts, elapsed time |
+| `QueryBudget` | Page and result entries, returned bytes, scanned entries, source fetches, accounted memory, elapsed time |
+| `MaintenanceBudget` | Source and derived entries, findings, memory, spill bytes and runs, merge fan-in, CAS attempts, elapsed time |
+| `TransferBudget` | Encoded and decoded bytes, nodes, verification work, accounted memory, elapsed time |
+
+Use `apply_with_budget`, `ensure_index_with_budget`, `verify_all_with_budget`, `repair_index_with_budget`, bundle budget methods, and `index.query` to supply explicit limits.
+
+The default values are safety ceilings, not capacity promises. Lower them for request paths and raise them only after measuring memory, latency, spill capacity, and retry behavior.
+
+## Observe indexed operations
+
+`metrics()` returns counters accumulated by the current `IndexedMap` metrics handle.
+
+```rust
+let metrics = users.metrics();
+println!("mutations={}", metrics.normalized_source_mutations);
+println!("emitted_terms={}", metrics.terms_emitted);
+println!("retries={}", metrics.retries);
+println!("verification={}", metrics.verification_outcomes);
+```
+
+Export these measurements with operation latency and store-level input/output metrics. Alert on sustained retries, extraction failures, resource-limit errors, verification differences, unexpected projection growth, and retained-root growth.
+
+The logical counters do not claim to measure physical backend writes. Store adapters should expose their own requests, bytes, throttling, transaction conflicts, and durability failures.
+
+## Handle errors by code and retry advice
+
+`Error::index_code()` classifies secondary-index failures without parsing redacted display strings. `Error::retry_advice()` distinguishes fresh-state retries, delayed store retries, and non-retryable failures.
+
+| Error code | Meaning | Application response |
+| --- | --- | --- |
+| `FormatUnsupported` | Persisted indexed format is obsolete | Hard cut over to an empty destination |
+| `Conflict` | Source moved during bounded publication | Reload and retry within policy |
+| `DefinitionInvalid` | Runtime definition or fingerprint is wrong | Fix deployment configuration or code |
+| `RuntimeDefinitionMissing` | A selected generation has no callback | Register active and retained definitions |
+| `ManagedWriteRequired` | A raw write bypassed `IndexedMap` | Route the mutation through `IndexedMap` |
+| `OperationUnsupported` | The requested operation lacks a safe indexed implementation | Use the supported lifecycle path or change the operation |
+| `ExtractionFailed` | An extractor rejected source bytes | Reject or repair the source record |
+| `ProjectionInvalid` | Emission does not match projection mode | Fix the extractor |
+| `ResourceLimit` | Typed budget or semantic limit was exceeded | Reduce work or revise an explicit limit |
+| `CursorInvalid` | Cursor identity does not match the query | Restart pagination from a fresh snapshot |
+| `SnapshotUnavailable` | Retention removed or never created the snapshot | Return an expired-history response |
+| `Corruption` | Selected source and index closure disagree | Stop unsafe writes and investigate |
+| `BundleInvalid` | Transfer envelope or closure failed validation | Reject the bundle |
+
+Display and debug messages redact application keys, terms, values, bounds, and extractor text. Log structured sensitive fields only through an explicitly access-controlled application path.
+
+## Tune performance from workload shape
+
+Index cost depends on source write rate, active index count, terms per record, projection bytes, and backend publication cost.
+
+Use these rules before tuning low-level tree parameters:
+
+- Batch related mutations with `edit` or `apply`
+- Emit only queryable terms
+- Prefer `KeysOnly` unless projection avoids measured source fetch cost
+- Prefer `Include` over `All` when a bounded summary serves the endpoint
+- Place the highest-value range prefix first in composite terms
+- Use big-endian or `KeyBuilder` numeric encodings
+- Paginate high-cardinality terms
+- Stream scans when the consumer can process one entry at a time
+- Set budgets from service-level objectives and observed distribution tails
+- Build and verify large indexes in maintenance paths with bounded spill storage
+- Monitor write amplification after adding each index
+
+An index with one emitted term per record adds one derived upsert or delete when that term changes. Multi-valued and `All` indexes multiply derived bytes. Measure with production-shaped values and term distributions.
+
+## Preserve correctness and security
+
+Treat extractor code as part of the persisted schema. Review it for determinism, denial-of-service bounds, sensitive projections, and normalization ambiguity.
+
+Apply this checklist:
+
+- Reject invalid source encoding before publication
+- Cap source value, term, term-count, and projection sizes
+- Avoid secrets in terms because terms influence physical keys and diagnostics
+- Avoid secrets in `Include` projections unless the index store has matching controls
+- Keep authorization checks outside candidate lookup indexes
+- Authenticate and integrity-check transport around snapshot bundles
+- Register all retained extractor generations before opening historical snapshots
+- Verify indexes after restore, adapter changes, and extractor replacement
+- Pin snapshots during long-running exports or audits
+- Require explicit quiescence before destructive indexed garbage collection
+
+Content addressing detects changed node bytes. It does not encrypt application data or authenticate an untrusted caller.
+
+## Operate retention and garbage collection safely
+
+Retention removes canonical references to old snapshot records. Garbage collection (GC) later reclaims unreachable nodes from the shared store.
+
+Use `plan_indexed_gc` to inspect candidates when the store implements node and manifest scans. `sweep_indexed_gc(true)` requires the caller to assert an external quiescence or lease-safety proof.
+
+Do not infer reader safety from cache residency. Coordinate all processes, readers, backups, transfers, and other named roots before sweeping a shared store.
+
+## Qualify a store deployment
+
+An adapter type alone does not prove that every deployment configuration is safe. Qualify the exact store settings and process topology you will run.
+
+Verify these properties:
+
+- Immutable node writes are durable before manifest publication
+- Manifest compare-and-swap is atomic under concurrency
+- Candidate roots are readable before visibility changes
+- Multiple processes agree on one manifest coordination domain
+- Restart and forced-termination tests preserve the old or new complete state
+- Backup and restore preserve the canonical state closure
+- Timeouts and retries do not publish a partial collection
+- Garbage collection coordinates with live readers and writers
+- Credentials and encryption protect source values, projections, and terms
+- Store-level observability exposes requests, bytes, conflicts, throttling, and errors
+
+Run the adapter’s indexed-map contract test against the deployed configuration when possible.
+
+## Test definitions and release gates
+
+Extractor tests should prove semantics before integration tests exercise storage and publication.
+
+Cover at least:
+
+- Empty, malformed, minimum-size, and maximum-size source records
+- Case, Unicode, whitespace, and normalization boundaries
+- Zero, one, duplicate, and maximum term counts
+- Stable output ordering and deduplication
+- Projection encoding and size limits
+- Insert, update, term removal, and delete maintenance
+- Exact, prefix, range, reverse, page, and cursor behavior
+- Concurrent writers and bounded CAS conflicts
+- Current and historical snapshot consistency
+- Definition replacement with retained generations
+- Verification, repair, export, import, retention, pins, and GC planning
+- Restart and forced-termination qualification for durable adapters
+- Benchmark baselines for representative cardinality and skew
+
+Run the repository example and focused test suite:
+
+```sh
+cargo run --example indexed_map_real_world
+cargo run --example secondary_index
+cargo test --test secondary_index
+```
+
+Release only when API inventory, formatting, lint, correctness, adapter, binding, address-sanitizer, minimum-supported-Rust-version, and bounded benchmark gates pass on the exact release commit.
+
+## Use the API surface by task
+
+This table summarizes the primary application methods.
+
+| Task | API |
+| --- | --- |
+| Open a collection | `engine.indexed_map(source_map_id, registry)` |
+| Activate a registered definition | `ensure_index` or `ensure_index_with_budget` |
+| Read one source value | `get` or `get_with` |
+| Mutate source and indexes | `put`, `delete`, `edit`, `apply`, `apply_with_budget` |
+| Compare-and-set a source version | `apply_if` |
+| Open current state | `snapshot` |
+| Open retained history | `snapshot_at` or `snapshot_by_id` |
+| Query an index | `exact`, `prefix`, `range`, reverse variants, or page variants |
+| Control query resources | `query(QueryBudget)` |
+| Resolve complete source records | `records` or `scan_records` |
+| Replace semantics | `replace_index` with a greater generation |
+| Retire an index | `deactivate_index` |
+| Inspect structural health | `health` |
+| Inspect logical work | `metrics` |
+| Verify semantics | `verify_index`, `verify_all`, or budget variants |
+| Repair the head index | `repair_index` or `repair_index_with_budget` |
+| Keep history | `keep_last`, `pin_snapshot`, `retain_snapshot_pin` |
+| Transfer current state | `export_current`, bundle verification, `import_current` |
+| Plan or sweep GC | `plan_indexed_gc`, `sweep_indexed_gc` |
+
+## Continue into semantics and implementation details
+
+This guide covers application use and operations. Read [IndexedMap secondary-index semantics](secondary-index-design.md) for the canonical state layout, cursor identity, physical publication, retention closure, transfer validation, and observability contract.
+
+The repository includes two complementary executable examples:
+
+- [`indexed_map_real_world.rs`](../examples/indexed_map_real_world.rs) runs all 14 application patterns from this guide
+- [`secondary_index.rs`](../examples/secondary_index.rs) focuses on projections, atomic edits, verification, generation replacement, retention, export, and import

--- a/docs/versioned-map.md
+++ b/docs/versioned-map.md
@@ -135,7 +135,8 @@ other ordered key/value state. “Versioned map” describes lifecycle and histo
 
 When the engine must maintain derived indexes synchronously and prevent writes
 from bypassing maintenance, use `IndexedMap` rather than manually coordinating
-separate `VersionedMap` heads. See [IndexedMap Secondary Indexes](secondary-index-design.md).
+separate `VersionedMap` heads. See [Build and operate secondary indexes with
+`IndexedMap`](secondary-indexes.md).
 
 For example:
 

--- a/examples/indexed_map_real_world.rs
+++ b/examples/indexed_map_real_world.rs
@@ -1,0 +1,612 @@
+//! Runnable secondary-index patterns for production-shaped application data.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run --example indexed_map_real_world
+//! ```
+
+use prolly::{
+    Config, Error, IndexProjection, KeyBuilder, MemStore, Prolly, SecondaryIndex,
+    SecondaryIndexEntry, SecondaryIndexError, SecondaryIndexRegistry,
+};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+type ExampleResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct User {
+    tenant_id: String,
+    status: String,
+    email: String,
+    display_name: String,
+    plan: String,
+    tags: Vec<String>,
+    group_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct UserSummary {
+    display_name: String,
+    plan: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct Order {
+    customer_id: String,
+    total_cents: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct Task {
+    state: String,
+    due_timestamp_ms: u64,
+    title: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct ExpiringItem {
+    expires_at_ms: u64,
+    payload: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct Place {
+    geohash: String,
+    latitude: f64,
+    longitude: f64,
+    name: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct Document {
+    path: String,
+    title: String,
+    body: String,
+}
+
+fn decode<T: DeserializeOwned>(value: &[u8]) -> Result<T, SecondaryIndexError> {
+    serde_json::from_slice(value)
+        .map_err(|_| SecondaryIndexError::new("source value is not valid application JSON"))
+}
+
+fn encode<T: Serialize>(value: &T) -> ExampleResult<Vec<u8>> {
+    Ok(serde_json::to_vec(value)?)
+}
+
+fn normalize(value: &str) -> String {
+    value.trim().to_lowercase()
+}
+
+fn tenant_status_term(tenant_id: &str, status: &str) -> Vec<u8> {
+    KeyBuilder::new()
+        .push_str(tenant_id)
+        .push_str(status)
+        .finish()
+}
+
+fn tenant_prefix(tenant_id: &str) -> Vec<u8> {
+    KeyBuilder::new().push_str(tenant_id).finish()
+}
+
+fn state_due_term(state: &str, due_timestamp_ms: u64) -> Vec<u8> {
+    KeyBuilder::new()
+        .push_str(state)
+        .push_u64(due_timestamp_ms)
+        .finish()
+}
+
+fn canonical_path_term(path: &str) -> Result<Vec<u8>, SecondaryIndexError> {
+    let mut builder = KeyBuilder::new();
+    for segment in path.split('/').filter(|segment| !segment.is_empty()) {
+        if segment == "." || segment == ".." {
+            return Err(SecondaryIndexError::new(
+                "document paths must not contain dot segments",
+            ));
+        }
+        builder = builder.push_str(segment);
+    }
+    Ok(builder.finish())
+}
+
+fn normalized_tokens(text: &str) -> Vec<Vec<u8>> {
+    text.split(|character: char| !character.is_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(normalize)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(String::into_bytes)
+        .collect()
+}
+
+fn user_registry() -> Result<SecondaryIndexRegistry, Error> {
+    let by_status =
+        SecondaryIndex::non_unique("by-status", 1, "examples.users.by-status/1", |_, value| {
+            let user = decode::<User>(value)?;
+            Ok(vec![normalize(&user.status).into_bytes()])
+        })?;
+
+    let by_tenant_status = SecondaryIndex::non_unique(
+        "by-tenant-status",
+        1,
+        "examples.users.by-tenant-status/1",
+        |_, value| {
+            let user = decode::<User>(value)?;
+            Ok(vec![tenant_status_term(
+                &normalize(&user.tenant_id),
+                &normalize(&user.status),
+            )])
+        },
+    )?;
+
+    let by_tag = SecondaryIndex::non_unique("by-tag", 1, "examples.users.by-tag/1", |_, value| {
+        let user = decode::<User>(value)?;
+        Ok(user
+            .tags
+            .iter()
+            .map(|tag| normalize(tag).into_bytes())
+            .collect())
+    })?;
+
+    let by_group =
+        SecondaryIndex::non_unique("by-group", 1, "examples.users.by-group/1", |_, value| {
+            let user = decode::<User>(value)?;
+            Ok(user
+                .group_ids
+                .iter()
+                .map(|group_id| normalize(group_id).into_bytes())
+                .collect())
+        })?;
+
+    let by_email =
+        SecondaryIndex::non_unique("by-email", 1, "examples.users.by-email/1", |_, value| {
+            let user = decode::<User>(value)?;
+            Ok(vec![normalize(&user.email).into_bytes()])
+        })?;
+
+    let by_status_summary =
+        SecondaryIndex::builder("by-status-summary", 1, "examples.users.by-status-summary/1")
+            .projection(IndexProjection::Include)
+            .extract(|_, value| {
+                let user = decode::<User>(value)?;
+                let summary = UserSummary {
+                    display_name: user.display_name,
+                    plan: user.plan,
+                };
+                let projection = serde_json::to_vec(&summary)
+                    .map_err(|_| SecondaryIndexError::new("could not encode user summary"))?;
+                Ok(vec![SecondaryIndexEntry::included(
+                    normalize(&user.status),
+                    projection,
+                )])
+            })?;
+
+    SecondaryIndexRegistry::new()
+        .register(by_status)?
+        .register(by_tenant_status)?
+        .register(by_tag)?
+        .register(by_group)?
+        .register(by_email)?
+        .register(by_status_summary)
+}
+
+fn order_registry() -> Result<SecondaryIndexRegistry, Error> {
+    let by_customer = SecondaryIndex::non_unique(
+        "by-customer",
+        1,
+        "examples.orders.by-customer/1",
+        |_, value| {
+            let order = decode::<Order>(value)?;
+            Ok(vec![normalize(&order.customer_id).into_bytes()])
+        },
+    )?;
+    SecondaryIndexRegistry::new().register(by_customer)
+}
+
+fn task_registry() -> Result<SecondaryIndexRegistry, Error> {
+    let by_state_due = SecondaryIndex::non_unique(
+        "by-state-due",
+        1,
+        "examples.tasks.by-state-due/1",
+        |_, value| {
+            let task = decode::<Task>(value)?;
+            Ok(vec![state_due_term(
+                &normalize(&task.state),
+                task.due_timestamp_ms,
+            )])
+        },
+    )?;
+
+    let pending_only = SecondaryIndex::non_unique(
+        "pending-only",
+        1,
+        "examples.tasks.pending-only/1",
+        |_, value| {
+            let task = decode::<Task>(value)?;
+            if normalize(&task.state) == "pending" {
+                Ok(vec![b"pending".to_vec()])
+            } else {
+                Ok(Vec::new())
+            }
+        },
+    )?;
+
+    SecondaryIndexRegistry::new()
+        .register(by_state_due)?
+        .register(pending_only)
+}
+
+fn expiration_registry() -> Result<SecondaryIndexRegistry, Error> {
+    let by_expiry = SecondaryIndex::non_unique(
+        "by-expiry",
+        1,
+        "examples.expiration.by-expiry/1",
+        |_, value| {
+            let item = decode::<ExpiringItem>(value)?;
+            Ok(vec![item.expires_at_ms.to_be_bytes().to_vec()])
+        },
+    )?;
+    SecondaryIndexRegistry::new().register(by_expiry)
+}
+
+fn place_registry() -> Result<SecondaryIndexRegistry, Error> {
+    let by_cell = SecondaryIndex::builder("by-cell", 1, "examples.places.by-cell/1")
+        .projection(IndexProjection::All)
+        .extract_terms(|_, value| {
+            let place = decode::<Place>(value)?;
+            Ok(vec![normalize(&place.geohash).into_bytes()])
+        })?;
+    SecondaryIndexRegistry::new().register(by_cell)
+}
+
+fn document_registry() -> Result<SecondaryIndexRegistry, Error> {
+    let by_path =
+        SecondaryIndex::non_unique("by-path", 1, "examples.documents.by-path/1", |_, value| {
+            let document = decode::<Document>(value)?;
+            Ok(vec![canonical_path_term(&document.path)?])
+        })?;
+
+    let by_token = SecondaryIndex::non_unique(
+        "by-token",
+        1,
+        "examples.documents.by-token/1",
+        |_, value| {
+            let document = decode::<Document>(value)?;
+            Ok(normalized_tokens(&format!(
+                "{} {}",
+                document.title, document.body
+            )))
+        },
+    )?;
+
+    SecondaryIndexRegistry::new()
+        .register(by_path)?
+        .register(by_token)
+}
+
+fn main() -> ExampleResult {
+    let engine = Prolly::new(Arc::new(MemStore::new()), Config::default());
+    user_and_access_patterns(&engine)?;
+    order_pattern(&engine)?;
+    task_and_expiration_patterns(&engine)?;
+    path_text_and_geospatial_patterns(&engine)?;
+    println!("verified 14 IndexedMap real-world secondary-index patterns");
+    Ok(())
+}
+
+fn user_and_access_patterns(engine: &Prolly<Arc<MemStore>>) -> ExampleResult {
+    let users = engine.indexed_map(b"example-users", user_registry()?)?;
+    for name in [
+        b"by-status".as_slice(),
+        b"by-tenant-status".as_slice(),
+        b"by-tag".as_slice(),
+        b"by-group".as_slice(),
+        b"by-email".as_slice(),
+        b"by-status-summary".as_slice(),
+    ] {
+        users.ensure_index(name)?;
+    }
+
+    let ada = User {
+        tenant_id: "acme".into(),
+        status: "active".into(),
+        email: "ADA@Example.com ".into(),
+        display_name: "Ada".into(),
+        plan: "enterprise".into(),
+        tags: vec!["rust".into(), "database".into()],
+        group_ids: vec!["admins".into(), "billing".into()],
+    };
+    let grace = User {
+        tenant_id: "acme".into(),
+        status: "invited".into(),
+        email: "ada@example.com".into(),
+        display_name: "Grace".into(),
+        plan: "team".into(),
+        tags: vec!["database".into()],
+        group_ids: vec!["billing".into()],
+    };
+    let lin = User {
+        tenant_id: "northwind".into(),
+        status: "active".into(),
+        email: "lin@example.com".into(),
+        display_name: "Lin".into(),
+        plan: "free".into(),
+        tags: vec!["rust".into()],
+        group_ids: vec!["readers".into()],
+    };
+
+    users.edit(|edit| {
+        edit.put(b"user-ada".to_vec(), encode(&ada).unwrap());
+        edit.put(b"user-grace".to_vec(), encode(&grace).unwrap());
+        edit.put(b"user-lin".to_vec(), encode(&lin).unwrap());
+    })?;
+    let first_version = users.snapshot()?.source_version().clone();
+    let snapshot = users.snapshot()?;
+
+    // 1. Users by status: exact lookup.
+    assert_eq!(
+        snapshot.index(b"by-status")?.primary_keys(b"active")?,
+        vec![b"user-ada".to_vec(), b"user-lin".to_vec()]
+    );
+
+    // 2. Multi-tenant status: exact lookup and tenant prefix scan.
+    let acme_active = tenant_status_term("acme", "active");
+    assert_eq!(
+        snapshot
+            .index(b"by-tenant-status")?
+            .primary_keys(&acme_active)?,
+        vec![b"user-ada".to_vec()]
+    );
+    assert_eq!(
+        snapshot
+            .index(b"by-tenant-status")?
+            .prefix(&tenant_prefix("acme"))?
+            .len(),
+        2
+    );
+
+    // 3. Tags and categories: one emitted term per tag.
+    assert_eq!(
+        snapshot.index(b"by-tag")?.primary_keys(b"database")?,
+        vec![b"user-ada".to_vec(), b"user-grace".to_vec()]
+    );
+
+    // 4. Access-control-list reverse lookup: one term per group membership.
+    assert_eq!(
+        snapshot.index(b"by-group")?.primary_keys(b"billing")?,
+        vec![b"user-ada".to_vec(), b"user-grace".to_vec()]
+    );
+
+    // 5. Normalized email lookup: exact lookup does not enforce uniqueness.
+    assert_eq!(
+        snapshot
+            .index(b"by-email")?
+            .primary_keys(b"ada@example.com")?
+            .len(),
+        2
+    );
+
+    // 6. Covering dashboard: read summary projections without source fetches.
+    let summaries = snapshot.index(b"by-status-summary")?.projected(b"active")?;
+    let ada_summary: UserSummary = serde_json::from_slice(
+        summaries
+            .iter()
+            .find(|(key, _)| key == b"user-ada")
+            .and_then(|(_, projection)| projection.as_deref())
+            .expect("Ada has an included projection"),
+    )?;
+    assert_eq!(ada_summary.plan, "enterprise");
+
+    // 7. Historical audit query: retain and reopen the old source version.
+    let mut updated_ada = ada;
+    updated_ada.status = "suspended".into();
+    users.put(b"user-ada", encode(&updated_ada)?)?;
+    users.keep_last(2)?;
+    let historical = users.snapshot_at(&first_version)?;
+    assert_eq!(
+        historical.index(b"by-status")?.primary_keys(b"active")?,
+        vec![b"user-ada".to_vec(), b"user-lin".to_vec()]
+    );
+    assert_eq!(
+        users
+            .snapshot()?
+            .index(b"by-status")?
+            .primary_keys(b"suspended")?,
+        vec![b"user-ada".to_vec()]
+    );
+    Ok(())
+}
+
+fn order_pattern(engine: &Prolly<Arc<MemStore>>) -> ExampleResult {
+    let orders = engine.indexed_map(b"example-orders", order_registry()?)?;
+    orders.ensure_index(b"by-customer")?;
+    orders.edit(|edit| {
+        edit.put(
+            b"order-100".to_vec(),
+            encode(&Order {
+                customer_id: "customer-7".into(),
+                total_cents: 12_500,
+            })
+            .unwrap(),
+        );
+        edit.put(
+            b"order-101".to_vec(),
+            encode(&Order {
+                customer_id: "customer-7".into(),
+                total_cents: 8_000,
+            })
+            .unwrap(),
+        );
+    })?;
+
+    // 8. Orders by customer: exact reverse lookup from customer to orders.
+    assert_eq!(
+        orders
+            .snapshot()?
+            .index(b"by-customer")?
+            .primary_keys(b"customer-7")?
+            .len(),
+        2
+    );
+    Ok(())
+}
+
+fn task_and_expiration_patterns(engine: &Prolly<Arc<MemStore>>) -> ExampleResult {
+    let tasks = engine.indexed_map(b"example-tasks", task_registry()?)?;
+    tasks.ensure_index(b"by-state-due")?;
+    tasks.ensure_index(b"pending-only")?;
+    tasks.edit(|edit| {
+        for (key, state, due, title) in [
+            ("task-1", "pending", 1_000, "send invoice"),
+            ("task-2", "pending", 2_000, "renew certificate"),
+            ("task-3", "done", 1_500, "archive export"),
+        ] {
+            edit.put(
+                key.as_bytes().to_vec(),
+                encode(&Task {
+                    state: state.into(),
+                    due_timestamp_ms: due,
+                    title: title.into(),
+                })
+                .unwrap(),
+            );
+        }
+    })?;
+    let snapshot = tasks.snapshot()?;
+
+    // 9. Tasks ordered by state and time: range and reverse-range lookup.
+    let start = state_due_term("pending", 0);
+    let end = state_due_term("pending", 3_000);
+    let ascending = snapshot.index(b"by-state-due")?.range(&start, Some(&end))?;
+    let descending =
+        snapshot
+            .index(b"by-state-due")?
+            .range_reverse_page(&start, Some(&end), None, 10)?;
+    assert_eq!(ascending.len(), 2);
+    assert_eq!(descending.matches[0].primary_key, b"task-2");
+
+    // 10. Sparse pending jobs: completed tasks emit no index term.
+    assert_eq!(
+        snapshot
+            .index(b"pending-only")?
+            .primary_keys(b"pending")?
+            .len(),
+        2
+    );
+
+    let expiring = engine.indexed_map(b"example-expiring", expiration_registry()?)?;
+    expiring.ensure_index(b"by-expiry")?;
+    expiring.edit(|edit| {
+        for (key, expires_at_ms) in [("session-1", 900_u64), ("session-2", 1_100)] {
+            edit.put(
+                key.as_bytes().to_vec(),
+                encode(&ExpiringItem {
+                    expires_at_ms,
+                    payload: key.into(),
+                })
+                .unwrap(),
+            );
+        }
+    })?;
+
+    // 11. Expiration processing: big-endian timestamps preserve numeric order.
+    let minimum = 0_u64.to_be_bytes();
+    let cutoff_exclusive = 1_001_u64.to_be_bytes();
+    let expired = expiring
+        .snapshot()?
+        .index(b"by-expiry")?
+        .range(&minimum, Some(&cutoff_exclusive))?;
+    assert_eq!(expired.len(), 1);
+    assert_eq!(expired[0].primary_key, b"session-1");
+    Ok(())
+}
+
+fn path_text_and_geospatial_patterns(engine: &Prolly<Arc<MemStore>>) -> ExampleResult {
+    let documents = engine.indexed_map(b"example-documents", document_registry()?)?;
+    documents.ensure_index(b"by-path")?;
+    documents.ensure_index(b"by-token")?;
+    documents.edit(|edit| {
+        for (key, path, title, body) in [
+            (
+                "doc-1",
+                "/acme/projects/alpha/readme",
+                "Rust storage",
+                "Content addressed database nodes",
+            ),
+            (
+                "doc-2",
+                "/acme/projects/beta/readme",
+                "Database guide",
+                "Rust indexing patterns",
+            ),
+            (
+                "doc-3",
+                "/northwind/reports/q1",
+                "Quarterly report",
+                "Revenue and expenses",
+            ),
+        ] {
+            edit.put(
+                key.as_bytes().to_vec(),
+                encode(&Document {
+                    path: path.into(),
+                    title: title.into(),
+                    body: body.into(),
+                })
+                .unwrap(),
+            );
+        }
+    })?;
+    let snapshot = documents.snapshot()?;
+
+    // 12. Hierarchical paths: canonical segments support subtree prefixes.
+    let acme_projects = canonical_path_term("/acme/projects")?;
+    assert_eq!(snapshot.index(b"by-path")?.prefix(&acme_projects)?.len(), 2);
+
+    // 13. Basic inverted text: emit one normalized term per distinct token.
+    assert_eq!(
+        snapshot.index(b"by-token")?.primary_keys(b"rust")?,
+        vec![b"doc-1".to_vec(), b"doc-2".to_vec()]
+    );
+    assert_eq!(snapshot.index(b"by-token")?.prefix(b"data")?.len(), 2);
+
+    let places = engine.indexed_map(b"example-places", place_registry()?)?;
+    places.ensure_index(b"by-cell")?;
+    places.edit(|edit| {
+        for (key, geohash, latitude, longitude, name) in [
+            ("place-1", "c2b2q", 49.2827, -123.1207, "Vancouver"),
+            ("place-2", "c2b2r", 49.25, -123.1, "South Vancouver"),
+            ("place-3", "dr5ru", 40.7128, -74.006, "New York"),
+        ] {
+            edit.put(
+                key.as_bytes().to_vec(),
+                encode(&Place {
+                    geohash: geohash.into(),
+                    latitude,
+                    longitude,
+                    name: name.into(),
+                })
+                .unwrap(),
+            );
+        }
+    })?;
+
+    // 14. Geospatial buckets: prefix candidates, then apply exact geometry.
+    let candidates = places.snapshot()?.index(b"by-cell")?.prefix(b"c2b2")?;
+    let inside_box = candidates
+        .iter()
+        .filter_map(|matched| matched.projection.as_deref())
+        .map(serde_json::from_slice::<Place>)
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .filter(|place| {
+            (49.20..=49.30).contains(&place.latitude)
+                && (-123.20..=-123.00).contains(&place.longitude)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(inside_box.len(), 2);
+    Ok(())
+}


### PR DESCRIPTION
## What changed

- Add a comprehensive `IndexedMap` secondary-index usage and operations guide
- Add a runnable Rust example covering 14 production-shaped index patterns
- Document exact, prefix, range, reverse, streaming, pagination, projection, and historical query usage
- Document atomic mutation, index activation and replacement, hard cutover, retention, pins, transfer, verification, repair, resource budgets, observability, errors, garbage collection, security, and store qualification
- Link the guide and example from the repository README, docs index, versioned-map guide, and lower-level semantics reference

## Why

The existing semantics reference explained the persisted architecture but did not provide a self-contained application path or comprehensive real-world patterns. Users needed copyable examples for common access paths and operational guidance for running `IndexedMap` safely.

## Developer impact

This PR changes documentation and examples only. It does not change the public API or persisted format. The new example demonstrates users by status, orders by customer, tenant/status composites, state/time ranges, tags, sparse pending work, ACL reverse lookup, normalized email, covering projections, expiry processing, hierarchical paths, geospatial candidates, inverted tokens, and retained historical queries.

## Validation

- `cargo run --example indexed_map_real_world`
- `cargo test`
- `cargo test --test secondary_index`
- `cargo clippy --example indexed_map_real_world -- -D warnings`
- `cargo fmt --check`
- `./scripts/check-secondary-index-cutover.sh`
- `python3 scripts/binding_api_inventory.py check`
- `cargo package --allow-dirty --no-verify --list`
- Documentation pattern, terminology, whitespace, and local-link checks

## Authoring note

Implemented and reviewed with Codex using the existing `IndexedMap` implementation, tests, and release gates as the technical source of truth.
