### PR TITLE
Add synchronous IndexedMap support for remote stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   conditional mutation into an unconditional write.
 - Coordinate `FileNodeStore` manifest writes with an operating-system file lock
   so independently opened handles and processes serialize root transactions.
+- Add a shared Tokio-backed synchronous remote-store facade and first-class
+  IndexedMap store aliases for PostgreSQL, MySQL, Redis, Turso, DynamoDB,
+  Cosmos DB, and Spanner.
 
 ## 0.7.0 — 2026-07-30
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ reflogs, patches, merge orchestration, sync planning, and repository-level GC.
   historical snapshots, durable pins, safe GC, structured diagnostics, and
   verified bounded transfer. Applications open it through one
   `engine.indexed_map(...)` API and choose a synchronous `IndexedStore` with
-  strict transactional root publication.
+  strict transactional root publication. First-class synchronous facades are
+  available for PostgreSQL, MySQL, Redis, Turso, DynamoDB, Cosmos DB, and
+  Spanner in addition to the embedded adapters.
 - Store-independent single-key, shared multi-key, complete range, cursor-page,
   and diff-page proofs for a tree root.
 - Tree statistics for inspecting shape, fill factor, fanout, and serialized size.

--- a/docs/secondary-index-design.md
+++ b/docs/secondary-index-design.md
@@ -66,6 +66,13 @@ visibility; durable acknowledgement; and immediate readability of nodes named
 by an applied root. The library fails closed when transaction support is absent,
 but cannot compensate for an adapter that falsely claims these guarantees.
 
+Remote provider crates expose `Sync*Store` aliases backed by the common
+`BlockingRemoteProllyStore`. The facade preserves provider-native batch,
+manifest, scan, hint, and transaction operations and owns a Tokio runtime for
+driver lifecycle. It detects calls from an existing Tokio runtime and bridges
+them without nesting runtimes; applications should still schedule synchronous
+IndexedMap work on blocking workers when running inside an async server.
+
 ## Runtime definitions
 
 An extractor receives the primary key and exact stored source bytes and emits

--- a/docs/secondary-indexes.md
+++ b/docs/secondary-indexes.md
@@ -70,6 +70,41 @@ let engine = Prolly::new(store, Config::default());
 
 You remain responsible for store credentials, durability mode, backups, multi-process coordination, and safe garbage-collection windows.
 
