### PR TITLE
Make IndexedMap publication transactional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- Require strict `TransactionalStore` support for the sole `IndexedMap`
+  constructor and route every canonical collection-root transition, including
+  bundle import, through the engine transaction layer.
+- Make `IndexedMap::apply_if` validate its expected source version inside the
+  publication retry loop so a concurrent writer can never turn a stale
+  conditional mutation into an unconditional write.
+- Coordinate `FileNodeStore` manifest writes with an operating-system file lock
+  so independently opened handles and processes serialize root transactions.
+
 ## 0.7.0 — 2026-07-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ reflogs, patches, merge orchestration, sync planning, and repository-level GC.
   and multi-valued terms, `KeysOnly`/`Include`/`All` projections, exact
   historical snapshots, durable pins, safe GC, structured diagnostics, and
   verified bounded transfer. Applications open it through one
-  `engine.indexed_map(...)` API and choose a synchronous store implementing
-  `Store`, `ManifestStore`, and `IndexedStore`.
+  `engine.indexed_map(...)` API and choose a synchronous `IndexedStore` with
+  strict transactional root publication.
 - Store-independent single-key, shared multi-key, complete range, cursor-page,
   and diff-page proofs for a tree root.
 - Tree statistics for inspecting shape, fill factor, fanout, and serialized size.

--- a/docs/secondary-index-design.md
+++ b/docs/secondary-index-design.md
@@ -32,7 +32,7 @@ A mutation or maintenance operation:
 2. derives immutable source, index, snapshot, and state objects;
 3. writes every immutable node;
 4. confirms that every candidate root is readable;
-5. performs one compare-and-swap of the collection root.
+5. transactionally validates and advances the collection root.
 
 Only the last step changes visibility. Readers therefore observe the complete
 old state or the complete new state, never a mix. Conflicts reload the entire
@@ -46,16 +46,25 @@ through `IndexedMap`.
 
 There is one indexed-map API:
 `engine.indexed_map(source_map_id, registry)`. It accepts synchronous stores
-implementing `Store`, `ManifestStore`, and `IndexedStore`; there is no
-production/verification profile or alternate production constructor.
+implementing `IndexedStore`, whose contract includes `Store`, `ManifestStore`,
+and strict `TransactionalStore`; there is no production/verification profile or
+alternate production constructor. Opening fails with
+`UnsupportedTransactions` when the backend does not enable strict transactions.
 
 The application owns deployment choices such as persistence mode, durability
-settings, process topology, backup policy, and GC quiescence. The coordinator
-always uses immutable node publication followed by one manifest compare-and-
-swap, and confirms candidate roots are readable before that visibility change.
-An adapter must implement those store contracts correctly for its deployment.
-The library does not infer operational safety from an adapter name or attach a
-blanket production label to a configuration.
+settings, backup policy, and GC quiescence. The coordinator publishes immutable
+candidate nodes, confirms candidate roots are readable, then advances the one
+canonical root through the engine transaction layer. The transaction validates
+the previously loaded root and makes a successful commit the only visibility
+transition. A conflict exposes no candidate root and retries from a complete new
+state. Unreachable candidate nodes left by a conflict or pre-commit failure are
+safe content-addressed garbage and are reclaimed by quiescent GC.
+
+An adapter that reports transaction support must provide linearizable
+cross-thread, cross-handle, and cross-process root validation; atomic root-write
+visibility; durable acknowledgement; and immediate readability of nodes named
+by an applied root. The library fails closed when transaction support is absent,
+but cannot compensate for an adapter that falsely claims these guarantees.
 
 ## Runtime definitions
 
@@ -125,9 +134,9 @@ reverse scans resume strictly before it.
 
 ## Retention, transfer, and GC
 
-Retention is a new canonical state followed by the same one-root CAS. Durable
-snapshot pins prevent retained records from being removed. A pin guard releases
-its pin explicitly or on drop.
+Retention is a new canonical state followed by the same transactional one-root
+commit. Durable snapshot pins prevent retained records from being removed. A
+pin guard releases its pin explicitly or on drop.
 
 Bundles contain one canonical state closure and a globally deduplicated,
 content-address-ordered node set. Export and import are bounded; import checks

--- a/docs/secondary-indexes.md
+++ b/docs/secondary-indexes.md
@@ -36,7 +36,7 @@ Each visible snapshot selects:
 - The descriptor fingerprint for each selected index generation
 - The parent snapshot used by retention and historical traversal
 
-A write stages every new immutable source, index, snapshot, and state node. One compare-and-swap (CAS) of the collection root makes the complete candidate visible. Readers observe the previous collection state or the next collection state, never a partially published mixture.
+A write publishes new immutable source, index, snapshot, and state nodes, confirms the candidate roots are readable, and then transactionally validates and advances the collection root. The successful transaction makes the complete candidate visible. Readers observe the previous collection state or the next collection state, never a partially published mixture. Nodes left unreachable by a conflict are safe to reclaim during quiescent garbage collection.
 
 The public constructor is:
 