+Remote-first adapters expose synchronous IndexedMap facades backed by their
+existing native async transaction implementations:
+
+- `SyncPostgresStore`
+- `SyncMySqlStore`
+- `SyncRedisStore`
+- `SyncTursoStore`
+- `SyncDynamoDbStore`
+- `SyncCosmosDbStore`
+- `SyncSpannerStore`
+
+Use `build` when provider initialization is asynchronous. It creates the
+backend on a runtime owned by the store, keeping driver background tasks alive
+for the complete store lifetime:
+
+```rust,no_run
+use prolly::{Config, Prolly, SecondaryIndexRegistry};
+use prolly_store_postgres::{PostgresBackend, SyncPostgresStore};
+
+let database_url = std::env::var("DATABASE_URL")?;
+let store = SyncPostgresStore::build(move || async move {
+    let backend = PostgresBackend::connect(&database_url).await?;
+    backend.initialize_schema().await?;
+    Ok::<_, sqlx::Error>(backend)
+})?;
+let engine = Prolly::new(store, Config::default());
+let users = engine.indexed_map(b"users", SecondaryIndexRegistry::new())?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+`Sync*Store::new(existing_backend)` is also available for caller-configured
+clients. Synchronous calls are safe when invoked from a Tokio context, but they
+still block the calling task; latency-sensitive async services should execute
+the synchronous IndexedMap workflow on their blocking-work pool.
+
 ## Define the source schema
 
 `IndexedMap` stores raw byte keys and values. Typed applications should choose one deterministic encoding and reject malformed records in every extractor.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,6 +368,10 @@ pub use prolly::remote::{
     RemoteNamedRoot, RemoteProllyStore, RemoteRootCondition, RemoteRootWrite, RemoteStoreBackend,
     RemoteStoreConfig, RemoteTransactionConflict, RemoteTransactionUpdate,
 };
+#[cfg(feature = "tokio")]
+pub use prolly::remote::{
+    BlockingRemoteBuildError, BlockingRemoteProllyStore, BlockingRemoteStoreError,
+};
 pub use prolly::secondary_index::{
     decode_physical_index_key, decode_physical_index_key_ref, indexed_collection_root_name,
     physical_index_key, term_bounds_exact, term_bounds_prefix, term_bounds_range,

--- a/src/prolly/remote.rs
+++ b/src/prolly/remote.rs
@@ -21,6 +21,11 @@ use super::transaction::{
     AsyncTransactionalStore, RootCondition, RootWrite, TransactionConflict, TransactionNodeWrite,
     TransactionUpdate,
 };
+#[cfg(feature = "tokio")]
+use super::{
+    manifest::{ManifestStore, ManifestStoreScan},
+    store::{NodeStoreScan, Store},
+};
 
 /// Batch operation passed to a remote backend.
 #[derive(Debug, Clone, Copy)]
@@ -456,6 +461,554 @@ impl<B> RemoteProllyStore<B> {
     pub fn into_backend(self) -> B {
         self.backend
     }
+}
+
+/// Synchronous facade for a Tokio-based [`RemoteProllyStore`].
+///
+/// The facade owns a multi-thread Tokio runtime shared by all clones and
+/// forwards native remote batches, hints, manifest operations, scans, and
+/// strict transactions without changing their semantics. Calls made from an
+/// existing Tokio runtime are executed on a scoped helper thread, avoiding
+/// nested-runtime panics while preserving the synchronous API contract.
+///
+/// Provider crates expose concrete aliases such as `SyncPostgresStore` and
+/// `SyncDynamoDbStore`. Construct the provider backend normally, wrap it here,
+/// and pass the result to [`crate::Prolly::new`] before calling
+/// [`crate::Prolly::indexed_map`].
+#[cfg(feature = "tokio")]
+#[derive(Clone, Debug)]
+pub struct BlockingRemoteProllyStore<B> {
+    inner: RemoteProllyStore<B>,
+    runtime: Arc<BlockingRemoteRuntime>,
+}
+
+#[cfg(feature = "tokio")]
+impl<B> BlockingRemoteProllyStore<B> {
+    /// Create a synchronous remote store with default remote configuration.
+    pub fn new(backend: B) -> Result<Self, std::io::Error> {
+        Self::with_config(backend, RemoteStoreConfig::default())
+    }
+
+    /// Create a synchronous remote store with explicit remote configuration.
+    pub fn with_config(backend: B, config: RemoteStoreConfig) -> Result<Self, std::io::Error> {
+        let runtime = create_blocking_remote_runtime()?;
+        Ok(Self {
+            inner: RemoteProllyStore::with_config(backend, config),
+            runtime: Arc::new(BlockingRemoteRuntime::new(runtime)),
+        })
+    }
+
+    /// Build a provider backend on the facade's owned runtime.
+    ///
+    /// Prefer this constructor when the provider's connection or client setup
+    /// is asynchronous. Runtime-owned background tasks then remain alive for
+    /// exactly as long as the synchronous store and all of its clones.
+    pub fn build<E, F, Fut>(builder: F) -> Result<Self, BlockingRemoteBuildError<E>>
+    where
+        E: StdError + Send + Sync + 'static,
+        F: FnOnce() -> Fut + Send,
+        Fut: std::future::Future<Output = Result<B, E>>,
+        B: Send,
+    {
+        Self::build_with_config(builder, RemoteStoreConfig::default())
+    }
+
+    /// Build a provider backend on the owned runtime with explicit remote
+    /// configuration.
+    pub fn build_with_config<E, F, Fut>(
+        builder: F,
+        config: RemoteStoreConfig,
+    ) -> Result<Self, BlockingRemoteBuildError<E>>
+    where
+        E: StdError + Send + Sync + 'static,
+        F: FnOnce() -> Fut + Send,
+        Fut: std::future::Future<Output = Result<B, E>>,
+        B: Send,
+    {
+        let runtime = Arc::new(BlockingRemoteRuntime::new(
+            create_blocking_remote_runtime().map_err(BlockingRemoteBuildError::Runtime)?,
+        ));
+        let backend = if tokio::runtime::Handle::try_current().is_ok() {
+            std::thread::scope(|scope| {
+                scope
+                    .spawn(|| runtime.block_on(builder()))
+                    .join()
+                    .map_err(|_| BlockingRemoteBuildError::RuntimeBridgePanicked)?
+                    .map_err(BlockingRemoteBuildError::Backend)
+            })?
+        } else {
+            runtime
+                .block_on(builder())
+                .map_err(BlockingRemoteBuildError::Backend)?
+        };
+        Ok(Self {
+            inner: RemoteProllyStore::with_config(backend, config),
+            runtime,
+        })
+    }
+
+    /// Borrow the wrapped asynchronous store.
+    pub fn async_store(&self) -> &RemoteProllyStore<B> {
+        &self.inner
+    }
+
+    /// Borrow the provider backend.
+    pub fn backend(&self) -> &B {
+        self.inner.backend()
+    }
+}
+
+#[cfg(feature = "tokio")]
+fn create_blocking_remote_runtime() -> Result<tokio::runtime::Runtime, std::io::Error> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+}
+
+#[cfg(feature = "tokio")]
+#[derive(Debug)]
+struct BlockingRemoteRuntime {
+    runtime: Option<tokio::runtime::Runtime>,
+}
+
+#[cfg(feature = "tokio")]
+impl BlockingRemoteRuntime {
+    fn new(runtime: tokio::runtime::Runtime) -> Self {
+        Self {
+            runtime: Some(runtime),
+        }
+    }
+
+    fn block_on<F: std::future::Future>(&self, future: F) -> F::Output {
+        self.runtime
+            .as_ref()
+            .expect("blocking remote runtime is active")
+            .block_on(future)
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl Drop for BlockingRemoteRuntime {
+    fn drop(&mut self) {
+        let Some(runtime) = self.runtime.take() else {
+            return;
+        };
+        if tokio::runtime::Handle::try_current().is_ok() {
+            // Tokio forbids dropping a runtime from one of its async contexts
+            // because shutdown may block. Move the final drop to a scoped OS
+            // thread so provider tasks are cancelled and joined instead of
+            // being leaked through `shutdown_background`.
+            let _ = std::thread::scope(|scope| scope.spawn(move || drop(runtime)).join());
+        } else {
+            drop(runtime);
+        }
+    }
+}
+
+/// Error returned while constructing a synchronous remote store.
+#[cfg(feature = "tokio")]
+#[derive(Debug)]
+pub enum BlockingRemoteBuildError<E> {
+    /// The owned Tokio runtime could not be created.
+    Runtime(std::io::Error),
+    /// Provider-specific asynchronous initialization failed.
+    Backend(E),
+    /// A scoped runtime bridge thread panicked during initialization.
+    RuntimeBridgePanicked,
+}
+
+#[cfg(feature = "tokio")]
+impl<E: fmt::Display> fmt::Display for BlockingRemoteBuildError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Runtime(err) => write!(formatter, "failed to create remote runtime: {err}"),
+            Self::Backend(err) => write!(formatter, "remote backend initialization failed: {err}"),
+            Self::RuntimeBridgePanicked => {
+                formatter.write_str("synchronous remote initialization bridge panicked")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<E: StdError + 'static> StdError for BlockingRemoteBuildError<E> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Runtime(err) => Some(err),
+            Self::Backend(err) => Some(err),
+            Self::RuntimeBridgePanicked => None,
+        }
+    }
+}
+
+/// Error returned by synchronous remote-store operations.
+#[cfg(feature = "tokio")]
+#[derive(Debug)]
+pub enum BlockingRemoteStoreError<E> {
+    /// The shared asynchronous adapter rejected or failed the operation.
+    Remote(RemoteAdapterError<E>),
+    /// A scoped runtime bridge thread panicked.
+    RuntimeBridgePanicked,
+}
+
+#[cfg(feature = "tokio")]
+impl<E: fmt::Display> fmt::Display for BlockingRemoteStoreError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Remote(err) => write!(formatter, "{err}"),
+            Self::RuntimeBridgePanicked => {
+                formatter.write_str("synchronous remote runtime bridge panicked")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<E: StdError + 'static> StdError for BlockingRemoteStoreError<E> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Remote(err) => Some(err),
+            Self::RuntimeBridgePanicked => None,
+        }
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<B> BlockingRemoteProllyStore<B>
+where
+    B: RemoteStoreBackend + Clone + 'static,
+{
+    fn run<T, F, Fut>(&self, operation: F) -> Result<T, BlockingRemoteStoreError<B::Error>>
+    where
+        T: Send,
+        F: FnOnce(RemoteProllyStore<B>) -> Fut + Send,
+        Fut: std::future::Future<Output = Result<T, RemoteAdapterError<B::Error>>>,
+    {
+        let store = self.inner.clone();
+        if tokio::runtime::Handle::try_current().is_ok() {
+            return std::thread::scope(|scope| {
+                scope
+                    .spawn(|| self.runtime.block_on(operation(store)))
+                    .join()
+                    .map_err(|_| BlockingRemoteStoreError::RuntimeBridgePanicked)?
+                    .map_err(BlockingRemoteStoreError::Remote)
+            });
+        }
+        self.runtime
+            .block_on(operation(store))
+            .map_err(BlockingRemoteStoreError::Remote)
+    }
+
+    fn run_transaction<T, F, Fut>(&self, operation: F) -> Result<T, Error>
+    where
+        T: Send,
+        F: FnOnce(RemoteProllyStore<B>) -> Fut + Send,
+        Fut: std::future::Future<Output = Result<T, Error>>,
+    {
+        let store = self.inner.clone();
+        if tokio::runtime::Handle::try_current().is_ok() {
+            return std::thread::scope(|scope| {
+                scope
+                    .spawn(|| self.runtime.block_on(operation(store)))
+                    .join()
+                    .map_err(|_| {
+                        Error::Store(Box::new(
+                            BlockingRemoteStoreError::<B::Error>::RuntimeBridgePanicked,
+                        ))
+                    })?
+            });
+        }
+        self.runtime.block_on(operation(store))
+    }
+}
+
+#[cfg(feature = "tokio")]
+#[derive(Clone)]
+enum OwnedBatchOp {
+    Upsert { key: Vec<u8>, value: Vec<u8> },
+    Delete { key: Vec<u8> },
+}
+
+#[cfg(feature = "tokio")]
+impl<B> Store for BlockingRemoteProllyStore<B>
+where
+    B: RemoteStoreBackend + Clone + 'static,
+{
+    type Error = BlockingRemoteStoreError<B::Error>;
+
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        let key = key.to_vec();
+        self.run(move |store| async move { AsyncStore::get(&store, &key).await })
+    }
+
+    fn put(&self, key: &[u8], value: &[u8]) -> Result<(), Self::Error> {
+        let key = key.to_vec();
+        let value = value.to_vec();
+        self.run(move |store| async move { AsyncStore::put(&store, &key, &value).await })
+    }
+
+    fn delete(&self, key: &[u8]) -> Result<(), Self::Error> {
+        let key = key.to_vec();
+        self.run(move |store| async move { AsyncStore::delete(&store, &key).await })
+    }
+
+    fn batch(&self, ops: &[BatchOp<'_>]) -> Result<(), Self::Error> {
+        let ops = ops
+            .iter()
+            .map(|op| match op {
+                BatchOp::Upsert { key, value } => OwnedBatchOp::Upsert {
+                    key: key.to_vec(),
+                    value: value.to_vec(),
+                },
+                BatchOp::Delete { key } => OwnedBatchOp::Delete { key: key.to_vec() },
+            })
+            .collect::<Vec<_>>();
+        self.run(move |store| async move {
+            let borrowed = ops
+                .iter()
+                .map(|op| match op {
+                    OwnedBatchOp::Upsert { key, value } => BatchOp::Upsert { key, value },
+                    OwnedBatchOp::Delete { key } => BatchOp::Delete { key },
+                })
+                .collect::<Vec<_>>();
+            AsyncStore::batch(&store, &borrowed).await
+        })
+    }
+
+    fn batch_get_ordered(&self, keys: &[&[u8]]) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
+        let keys = keys.iter().map(|key| key.to_vec()).collect::<Vec<_>>();
+        self.run(move |store| async move {
+            let borrowed = keys.iter().map(Vec::as_slice).collect::<Vec<_>>();
+            AsyncStore::batch_get_ordered(&store, &borrowed).await
+        })
+    }
+
+    fn batch_get_ordered_unique(
+        &self,
+        keys: &[&[u8]],
+    ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
+        let keys = keys.iter().map(|key| key.to_vec()).collect::<Vec<_>>();
+        self.run(move |store| async move {
+            let borrowed = keys.iter().map(Vec::as_slice).collect::<Vec<_>>();
+            AsyncStore::batch_get_ordered_unique(&store, &borrowed).await
+        })
+    }
+
+    fn prefers_batch_reads(&self) -> bool {
+        AsyncStore::prefers_batch_reads(&self.inner)
+    }
+
+    fn batch_put(&self, entries: &[(&[u8], &[u8])]) -> Result<(), Self::Error> {
+        let entries = entries
+            .iter()
+            .map(|(key, value)| (key.to_vec(), value.to_vec()))
+            .collect::<Vec<_>>();
+        self.run(move |store| async move {
+            let borrowed = entries
+                .iter()
+                .map(|(key, value)| (key.as_slice(), value.as_slice()))
+                .collect::<Vec<_>>();
+            AsyncStore::batch_put(&store, &borrowed).await
+        })
+    }
+
+    fn supports_hints(&self) -> bool {
+        AsyncStore::supports_hints(&self.inner)
+    }
+
+    fn prefers_rightmost_path_hints(&self) -> bool {
+        AsyncStore::prefers_rightmost_path_hints(&self.inner)
+    }
+
+    fn get_hint(&self, namespace: &[u8], key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        let namespace = namespace.to_vec();
+        let key = key.to_vec();
+        self.run(move |store| async move { AsyncStore::get_hint(&store, &namespace, &key).await })
+    }
+
+    fn put_hint(&self, namespace: &[u8], key: &[u8], value: &[u8]) -> Result<(), Self::Error> {
+        let namespace = namespace.to_vec();
+        let key = key.to_vec();
+        let value = value.to_vec();
+        self.run(move |store| async move {
+            AsyncStore::put_hint(&store, &namespace, &key, &value).await
+        })
+    }
+
+    fn batch_put_with_hint(
+        &self,
+        entries: &[(&[u8], &[u8])],
+        namespace: &[u8],
+        key: &[u8],
+        value: &[u8],
+    ) -> Result<(), Self::Error> {
+        let entries = entries
+            .iter()
+            .map(|(key, value)| (key.to_vec(), value.to_vec()))
+            .collect::<Vec<_>>();
+        let namespace = namespace.to_vec();
+        let key = key.to_vec();
+        let value = value.to_vec();
+        self.run(move |store| async move {
+            let borrowed = entries
+                .iter()
+                .map(|(key, value)| (key.as_slice(), value.as_slice()))
+                .collect::<Vec<_>>();
+            AsyncStore::batch_put_with_hint(&store, &borrowed, &namespace, &key, &value).await
+        })
+    }
+
+    fn publish_nodes(&self, publication: NodePublication<'_>) -> Result<(), Self::Error> {
+        let entries = publication
+            .entries()
+            .iter()
+            .map(|(key, value)| (key.to_vec(), value.to_vec()))
+            .collect::<Vec<_>>();
+        let hint = publication.hint().map(|hint| {
+            (
+                hint.namespace().to_vec(),
+                hint.key().to_vec(),
+                hint.value().to_vec(),
+            )
+        });
+        let origin = publication.origin();
+        self.run(move |store| async move {
+            let borrowed = entries
+                .iter()
+                .map(|(key, value)| (key.as_slice(), value.as_slice()))
+                .collect::<Vec<_>>();
+            let publication = match hint.as_ref() {
+                Some((namespace, key, value)) => NodePublication::with_hint(
+                    &borrowed,
+                    NodePublicationHint::new(namespace, key, value),
+                    origin,
+                ),
+                None => NodePublication::new(&borrowed, origin),
+            };
+            AsyncStore::publish_nodes(&store, publication).await
+        })
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<B> ManifestStore for BlockingRemoteProllyStore<B>
+where
+    B: RemoteStoreBackend + Clone + 'static,
+{
+    type Error = BlockingRemoteStoreError<B::Error>;
+
+    fn get_root(&self, name: &[u8]) -> Result<Option<RootManifest>, Self::Error> {
+        let name = name.to_vec();
+        self.run(move |store| async move { AsyncManifestStore::get_root(&store, &name).await })
+    }
+
+    fn put_root(&self, name: &[u8], manifest: &RootManifest) -> Result<(), Self::Error> {
+        let name = name.to_vec();
+        let manifest = manifest.clone();
+        self.run(move |store| async move {
+            AsyncManifestStore::put_root(&store, &name, &manifest).await
+        })
+    }
+
+    fn delete_root(&self, name: &[u8]) -> Result<(), Self::Error> {
+        let name = name.to_vec();
+        self.run(move |store| async move { AsyncManifestStore::delete_root(&store, &name).await })
+    }
+
+    fn compare_and_swap_root(
+        &self,
+        name: &[u8],
+        expected: Option<&RootManifest>,
+        new: Option<&RootManifest>,
+    ) -> Result<ManifestUpdate, Self::Error> {
+        let name = name.to_vec();
+        let expected = expected.cloned();
+        let new = new.cloned();
+        self.run(move |store| async move {
+            AsyncManifestStore::compare_and_swap_root(
+                &store,
+                &name,
+                expected.as_ref(),
+                new.as_ref(),
+            )
+            .await
+        })
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<B> ManifestStoreScan for BlockingRemoteProllyStore<B>
+where
+    B: RemoteStoreBackend + Clone + 'static,
+{
+    fn list_roots(&self) -> Result<Vec<NamedRootManifest>, Self::Error> {
+        self.run(move |store| async move { AsyncManifestStoreScan::list_roots(&store).await })
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<B> NodeStoreScan for BlockingRemoteProllyStore<B>
+where
+    B: RemoteStoreBackend + Clone + 'static,
+{
+    type Error = BlockingRemoteStoreError<B::Error>;
+
+    fn list_node_cids(&self) -> Result<Vec<Cid>, Self::Error> {
+        let mut cids = self.run(move |store| async move {
+            store
+                .backend()
+                .list_node_cids()
+                .await
+                .map_err(RemoteAdapterError::Backend)
+        })?;
+        let mut decoded = Vec::with_capacity(cids.len());
+        for key in cids.drain(..) {
+            let bytes: [u8; 32] = key.as_slice().try_into().map_err(|_| {
+                BlockingRemoteStoreError::Remote(RemoteAdapterError::InvalidCidLength {
+                    len: key.len(),
+                })
+            })?;
+            decoded.push(Cid(bytes));
+        }
+        decoded.sort_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
+        Ok(decoded)
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<B> super::transaction::TransactionalStore for BlockingRemoteProllyStore<B>
+where
+    B: RemoteStoreBackend + Clone + 'static,
+{
+    fn supports_transactions(&self) -> bool {
+        AsyncTransactionalStore::supports_transactions(&self.inner)
+    }
+
+    fn commit_transaction(
+        &self,
+        node_writes: &[TransactionNodeWrite],
+        root_conditions: &[RootCondition],
+        root_writes: &[RootWrite],
+    ) -> Result<TransactionUpdate, Error> {
+        let node_writes = node_writes.to_vec();
+        let root_conditions = root_conditions.to_vec();
+        let root_writes = root_writes.to_vec();
+        self.run_transaction(move |store| async move {
+            AsyncTransactionalStore::commit_transaction(
+                &store,
+                &node_writes,
+                &root_conditions,
+                &root_writes,
+            )
+            .await
+        })
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<B> super::secondary_index::IndexedStore for BlockingRemoteProllyStore<B> where
+    B: RemoteStoreBackend + Clone + 'static
+{
 }
 
 impl<B: RemoteStoreBackend> AsyncStore for RemoteProllyStore<B> {
@@ -1132,6 +1685,66 @@ pub mod conformance {
             Some(main_v1)
         );
     }
+
+    /// Assert that a transaction-capable remote backend supports the complete
+    /// synchronous `Prolly::indexed_map` API through the shared blocking facade.
+    #[cfg(feature = "tokio")]
+    pub fn assert_remote_backend_indexed_map_contract<B>(backend: B)
+    where
+        B: RemoteStoreBackend + Clone + 'static,
+        B::Error: Debug,
+    {
+        use crate::{IndexedMapUpdate, Mutation, Prolly, SecondaryIndex, SecondaryIndexRegistry};
+
+        let store = BlockingRemoteProllyStore::new(backend).unwrap();
+        assert!(super::super::transaction::TransactionalStore::supports_transactions(&store));
+        let engine = Prolly::new(store, Config::default());
+        let registry = SecondaryIndexRegistry::new()
+            .register(
+                SecondaryIndex::non_unique(
+                    "by-status",
+                    1,
+                    "remote-contract.by-status/v1",
+                    |_, value| Ok(vec![value.to_vec()]),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        let indexed = engine
+            .indexed_map(b"remote-indexed-contract", registry)
+            .unwrap();
+        indexed.put(b"user-1", b"active").unwrap();
+        indexed.ensure_index(b"by-status").unwrap();
+        let stale = indexed.put(b"user-2", b"pending").unwrap().source.id;
+        assert_eq!(
+            indexed
+                .snapshot()
+                .unwrap()
+                .index(b"by-status")
+                .unwrap()
+                .primary_keys(b"pending")
+                .unwrap(),
+            vec![b"user-2".to_vec()]
+        );
+
+        indexed.put(b"user-3", b"active").unwrap();
+        let update = indexed
+            .apply_if(
+                Some(&stale),
+                vec![Mutation::Upsert {
+                    key: b"must-not-publish".to_vec(),
+                    val: b"active".to_vec(),
+                }],
+            )
+            .unwrap();
+        assert!(matches!(update, IndexedMapUpdate::Conflict { .. }));
+        assert_eq!(indexed.get(b"must-not-publish").unwrap(), None);
+        assert!(indexed
+            .verify_all(indexed.snapshot().unwrap().source_version())
+            .unwrap()
+            .iter()
+            .all(super::super::secondary_index::IndexVerification::is_valid));
+    }
 }
 
 #[cfg(test)]
@@ -1460,6 +2073,33 @@ mod tests {
                 .unwrap_err();
             assert!(matches!(error, RemoteAdapterError::CidMismatch { .. }));
             assert!(unchecked_backend.publications.lock().unwrap().is_empty());
+        });
+    }
+
+    #[cfg(feature = "tokio")]
+    #[test]
+    fn blocking_remote_store_supports_indexed_map_inside_and_outside_tokio() {
+        use crate::{Prolly, SecondaryIndexRegistry};
+
+        let backend = Arc::new(MemoryBackend::default());
+        let store = BlockingRemoteProllyStore::new(backend).unwrap();
+        let engine = Prolly::new(store, Config::default());
+        let indexed = engine
+            .indexed_map(b"remote-users", SecondaryIndexRegistry::new())
+            .unwrap();
+        indexed.put(b"outside", b"runtime").unwrap();
+        assert_eq!(indexed.get(b"outside").unwrap(), Some(b"runtime".to_vec()));
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            indexed.put(b"inside", b"runtime").unwrap();
+            assert_eq!(indexed.get(b"inside").unwrap(), Some(b"runtime".to_vec()));
+
+            let nested = BlockingRemoteProllyStore::build(|| async {
+                Ok::<_, MemoryBackendError>(Arc::new(MemoryBackend::default()))
+            })
+            .unwrap();
+            drop(nested);
         });
     }
 

--- a/src/prolly/write.rs
+++ b/src/prolly/write.rs
@@ -1873,7 +1873,10 @@ pub(crate) fn append_tree_suffix<M: CanonicalWriteManager>(
     let Some(max_key) = last_leaf.keys.last() else {
         return Err(Error::InvalidNode);
     };
-    if !last_leaf.leaf || last_leaf.keys.len() != last_leaf.vals.len() || start_key <= max_key {
+    if !last_leaf.leaf
+        || last_leaf.keys.len() != last_leaf.vals.len()
+        || start_key <= max_key.as_slice()
+    {
         return Ok(None);
     }
 

--- a/stores/prolly-store-cosmosdb/Cargo.toml
+++ b/stores/prolly-store-cosmosdb/Cargo.toml
@@ -23,7 +23,7 @@ hmac = "0.12.1"
 httpdate = "1.0.3"
 futures-util = "0.3"
 percent-encoding = "2.3.2"
-prolly = { package = "prolly-map", path = "../..", version = "0.7.0", features = ["async-store"] }
+prolly = { package = "prolly-map", path = "../..", version = "0.7.0", features = ["async-store", "tokio"] }
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/stores/prolly-store-cosmosdb/README.md
+++ b/stores/prolly-store-cosmosdb/README.md
@@ -3,9 +3,25 @@
 Azure Cosmos DB-backed remote store adapter for `prolly-map`.
 
 This crate implements `RemoteStoreBackend` using the Cosmos DB SQL API REST
-surface with key authentication. Use it through `RemoteProllyStore` and
-`AsyncProlly` when your deployment is Azure-native and needs globally available
-Prolly tree storage.
+surface with key authentication. It supports `RemoteProllyStore` with
+`AsyncProlly` and the first-class `SyncCosmosDbStore` facade with synchronous
+`Prolly::indexed_map`.
+
+## Synchronous IndexedMap
+
+```rust,no_run
+use prolly::{Config, Prolly, SecondaryIndexRegistry};
+use prolly_store_cosmosdb::{CosmosDbBackend, SyncCosmosDbStore};
+
+fn open(backend: CosmosDbBackend) -> Result<(), Box<dyn std::error::Error>> {
+    let engine = Prolly::new(SyncCosmosDbStore::new(backend)?, Config::default());
+    let _users = engine.indexed_map(b"users", SecondaryIndexRegistry::new())?;
+    Ok(())
+}
+```
+
+The indexed collection must stay within one Cosmos logical partition so its
+canonical-root transaction remains atomic.
 
 ## Installation
 

--- a/stores/prolly-store-cosmosdb/src/lib.rs
+++ b/stores/prolly-store-cosmosdb/src/lib.rs
@@ -1,8 +1,9 @@
 #![doc = include_str!("../README.md")]
 
 pub use prolly::{
-    RemoteBatchOp, RemoteManifestUpdate, RemoteNamedRoot, RemoteProllyStore, RemoteRootCondition,
-    RemoteRootWrite, RemoteStoreBackend, RemoteTransactionConflict, RemoteTransactionUpdate,
+    BlockingRemoteBuildError, BlockingRemoteProllyStore, BlockingRemoteStoreError, RemoteBatchOp,
+    RemoteManifestUpdate, RemoteNamedRoot, RemoteProllyStore, RemoteRootCondition, RemoteRootWrite,
+    RemoteStoreBackend, RemoteTransactionConflict, RemoteTransactionUpdate,
 };
 
 /// Cosmos DB adapter entry point.
@@ -30,6 +31,9 @@ pub mod cosmosdb {
 
     /// Store adapter for Cosmos DB-backed prolly nodes and roots.
     pub type CosmosDbStore = crate::RemoteProllyStore<CosmosDbBackend>;
+
+    /// Synchronous Cosmos DB store supporting `Prolly::indexed_map`.
+    pub type SyncCosmosDbStore = crate::BlockingRemoteProllyStore<CosmosDbBackend>;
 
     /// Cosmos DB REST-backed backend.
     ///
@@ -1345,7 +1349,7 @@ pub mod cosmosdb {
                             .batch_upsert_operations(NODE_KIND, &[(logical_key.as_slice(), value)])
                             .await?;
                         operation_conditions
-                            .extend(std::iter::repeat(None).take(node_operations.len()));
+                                .extend(std::iter::repeat_n(None, node_operations.len()));
                         operations.extend(node_operations);
                     }
                     RemoteBatchOp::Delete { key } => {

--- a/stores/prolly-store-cosmosdb/tests/cosmosdb_backend.rs
+++ b/stores/prolly-store-cosmosdb/tests/cosmosdb_backend.rs
@@ -47,7 +47,8 @@ fn cosmosdb_backend_satisfies_remote_backend_contract_when_env_is_set() {
 
     runtime().block_on(async {
         use prolly::remote_conformance::{
-            assert_remote_backend_contract, assert_remote_backend_transaction_contract,
+            assert_remote_backend_contract, assert_remote_backend_indexed_map_contract,
+            assert_remote_backend_transaction_contract,
         };
         use prolly::{RemoteManifestUpdate, RemoteStoreBackend};
         use prolly_store_cosmosdb::CosmosDbBackend;
@@ -59,6 +60,9 @@ fn cosmosdb_backend_satisfies_remote_backend_contract_when_env_is_set() {
         backend.clear_namespace().await.unwrap();
         assert_remote_backend_contract(&backend).await;
         assert_remote_backend_transaction_contract(&backend).await;
+        backend.clear_namespace().await.unwrap();
+        assert_remote_backend_indexed_map_contract(backend.clone());
+        backend.clear_namespace().await.unwrap();
 
         let mut contenders = tokio::task::JoinSet::new();
         for contender in 0..16u8 {

--- a/stores/prolly-store-dynamodb/Cargo.toml
+++ b/stores/prolly-store-dynamodb/Cargo.toml
@@ -32,7 +32,7 @@ aws-smithy-schema = "=0.1.0"
 aws-smithy-types = "=1.5.0"
 aws-types = "=1.3.16"
 futures-util = "0.3"
-prolly = { package = "prolly-map", path = "../..", version = "0.7.0", features = ["async-store"] }
+prolly = { package = "prolly-map", path = "../..", version = "0.7.0", features = ["async-store", "tokio"] }
 tokio = { version = "1.45", features = ["time"] }
 
 [dev-dependencies]

--- a/stores/prolly-store-dynamodb/README.md
+++ b/stores/prolly-store-dynamodb/README.md
@@ -3,8 +3,24 @@
 DynamoDB-backed remote store adapter for `prolly-map`.
 
 This crate implements `RemoteStoreBackend` with the AWS SDK for DynamoDB. Use it
-through `RemoteProllyStore` and `AsyncProlly` for serverless, managed,
-content-addressed Prolly tree storage.
+through `RemoteProllyStore` and `AsyncProlly`, or through the first-class
+`SyncDynamoDbStore` facade with synchronous `Prolly::indexed_map`.
+
+## Synchronous IndexedMap
+
+```rust,no_run
+use prolly::{Config, Prolly, SecondaryIndexRegistry};
+use prolly_store_dynamodb::{DynamoDbBackend, SyncDynamoDbStore};
+
+fn open(backend: DynamoDbBackend) -> Result<(), Box<dyn std::error::Error>> {
+    let engine = Prolly::new(SyncDynamoDbStore::new(backend)?, Config::default());
+    let _users = engine.indexed_map(b"users", SecondaryIndexRegistry::new())?;
+    Ok(())
+}
+```
+
+Use `SyncDynamoDbStore::build` when asynchronous SDK initialization or schema
+validation must live on the store-owned runtime.
 
 ## Installation
 

--- a/stores/prolly-store-dynamodb/examples/language_interop.rs
+++ b/stores/prolly-store-dynamodb/examples/language_interop.rs
@@ -75,7 +75,7 @@ fn required(args: &mut impl Iterator<Item = String>, name: &str) -> io::Result<S
 }
 
 fn decode_hex(value: &str) -> io::Result<Vec<u8>> {
-    if value.len() % 2 != 0 {
+    if !value.len().is_multiple_of(2) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "key prefix hex must have an even length",

--- a/stores/prolly-store-dynamodb/src/lib.rs
+++ b/stores/prolly-store-dynamodb/src/lib.rs
@@ -1,8 +1,9 @@
 #![doc = include_str!("../README.md")]
 
 pub use prolly::{
-    RemoteBatchOp, RemoteManifestUpdate, RemoteNamedRoot, RemoteProllyStore, RemoteRootCondition,
-    RemoteRootWrite, RemoteStoreBackend, RemoteTransactionConflict, RemoteTransactionUpdate,
+    BlockingRemoteBuildError, BlockingRemoteProllyStore, BlockingRemoteStoreError, RemoteBatchOp,
+    RemoteManifestUpdate, RemoteNamedRoot, RemoteProllyStore, RemoteRootCondition, RemoteRootWrite,
+    RemoteStoreBackend, RemoteTransactionConflict, RemoteTransactionUpdate,
 };
 
 /// DynamoDB adapter entry point.
@@ -33,6 +34,9 @@ pub mod dynamodb {
 
     /// Store adapter for DynamoDB-backed prolly nodes and roots.
     pub type DynamoDbStore = crate::RemoteProllyStore<DynamoDbBackend>;
+
+    /// Synchronous DynamoDB store supporting `Prolly::indexed_map`.
+    pub type SyncDynamoDbStore = crate::BlockingRemoteProllyStore<DynamoDbBackend>;
 
     /// AWS SDK-backed DynamoDB backend.
     ///

--- a/stores/prolly-store-dynamodb/tests/dynamodb_backend.rs
+++ b/stores/prolly-store-dynamodb/tests/dynamodb_backend.rs
@@ -35,7 +35,10 @@ fn dynamodb_backend_satisfies_remote_backend_contract_when_table_is_set() {
     };
 
     runtime().block_on(async {
-        use prolly::remote_conformance::assert_remote_backend_contract;
+        use prolly::remote_conformance::{
+            assert_remote_backend_contract, assert_remote_backend_indexed_map_contract,
+            assert_remote_backend_transaction_contract,
+        };
         use prolly_store_dynamodb::DynamoDbBackend;
 
         let client = dynamodb_client().await;
@@ -45,6 +48,9 @@ fn dynamodb_backend_satisfies_remote_backend_contract_when_table_is_set() {
         backend.initialize_schema().await.unwrap();
         backend.clear_namespace().await.unwrap();
         assert_remote_backend_contract(&backend).await;
+        assert_remote_backend_transaction_contract(&backend).await;
+        backend.clear_namespace().await.unwrap();
+        assert_remote_backend_indexed_map_contract(backend.clone());
         backend.clear_namespace().await.unwrap();
     });
 }

--- a/stores/prolly-store-mysql/Cargo.toml
+++ b/stores/prolly-store-mysql/Cargo.toml
@@ -17,7 +17,7 @@ name = "prolly_store_mysql"
 path = "src/lib.rs"
 
 [dependencies]
-prolly = { package = "prolly-map", path = "../..", version = "0.7.0", features = ["async-store"] }
+prolly = { package = "prolly-map", path = "../..", version = "0.7.0", features = ["async-store", "tokio"] }
 sqlx = { version = "0.8", default-features = false, features = ["mysql", "runtime-tokio"] }
 
 [dev-dependencies]

--- a/stores/prolly-store-mysql/README.md
+++ b/stores/prolly-store-mysql/README.md
@@ -2,9 +2,25 @@
 
 MySQL-backed remote store adapter for `prolly-map`.
 
-This crate implements `RemoteStoreBackend` using `sqlx::MySqlPool`. Use it
-through `RemoteProllyStore` and `AsyncProlly` when your deployment standardizes
-on MySQL and you want durable Prolly nodes, hints, and named roots in SQL.
+This crate implements `RemoteStoreBackend` using `sqlx::MySqlPool`. It supports
+both `RemoteProllyStore` with `AsyncProlly` and the first-class
+`SyncMySqlStore` facade with synchronous `Prolly::indexed_map`.
+
+## Synchronous IndexedMap
+
+```rust,no_run
+use prolly::{Config, Prolly, SecondaryIndexRegistry};
+use prolly_store_mysql::{MySqlBackend, SyncMySqlStore};
+
+fn open(backend: MySqlBackend) -> Result<(), Box<dyn std::error::Error>> {
+    let engine = Prolly::new(SyncMySqlStore::new(backend)?, Config::default());
+    let _users = engine.indexed_map(b"users", SecondaryIndexRegistry::new())?;
+    Ok(())
+}
+```
+
+Use `SyncMySqlStore::build` to run asynchronous connection and schema setup on
+the store-owned runtime.
 
 ## Installation
 

--- a/stores/prolly-store-mysql/src/lib.rs
+++ b/stores/prolly-store-mysql/src/lib.rs
@@ -1,8 +1,9 @@
 #![doc = include_str!("../README.md")]
 
 pub use prolly::{
-    RemoteBatchOp, RemoteManifestUpdate, RemoteNamedRoot, RemoteProllyStore, RemoteRootCondition,
-    RemoteRootWrite, RemoteStoreBackend, RemoteTransactionConflict, RemoteTransactionUpdate,
+    BlockingRemoteBuildError, BlockingRemoteProllyStore, BlockingRemoteStoreError, RemoteBatchOp,
+    RemoteManifestUpdate, RemoteNamedRoot, RemoteProllyStore, RemoteRootCondition, RemoteRootWrite,
+    RemoteStoreBackend, RemoteTransactionConflict, RemoteTransactionUpdate,
 };
 
 /// MySQL adapter entry point.
@@ -19,6 +20,9 @@ pub mod mysql {
 
     /// Store adapter for MySQL-backed prolly nodes and roots.
     pub type MySqlStore = crate::RemoteProllyStore<MySqlBackend>;
+
+    /// Synchronous MySQL store supporting `Prolly::indexed_map`.
+    pub type SyncMySqlStore = crate::BlockingRemoteProllyStore<MySqlBackend>;
 
     /// MySQL adapter tuning that does not change stored data.
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/stores/prolly-store-mysql/tests/mysql_backend.rs
+++ b/stores/prolly-store-mysql/tests/mysql_backend.rs
@@ -26,11 +26,17 @@ fn mysql_backend_satisfies_remote_backend_contract_when_url_is_set() {
     let _database_guard = database_test_guard();
 
     runtime().block_on(async {
-        use prolly::remote_conformance::assert_remote_backend_contract;
+        use prolly::remote_conformance::{
+            assert_remote_backend_contract, assert_remote_backend_indexed_map_contract,
+            assert_remote_backend_transaction_contract,
+        };
         let backend = MySqlBackend::connect(&database_url).await.unwrap();
         backend.initialize_schema().await.unwrap();
         clear_mysql(backend.pool()).await.unwrap();
         assert_remote_backend_contract(&backend).await;
+        assert_remote_backend_transaction_contract(&backend).await;
+        clear_mysql(backend.pool()).await.unwrap();
+        assert_remote_backend_indexed_map_contract(backend.clone());
         clear_mysql(backend.pool()).await.unwrap();
     });
 }

--- a/stores/prolly-store-postgres/Cargo.toml
+++ b/stores/prolly-store-postgres/Cargo.toml
@@ -17,7 +17,7 @@ name = "prolly_store_postgres"
 path = "src/lib.rs"
 
 [dependencies]
-prolly = { package = "prolly-map", path = "../..", version = "0.7.0", features = ["async-store"] }
+prolly = { package = "prolly-map", path = "../..", version = "0.7.0", features = ["async-store", "tokio"] }
 sqlx = { version = "0.8", default-features = false, features = ["postgres", "runtime-tokio"] }
 
 [dev-dependencies]

--- a/stores/prolly-store-postgres/README.md
+++ b/stores/prolly-store-postgres/README.md
@@ -2,9 +2,25 @@
 
 PostgreSQL-backed remote store adapter for `prolly-map`.
 
-This crate implements `RemoteStoreBackend` using `sqlx::PgPool`. Use it through
-`RemoteProllyStore` and `AsyncProlly` when you want Prolly tree nodes, traversal
-hints, and named root manifests in PostgreSQL.
+This crate implements `RemoteStoreBackend` using `sqlx::PgPool`. It supports
+both `RemoteProllyStore` with `AsyncProlly` and the first-class
+`SyncPostgresStore` facade with synchronous `Prolly::indexed_map`.
+
+## Synchronous IndexedMap
+
+```rust,no_run
+use prolly::{Config, Prolly, SecondaryIndexRegistry};
+use prolly_store_postgres::{PostgresBackend, SyncPostgresStore};
+
+fn open(backend: PostgresBackend) -> Result<(), Box<dyn std::error::Error>> {
+    let engine = Prolly::new(SyncPostgresStore::new(backend)?, Config::default());
+    let _users = engine.indexed_map(b"users", SecondaryIndexRegistry::new())?;
+    Ok(())
+}
+```
+
+Use `SyncPostgresStore::build` to run asynchronous connection and schema setup
+on the store-owned runtime.
 
 ## Installation
 

--- a/stores/prolly-store-postgres/src/lib.rs
+++ b/stores/prolly-store-postgres/src/lib.rs
@@ -1,8 +1,9 @@
 #![doc = include_str!("../README.md")]
 
 pub use prolly::{
-    RemoteBatchOp, RemoteManifestUpdate, RemoteNamedRoot, RemoteProllyStore, RemoteRootCondition,
-    RemoteRootWrite, RemoteStoreBackend, RemoteTransactionConflict, RemoteTransactionUpdate,
+    BlockingRemoteBuildError, BlockingRemoteProllyStore, BlockingRemoteStoreError, RemoteBatchOp,
+    RemoteManifestUpdate, RemoteNamedRoot, RemoteProllyStore, RemoteRootCondition, RemoteRootWrite,
+    RemoteStoreBackend, RemoteTransactionConflict, RemoteTransactionUpdate,
 };
 
 /// Postgres adapter entry point.
@@ -19,6 +20,9 @@ pub mod postgres {
 
     /// Store adapter for PostgreSQL-backed prolly nodes and roots.
     pub type PostgresStore = crate::RemoteProllyStore<PostgresBackend>;
+
+    /// Synchronous PostgreSQL store supporting `Prolly::indexed_map`.
+    pub type SyncPostgresStore = crate::BlockingRemoteProllyStore<PostgresBackend>;
 
     /// PostgreSQL adapter tuning that does not change stored data.
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/stores/prolly-store-postgres/tests/postgres_backend.rs
+++ b/stores/prolly-store-postgres/tests/postgres_backend.rs
@@ -35,12 +35,18 @@ fn postgres_backend_satisfies_remote_backend_contract_when_url_is_set() {
     };
 
     runtime().block_on(async {
-        use prolly::remote_conformance::assert_remote_backend_contract;
+        use prolly::remote_conformance::{
+            assert_remote_backend_contract, assert_remote_backend_indexed_map_contract,
+            assert_remote_backend_transaction_contract,
+        };
 
         let backend = PostgresBackend::connect(&database_url).await.unwrap();
         backend.initialize_schema().await.unwrap();
         clear_postgres(backend.pool()).await.unwrap();
         assert_remote_backend_contract(&backend).await;
+        assert_remote_backend_transaction_contract(&backend).await;
+        clear_postgres(backend.pool()).await.unwrap();
+        assert_remote_backend_indexed_map_contract(backend.clone());
         clear_postgres(backend.pool()).await.unwrap();
         assert_set_based_batches(&backend).await;
         clear_postgres(backend.pool()).await.unwrap();

--- a/stores/prolly-store-redis/Cargo.toml
+++ b/stores/prolly-store-redis/Cargo.toml
@@ -17,7 +17,7 @@ name = "prolly_store_redis"
 path = "src/lib.rs"
 
 [dependencies]
-prolly = { package = "prolly-map", path = "../..", version = "0.7.0", features = ["async-store"] }
+prolly = { package = "prolly-map", path = "../..", version = "0.7.0", features = ["async-store", "tokio"] }
 redis-client = { package = "redis", version = "0.32.7", default-features = false, features = [
     "aio",
     "tokio-comp",

--- a/stores/prolly-store-redis/README.md
+++ b/stores/prolly-store-redis/README.md
@@ -2,8 +2,26 @@
 
 Redis-backed remote store adapter for `prolly-map`.
 
-This crate implements `RemoteStoreBackend` for Redis and is intended for async
-`prolly-map` use through `RemoteProllyStore` and `AsyncProlly`.
+This crate implements `RemoteStoreBackend` for Redis. It supports both
+`RemoteProllyStore` with `AsyncProlly` and the first-class `SyncRedisStore`
+facade with synchronous `Prolly::indexed_map`.
+
+## Synchronous IndexedMap
+
+```rust,no_run
+use prolly::{Config, Prolly, SecondaryIndexRegistry};
+use prolly_store_redis::{RedisBackend, SyncRedisStore};
+
+fn open(backend: RedisBackend) -> Result<(), Box<dyn std::error::Error>> {
+    let engine = Prolly::new(SyncRedisStore::new(backend)?, Config::default());
+    let _users = engine.indexed_map(b"users", SecondaryIndexRegistry::new())?;
+    Ok(())
+}
+```
+
+Use `SyncRedisStore::build` to create Redis connections on the store-owned
+runtime. Production IndexedMap deployments must configure Redis persistence,
+replication, backups, and a non-evicting policy.
 
 ## Installation
 

--- a/stores/prolly-store-redis/examples/language_interop.rs
+++ b/stores/prolly-store-redis/examples/language_interop.rs
@@ -68,7 +68,7 @@ fn required(args: &mut impl Iterator<Item = String>, name: &str) -> io::Result<S
 }
 
 fn decode_hex(value: &str) -> io::Result<Vec<u8>> {
-    if value.len() % 2 != 0 {
+    if !value.len().is_multiple_of(2) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "key prefix hex must have an even length",

--- a/stores/prolly-store-redis/src/lib.rs
+++ b/stores/prolly-store-redis/src/lib.rs
@@ -1,8 +1,9 @@
 #![doc = include_str!("../README.md")]
 
 pub use prolly::{
-    RemoteBatchOp, RemoteManifestUpdate, RemoteNamedRoot, RemoteProllyStore, RemoteRootCondition,
-    RemoteRootWrite, RemoteStoreBackend, RemoteTransactionConflict, RemoteTransactionUpdate,
+    BlockingRemoteBuildError, BlockingRemoteProllyStore, BlockingRemoteStoreError, RemoteBatchOp,
+    RemoteManifestUpdate, RemoteNamedRoot, RemoteProllyStore, RemoteRootCondition, RemoteRootWrite,
+    RemoteStoreBackend, RemoteTransactionConflict, RemoteTransactionUpdate,
 };
 
 /// Redis adapter entry point.
@@ -21,6 +22,9 @@ pub mod redis {
     /// Redis should be treated as a cache or edge store unless persistence and
     /// durability are explicitly configured for the Redis deployment.
     pub type RedisStore = crate::RemoteProllyStore<RedisBackend>;
+
+    /// Synchronous Redis store supporting `Prolly::indexed_map`.
+    pub type SyncRedisStore = crate::BlockingRemoteProllyStore<RedisBackend>;
 
     /// Redis-backed prolly node/root backend.
     #[derive(Clone)]

--- a/stores/prolly-store-redis/tests/redis_backend.rs
+++ b/stores/prolly-store-redis/tests/redis_backend.rs
@@ -33,7 +33,8 @@ fn redis_backend_satisfies_remote_backend_contract_when_url_is_set() {
 
     runtime().block_on(async {
         use prolly::remote_conformance::{
-            assert_remote_backend_contract, assert_remote_backend_transaction_contract,
+            assert_remote_backend_contract, assert_remote_backend_indexed_map_contract,
+            assert_remote_backend_transaction_contract,
         };
         use prolly_store_redis::RedisBackend;
 
@@ -45,6 +46,8 @@ fn redis_backend_satisfies_remote_backend_contract_when_url_is_set() {
         backend.clear_namespace().await.unwrap();
         assert_remote_backend_contract(&backend).await;
         assert_remote_backend_transaction_contract(&backend).await;
+        backend.clear_namespace().await.unwrap();
+        assert_remote_backend_indexed_map_contract(backend.clone());
         backend.clear_namespace().await.unwrap();
     });
 }

--- a/stores/prolly-store-spanner/Cargo.toml
+++ b/stores/prolly-store-spanner/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 google-cloud-googleapis = { package = "gcloud-googleapis", version = "1.3.0", features = ["spanner"] }
 google-cloud-gax = { package = "gcloud-gax", version = "1.4.0" }
 google-cloud-spanner = { package = "gcloud-spanner", version = "=1.8.1" }
-prolly = { package = "prolly-map", path = "../..", version = "0.7.0", features = ["async-store"] }
+prolly = { package = "prolly-map", path = "../..", version = "0.7.0", features = ["async-store", "tokio"] }
 tokio = { version = "1.45", features = ["time"] }
 
 [dev-dependencies]

--- a/stores/prolly-store-spanner/README.md
+++ b/stores/prolly-store-spanner/README.md
@@ -3,8 +3,24 @@
 Cloud Spanner-backed remote store adapter for `prolly-map`.
 
 This crate implements `RemoteStoreBackend` using `gcloud-spanner`. Use it
-through `RemoteProllyStore` and `AsyncProlly` when you need globally consistent
-SQL-backed Prolly tree storage on Google Cloud Spanner.
+through `RemoteProllyStore` and `AsyncProlly`, or through the first-class
+`SyncSpannerStore` facade with synchronous `Prolly::indexed_map`.
+
+## Synchronous IndexedMap
+
+```rust,no_run
+use prolly::{Config, Prolly, SecondaryIndexRegistry};
+use prolly_store_spanner::{SpannerBackend, SyncSpannerStore};
+
+fn open(backend: SpannerBackend) -> Result<(), Box<dyn std::error::Error>> {
+    let engine = Prolly::new(SyncSpannerStore::new(backend)?, Config::default());
+    let _users = engine.indexed_map(b"users", SecondaryIndexRegistry::new())?;
+    Ok(())
+}
+```
+
+Use `SyncSpannerStore::build` when client connection and authentication should
+run on the store-owned runtime.
 
 ## Installation
 

--- a/stores/prolly-store-spanner/src/lib.rs
+++ b/stores/prolly-store-spanner/src/lib.rs
@@ -1,8 +1,9 @@
 #![doc = include_str!("../README.md")]
 
 pub use prolly::{
-    RemoteBatchOp, RemoteManifestUpdate, RemoteNamedRoot, RemoteProllyStore, RemoteRootCondition,
-    RemoteRootWrite, RemoteStoreBackend, RemoteTransactionConflict, RemoteTransactionUpdate,
+    BlockingRemoteBuildError, BlockingRemoteProllyStore, BlockingRemoteStoreError, RemoteBatchOp,
+    RemoteManifestUpdate, RemoteNamedRoot, RemoteProllyStore, RemoteRootCondition, RemoteRootWrite,
+    RemoteStoreBackend, RemoteTransactionConflict, RemoteTransactionUpdate,
 };
 
 /// Spanner adapter entry point.
@@ -26,6 +27,9 @@ pub mod spanner {
 
     /// Store adapter for Spanner-backed prolly nodes and roots.
     pub type SpannerStore = crate::RemoteProllyStore<SpannerBackend>;
+
+    /// Synchronous Spanner store supporting `Prolly::indexed_map`.
+    pub type SyncSpannerStore = crate::BlockingRemoteProllyStore<SpannerBackend>;
 
     /// Google Cloud Spanner-backed backend.
     #[derive(Clone)]

--- a/stores/prolly-store-spanner/tests/spanner_backend.rs
+++ b/stores/prolly-store-spanner/tests/spanner_backend.rs
@@ -24,7 +24,8 @@ fn spanner_backend_satisfies_remote_backend_contract_when_database_is_set() {
     runtime().block_on(async {
         use google_cloud_spanner::client::ClientConfig;
         use prolly::remote_conformance::{
-            assert_remote_backend_contract, assert_remote_backend_transaction_contract,
+            assert_remote_backend_contract, assert_remote_backend_indexed_map_contract,
+            assert_remote_backend_transaction_contract,
         };
         use prolly::{RemoteManifestUpdate, RemoteStoreBackend};
         use prolly_store_spanner::{SpannerBackend, SpannerBackendOptions};
@@ -38,6 +39,9 @@ fn spanner_backend_satisfies_remote_backend_contract_when_database_is_set() {
         clear_spanner(backend.client()).await.unwrap();
         assert_remote_backend_contract(&backend).await;
         assert_remote_backend_transaction_contract(&backend).await;
+        clear_spanner(backend.client()).await.unwrap();
+        assert_remote_backend_indexed_map_contract(backend.clone());
+        clear_spanner(backend.client()).await.unwrap();
 
         let mut contenders = tokio::task::JoinSet::new();
         for contender in 0..32u8 {

--- a/stores/prolly-store-turso/Cargo.toml
+++ b/stores/prolly-store-turso/Cargo.toml
@@ -21,7 +21,7 @@ default = []
 turso-cloud-sync = ["turso/sync"]
 
 [dependencies]
-prolly = { package = "prolly-map", path = "../..", version = "0.7.0", features = ["async-store"] }
+prolly = { package = "prolly-map", path = "../..", version = "0.7.0", features = ["async-store", "tokio"] }
 turso = { version = "0.7", default-features = false }
 
 [dev-dependencies]

--- a/stores/prolly-store-turso/README.md
+++ b/stores/prolly-store-turso/README.md
@@ -7,6 +7,25 @@ The default build embeds Turso locally. Optional Turso Cloud synchronization is
 local-first and explicit: prolly reads and writes never perform network I/O;
 your application decides when to call `push()` or `pull()`.
 
+## Synchronous IndexedMap
+
+`SyncTursoStore` forwards the native Turso transaction implementation to the
+synchronous engine:
+
+```rust,no_run
+use prolly::{Config, Prolly, SecondaryIndexRegistry};
+use prolly_store_turso::{SyncTursoStore, TursoBackend};
+
+fn open(backend: TursoBackend) -> Result<(), Box<dyn std::error::Error>> {
+    let engine = Prolly::new(SyncTursoStore::new(backend)?, Config::default());
+    let _users = engine.indexed_map(b"users", SecondaryIndexRegistry::new())?;
+    Ok(())
+}
+```
+
+Use `SyncTursoStore::build` when opening the database asynchronously so its
+runtime-owned work remains alive for the complete store lifetime.
+
 ## Requirements
 
 - Rust 1.90 or newer. The core `prolly-map` hard-cutover release line supports

--- a/stores/prolly-store-turso/src/lib.rs
+++ b/stores/prolly-store-turso/src/lib.rs
@@ -5,17 +5,20 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 use prolly::{
-    NodePublication, NodePublicationHint, PublicationOrigin, RemoteBatchOp, RemoteManifestUpdate,
-    RemoteNamedRoot, RemoteRootCondition, RemoteRootWrite, RemoteStoreBackend,
-    RemoteTransactionConflict, RemoteTransactionUpdate,
+    BlockingRemoteProllyStore, NodePublication, NodePublicationHint, PublicationOrigin,
+    RemoteBatchOp, RemoteManifestUpdate, RemoteNamedRoot, RemoteRootCondition, RemoteRootWrite,
+    RemoteStoreBackend, RemoteTransactionConflict, RemoteTransactionUpdate,
 };
 use turso::transaction::TransactionBehavior;
 use turso::{Connection, Database, IntoParams};
 
-pub use prolly::RemoteProllyStore;
+pub use prolly::{BlockingRemoteBuildError, BlockingRemoteStoreError, RemoteProllyStore};
 
 /// A complete async prolly store backed by native Turso Database.
 pub type TursoStore = RemoteProllyStore<TursoBackend>;
+
+/// Synchronous Turso store supporting `Prolly::indexed_map`.
+pub type SyncTursoStore = BlockingRemoteProllyStore<TursoBackend>;
 
 /// Native Turso backend used by [`TursoStore`].
 #[derive(Clone)]

--- a/stores/prolly-store-turso/tests/turso_backend.rs
+++ b/stores/prolly-store-turso/tests/turso_backend.rs
@@ -55,6 +55,16 @@ async fn local_backend_satisfies_transaction_contract() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn local_backend_supports_synchronous_indexed_maps() {
+    let temp = tempfile::tempdir().unwrap();
+    let backend = TursoBackend::open(temp.path().join("indexed-map.db"))
+        .await
+        .unwrap();
+
+    prolly::remote_conformance::assert_remote_backend_indexed_map_contract(backend);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn concurrent_root_cas_has_one_winner_and_one_conflict() {
     async fn cas_with_busy_retry(
         backend: &TursoBackend,


### PR DESCRIPTION
## Summary

- add a shared `BlockingRemoteProllyStore` that exposes the synchronous `Store`, manifest, scan, strict transaction, and `IndexedStore` contracts over native async remote backends
- add first-class `Sync*Store` aliases for PostgreSQL, MySQL, Redis, Turso, DynamoDB, Cosmos DB, and Spanner
- safely bridge calls made inside existing Tokio runtimes and own provider runtime lifecycle, including clean final drop from async contexts
- extend every provider conformance suite with the real synchronous `engine.indexed_map(...)` workflow and document production usage

## Correctness

IndexedMap continues to pre-publish immutable content-addressed nodes, then validates and advances its sole canonical collection root through the provider native strict transaction. A conflict publishes no visible state. This keeps the visibility transaction small for DynamoDB and Cosmos DB service limits while preserving immediate readability after an applied root.

## Verification

- `cargo test --features tokio`
- `cargo clippy --features tokio --all-targets -- -D warnings`
- `cargo +1.89.0 check --features tokio --all-targets`
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --features tokio`
- default-feature `cargo check --all-targets`
- all seven adapter crates: `cargo check --all-targets`, strict clippy, and doctests
- Turso local synchronous IndexedMap integration test
- PostgreSQL, MySQL, Redis, DynamoDB, Cosmos DB, and Spanner live IndexedMap conformance tests remain credential-gated
- `./scripts/check-secondary-index-cutover.sh`