@@ -57,7 +57,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ```
 
-`indexed_map` requires a synchronous store that implements `Store`, `ManifestStore`, and `IndexedStore`. `MemStore` works for tests and examples. Use a durable adapter and configure its durability guarantees for persistent deployments.
+`indexed_map` requires a synchronous `IndexedStore`, which includes `Store`, `ManifestStore`, and strict `TransactionalStore`. The constructor fails closed if strict transactions are disabled. `MemStore` works for tests and examples. Use a durable adapter whose transaction implementation is linearizable across every process and handle sharing the store and configure durable acknowledgements for persistent deployments.
 
 ```rust
 use prolly::{Config, MemStore, Prolly};
@@ -867,7 +867,7 @@ An adapter type alone does not prove that every deployment configuration is safe
 Verify these properties:
 
 - Immutable node writes are durable before manifest publication
-- Manifest compare-and-swap is atomic under concurrency
+- Transactional root validation and commit are linearizable under concurrency
 - Candidate roots are readable before visibility changes
 - Multiple processes agree on one manifest coordination domain
 - Restart and forced-termination tests preserve the old or new complete state
@@ -892,7 +892,7 @@ Cover at least:
 - Projection encoding and size limits
 - Insert, update, term removal, and delete maintenance
 - Exact, prefix, range, reverse, page, and cursor behavior
-- Concurrent writers and bounded CAS conflicts
+- Concurrent writers, stale conditional writes, and bounded transaction conflicts
 - Current and historical snapshot consistency
 - Definition replacement with retained generations
 - Verification, repair, export, import, retention, pins, and GC planning

--- a/src/prolly/secondary_index/bundle.rs
+++ b/src/prolly/secondary_index/bundle.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 
 use super::super::cid::Cid;
 use super::super::error::Error;
-use super::super::manifest::NamedRootUpdate;
 use super::super::node::Node;
 use super::super::store::{MemStore, Store};
 use super::super::sync::{verify_node_bytes, SnapshotBundleNode};
@@ -486,18 +485,13 @@ impl<S: IndexedStore> IndexedMap<'_, S> {
         self.prolly
             .store()
             .confirm_indexed_publication(&[&bundle.state_tree])?;
-        match self.prolly.compare_and_swap_named_root(
-            &super::state::indexed_collection_root_name(&self.source_map_id)?,
-            Some(&loaded.tree),
-            Some(&bundle.state_tree),
-        )? {
-            NamedRootUpdate::Applied => {
-                let imported = self.load_state()?;
-                self.current_version(&imported)
-            }
-            NamedRootUpdate::Conflict { .. } => Err(Error::InvalidVersionedMap(
-                "indexed bundle import CAS conflict".to_string(),
-            )),
+        if self.commit_collection_root(Some(&loaded.tree), &bundle.state_tree)? {
+            let imported = self.load_state()?;
+            self.current_version(&imported)
+        } else {
+            Err(Error::InvalidVersionedMap(
+                "indexed bundle import transaction conflict".to_string(),
+            ))
         }
     }
 }

--- a/src/prolly/secondary_index/coordinator.rs
+++ b/src/prolly/secondary_index/coordinator.rs
@@ -8,6 +8,7 @@ use super::super::error::{Error, Mutation};
 use super::super::gc::{GcPlan, GcSweep};
 use super::super::manifest::{ManifestStoreScan, NamedRootRetention, NamedRootUpdate};
 use super::super::store::{NodeStoreScan, Store};
+use super::super::transaction::TransactionUpdate;
 use super::super::tree::Tree;
 use super::super::versioned_map::{MapVersion, MapVersionId};
 use super::super::Prolly;
@@ -261,6 +262,11 @@ impl<'a, S: IndexedStore> IndexedMap<'a, S> {
         source_map_id: impl AsRef<[u8]>,
         registry: SecondaryIndexRegistry,
     ) -> Result<Self, Error> {
+        if !prolly.store().supports_transactions() {
+            return Err(Error::UnsupportedTransactions {
+                store: std::any::type_name::<S>(),
+            });
+        }
         if source_map_id.as_ref().is_empty() {
             return Err(Error::InvalidIndexDefinition {
                 reason: "indexed source map ID must not be empty".to_string(),
@@ -408,6 +414,28 @@ impl<'a, S: IndexedStore> IndexedMap<'a, S> {
         indexed_collection_root_name(&self.source_map_id)
     }
 
+    pub(crate) fn commit_collection_root(
+        &self,
+        expected: Option<&Tree>,
+        candidate: &Tree,
+    ) -> Result<bool, Error> {
+        let transaction = self.prolly.begin_transaction()?;
+        match transaction.compare_and_swap_named_root(
+            &self.root_name()?,
+            expected,
+            Some(candidate),
+        )? {
+            NamedRootUpdate::Conflict { .. } => {
+                transaction.rollback();
+                Ok(false)
+            }
+            NamedRootUpdate::Applied => match transaction.commit()? {
+                TransactionUpdate::Applied { .. } => Ok(true),
+                TransactionUpdate::Conflict(_) => Ok(false),
+            },
+        }
+    }
+
     fn initialize_or_load(&self) -> Result<(), Error> {
         if self.prolly.load_named_root(&self.root_name()?)?.is_some() {
             self.load_state()?;
@@ -439,17 +467,11 @@ impl<'a, S: IndexedStore> IndexedMap<'a, S> {
         self.prolly
             .store()
             .confirm_indexed_publication(&[&source, &state_tree])?;
-        match self.prolly.compare_and_swap_named_root(
-            &self.root_name()?,
-            None,
-            Some(&state_tree),
-        )? {
-            NamedRootUpdate::Applied => Ok(()),
-            NamedRootUpdate::Conflict { .. } => {
-                self.load_state()?;
-                Ok(())
-            }
+        if self.commit_collection_root(None, &state_tree)? {
+            return Ok(());
         }
+        self.load_state()?;
+        Ok(())
     }
 
     pub(crate) fn load_state(&self) -> Result<LoadedIndexedState, Error> {
@@ -482,14 +504,7 @@ impl<'a, S: IndexedStore> IndexedMap<'a, S> {
         self.prolly
             .store()
             .confirm_indexed_publication(&referenced)?;
-        match self.prolly.compare_and_swap_named_root(
-            &self.root_name()?,
-            Some(&loaded.tree),
-            Some(&candidate_tree),
-        )? {
-            NamedRootUpdate::Applied => Ok(true),
-            NamedRootUpdate::Conflict { .. } => Ok(false),
-        }
+        self.commit_collection_root(Some(&loaded.tree), &candidate_tree)
     }
 
     pub(crate) fn current_version(
@@ -611,6 +626,26 @@ impl<'a, S: IndexedStore> IndexedMap<'a, S> {
         mutations: Vec<Mutation>,
         budget: &MutationBudget,
     ) -> Result<IndexedVersion, Error> {
+        match self.apply_with_budget_internal(mutations, budget, None)? {
+            IndexedMapUpdate::Applied { current, .. }
+            | IndexedMapUpdate::Unchanged {
+                current: Some(current),
+            } => Ok(current),
+            IndexedMapUpdate::Unchanged { current: None } => Err(Error::InvalidVersionedMap(
+                "initialized indexed map has no current version".to_string(),
+            )),
+            IndexedMapUpdate::Conflict { .. } => Err(Error::InvalidVersionedMap(
+                "unconditional indexed mutation returned a conflict".to_string(),
+            )),
+        }
+    }
+
+    fn apply_with_budget_internal(
+        &self,
+        mutations: Vec<Mutation>,
+        budget: &MutationBudget,
+        expected: Option<Option<&MapVersionId>>,
+    ) -> Result<IndexedMapUpdate, Error> {
         budget.validate()?;
         let counter = BudgetCounter::new();
         if mutations.len() > budget.max_input_records {
@@ -651,10 +686,19 @@ impl<'a, S: IndexedStore> IndexedMap<'a, S> {
             let loaded = self.load_state()?;
             let head = loaded.state.head_snapshot()?;
             let previous = MapVersionId::for_tree(&head.source.tree)?;
+            if let Some(expected) = expected {
+                if expected != Some(&previous) {
+                    return Ok(IndexedMapUpdate::Conflict {
+                        current: Some(self.current_version(&loaded)?),
+                    });
+                }
+            }
             let source_mutations = normalized.values().cloned().collect::<Vec<_>>();
             let source_tree = self.prolly.batch(&head.source.tree, source_mutations)?;
             if source_tree == head.source.tree {
-                return self.current_version(&loaded);
+                return Ok(IndexedMapUpdate::Unchanged {
+                    current: Some(self.current_version(&loaded)?),
+                });
             }
             let mut source_entry_delta = 0i64;
             for (key, mutation) in &normalized {
@@ -830,15 +874,12 @@ impl<'a, S: IndexedStore> IndexedMap<'a, S> {
                 self.metrics
                     .unchanged_emissions_skipped
                     .fetch_add(unchanged_skipped, Ordering::Relaxed);
-                return self.current_version(&loaded);
+                return Ok(IndexedMapUpdate::Applied {
+                    previous: Some(previous),
+                    current: self.current_version(&loaded)?,
+                });
             }
             self.metrics.retries.fetch_add(1, Ordering::Relaxed);
-            let current = self.load_state()?;
-            if MapVersionId::for_tree(&current.state.head_snapshot()?.source.tree)? == previous {
-                return Err(Error::InvalidVersionedMap(
-                    "collection CAS conflicted without advancing source".to_string(),
-                ));
-            }
         }
         Err(Error::IndexBuildConflictLimitExceeded {
             name: b"mutation".to_vec(),
@@ -851,24 +892,7 @@ impl<'a, S: IndexedStore> IndexedMap<'a, S> {
         expected: Option<&MapVersionId>,
         mutations: Vec<Mutation>,
     ) -> Result<IndexedMapUpdate, Error> {
-        let loaded = self.load_state()?;
-        let current_id = MapVersionId::for_tree(&loaded.state.head_snapshot()?.source.tree)?;
-        if expected != Some(&current_id) {
-            return Ok(IndexedMapUpdate::Conflict {
-                current: Some(self.current_version(&loaded)?),
-            });
-        }
-        let current = self.apply(mutations)?;
-        if current.source.id == current_id {
-            Ok(IndexedMapUpdate::Unchanged {
-                current: Some(current),
-            })
-        } else {
-            Ok(IndexedMapUpdate::Applied {
-                previous: Some(current_id),
-                current,
-            })
-        }
+        self.apply_with_budget_internal(mutations, &MutationBudget::default(), Some(expected))
     }
 
     pub fn put(

--- a/src/prolly/secondary_index/publication.rs
+++ b/src/prolly/secondary_index/publication.rs
@@ -1,15 +1,18 @@
 use super::super::error::Error;
 use super::super::manifest::ManifestStore;
 use super::super::store::{FileNodeStore, MemStore, Store};
+use super::super::transaction::TransactionalStore;
 use super::super::tree::Tree;
 use std::sync::Arc;
 
 /// Store contract used by the canonical single-root index coordinator.
 ///
-/// General multi-map transactions are deliberately not part of this trait.
-/// Immutable nodes are published first; one manifest CAS is the visibility
+/// Immutable nodes may be published before the visibility transition because
+/// they are content addressed and unreachable nodes are safe to reclaim. The
+/// canonical collection root is always validated and advanced through a strict
+/// store transaction, so a successful transaction is the only visibility
 /// transition.
-pub trait IndexedStore: Store + ManifestStore {
+pub trait IndexedStore: Store + ManifestStore + TransactionalStore {
     /// Confirm every non-empty candidate tree root is readable before CAS.
     fn confirm_indexed_publication(&self, trees: &[&Tree]) -> Result<(), Error> {
         for tree in trees {

--- a/src/prolly/store/file.rs
+++ b/src/prolly/store/file.rs
@@ -5,7 +5,7 @@
 //! manifests live under separate namespaces. It is useful as a local durable
 //! store and as a reference layout for S3/R2/GCS-style adapters.
 
-use std::fs::{self, DirEntry, OpenOptions};
+use std::fs::{self, DirEntry, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -98,6 +98,23 @@ impl FileNodeStore {
 
     fn root_path(&self, name: &[u8]) -> PathBuf {
         self.root_namespace_dir().join(hex_label(name))
+    }
+
+    fn lock_manifest_file(&self) -> Result<File, FileNodeStoreError> {
+        let path = self.root.join(".prolly-manifest.lock");
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .map_err(|source| FileNodeStoreError::Io {
+                path: path.clone(),
+                source,
+            })?;
+        file.lock()
+            .map_err(|source| FileNodeStoreError::Io { path, source })?;
+        Ok(file)
     }
 
     fn read_node_path(
@@ -336,6 +353,11 @@ impl ManifestStore for FileNodeStore {
     type Error = FileNodeStoreError;
 
     fn get_root(&self, name: &[u8]) -> Result<Option<RootManifest>, Self::Error> {
+        let _guard = self
+            .manifest_lock
+            .lock()
+            .map_err(|err| FileNodeStoreError::LockPoisoned(err.to_string()))?;
+        let _file_guard = self.lock_manifest_file()?;
         self.read_root_path(&self.root_path(name))
     }
 
@@ -344,6 +366,7 @@ impl ManifestStore for FileNodeStore {
             .manifest_lock
             .lock()
             .map_err(|err| FileNodeStoreError::LockPoisoned(err.to_string()))?;
+        let _file_guard = self.lock_manifest_file()?;
         self.write_root_path(&self.root_path(name), manifest)
     }
 
@@ -352,6 +375,7 @@ impl ManifestStore for FileNodeStore {
             .manifest_lock
             .lock()
             .map_err(|err| FileNodeStoreError::LockPoisoned(err.to_string()))?;
+        let _file_guard = self.lock_manifest_file()?;
         let path = self.root_path(name);
         match fs::remove_file(&path) {
             Ok(()) => Ok(()),
@@ -370,6 +394,7 @@ impl ManifestStore for FileNodeStore {
             .manifest_lock
             .lock()
             .map_err(|err| FileNodeStoreError::LockPoisoned(err.to_string()))?;
+        let _file_guard = self.lock_manifest_file()?;
         let path = self.root_path(name);
         let current = self.read_root_path(&path)?;
         if current.as_ref() != expected {
@@ -391,6 +416,11 @@ impl ManifestStore for FileNodeStore {
 
 impl ManifestStoreScan for FileNodeStore {
     fn list_roots(&self) -> Result<Vec<NamedRootManifest>, Self::Error> {
+        let _guard = self
+            .manifest_lock
+            .lock()
+            .map_err(|err| FileNodeStoreError::LockPoisoned(err.to_string()))?;
+        let _file_guard = self.lock_manifest_file()?;
         let namespace = self.root_namespace_dir();
         if !namespace.exists() {
             return Ok(Vec::new());
@@ -461,6 +491,9 @@ impl TransactionalStore for FileNodeStore {
         let _guard = self.manifest_lock.lock().map_err(|err| {
             Error::Store(Box::new(FileNodeStoreError::LockPoisoned(err.to_string())))
         })?;
+        let _file_guard = self
+            .lock_manifest_file()
+            .map_err(|err| Error::Store(Box::new(err)))?;
 
         for condition in root_conditions {
             let current = self

--- a/src/prolly/transaction.rs
+++ b/src/prolly/transaction.rs
@@ -147,12 +147,24 @@ impl TransactionUpdate {
 
 /// Store support for strict atomic transaction commits.
 pub trait TransactionalStore: Store + ManifestStore {
-    /// Whether this backend can atomically commit staged nodes and roots.
+    /// Whether this backend satisfies the strict transaction contract.
+    ///
+    /// Returning `true` promises that root conditions are evaluated against one
+    /// linearizable backend state across threads, handles, and processes that
+    /// share the store; conflicting commits expose no root writes; all root
+    /// writes in an applied commit become visible atomically; and every node
+    /// referenced by an applied root is durably readable before success is
+    /// acknowledged. Implementations may retain unreachable content-addressed
+    /// node writes after an error because those nodes do not affect visibility.
     fn supports_transactions(&self) -> bool {
         false
     }
 
-    /// Atomically validate root conditions, write nodes, and apply root writes.
+    /// Validate root conditions, write nodes, and atomically apply root writes.
+    ///
+    /// `Conflict` must leave every root unchanged. `Applied` must be returned
+    /// only after the complete root-write set and all referenced node bytes meet
+    /// the durability and visibility guarantees of [`Self::supports_transactions`].
     fn commit_transaction(
         &self,
         _node_writes: &[TransactionNodeWrite],

--- a/stores/prolly-store-test/src/lib.rs
+++ b/stores/prolly-store-test/src/lib.rs
@@ -128,6 +128,7 @@ pub fn assert_indexed_map_contract<S>(store: S)
 where
     S: IndexedStore + Send + Sync,
 {
+    assert!(store.supports_transactions());
     let prolly = Prolly::new(std::sync::Arc::new(store), Config::default());
 
     let registry = SecondaryIndexRegistry::new()
@@ -160,6 +161,20 @@ where
         .unwrap()
         .iter()
         .all(prolly::IndexVerification::is_valid));
+
+    let stale = snapshot.source_version().clone();
+    indexed.put(b"user-3", b"active").unwrap();
+    let update = indexed
+        .apply_if(
+            Some(&stale),
+            vec![prolly::Mutation::Upsert {
+                key: b"must-not-publish".to_vec(),
+                val: b"active".to_vec(),
+            }],
+        )
+        .unwrap();
+    assert!(matches!(update, prolly::IndexedMapUpdate::Conflict { .. }));
+    assert_eq!(indexed.get(b"must-not-publish").unwrap(), None);
 }
 
 pub fn assert_indexed_store<S>(store: S)

--- a/tests/secondary_index_concurrency.rs
+++ b/tests/secondary_index_concurrency.rs
@@ -3,8 +3,9 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier};
 
 use prolly::{
-    BatchOp, Config, IndexedStore, ManifestStore, ManifestUpdate, MemStore, Prolly, RootManifest,
-    SecondaryIndex, SecondaryIndexRegistry, Store,
+    BatchOp, Config, Error, IndexedStore, ManifestStore, ManifestUpdate, MemStore, Prolly,
+    RootCondition, RootManifest, RootWrite, SecondaryIndex, SecondaryIndexRegistry, Store,
+    TransactionNodeWrite, TransactionUpdate, TransactionalStore,
 };
 
 #[derive(Debug)]
@@ -90,6 +91,30 @@ impl ManifestStore for BarrierStore {
         }
         ManifestStore::compare_and_swap_root(&self.inner, name, expected, new)
             .map_err(|_| BarrierStoreError)
+    }
+}
+
+impl TransactionalStore for BarrierStore {
+    fn supports_transactions(&self) -> bool {
+        true
+    }
+
+    fn commit_transaction(
+        &self,
+        node_writes: &[TransactionNodeWrite],
+        root_conditions: &[RootCondition],
+        root_writes: &[RootWrite],
+    ) -> Result<TransactionUpdate, Error> {
+        if self.enabled.load(Ordering::SeqCst) && self.arrivals.fetch_add(1, Ordering::SeqCst) < 2 {
+            self.arrived.wait();
+            self.release.wait();
+        }
+        TransactionalStore::commit_transaction(
+            &self.inner,
+            node_writes,
+            root_conditions,
+            root_writes,
+        )
     }
 }
 

--- a/tests/secondary_index_faults.rs
+++ b/tests/secondary_index_faults.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 
 use prolly::{
     BatchOp, Config, Error, IndexedStore, ManifestStore, ManifestUpdate, MemStore, Prolly,
-    RootManifest, SecondaryIndex, SecondaryIndexRegistry, Store, Tree,
+    RootCondition, RootManifest, RootWrite, SecondaryIndex, SecondaryIndexRegistry, Store,
+    TransactionNodeWrite, TransactionUpdate, TransactionalStore, Tree,
 };
 
 #[derive(Debug)]
@@ -22,7 +23,7 @@ impl std::error::Error for FaultError {}
 struct FaultStore {
     inner: MemStore,
     fail_confirmation: AtomicBool,
-    fail_cas: AtomicBool,
+    fail_commit: AtomicBool,
 }
 
 impl FaultStore {
@@ -30,8 +31,8 @@ impl FaultStore {
         self.fail_confirmation.store(true, Ordering::SeqCst);
     }
 
-    fn fail_next_cas(&self) {
-        self.fail_cas.store(true, Ordering::SeqCst);
+    fn fail_next_commit(&self) {
+        self.fail_commit.store(true, Ordering::SeqCst);
     }
 }
 
@@ -85,11 +86,33 @@ impl ManifestStore for FaultStore {
         expected: Option<&RootManifest>,
         new: Option<&RootManifest>,
     ) -> Result<ManifestUpdate, Self::Error> {
-        if self.fail_cas.swap(false, Ordering::SeqCst) {
-            return Err(FaultError("injected root CAS failure"));
-        }
         ManifestStore::compare_and_swap_root(&self.inner, name, expected, new)
             .map_err(|_| FaultError("root CAS failed"))
+    }
+}
+
+impl TransactionalStore for FaultStore {
+    fn supports_transactions(&self) -> bool {
+        true
+    }
+
+    fn commit_transaction(
+        &self,
+        node_writes: &[TransactionNodeWrite],
+        root_conditions: &[RootCondition],
+        root_writes: &[RootWrite],
+    ) -> Result<TransactionUpdate, Error> {
+        if self.fail_commit.swap(false, Ordering::SeqCst) {
+            return Err(Error::Store(Box::new(FaultError(
+                "injected transaction commit failure",
+            ))));
+        }
+        TransactionalStore::commit_transaction(
+            &self.inner,
+            node_writes,
+            root_conditions,
+            root_writes,
+        )
     }
 }
 
@@ -127,7 +150,7 @@ fn registry() -> SecondaryIndexRegistry {
 }
 
 #[test]
-fn failures_before_the_single_root_cas_leave_the_old_state_visible() {
+fn failures_before_or_during_the_root_transaction_leave_the_old_state_visible() {
     let store = Arc::new(FaultStore::default());
     let engine = Prolly::new(store.clone(), Config::default());
     let indexed = engine.indexed_map(b"users", registry()).unwrap();
@@ -140,10 +163,10 @@ fn failures_before_the_single_root_cas_leave_the_old_state_visible() {
     assert_eq!(indexed.health().unwrap().state_version, old_state);
     assert_eq!(indexed.get(b"confirmation").unwrap(), None);
 
-    store.fail_next_cas();
-    assert!(indexed.put(b"cas", b"not-visible").is_err());
+    store.fail_next_commit();
+    assert!(indexed.put(b"commit", b"not-visible").is_err());
     assert_eq!(indexed.health().unwrap().state_version, old_state);
-    assert_eq!(indexed.get(b"cas").unwrap(), None);
+    assert_eq!(indexed.get(b"commit").unwrap(), None);
 
     indexed.put(b"published", b"new").unwrap();
     let snapshot = indexed.snapshot().unwrap();

--- a/tests/secondary_index_transactions.rs
+++ b/tests/secondary_index_transactions.rs
@@ -1,0 +1,190 @@
+use std::fmt;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
+
+use prolly::{
+    BatchOp, Config, Error, IndexedMapUpdate, IndexedStore, ManifestStore, ManifestUpdate,
+    MemStore, Mutation, Prolly, RootCondition, RootManifest, RootWrite, SecondaryIndexRegistry,
+    Store, TransactionNodeWrite, TransactionUpdate, TransactionalStore,
+};
+
+#[derive(Debug)]
+struct AuditStoreError;
+
+impl fmt::Display for AuditStoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("secondary-index transaction audit store failure")
+    }
+}
+
+impl std::error::Error for AuditStoreError {}
+
+struct TransactionAuditStore {
+    inner: MemStore,
+    transactions_enabled: AtomicBool,
+    commits: AtomicUsize,
+    intercept_reads: AtomicBool,
+    intercepted_reads: AtomicUsize,
+    second_read_reached: Barrier,
+    release_second_read: Barrier,
+}
+
+impl TransactionAuditStore {
+    fn new(transactions_enabled: bool) -> Self {
+        Self {
+            inner: MemStore::new(),
+            transactions_enabled: AtomicBool::new(transactions_enabled),
+            commits: AtomicUsize::new(0),
+            intercept_reads: AtomicBool::new(false),
+            intercepted_reads: AtomicUsize::new(0),
+            second_read_reached: Barrier::new(2),
+            release_second_read: Barrier::new(2),
+        }
+    }
+
+    fn intercept_second_root_read(&self) {
+        self.intercepted_reads.store(0, Ordering::SeqCst);
+        self.intercept_reads.store(true, Ordering::SeqCst);
+    }
+}
+
+impl Store for TransactionAuditStore {
+    type Error = AuditStoreError;
+
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.inner.get(key).map_err(|_| AuditStoreError)
+    }
+
+    fn put(&self, key: &[u8], value: &[u8]) -> Result<(), Self::Error> {
+        self.inner.put(key, value).map_err(|_| AuditStoreError)
+    }
+
+    fn delete(&self, key: &[u8]) -> Result<(), Self::Error> {
+        self.inner.delete(key).map_err(|_| AuditStoreError)
+    }
+
+    fn batch(&self, ops: &[BatchOp<'_>]) -> Result<(), Self::Error> {
+        self.inner.batch(ops).map_err(|_| AuditStoreError)
+    }
+}
+
+impl ManifestStore for TransactionAuditStore {
+    type Error = AuditStoreError;
+
+    fn get_root(&self, name: &[u8]) -> Result<Option<RootManifest>, Self::Error> {
+        if self.intercept_reads.load(Ordering::SeqCst)
+            && self.intercepted_reads.fetch_add(1, Ordering::SeqCst) == 1
+        {
+            self.second_read_reached.wait();
+            self.release_second_read.wait();
+        }
+        ManifestStore::get_root(&self.inner, name).map_err(|_| AuditStoreError)
+    }
+
+    fn put_root(&self, name: &[u8], manifest: &RootManifest) -> Result<(), Self::Error> {
+        ManifestStore::put_root(&self.inner, name, manifest).map_err(|_| AuditStoreError)
+    }
+
+    fn delete_root(&self, name: &[u8]) -> Result<(), Self::Error> {
+        ManifestStore::delete_root(&self.inner, name).map_err(|_| AuditStoreError)
+    }
+
+    fn compare_and_swap_root(
+        &self,
+        name: &[u8],
+        expected: Option<&RootManifest>,
+        new: Option<&RootManifest>,
+    ) -> Result<ManifestUpdate, Self::Error> {
+        ManifestStore::compare_and_swap_root(&self.inner, name, expected, new)
+            .map_err(|_| AuditStoreError)
+    }
+}
+
+impl TransactionalStore for TransactionAuditStore {
+    fn supports_transactions(&self) -> bool {
+        self.transactions_enabled.load(Ordering::SeqCst)
+    }
+
+    fn commit_transaction(
+        &self,
+        node_writes: &[TransactionNodeWrite],
+        root_conditions: &[RootCondition],
+        root_writes: &[RootWrite],
+    ) -> Result<TransactionUpdate, Error> {
+        self.commits.fetch_add(1, Ordering::SeqCst);
+        TransactionalStore::commit_transaction(
+            &self.inner,
+            node_writes,
+            root_conditions,
+            root_writes,
+        )
+    }
+}
+
+impl IndexedStore for TransactionAuditStore {}
+
+#[test]
+fn indexed_map_rejects_a_store_without_strict_transactions() {
+    let engine = Prolly::new(TransactionAuditStore::new(false), Config::default());
+    assert!(matches!(
+        engine.indexed_map(b"users", SecondaryIndexRegistry::new()),
+        Err(Error::UnsupportedTransactions { .. })
+    ));
+}
+
+#[test]
+fn indexed_publication_commits_through_the_transaction_store() {
+    let store = Arc::new(TransactionAuditStore::new(true));
+    let engine = Prolly::new(store.clone(), Config::default());
+    let indexed = engine
+        .indexed_map(b"users", SecondaryIndexRegistry::new())
+        .unwrap();
+    let commits_after_initialization = store.commits.load(Ordering::SeqCst);
+    assert!(commits_after_initialization > 0);
+
+    indexed.put(b"user-1", b"active").unwrap();
+    assert!(store.commits.load(Ordering::SeqCst) > commits_after_initialization);
+}
+
+#[test]
+fn apply_if_never_applies_after_the_expected_version_is_superseded() {
+    let store = Arc::new(TransactionAuditStore::new(true));
+    let engine = Arc::new(Prolly::new(store.clone(), Config::default()));
+    let indexed = engine
+        .indexed_map(b"users", SecondaryIndexRegistry::new())
+        .unwrap();
+    let expected = indexed.put(b"initial", b"0").unwrap().source.id;
+    let conditional_ready = Arc::new(Barrier::new(2));
+    let conditional_start = Arc::new(Barrier::new(2));
+
+    let conditional_engine = engine.clone();
+    let thread_ready = conditional_ready.clone();
+    let thread_start = conditional_start.clone();
+    let conditional = std::thread::spawn(move || {
+        let conditional_indexed = conditional_engine
+            .indexed_map(b"users", SecondaryIndexRegistry::new())
+            .unwrap();
+        thread_ready.wait();
+        thread_start.wait();
+        conditional_indexed.apply_if(
+            Some(&expected),
+            vec![Mutation::Upsert {
+                key: b"conditional".to_vec(),
+                val: b"1".to_vec(),
+            }],
+        )
+    });
+
+    conditional_ready.wait();
+    store.intercept_second_root_read();
+    conditional_start.wait();
+    store.second_read_reached.wait();
+    store.intercept_reads.store(false, Ordering::SeqCst);
+    indexed.put(b"concurrent", b"2").unwrap();
+    store.release_second_read.wait();
+
+    let update = conditional.join().unwrap().unwrap();
+    assert!(matches!(update, IndexedMapUpdate::Conflict { .. }));
+    assert_eq!(indexed.get(b"conditional").unwrap(), None);
+    assert_eq!(indexed.get(b"concurrent").unwrap(), Some(b"2".to_vec()));
+}

--- a/tests/transactions.rs
+++ b/tests/transactions.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Barrier};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use prolly::{
@@ -259,4 +259,53 @@ fn file_store_supports_strict_root_transactions() {
     with_file_prolly(assert_manual_commit_reports_applied_counts);
     with_file_prolly(assert_manual_commit_reports_conflict_without_applying_writes);
     with_file_prolly(assert_owned_transaction_commits);
+}
+
+#[test]
+fn independently_opened_file_stores_serialize_transaction_commits() {
+    let path = temp_store_path("prolly-file-transaction-coordination");
+    let seed = Prolly::new(
+        Arc::new(FileNodeStore::open(&path).unwrap()),
+        Config::default(),
+    );
+    let candidate = seed
+        .put(&seed.create(), b"winner".to_vec(), b"one".to_vec())
+        .unwrap();
+    let ready = Arc::new(Barrier::new(3));
+
+    let handles = (0..2)
+        .map(|_| {
+            let engine = Prolly::new(
+                Arc::new(FileNodeStore::open(&path).unwrap()),
+                Config::default(),
+            );
+            let candidate = candidate.clone();
+            let ready = ready.clone();
+            std::thread::spawn(move || {
+                let transaction = engine.begin_transaction().unwrap();
+                assert!(transaction
+                    .compare_and_swap_named_root(b"coordinated", None, Some(&candidate))
+                    .unwrap()
+                    .is_applied());
+                ready.wait();
+                transaction.commit().unwrap()
+            })
+        })
+        .collect::<Vec<_>>();
+
+    ready.wait();
+    let results = handles
+        .into_iter()
+        .map(|handle| handle.join().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        results.iter().filter(|result| result.is_applied()).count(),
+        1
+    );
+    assert_eq!(
+        results.iter().filter(|result| result.is_conflict()).count(),
+        1
+    );
+
+    let _ = std::fs::remove_dir_all(path);
 }


### PR DESCRIPTION
## Summary

- require strict `TransactionalStore` support behind the sole `engine.indexed_map(...)` constructor
- route initialization, mutation, retention, maintenance, and bundle-import visibility transitions through one transactional canonical-root commit
- validate `apply_if` expectations inside every publication retry so a superseded conditional write cannot publish
- strengthen the transaction contract and shared IndexedMap adapter conformance suite
- serialize `FileNodeStore` manifest reads and writes across independently opened handles and processes with an OS file lock
- document the publication, retry, durability, and garbage-collection model

## Root cause

The IndexedMap store abstraction previously required only `Store + ManifestStore`, so the coordinator published its canonical state with a direct root CAS even when the engine exposed strict multi-key transactions. In addition, `apply_if` checked its expected source version before calling the unconditional retrying mutation path. A concurrent writer could supersede that version between the check and publication, turning the conditional operation into a successful write.

`FileNodeStore` also coordinated manifests only with a mutex shared by cloned handles. Independently opened handles or separate processes could race root transactions.

## Correctness model

Source data, secondary indexes, snapshot metadata, descriptors, retention, and pins remain immutable content-addressed objects selected by one canonical collection root. Candidate nodes may be written before commit, but they are unreachable. The strict transaction validates the previously loaded canonical root and advances that one root as the only visibility transition. Readers therefore observe the complete old state or complete new state. Conflicts retry from a fresh state; unreachable candidate nodes are safe for quiescent GC.

Keeping immutable node publication outside the transaction and committing one root preserves a constant-size transactional visibility boundary while supporting arbitrarily large source/index updates.

## Impact

Existing callers continue to use only `engine.indexed_map(...)`. Backends without strict transactions now fail closed with `UnsupportedTransactions`. Backends claiming support must provide linearizable root validation and atomic publication across all handles/processes sharing the store.

## Validation

- `cargo test` — 500 unit tests, all integration tests, and 74 doc tests passed
- `cargo clippy --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps`
- `./scripts/check-secondary-index-cutover.sh`
- IndexedMap adapter contracts passed for SQLite, redb, RocksDB, PGlite, and SlateDB
- deterministic regression for the superseded-`apply_if` race
- transaction failure/visibility and concurrent-writer tests
- repeated independent-`FileNodeStore` handle race
