### PR TITLE
Add WASM-backed prolly tree visualizer

### DIFF
--- a/3rd/README.md
+++ b/3rd/README.md
@@ -1,0 +1,16 @@
+# Third-party projects
+
+This directory contains projects incorporated into the `prolly` repository and
+adapted for integration with its packages.
+
+## Prolly Tree Visualizer
+
+[`prolly-tree-visualizer`](prolly-tree-visualizer/README.md) is based on the
+original
+[`timsehn/prolly-tree-visualizer`](https://github.com/timsehn/prolly-tree-visualizer)
+repository. Credit goes to Tim Sehn and the original contributors for the
+visualizer's design and implementation.
+
+The version vendored here replaces the original DoltLite backend with this
+repository's `@trail/prolly-wasm` binding so it can render the actual trees,
+content IDs, lookups, diffs, and storage behavior produced by `prolly-map`.

--- a/3rd/prolly-tree-visualizer/.gitignore
+++ b/3rd/prolly-tree-visualizer/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.DS_Store
+*.log
+coverage/

--- a/3rd/prolly-tree-visualizer/README.md
+++ b/3rd/prolly-tree-visualizer/README.md
@@ -1,0 +1,77 @@
+# Prolly Tree Visualizer
+
+An interactive browser visualizer for the real trees produced by this
+repository's Rust `prolly-map` engine. The interaction model is inspired by
+[btree.app](https://btree.app/), but mutations execute in the
+`@trail/prolly-wasm` binding rather than in a JavaScript tree simulation.
+
+The visualizer demonstrates:
+
+- content-defined leaf boundaries and node splits;
+- SHA-256 content IDs for leaf and internal nodes;
+- copy-on-write updates and structural sharing between versions;
+- point and range lookup paths through lower-bound separators;
+- hash-pruned structural diffs;
+- history-independent builds from different insertion orders;
+- inserts, updates, deletes, random writes, and sequential growth;
+- live and historical encoded-node storage.
+
+## Run it
+
+Prerequisites: Node.js 18 or newer, npm, and the checked-in generated WASM
+artifacts under `bindings/wasm/pkg/`.
+
+```bash
+npm --prefix 3rd/prolly-tree-visualizer install
+npm --prefix 3rd/prolly-tree-visualizer run dev
+```
+
+The app starts a fresh in-memory Rust engine on each page load. It runs fully
+inside the browser and sends no rows to a server.
+
+For a production build:
+
+```bash
+npm --prefix 3rd/prolly-tree-visualizer run build
+npm --prefix 3rd/prolly-tree-visualizer run preview
+```
+
+## Engine data path
+
+```text
+browser control
+  → @trail/prolly-wasm
+  → Rust prolly-map mutation
+  → content-addressed in-memory node store
+  → typed Rust debug traversal and real node CIDs
+  → SVG visualization
+```
+
+`src/engine.ts` owns the WASM memory engine and persistent tree handle.
+`src/prolly.ts` converts the binding's deterministic breadth-first debug view
+into the hierarchy consumed by the existing canvas. Internal routing uses this
+engine's lower-bound separator convention. Leaf rows come back through the
+binding's ordered range API, while node levels, encoded sizes, ranges, and CIDs
+come from Rust diagnostics.
+
+The storage view tracks every distinct encoded node observed in the current
+in-memory engine. Garbage collection rebuilds HEAD in a fresh engine and
+verifies that its root CID remains unchanged before replacing the old store.
+
+## Validation
+
+```bash
+npm --prefix 3rd/prolly-tree-visualizer test
+npm --prefix 3rd/prolly-tree-visualizer run build
+npm --prefix 3rd/prolly-tree-visualizer run smoke:wasm
+```
+
+## Project layout
+
+```text
+src/engine.ts                    prolly WASM mutation and snapshot adapter
+src/prolly.ts                    debug-view hierarchy, search, and diff helpers
+src/components/TreeCanvas.tsx    SVG tree layout and version highlighting
+src/components/NodeInspector.tsx selected node details
+src/App.tsx                      controls, views, timeline, guided demos
+```

--- a/3rd/prolly-tree-visualizer/README.md
+++ b/3rd/prolly-tree-visualizer/README.md
@@ -58,6 +58,14 @@ The storage view tracks every distinct encoded node observed in the current
 in-memory engine. Garbage collection rebuilds HEAD in a fresh engine and
 verifies that its root CID remains unchanged before replacing the old store.
 
+## Attribution
+
+This project is based on
+[`timsehn/prolly-tree-visualizer`](https://github.com/timsehn/prolly-tree-visualizer).
+Credit goes to Tim Sehn and the original contributors for the visualizer's
+design and implementation. This vendored version adapts the original project
+to use the `prolly-map` WASM engine.
+
 ## Validation
 
 ```bash

--- a/3rd/prolly-tree-visualizer/index.html
+++ b/3rd/prolly-tree-visualizer/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Explore real prolly-map trees in your browser." />
+    <title>Prolly Tree</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/3rd/prolly-tree-visualizer/package-lock.json
+++ b/3rd/prolly-tree-visualizer/package-lock.json
@@ -1,0 +1,2342 @@
+{
+  "name": "prolly-tree-visualizer",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "prolly-tree-visualizer",
+      "version": "0.1.0",
+      "dependencies": {
+        "@trail/prolly-wasm": "file:../../bindings/wasm",
+        "react": "19.1.1",
+        "react-dom": "19.1.1"
+      },
+      "devDependencies": {
+        "@types/react": "19.1.9",
+        "@types/react-dom": "19.1.7",
+        "@vitejs/plugin-react": "4.7.0",
+        "typescript": "5.9.2",
+        "vite": "6.4.3",
+        "vitest": "3.2.7"
+      }
+    },
+    "../../bindings/wasm": {
+      "name": "@trail/prolly-wasm",
+      "version": "0.1.0"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@trail/prolly-wasm": {
+      "resolved": "../../bindings/wasm",
+      "link": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
+      "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
+      "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.402",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.402.tgz",
+      "integrity": "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
+      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/3rd/prolly-tree-visualizer/package.json
+++ b/3rd/prolly-tree-visualizer/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "prolly-tree-visualizer",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "smoke:wasm": "node scripts/smoke-wasm.mjs"
+  },
+  "dependencies": {
+    "@trail/prolly-wasm": "file:../../bindings/wasm",
+    "react": "19.1.1",
+    "react-dom": "19.1.1"
+  },
+  "devDependencies": {
+    "@types/react": "19.1.9",
+    "@types/react-dom": "19.1.7",
+    "@vitejs/plugin-react": "4.7.0",
+    "typescript": "5.9.2",
+    "vite": "6.4.3",
+    "vitest": "3.2.7"
+  }
+}

--- a/3rd/prolly-tree-visualizer/scripts/smoke-wasm.mjs
+++ b/3rd/prolly-tree-visualizer/scripts/smoke-wasm.mjs
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { loadProllyWasm } from '@trail/prolly-wasm';
+
+const wasmBytes = readFileSync(new URL('../../../bindings/wasm/pkg/prolly_wasm_bg.wasm', import.meta.url));
+const prolly = await loadProllyWasm(undefined, wasmBytes);
+const engine = prolly.WasmProllyEngine.memory();
+let tree = engine.create();
+const encoder = new TextEncoder();
+const rowCount = Number(process.env.SMOKE_ROWS ?? 240);
+
+try {
+  const entries = Array.from({ length: rowCount }, (_, index) => {
+    const key = index + 1;
+    return { key: prolly.i64Key(String(key)), value: encoder.encode(`value-${key}`) };
+  });
+  const built = engine.buildFromSortedEntries(entries);
+  tree.free();
+  tree = built;
+
+  const root = Buffer.from(tree.root).toString('hex');
+  const debug = engine.debugTree(tree);
+  const bundle = engine.exportSnapshot(tree);
+  const rows = engine.range(tree, new Uint8Array());
+  try {
+    if (!/^[0-9a-f]{64}$/.test(root)) throw new Error(`invalid root CID: ${root}`);
+    if (rows.length !== rowCount) throw new Error(`expected ${rowCount} rows, got ${rows.length}`);
+    if (debug.levels.length === 0) throw new Error('debug tree has no levels');
+    if (bundle.nodeCount === 0 || bundle.byteCount === 0) throw new Error('snapshot has no nodes');
+    console.log('engine=prolly-map');
+    console.log(`root=${root}`);
+    console.log(`rows=${rows.length}`);
+    console.log(`nodes=${bundle.nodeCount}`);
+    console.log(`node_bytes=${bundle.byteCount}`);
+  } finally {
+    bundle.free();
+  }
+} finally {
+  tree.free();
+  engine.free();
+}

--- a/3rd/prolly-tree-visualizer/src/App.tsx
+++ b/3rd/prolly-tree-visualizer/src/App.tsx
@@ -1,0 +1,836 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ProllyEngine, type GrowthResult, type InsertionOrderResult } from './engine';
+import { countSharedNodes, diffRows, estimateMutationSplitProbability, leafNodes, traceRange, traceSearch } from './prolly';
+import { calculateVersionStorage, countHistoricalTreeChunks } from './storage';
+import { calculateMutationCost } from './mutationCost';
+import { buildDiffTraversal, type DiffTraversalFrame } from './diffTraversal';
+import type { LookupResult, ProllyNode, TreeSnapshot } from './types';
+import { InfoTip } from './components/InfoTip';
+import { DiffPlaybackPanel } from './components/DiffPlaybackPanel';
+import { LookupDetailsPanel, type LookupDetails } from './components/LookupDetailsPanel';
+import { MutationCostPanel } from './components/MutationCostPanel';
+import { NodeInspector } from './components/NodeInspector';
+import { TreeCanvas } from './components/TreeCanvas';
+
+type Tab = 'tree' | 'diff' | 'chunks' | 'storage' | 'order';
+type ControlMode = 'modify' | 'lookup';
+type ActionDetails = 'mutation' | 'lookup' | 'diff';
+type DiffPlayback = DiffTraversalFrame & { step: number; totalSteps: number; running: boolean };
+const NO_HIGHLIGHTS = new Set<string>();
+const NO_ROW_DIFFS: [] = [];
+
+interface GarbageCollectionReport {
+  versionsBefore: number;
+  versionsRemoved: number;
+  treeChunksBefore: number;
+  sharedTreeChunksBefore: number;
+  beforeChunks: number;
+  afterChunks: number;
+  beforeBytes: number;
+  afterBytes: number;
+  message: string;
+}
+
+function formatProbability(probability: number) {
+  const percent = probability * 100;
+  if (percent === 0) return '0%';
+  if (percent < 0.1) return '<0.1%';
+  return `${percent.toFixed(percent < 10 ? 1 : 0)}%`;
+}
+
+function formatOrder(order: number[]) {
+  const shown = order.slice(0, 14).map((key) => key.toLocaleString()).join(' → ');
+  return order.length > 14 ? `${shown} → …` : shown;
+}
+
+function nextEditValue(key: number, currentValue: string) {
+  const prefix = `value-${key}-edit-`;
+  const revision = currentValue.startsWith(prefix)
+    ? Number.parseInt(currentValue.slice(prefix.length), 10) + 1
+    : 1;
+  return `${prefix}${Number.isSafeInteger(revision) ? revision : 1}`;
+}
+
+function formatStorageDelta(before: number, after: number, suffix = '') {
+  const delta = after - before;
+  return `${delta > 0 ? '+' : delta < 0 ? '−' : ''}${Math.abs(delta).toLocaleString()}${suffix}`;
+}
+
+function animationStepMs(nodeCount: number) {
+  if (nodeCount > 100) return 2400;
+  if (nodeCount > 20) return 1600;
+  return 1000;
+}
+
+function App() {
+  const engineRef = useRef<ProllyEngine | undefined>(undefined);
+  const operationPendingRef = useRef(false);
+  const animationTimersRef = useRef<number[]>([]);
+  const [snapshots, setSnapshots] = useState<TreeSnapshot[]>([]);
+  const [viewId, setViewId] = useState<number>();
+  const [compareFromId, setCompareFromId] = useState<number>();
+  const [selectedHash, setSelectedHash] = useState<string>();
+  const [tab, setTab] = useState<Tab>('tree');
+  const [controlMode, setControlMode] = useState<ControlMode>('modify');
+  const [busy, setBusy] = useState(true);
+  const [gcRunning, setGcRunning] = useState(false);
+  const [error, setError] = useState<string>();
+  const [keyInput, setKeyInput] = useState('49');
+  const [valueInput, setValueInput] = useState('value-49');
+  const [deleteInput, setDeleteInput] = useState('1');
+  const [searchInput, setSearchInput] = useState('24');
+  const [rangeStart, setRangeStart] = useState('1');
+  const [rangeEnd, setRangeEnd] = useState('48');
+  const [trace, setTrace] = useState<Set<string>>(new Set());
+  const [activeTraceHash, setActiveTraceHash] = useState<string>();
+  const [lookupResult, setLookupResult] = useState<LookupResult>();
+  const [diffHighlight, setDiffHighlight] = useState<Set<string>>(new Set());
+  const [activeDiffHashes, setActiveDiffHashes] = useState<Set<string>>(new Set());
+  const [diffSkipped, setDiffSkipped] = useState<Set<string>>(new Set());
+  const [activeDiffSkipped, setActiveDiffSkipped] = useState<Set<string>>(new Set());
+  const [diffPlayback, setDiffPlayback] = useState<DiffPlayback>();
+  const [showNewAddresses, setShowNewAddresses] = useState(false);
+  const [lastChangeActive, setLastChangeActive] = useState(false);
+  const [insertionOrderResult, setInsertionOrderResult] = useState<InsertionOrderResult>();
+  const [orderSelectedHash, setOrderSelectedHash] = useState<string>();
+  const [gcReport, setGcReport] = useState<GarbageCollectionReport>();
+  const [actionDetails, setActionDetails] = useState<ActionDetails>();
+  const [lookupDetails, setLookupDetails] = useState<LookupDetails>();
+
+  const latest = snapshots.at(-1);
+  const viewedIndex = viewId === undefined
+    ? snapshots.length - 1
+    : snapshots.findIndex((snapshot) => snapshot.id === viewId);
+  const current = snapshots[viewedIndex] ?? latest;
+  const requestedBaselineIndex = snapshots.findIndex((snapshot) => snapshot.id === compareFromId);
+  const baselineIndex = requestedBaselineIndex >= 0 && requestedBaselineIndex < viewedIndex
+    ? requestedBaselineIndex
+    : viewedIndex > 0 ? 0 : -1;
+  const diffBaseline = baselineIndex >= 0 ? snapshots[baselineIndex] : undefined;
+  const previous = viewedIndex > 0 ? snapshots[viewedIndex - 1] : undefined;
+  const viewingHistorical = Boolean(current && latest && current.id !== latest.id);
+
+  const cancelAnimation = (resetActive = true) => {
+    animationTimersRef.current.forEach((timer) => window.clearTimeout(timer));
+    animationTimersRef.current = [];
+    if (resetActive) {
+      setActiveTraceHash(undefined);
+      setActiveDiffHashes(new Set());
+      setDiffSkipped(new Set());
+      setActiveDiffSkipped(new Set());
+      setDiffPlayback(undefined);
+    }
+  };
+
+  const animateTrace = (path: string[]) => {
+    cancelAnimation();
+    if (path.length === 0) {
+      setTrace(new Set());
+      return;
+    }
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setTrace(new Set(path));
+      return;
+    }
+    const stepMs = animationStepMs(current.nodes.size);
+    setTrace(new Set([path[0]]));
+    setActiveTraceHash(path[0]);
+    animationTimersRef.current = path.slice(1).map((hash, index) => window.setTimeout(() => {
+      setTrace((visible) => new Set([...visible, hash]));
+      setActiveTraceHash(hash);
+    }, (index + 1) * stepMs));
+    animationTimersRef.current.push(window.setTimeout(() => setActiveTraceHash(undefined), path.length * stepMs));
+  };
+
+  const animateDiff = (baseline: TreeSnapshot) => {
+    cancelAnimation();
+    if (!current) return;
+    const frames = buildDiffTraversal(current, baseline, diffRows(baseline.rows, current.rows));
+    const applyFrame = (frame: DiffTraversalFrame, step: number, running: boolean) => {
+      setDiffHighlight(new Set(frame.changedHashes));
+      setDiffSkipped(new Set(frame.skippedHashes));
+      setActiveDiffHashes(new Set(frame.activeChangedHashes));
+      setActiveDiffSkipped(new Set(frame.activeSkippedHashes));
+      setDiffPlayback({ ...frame, step, totalSteps: frames.length, running });
+    };
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      applyFrame(frames.at(-1)!, frames.length - 1, false);
+      return;
+    }
+    const stepMs = animationStepMs(current.nodes.size);
+    applyFrame(frames[0], 0, true);
+    animationTimersRef.current = frames.slice(1).map((frame, index) => window.setTimeout(() => {
+      applyFrame(frame, index + 1, true);
+    }, (index + 1) * stepMs));
+    animationTimersRef.current.push(window.setTimeout(() => {
+      setActiveDiffHashes(new Set());
+      setActiveDiffSkipped(new Set());
+      setDiffPlayback((playback) => playback ? { ...playback, running: false } : playback);
+    }, frames.length * stepMs));
+  };
+
+  const resetTreeState = () => {
+    cancelAnimation();
+    setTrace(new Set());
+    setLookupResult(undefined);
+    setDiffHighlight(new Set());
+    setLastChangeActive(false);
+    setSelectedHash(undefined);
+    setShowNewAddresses(false);
+    setActionDetails(undefined);
+    setLookupDetails(undefined);
+  };
+
+  const selectExistingInputs = (snapshot: TreeSnapshot) => {
+    const first = snapshot.rows[0];
+    const middle = snapshot.rows[Math.floor(snapshot.rows.length / 2)];
+    const quarter = snapshot.rows[Math.floor(snapshot.rows.length / 4)];
+    if (!first || !middle || !quarter) {
+      setKeyInput('');
+      setValueInput('');
+      setDeleteInput('');
+      setSearchInput('');
+      setRangeStart('');
+      setRangeEnd('');
+      return;
+    }
+    setKeyInput(String(middle.key));
+    setValueInput(nextEditValue(middle.key, middle.value));
+    setDeleteInput(String(first.key));
+    setSearchInput(String(middle.key));
+    setRangeStart(String(first.key));
+    setRangeEnd(String(quarter.key));
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    void ProllyEngine.create().then((engine) => {
+      if (cancelled) {
+        engine.close();
+        return;
+      }
+      engineRef.current = engine;
+      const first = engine.seed();
+      setSnapshots([first]);
+      setCompareFromId(first.id);
+      selectExistingInputs(first);
+      setError(undefined);
+      setBusy(false);
+    }).catch((cause: unknown) => {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      setBusy(false);
+    });
+    return () => {
+      cancelled = true;
+      cancelAnimation(false);
+      engineRef.current?.close();
+    };
+  }, []);
+
+  const appendSnapshot = (snapshot: TreeSnapshot) => {
+    resetTreeState();
+    setSnapshots((existing) => [...existing, snapshot]);
+    setViewId(undefined);
+    setInsertionOrderResult(undefined);
+    setOrderSelectedHash(undefined);
+    setShowNewAddresses(true);
+    setActionDetails('mutation');
+    selectExistingInputs(snapshot);
+  };
+
+  const run = (operation: (engine: ProllyEngine) => TreeSnapshot, onComplete?: (snapshot: TreeSnapshot) => void) => {
+    const engine = engineRef.current;
+    if (!engine || operationPendingRef.current) return;
+    operationPendingRef.current = true;
+    resetTreeState();
+    setBusy(true);
+    setError(undefined);
+    window.setTimeout(() => {
+      try {
+        const snapshot = operation(engine);
+        appendSnapshot(snapshot);
+        onComplete?.(snapshot);
+      } catch (cause) {
+        setError(cause instanceof Error ? cause.message : String(cause));
+      } finally {
+        operationPendingRef.current = false;
+        setBusy(false);
+      }
+    }, 20);
+  };
+
+  const runGrowth = (operation: (engine: ProllyEngine) => GrowthResult) => {
+    const engine = engineRef.current;
+    if (!engine || operationPendingRef.current) return;
+    operationPendingRef.current = true;
+    resetTreeState();
+    setBusy(true);
+    setError(undefined);
+    window.setTimeout(() => {
+      try {
+        const result = operation(engine);
+        appendSnapshot(result.after);
+      } catch (cause) {
+        setError(cause instanceof Error ? cause.message : String(cause));
+      } finally {
+        operationPendingRef.current = false;
+        setBusy(false);
+      }
+    }, 20);
+  };
+
+  const runGarbageCollection = () => {
+    const engine = engineRef.current;
+    if (!engine || operationPendingRef.current || snapshots.length === 0) return;
+    const storageBefore = calculateVersionStorage(snapshots);
+    resetTreeState();
+    operationPendingRef.current = true;
+    setBusy(true);
+    setGcRunning(true);
+    setError(undefined);
+    window.setTimeout(() => {
+      try {
+        const result = engine.garbageCollect();
+        setSnapshots([result.head]);
+        setViewId(undefined);
+        setCompareFromId(result.head.id);
+        setInsertionOrderResult(undefined);
+        setOrderSelectedHash(undefined);
+        selectExistingInputs(result.head);
+        setGcReport({
+          versionsBefore: storageBefore.versions,
+          versionsRemoved: Math.max(0, storageBefore.versions - 1),
+          treeChunksBefore: storageBefore.withoutSharing,
+          sharedTreeChunksBefore: storageBefore.withSharing,
+          beforeChunks: result.beforeChunks,
+          afterChunks: result.afterChunks,
+          beforeBytes: result.beforeBytes,
+          afterBytes: result.afterBytes,
+          message: result.message,
+        });
+      } catch (cause) {
+        setError(cause instanceof Error ? cause.message : String(cause));
+      } finally {
+        operationPendingRef.current = false;
+        setGcRunning(false);
+        setBusy(false);
+      }
+    }, 20);
+  };
+
+  const metrics = useMemo(() => {
+    if (!current) return undefined;
+    const leaves = leafNodes(current.root);
+    const compare = (before?: TreeSnapshot) => {
+      const shared = before ? countSharedNodes(before.nodes, current.nodes) : 0;
+      const beforeLeaves = before ? leafNodes(before.root).length : leaves.length;
+      return {
+        shared,
+        fresh: before ? current.nodes.size - shared : 0,
+        replaced: before ? before.nodes.size - shared : 0,
+        splitDelta: leaves.length - beforeLeaves,
+        rowDiffs: before ? diffRows(before.rows, current.rows) : [],
+      };
+    };
+    return {
+      leaves,
+      tree: compare(previous),
+      diff: compare(diffBaseline),
+    };
+  }, [current, diffBaseline, previous]);
+  const storageMetrics = useMemo(() => calculateVersionStorage(snapshots), [snapshots]);
+  const mutationCost = useMemo(() => current && previous
+    ? calculateMutationCost(current, previous, diffRows(previous.rows, current.rows))
+    : undefined, [current, previous]);
+
+  const selectedNode: ProllyNode | undefined = selectedHash ? current?.nodes.get(selectedHash) : undefined;
+
+  if (busy && !current) {
+    return (
+      <main className="loading-screen">
+        <div className="loader-mark"><span /><span /><span /></div>
+        <p>Booting prolly-map’s Rust engine in WebAssembly…</p>
+      </main>
+    );
+  }
+
+  if (!current || !metrics) {
+    return <main className="loading-screen error-screen"><h1>Could not start the lab</h1><p>{error}</p></main>;
+  }
+
+  const physicalStore = latest ?? current;
+  const liveTableChunks = physicalStore.nodes.size;
+  const historicalTreeChunks = Math.min(countHistoricalTreeChunks(snapshots), Math.max(0, physicalStore.chunksInStore - liveTableChunks));
+  const metadataChunks = Math.max(0, physicalStore.chunksInStore - liveTableChunks - historicalTreeChunks);
+  const chunkWidth = (count: number) => physicalStore.chunksInStore === 0 ? 0 : count / physicalStore.chunksInStore * 100;
+
+  const highlightedRowDiffs = lastChangeActive && previous && diffPlayback?.revealedRows
+    ? diffRows(previous.rows, current.rows)
+    : [];
+  const diffBeforeRoot = diffBaseline?.rootHash ?? current.rootHash;
+
+  const doSearch = () => {
+    const key = Number(searchInput);
+    if (!Number.isSafeInteger(key)) return;
+    resetTreeState();
+    const path = traceSearch(current.root, key);
+    const found = current.rows.some((row) => row.key === key);
+    animateTrace(path);
+    setLookupResult({ kind: 'key', key, found });
+    setLookupDetails({ kind: 'key', key, found, path });
+    setActionDetails('lookup');
+    setDiffHighlight(new Set());
+    setLastChangeActive(false);
+    setTab('tree');
+  };
+
+  const doRangeSearch = () => {
+    const start = Number(rangeStart);
+    const end = Number(rangeEnd);
+    if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end)) return;
+    resetTreeState();
+    const path = traceRange(current.root, start, end);
+    const low = Math.min(start, end);
+    const high = Math.max(start, end);
+    const matchedRows = current.rows.filter((row) => row.key >= low && row.key <= high).length;
+    animateTrace(path);
+    setLookupResult({ kind: 'range', start, end });
+    setLookupDetails({ kind: 'range', start, end, matchedRows, path });
+    setActionDetails('lookup');
+    setDiffHighlight(new Set());
+    setLastChangeActive(false);
+    setTab('tree');
+  };
+
+  const doDiffLookup = () => {
+    if (lastChangeActive) {
+      resetTreeState();
+      return;
+    }
+    if (viewedIndex <= 0) return;
+    const previous = snapshots[viewedIndex - 1];
+    resetTreeState();
+    animateDiff(previous);
+    setActionDetails('diff');
+    setShowNewAddresses(false);
+    setLastChangeActive(true);
+    setSelectedHash(undefined);
+    setTab('tree');
+  };
+
+  const runInsertionOrderDemo = () => {
+    const engine = engineRef.current;
+    if (!engine || operationPendingRef.current) return;
+    operationPendingRef.current = true;
+    resetTreeState();
+    setBusy(true);
+    setError(undefined);
+    window.setTimeout(() => {
+      try {
+        setInsertionOrderResult(engine.compareInsertionOrder(current));
+        setOrderSelectedHash(undefined);
+      } catch (cause) {
+        setError(cause instanceof Error ? cause.message : String(cause));
+      } finally {
+        operationPendingRef.current = false;
+        setBusy(false);
+      }
+    }, 20);
+  };
+
+  return (
+    <div className="app-shell">
+      <header className="topbar">
+        <div className="brand">
+          <svg className="brand-mark" viewBox="0 0 40 40" aria-hidden="true">
+            <path className="brand-tree-link" d="M20 13v5M10 23v-2c0-2 1-3 3-3h14c2 0 3 1 3 3v2" />
+            <rect className="brand-root-node" x="14" y="5" width="12" height="9" rx="2.5" />
+            <rect className="brand-leaf-node" x="4" y="23" width="13" height="11" rx="2.5" />
+            <rect className="brand-leaf-node" x="23" y="23" width="13" height="11" rx="2.5" />
+            <path className="brand-hash-line" d="M8 27h5M8 30h3M27 27h5M27 30h3M18 9h4" />
+          </svg>
+          <div><strong>Prolly Tree</strong></div>
+        </div>
+        <a className="runtime-pill" href="https://github.com/crabbuild/prolly" target="_blank" rel="noreferrer">
+          <span>Powered by</span>
+          <strong>prolly-map</strong>
+          <b>{engineRef.current?.version}</b>
+        </a>
+      </header>
+
+      <section className="database-summary">
+        <div className="root-card">
+          <span>Tree root <InfoTip dark>The content address of the root chunk. A rewritten tree gets a new root address; a no-op keeps it.</InfoTip></span>
+          <code>{current.rootHash}</code>
+          <div><b>{current.rows.length}</b> rows <i /> <b>{current.nodes.size}</b> live nodes <i /> <b>{current.root.level + 1}</b> levels</div>
+        </div>
+      </section>
+
+      <section className="control-deck">
+        <div className="control-tabs" role="tablist" aria-label="Tree controls">
+          <button className={controlMode === 'modify' ? 'control-tab active' : 'control-tab'} role="tab" aria-selected={controlMode === 'modify'} aria-controls="modify-controls" onClick={() => { resetTreeState(); setControlMode('modify'); }}>Modify</button>
+          <button className={controlMode === 'lookup' ? 'control-tab active' : 'control-tab'} role="tab" aria-selected={controlMode === 'lookup'} aria-controls="lookup-controls" onClick={() => { resetTreeState(); setControlMode('lookup'); }}>Lookup</button>
+        </div>
+        {controlMode === 'modify' && <div className="control-row modify-row" id="modify-controls" role="tabpanel">
+          <div className="control-section put-section">
+            <label>Insert or update</label>
+            <div className="control-fields">
+              <input aria-label="Insert key" type="number" value={keyInput} onChange={(event) => setKeyInput(event.target.value)} />
+              <input className="value-input" aria-label="Value" value={valueInput} onChange={(event) => setValueInput(event.target.value)} />
+              <button className="primary-button" disabled={busy || viewingHistorical} onClick={() => {
+                const key = Number(keyInput);
+                if (Number.isSafeInteger(key)) run(
+                  (engine) => engine.put(key, valueInput || `value-${key}`),
+                  (snapshot) => {
+                    const row = snapshot.rows.find((candidate) => candidate.key === key);
+                    if (!row) return;
+                    setKeyInput(String(key));
+                    setValueInput(nextEditValue(key, row.value));
+                  },
+                );
+              }}>Put row</button>
+              <button title="Randomly insert a new key or update an existing row" disabled={busy || viewingHistorical} onClick={() => run((engine) => engine.addRandom())}>Random</button>
+            </div>
+          </div>
+          <div className="control-section delete-section">
+            <label>Delete</label>
+            <div className="control-fields">
+              <input aria-label="Delete key" type="number" value={deleteInput} onChange={(event) => setDeleteInput(event.target.value)} />
+              <button className="danger-quiet" disabled={busy || viewingHistorical} onClick={() => {
+                const key = Number(deleteInput);
+                if (Number.isSafeInteger(key)) run((engine) => engine.remove(key));
+              }}>Delete</button>
+            </div>
+          </div>
+          <div className="control-section bulk-section">
+            <label>Bulk actions</label>
+            <div className="control-fields bulk-actions">
+              <button disabled={busy || viewingHistorical} onClick={() => run((engine) => engine.addSequential(25))}>+ 25 rows</button>
+              <button disabled={busy || viewingHistorical} onClick={() => runGrowth((engine) => engine.growUntilSplit())}>Next split</button>
+              <button title={current.root.level >= 2 ? 'Three levels is the browser demo limit' : undefined} disabled={busy || viewingHistorical || current.root.level >= 2} onClick={() => runGrowth((engine) => engine.growUntilNextLevel())}>{current.root.level >= 2 ? 'Three levels reached' : 'Next tree level'}</button>
+              <button className="reset-button" disabled={busy || viewingHistorical} onClick={() => {
+                const engine = engineRef.current;
+                if (!engine) return;
+                resetTreeState();
+                setBusy(true);
+                window.setTimeout(() => {
+                  try {
+                    const snapshot = engine.reset();
+                    setSnapshots([snapshot]);
+                    setViewId(undefined);
+                    setCompareFromId(snapshot.id);
+                    setInsertionOrderResult(undefined);
+                    setOrderSelectedHash(undefined);
+                    setGcReport(undefined);
+                    selectExistingInputs(snapshot);
+                  } finally {
+                    setBusy(false);
+                  }
+                }, 20);
+              }}>Reset</button>
+            </div>
+          </div>
+        </div>}
+        {controlMode === 'lookup' && <div className="control-row lookup-row" id="lookup-controls" role="tabpanel">
+          <div className="control-section key-lookup-section">
+            <label>Key lookup</label>
+            <div className="control-fields">
+              <input aria-label="Search key" type="number" value={searchInput} onChange={(event) => { cancelAnimation(); setTrace(new Set()); setSearchInput(event.target.value); setLookupResult(undefined); }} onKeyDown={(event) => event.key === 'Enter' && doSearch()} />
+              <button disabled={busy} onClick={doSearch}>Find key</button>
+            </div>
+          </div>
+          <div className="control-section range-lookup-section">
+            <label>Range lookup</label>
+            <div className="control-fields">
+              <input aria-label="Range start" type="number" value={rangeStart} onChange={(event) => { cancelAnimation(); setTrace(new Set()); setRangeStart(event.target.value); }} />
+              <span className="range-arrow">to</span>
+              <input aria-label="Range end" type="number" value={rangeEnd} onChange={(event) => { cancelAnimation(); setTrace(new Set()); setRangeEnd(event.target.value); }} onKeyDown={(event) => event.key === 'Enter' && doRangeSearch()} />
+              <button disabled={busy} onClick={doRangeSearch}>Find range</button>
+            </div>
+          </div>
+          <div className="control-section diff-lookup-section">
+            <label>Diff lookup</label>
+            <div className="control-fields">
+              <button className={lastChangeActive ? 'diff-lookup-button active' : 'diff-lookup-button'} aria-pressed={lastChangeActive} disabled={busy || viewedIndex <= 0} onClick={doDiffLookup}>{lastChangeActive ? 'Clear last change' : 'Highlight last change'}</button>
+            </div>
+          </div>
+        </div>}
+      </section>
+
+      {viewingHistorical && (
+        <div className="history-view-banner">
+          <span>Viewing version {String(viewedIndex + 1).padStart(2, '0')} of {String(snapshots.length).padStart(2, '0')}. Editing is paused for historical states.</span>
+          <button onClick={() => { resetTreeState(); setViewId(undefined); setInsertionOrderResult(undefined); }}>Return to latest</button>
+        </div>
+      )}
+
+      {error && <div className="error-banner"><strong>Engine error</strong><span>{error}</span><button onClick={() => setError(undefined)}>×</button></div>}
+      {busy && <div className="busy-bar"><span /> {gcRunning ? 'prolly-map is collecting unreachable nodes…' : 'prolly-map is rebuilding and hashing the tree…'}</div>}
+
+      <div className={tab === 'order' ? 'workbench-layout order-mode' : 'workbench-layout'}>
+        <div className="workbench-main">
+          <nav className="tabs" aria-label="Visualizer views">
+            {([
+              ['tree', 'Tree'],
+              ['diff', `Fast diff${metrics.diff.rowDiffs.length ? ` · ${metrics.diff.rowDiffs.length}` : ''}`],
+              ['chunks', `Chunk boundaries · ${metrics.leaves.length}`],
+              ['storage', 'Storage'],
+              ['order', 'History independence'],
+            ] as [Tab, string][]).map(([id, label]) => (
+              <button key={id} className={tab === id ? 'active' : ''} onClick={() => setTab(id)}>{label}</button>
+            ))}
+          </nav>
+
+          <main className="workspace">
+        {tab === 'tree' && (
+          <>
+            <div className="view-toolbar">
+              <div className="legend">
+                <span><i className="legend-new" /> new address <InfoTip>A chunk address that did not exist in the immediately previous version.</InfoTip></span>
+                <span><i className="legend-trace" /> lookup path <InfoTip>Chunks visited while resolving the current key or range lookup.</InfoTip></span>
+                <span><i className="legend-diff" /> changed since previous <InfoTip>Chunks rewritten by the single change between this version and the version immediately before it.</InfoTip></span>
+                {lastChangeActive && <span><i className="legend-skip" /> shared subtree skipped <InfoTip>A matching content address proves every row below it is equal, so diff does not descend into the subtree.</InfoTip></span>}
+              </div>
+              {previous && (
+                <div className="change-summary">
+                  {metrics.tree.rowDiffs.length === 0 && current.rootHash === previous.rootHash && <strong className="no-content-change">No content change · addresses unchanged</strong>}
+                  {metrics.tree.splitDelta > 0 && <strong>Split! +{metrics.tree.splitDelta} leaf {metrics.tree.splitDelta === 1 ? 'chunk' : 'chunks'}</strong>}
+                  {metrics.tree.splitDelta < 0 && <strong className="chunk-combine">Combined! {Math.abs(metrics.tree.splitDelta)} fewer leaf {metrics.tree.splitDelta === -1 ? 'chunk' : 'chunks'}</strong>}
+                  <span>{metrics.tree.fresh} new</span><span>{metrics.tree.shared} shared</span><span>{metrics.tree.replaced} replaced</span>
+                </div>
+              )}
+            </div>
+            <div className={selectedNode ? 'tree-with-inspector open' : 'tree-with-inspector'}>
+              <TreeCanvas snapshot={current} baseline={showNewAddresses ? previous : undefined} trace={trace} activeTraceHash={activeTraceHash} diffHighlight={diffHighlight} activeDiffHashes={activeDiffHashes} diffSkipped={diffSkipped} activeDiffSkipped={activeDiffSkipped} rowDiffs={highlightedRowDiffs} lookup={lookupResult} selectedHash={selectedHash} onSelect={(hash) => { resetTreeState(); setSelectedHash(hash); }} />
+              <NodeInspector node={selectedNode} rows={current.rows} onClose={() => setSelectedHash(undefined)} />
+            </div>
+            <div className="tree-storage-note">
+              Leaf nodes store encoded keys and values. Internal nodes store lower-bound keys and child addresses. Select a node to inspect it.
+            </div>
+            {actionDetails === 'diff' && diffPlayback && <DiffPlaybackPanel playback={diffPlayback} rowDifferences={metrics.tree.rowDiffs.length} />}
+            {actionDetails === 'lookup' && lookupDetails && <LookupDetailsPanel details={lookupDetails} snapshot={current} visited={trace} activeHash={activeTraceHash} />}
+            {actionDetails === 'mutation' && mutationCost && <MutationCostPanel cost={mutationCost} label={current.label} split={metrics.tree.splitDelta > 0} onHighlight={(hashes) => {
+              cancelAnimation();
+              setTrace(new Set());
+              setLookupResult(undefined);
+              setDiffHighlight(new Set(hashes));
+              setLastChangeActive(false);
+              setShowNewAddresses(false);
+              setSelectedHash(undefined);
+            }} />}
+          </>
+        )}
+
+        {tab === 'diff' && (
+          <section className="panel-view diff-view">
+            <div className="data-view-head">
+              <h2>Fast diff <InfoTip>Content addresses let the diff skip shared subtrees and visit only changed nodes.</InfoTip></h2>
+              <div className="diff-version-picker">
+                <label htmlFor="compare-from">From</label>
+                <select id="compare-from" value={diffBaseline?.id ?? ''} disabled={!diffBaseline} onChange={(event) => setCompareFromId(Number(event.target.value))}>
+                  {snapshots.slice(0, Math.max(0, viewedIndex)).map((snapshot, index) => (
+                    <option key={snapshot.id} value={snapshot.id}>Version {String(index + 1).padStart(2, '0')} · {snapshot.label}</option>
+                  ))}
+                </select>
+                <span>→ Version {String(viewedIndex + 1).padStart(2, '0')}</span>
+              </div>
+            </div>
+            <div className="diff-metrics">
+              <div><b>{metrics.diff.shared}</b><span>subtrees skipped</span></div>
+              <div><b>{metrics.diff.fresh}</b><span>new nodes visited</span></div>
+              <div><b>{metrics.diff.rowDiffs.length}</b><span>row differences</span></div>
+            </div>
+            <div className="hash-compare">
+              <div><small>BEFORE</small><code>{diffBeforeRoot}</code></div>
+              <span className={diffBeforeRoot === current.rootHash ? 'same-root' : 'changed-root'}>{diffBeforeRoot === current.rootHash ? '=' : '≠'}</span>
+              <div><small>AFTER</small><code>{current.rootHash}</code></div>
+            </div>
+            <div className="row-diff-table">
+              {metrics.diff.rowDiffs.length === 0 ? <div className="empty-state">These snapshots contain the same rows.</div> : metrics.diff.rowDiffs.map((diff) => (
+                <div className={`row-diff ${diff.kind}`} key={diff.key}>
+                  <span className="diff-sign">{diff.kind === 'added' ? '+' : diff.kind === 'deleted' ? '−' : '±'}</span>
+                  <code>{diff.key}</code><span>{diff.before ?? '∅'}</span><span>→</span><span>{diff.after ?? '∅'}</span><em>{diff.kind}</em>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {tab === 'chunks' && (
+          <section className="panel-view chunks-view">
+            <div className="data-view-head">
+              <h2>Chunk boundaries <InfoTip>Content-defined boundaries decide where leaf chunks end, independent of insertion order.</InfoTip></h2>
+              <div className="chunk-summary">
+                <span><b>{metrics.leaves.length}</b> leaves</span>
+                <span><b>{metrics.leaves.reduce((total, leaf) => total + leaf.size, 0).toLocaleString()}</b> live bytes</span>
+                <span><b>{metrics.leaves.reduce((total, leaf) => total + leaf.entries.length, 0).toLocaleString()}</b> keys</span>
+              </div>
+            </div>
+            <div className="chunk-strip">
+              {metrics.leaves.map((leaf, index) => (
+                <button key={leaf.hash} style={{ flexGrow: Math.max(1, leaf.entries.length) }} onClick={() => { resetTreeState(); setSelectedHash(leaf.hash); setTab('tree'); }}>
+                  <span>chunk {index + 1}</span><b>{leaf.minKey}–{leaf.maxKey}</b><small>{leaf.size} B · {leaf.entries.length} keys</small><code>{leaf.hash}</code>
+                  <em>{formatProbability(estimateMutationSplitProbability(leaf))} split chance</em>
+                </button>
+              ))}
+            </div>
+            <div className="chunk-table">
+              <div className="chunk-row chunk-head"><span>#</span><span>Key range</span><span>Entries</span><span>Bytes</span><span>Split chance <InfoTip>Estimated chance that inserting an unused integer key in this range creates a new chunk boundary.</InfoTip></span><span>Content address</span></div>
+              {metrics.leaves.map((leaf, index) => (
+                <button className="chunk-row" key={leaf.hash} onClick={() => { resetTreeState(); setSelectedHash(leaf.hash); setTab('tree'); }}>
+                  <span>{index + 1}</span><span>{leaf.minKey} → {leaf.maxKey}</span><span>{leaf.entries.length}</span><span>{leaf.size.toLocaleString()}</span><strong>{formatProbability(estimateMutationSplitProbability(leaf))}</strong><code>{leaf.hash}</code>
+                </button>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {tab === 'storage' && (
+          <section className="panel-view storage-view">
+            <div className="data-view-head storage-head">
+              <div>
+                <h2>Storage <InfoTip>Counts cover content-addressed nodes retained by this in-memory prolly-map engine.</InfoTip></h2>
+                <span>{storageMetrics.versions} {storageMetrics.versions === 1 ? 'version' : 'versions'}</span>
+              </div>
+              <div className="storage-actions">
+                <span>Keep HEAD only <InfoTip>Removes earlier versions from this lab and rebuilds a fresh in-memory prolly-map store from HEAD.</InfoTip></span>
+                <button disabled={busy} onClick={runGarbageCollection}>{gcRunning ? 'Collecting…' : 'Garbage collect'}</button>
+              </div>
+            </div>
+
+            <div className="storage-comparison">
+              <article className="shared-storage-card">
+                <span>With structural sharing <InfoTip>Chunks with the same content address are reused across versions and counted only once.</InfoTip></span>
+                <b>{storageMetrics.withSharing.toLocaleString()}</b>
+                <small>distinct live tree content addresses</small>
+              </article>
+              <article>
+                <span>Without structural sharing <em>theoretical</em></span>
+                <b>{storageMetrics.withoutSharing.toLocaleString()}</b>
+                <small>live tree chunks counted once per version</small>
+              </article>
+              <article className="saved-storage-card">
+                <span>Chunks shared</span>
+                <b>{storageMetrics.savedChunks.toLocaleString()}</b>
+                <small>{Math.round(storageMetrics.savedFraction * 100)}% fewer chunks across history</small>
+              </article>
+            </div>
+
+            <div className="storage-ratio" aria-label={`${storageMetrics.withSharing} distinct chunks out of ${storageMetrics.withoutSharing} chunks without sharing`}>
+              <span style={{ width: `${storageMetrics.withoutSharing === 0 ? 0 : storageMetrics.withSharing / storageMetrics.withoutSharing * 100}%` }} />
+            </div>
+
+            <div className="physical-storage">
+              <div><span>In-memory node store</span><b>{physicalStore.chunksInStore.toLocaleString()} nodes</b></div>
+              <div><span>Encoded node bytes</span><b>{physicalStore.databaseBytes.toLocaleString()} B</b></div>
+            </div>
+
+            <div className="chunk-makeup">
+              <div className="chunk-makeup-head">
+                <span>Physical chunk makeup</span>
+                <small>{liveTableChunks} + {historicalTreeChunks} + {metadataChunks} = {physicalStore.chunksInStore}</small>
+              </div>
+              <div className="chunk-makeup-bar" aria-label={`${liveTableChunks} HEAD tree chunks, ${historicalTreeChunks} historical tree chunks, and ${metadataChunks} engine metadata chunks`}>
+                <span className="makeup-live" style={{ width: `${chunkWidth(liveTableChunks)}%` }} />
+                <span className="makeup-history" style={{ width: `${chunkWidth(historicalTreeChunks)}%` }} />
+                <span className="makeup-metadata" style={{ width: `${chunkWidth(metadataChunks)}%` }} />
+              </div>
+              <div className="chunk-makeup-legend">
+                <span><i className="makeup-live" /><span>HEAD tree <InfoTip>Every live root, internal, and leaf chunk shown in the Tree tab.</InfoTip></span><b>{liveTableChunks}</b></span>
+                <span><i className="makeup-history" /><span>Historical trees <InfoTip>Root, internal, and leaf chunks used only by earlier versions.</InfoTip></span><b>{historicalTreeChunks}</b></span>
+                <span><i className="makeup-metadata" /><span>Other retained nodes <InfoTip>Content-addressed nodes retained by the engine but not present in the visible version timeline.</InfoTip></span><b>{metadataChunks}</b></span>
+              </div>
+            </div>
+
+            {gcReport && (
+              <div className="gc-report" role="status">
+                <div className="gc-report-head"><span>Last garbage collection</span><strong>{gcReport.message}</strong></div>
+                <div className="gc-deltas">
+                  <div><span>Versions</span><b>{gcReport.versionsBefore} → 1</b><em>−{gcReport.versionsRemoved}</em></div>
+                  <div><span>Stored chunks</span><b>{gcReport.beforeChunks.toLocaleString()} → {gcReport.afterChunks.toLocaleString()}</b><em>{formatStorageDelta(gcReport.beforeChunks, gcReport.afterChunks)}</em></div>
+                  <div><span>Database bytes</span><b>{gcReport.beforeBytes.toLocaleString()} → {gcReport.afterBytes.toLocaleString()}</b><em>{formatStorageDelta(gcReport.beforeBytes, gcReport.afterBytes, ' B')}</em></div>
+                </div>
+                <small>Before collection: {gcReport.treeChunksBefore.toLocaleString()} theoretical tree chunks, {gcReport.sharedTreeChunksBefore.toLocaleString()} with structural sharing.</small>
+              </div>
+            )}
+          </section>
+        )}
+
+        {tab === 'order' && (
+          <section className="panel-view history-order-view">
+            <div className="history-order-head">
+              <div>
+                <h2>History independence <InfoTip>The same final rows produce the same chunks and root address even when edits arrive in a different order.</InfoTip></h2>
+                <p>Rebuild the current {current.rows.length.toLocaleString()} rows in shuffled order, with temporary draft-value updates.</p>
+              </div>
+              <button className="run-order-button" disabled={busy} onClick={runInsertionOrderDemo}>{insertionOrderResult ? 'Rebuild again' : 'Rebuild current tree'}</button>
+            </div>
+
+            {insertionOrderResult ? (
+              <>
+                <div className={insertionOrderResult.identicalRoot && insertionOrderResult.identicalChunks ? 'history-match pass' : 'history-match fail'}>
+                  <code>{insertionOrderResult.current.rootHash}</code>
+                  <span>{insertionOrderResult.identicalRoot ? 'same root' : 'different roots'}</span>
+                  <span>{insertionOrderResult.identicalChunks ? `${insertionOrderResult.current.nodeHashes.length} / ${insertionOrderResult.rebuilt.nodeHashes.length} live chunk addresses match` : 'live chunk addresses differ'}</span>
+                </div>
+                <div className="history-trees">
+                  <article className="history-tree">
+                    <header>
+                      <div><span>CURRENT</span><h3>{insertionOrderResult.current.snapshot.label}</h3></div>
+                      <code>{insertionOrderResult.current.snapshot.rows.length.toLocaleString()} rows · {insertionOrderResult.current.snapshot.nodes.size.toLocaleString()} live chunks</code>
+                    </header>
+                    <div className="history-tree-canvas">
+                      <TreeCanvas snapshot={insertionOrderResult.current.snapshot} trace={NO_HIGHLIGHTS} diffHighlight={NO_HIGHLIGHTS} rowDiffs={NO_ROW_DIFFS} compact selectedHash={orderSelectedHash} onSelect={setOrderSelectedHash} />
+                    </div>
+                  </article>
+                  <article className="history-tree">
+                    <header>
+                      <div><span>REBUILT</span><h3>Shuffled inserts + {insertionOrderResult.rebuilt.updates.length} updates</h3></div>
+                      <code>{formatOrder(insertionOrderResult.rebuilt.order)}</code>
+                    </header>
+                    <div className="history-tree-canvas">
+                      <TreeCanvas snapshot={insertionOrderResult.rebuilt.snapshot} trace={NO_HIGHLIGHTS} diffHighlight={NO_HIGHLIGHTS} rowDiffs={NO_ROW_DIFFS} compact selectedHash={orderSelectedHash} onSelect={setOrderSelectedHash} />
+                    </div>
+                  </article>
+                </div>
+                <p className="history-node-hint">Select a node in either tree to match its address in both.</p>
+              </>
+            ) : (
+              <div className="history-empty">The current tree and its shuffled rebuild will render here.</div>
+            )}
+          </section>
+        )}
+
+          </main>
+        </div>
+
+        {tab !== 'order' && <aside className="timeline-section" aria-label="Version history">
+          <div className="timeline-head">
+            <div><h2>History <InfoTip dark>Select a version to render its tree. Highlights compare it only with the version immediately before it.</InfoTip></h2></div>
+          </div>
+          <div className="timeline">
+            {[...snapshots].reverse().map((snapshot, reverseIndex) => {
+              const index = snapshots.length - reverseIndex - 1;
+              return (
+                <button key={snapshot.id} className={snapshot.id === current.id ? 'selected' : ''} onClick={() => { resetTreeState(); setViewId(snapshot.id); setInsertionOrderResult(undefined); }} disabled={snapshot.id === current.id}>
+                  <span>Version {String(index + 1).padStart(2, '0')}{index === snapshots.length - 1 && <em>latest</em>}</span>
+                  <b>{snapshot.label}</b>
+                  <code>{snapshot.rootHash}</code>
+                  <small>{snapshot.rows.length} rows · {snapshot.nodes.size} nodes</small>
+                </button>
+              );
+            })}
+          </div>
+        </aside>}
+      </div>
+
+      {tab !== 'order' && <footer>
+        <span>Runs entirely in your browser. No database server, no simulated tree.</span>
+        <a href="https://www.dolthub.com/docs/architecture/storage-engine/prolly-tree/" target="_blank" rel="noreferrer">Read more about Prolly Trees</a>
+        <span>prolly-map compact format · {current.databaseBytes.toLocaleString()} encoded B · {current.chunksInStore} stored nodes</span>
+      </footer>}
+    </div>
+  );
+}
+
+export default App;

--- a/3rd/prolly-tree-visualizer/src/bootstrap.test.ts
+++ b/3rd/prolly-tree-visualizer/src/bootstrap.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { bootstrapKeys, deterministicShuffle } from './bootstrap';
+
+describe('bootstrap keys', () => {
+  it('builds a reproducible, ordered, sparse key set', () => {
+    const first = bootstrapKeys(240);
+    const second = bootstrapKeys(240);
+    const gaps = first.slice(1).map((key, index) => key - first[index]);
+
+    expect(first).toEqual(second);
+    expect(new Set(first).size).toBe(240);
+    expect(gaps.every((gap) => gap > 0)).toBe(true);
+    expect(new Set(gaps).size).toBeGreaterThan(5);
+    expect(first.at(-1)).toBeGreaterThan(1_000);
+  });
+
+  it('reorders values reproducibly without changing the set', () => {
+    const values = bootstrapKeys(40);
+    const shuffled = deterministicShuffle(values);
+
+    expect(shuffled).toEqual(deterministicShuffle(values));
+    expect(shuffled).not.toEqual(values);
+    expect([...shuffled].sort((left, right) => left - right)).toEqual(values);
+  });
+});

--- a/3rd/prolly-tree-visualizer/src/bootstrap.ts
+++ b/3rd/prolly-tree-visualizer/src/bootstrap.ts
@@ -1,0 +1,29 @@
+export function bootstrapKeys(count: number) {
+  const amount = Math.max(1, Math.trunc(count));
+  const keys: number[] = [];
+  let state = 0x5eed1234;
+  let key = 0;
+  for (let index = 0; index < amount; index += 1) {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    state >>>= 0;
+    key += 1 + state % 11;
+    keys.push(key);
+  }
+  return keys;
+}
+
+export function deterministicShuffle<T>(values: T[]) {
+  const shuffled = [...values];
+  let state = 0x0d1ce5ed;
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    state >>>= 0;
+    const swapIndex = state % (index + 1);
+    [shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]];
+  }
+  return shuffled;
+}

--- a/3rd/prolly-tree-visualizer/src/components/DiffPlaybackPanel.tsx
+++ b/3rd/prolly-tree-visualizer/src/components/DiffPlaybackPanel.tsx
@@ -1,0 +1,51 @@
+import type { DiffTraversalFrame } from '../diffTraversal';
+import { InfoTip } from './InfoTip';
+
+interface DiffPlaybackPanelProps {
+  playback: DiffTraversalFrame & { step: number; totalSteps: number; running: boolean };
+  rowDifferences: number;
+}
+
+export function DiffPlaybackPanel({ playback, rowDifferences }: DiffPlaybackPanelProps) {
+  const progress = (playback.step + 1) / playback.totalSteps * 100;
+  return (
+    <section className="mutation-cost diff-playback-panel" aria-label="Fast diff details">
+      <div className="mutation-cost-head">
+        <div><span>Fast diff</span><strong>{playback.message}</strong></div>
+        <em>{playback.running ? 'Diffing' : 'Complete'}</em>
+      </div>
+      <div className="mutation-flow">
+        <div className="mutation-stage mutation-input">
+          <span>Addresses checked</span>
+          <b>{playback.addressesChecked}</b>
+          <small>content-address comparisons</small>
+        </div>
+        <i aria-hidden="true">→</i>
+        <div className="mutation-stage">
+          <span>Changed nodes</span>
+          <b>{playback.nodesVisited}</b>
+          <small>chunks opened</small>
+        </div>
+        <i aria-hidden="true">→</i>
+        <div className="mutation-stage diff-skip-stage">
+          <span>Shared subtrees</span>
+          <b>{playback.skippedSubtrees}</b>
+          <small>skipped by address</small>
+        </div>
+        <i aria-hidden="true">→</i>
+        <div className="mutation-stage mutation-total">
+          <span>Rows avoided</span>
+          <b>{playback.skippedRows.toLocaleString()}</b>
+          <small>{rowDifferences} row {rowDifferences === 1 ? 'difference' : 'differences'} {playback.revealedRows ? 'emitted' : 'pending'}</small>
+        </div>
+      </div>
+      <div className="mutation-cost-foot">
+        <div className="mutation-cost-ratio">
+          <div className="mutation-cost-bar"><span style={{ width: `${progress}%` }} /></div>
+          <InfoTip>The bar advances as diff compares each tree level, skips matching addresses, and reaches the changed leaves.</InfoTip>
+        </div>
+        <span>step {playback.step + 1} of {playback.totalSteps}</span>
+      </div>
+    </section>
+  );
+}

--- a/3rd/prolly-tree-visualizer/src/components/InfoTip.tsx
+++ b/3rd/prolly-tree-visualizer/src/components/InfoTip.tsx
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+interface InfoTipProps {
+  children: string;
+  dark?: boolean;
+}
+
+export function InfoTip({ children, dark = false }: InfoTipProps) {
+  const id = useId();
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState({ left: 0, top: 0, above: false });
+
+  const updatePosition = useCallback(() => {
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+    const rect = trigger.getBoundingClientRect();
+    const halfWidth = Math.min(130, (window.innerWidth - 24) / 2);
+    const left = Math.min(window.innerWidth - 12 - halfWidth, Math.max(12 + halfWidth, rect.left + rect.width / 2));
+    const above = rect.bottom + 90 > window.innerHeight && rect.top > 90;
+    setPosition({ left, top: above ? rect.top - 8 : rect.bottom + 8, above });
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const reposition = () => updatePosition();
+    window.addEventListener('resize', reposition);
+    window.addEventListener('scroll', reposition, true);
+    return () => {
+      window.removeEventListener('resize', reposition);
+      window.removeEventListener('scroll', reposition, true);
+    };
+  }, [open, updatePosition]);
+
+  const show = () => {
+    updatePosition();
+    setOpen(true);
+  };
+
+  return (
+    <span ref={triggerRef} className={dark ? 'info-tip dark' : 'info-tip'} tabIndex={0} aria-label="More information" aria-describedby={id} onMouseEnter={show} onMouseLeave={() => setOpen(false)} onFocus={show} onBlur={() => setOpen(false)}>
+      <span className="info-tip-mark" aria-hidden="true">?</span>
+      {open && createPortal(
+        <span className={position.above ? 'info-tip-content above' : 'info-tip-content'} id={id} role="tooltip" style={{ left: position.left, top: position.top }}>{children}</span>,
+        document.body,
+      )}
+    </span>
+  );
+}

--- a/3rd/prolly-tree-visualizer/src/components/LookupDetailsPanel.tsx
+++ b/3rd/prolly-tree-visualizer/src/components/LookupDetailsPanel.tsx
@@ -1,0 +1,80 @@
+import type { ProllyNode, TreeSnapshot } from '../types';
+import { InfoTip } from './InfoTip';
+
+export type LookupDetails =
+  | { kind: 'key'; key: number; found: boolean; path: string[] }
+  | { kind: 'range'; start: number; end: number; matchedRows: number; path: string[] };
+
+interface LookupDetailsPanelProps {
+  details: LookupDetails;
+  snapshot: TreeSnapshot;
+  visited: Set<string>;
+  activeHash?: string;
+}
+
+function countLevel(path: string[], nodes: Map<string, ProllyNode>, leaf: boolean) {
+  return path.filter((hash) => (nodes.get(hash)?.level === 0) === leaf).length;
+}
+
+export function LookupDetailsPanel({ details, snapshot, visited, activeHash }: LookupDetailsPanelProps) {
+  const allHashes = [...snapshot.nodes.keys()];
+  const totalInternal = countLevel(allHashes, snapshot.nodes, false);
+  const totalLeaves = countLevel(allHashes, snapshot.nodes, true);
+  const visitedPath = details.path.filter((hash) => visited.has(hash));
+  const visitedInternal = countLevel(visitedPath, snapshot.nodes, false);
+  const visitedLeaves = countLevel(visitedPath, snapshot.nodes, true);
+  const progress = details.path.length === 0 ? 0 : visitedPath.length / details.path.length * 100;
+  const complete = visitedPath.length === details.path.length && activeHash === undefined;
+  const activeNode = activeHash ? snapshot.nodes.get(activeHash) : undefined;
+  const title = details.kind === 'key' ? 'Key lookup' : 'Range lookup';
+  const target = details.kind === 'key'
+    ? details.key.toLocaleString()
+    : `${Math.min(details.start, details.end).toLocaleString()} → ${Math.max(details.start, details.end).toLocaleString()}`;
+  const result = details.kind === 'key'
+    ? details.found ? 'Found' : 'Not found'
+    : details.matchedRows.toLocaleString();
+  const message = complete
+    ? details.kind === 'key' ? `Key ${details.key.toLocaleString()} ${details.found ? 'found' : 'not found'}` : `${details.matchedRows.toLocaleString()} rows returned`
+    : activeNode?.level === 0 ? 'Reading leaf chunk' : `Routing through level ${activeNode?.level ?? snapshot.root.level}`;
+  return (
+    <section className="mutation-cost lookup-details-panel" aria-label={`${title} details`}>
+      <div className="mutation-cost-head">
+        <div><span>{title}</span><strong>{message}</strong></div>
+        <em>{complete ? 'Complete' : 'Searching'}</em>
+      </div>
+      <div className="mutation-flow">
+        <div className="mutation-stage mutation-input">
+          <span>{details.kind === 'key' ? 'Key' : 'Range'}</span>
+          <b>{target}</b>
+          <small>{details.kind === 'key' ? 'point lookup' : 'inclusive lookup'}</small>
+        </div>
+        <i aria-hidden="true">→</i>
+        <div className="mutation-stage">
+          <span>Internal chunks</span>
+          <b>{visitedInternal} / {totalInternal}</b>
+          <small>live routing nodes visited</small>
+        </div>
+        <i aria-hidden="true">→</i>
+        <div className="mutation-stage">
+          <span>Leaf chunks</span>
+          <b>{visitedLeaves} / {totalLeaves}</b>
+          <small>live data chunks read</small>
+        </div>
+        <i aria-hidden="true">→</i>
+        <div className="mutation-stage mutation-total">
+          <span>Result</span>
+          <b>{complete ? result : '—'}</b>
+          <small>{details.kind === 'key' ? 'matching key' : 'rows returned'}</small>
+        </div>
+      </div>
+      <div className="mutation-cost-foot">
+        <div className="mutation-cost-ratio">
+          <div className="mutation-cost-bar"><span style={{ width: `${progress}%` }} /></div>
+          <InfoTip>{details.kind === 'key' ? 'A balanced prolly tree follows one root-to-leaf path in O(log n), like a B-tree.' : 'A range lookup seeks to the range in O(log n), then reads the matching leaves and returns k rows: O(log n + k).'}</InfoTip>
+        </div>
+        <span>{snapshot.rows.length.toLocaleString()} rows · {snapshot.root.level + 1} levels</span>
+        <span>{details.kind === 'key' ? 'O(log n)' : 'O(log n + k)'}</span>
+      </div>
+    </section>
+  );
+}

--- a/3rd/prolly-tree-visualizer/src/components/MutationCostPanel.tsx
+++ b/3rd/prolly-tree-visualizer/src/components/MutationCostPanel.tsx
@@ -1,0 +1,65 @@
+import type { MutationCost } from '../mutationCost';
+import { InfoTip } from './InfoTip';
+
+interface MutationCostPanelProps {
+  cost: MutationCost;
+  label: string;
+  split: boolean;
+  onHighlight(hashes: string[]): void;
+}
+
+function countLabel(count: number, singular: string) {
+  return `${count} ${count === 1 ? singular : `${singular}s`}`;
+}
+
+function amplificationLabel(amplification?: number) {
+  if (amplification === undefined) return '—';
+  return `${amplification < 10 ? amplification.toFixed(1) : Math.round(amplification).toLocaleString()}×`;
+}
+
+export function MutationCostPanel({ cost, label, split, onHighlight }: MutationCostPanelProps) {
+  const currentNodes = cost.changedHashes.length + cost.sharedNodes;
+  const changedWidth = currentNodes === 0 ? 0 : cost.changedHashes.length / currentNodes * 100;
+  return (
+    <section className="mutation-cost" aria-label="Mutation cost">
+      <div className="mutation-cost-head">
+        <div><span>Mutation cost</span><strong>{label}</strong></div>
+        {split && <em>Split</em>}
+      </div>
+      <div className="mutation-flow">
+        <div className="mutation-stage mutation-input">
+          <span>Mutation</span>
+          <b>{countLabel(cost.rowChanges, 'row')}</b>
+          <small>{cost.mutationBytes.toLocaleString()} B input</small>
+        </div>
+        <i aria-hidden="true">→</i>
+        <button className="mutation-stage" disabled={cost.leafHashes.length === 0} onClick={() => onHighlight(cost.leafHashes)}>
+          <span>Leaf chunks</span>
+          <b>{cost.leafHashes.length}</b>
+          <small>{cost.leafBytes.toLocaleString()} B changed</small>
+        </button>
+        <i aria-hidden="true">→</i>
+        <button className="mutation-stage" disabled={cost.internalHashes.length === 0} onClick={() => onHighlight(cost.internalHashes)}>
+          <span>Internal chunks</span>
+          <b>{cost.internalHashes.length}</b>
+          <small>{cost.internalBytes.toLocaleString()} B changed</small>
+        </button>
+        <i aria-hidden="true">→</i>
+        <button className="mutation-stage mutation-total" disabled={cost.changedHashes.length === 0} onClick={() => onHighlight(cost.changedHashes)}>
+          <span>Tree bytes changed</span>
+          <b>{cost.changedBytes.toLocaleString()} B</b>
+          <small>{amplificationLabel(cost.amplification)} amplification <InfoTip>Changed tree bytes divided by the submitted key and value bytes.</InfoTip></small>
+        </button>
+      </div>
+      <div className="mutation-cost-foot">
+        <div className="mutation-cost-ratio">
+          <div className="mutation-cost-bar"><span style={{ width: `${changedWidth}%` }} /></div>
+          <InfoTip>Orange is the share of HEAD nodes rewritten by this mutation. Gray nodes remained structurally shared.</InfoTip>
+        </div>
+        <span>{cost.changedHashes.length} rewritten</span>
+        <span>{cost.sharedNodes} shared</span>
+        <span>{cost.retiredNodes} retired</span>
+      </div>
+    </section>
+  );
+}

--- a/3rd/prolly-tree-visualizer/src/components/NodeInspector.tsx
+++ b/3rd/prolly-tree-visualizer/src/components/NodeInspector.tsx
@@ -1,0 +1,48 @@
+import type { ProllyNode, RowValue } from '../types';
+
+interface NodeInspectorProps {
+  node?: ProllyNode;
+  rows: RowValue[];
+  onClose(): void;
+}
+
+export function NodeInspector({ node, rows, onClose }: NodeInspectorProps) {
+  if (!node) return null;
+  const rowMap = new Map(rows.map((row) => [row.key, row.value]));
+  const visibleEntries = node.entries.slice(0, 12);
+  const hiddenEntries = node.entries.length - visibleEntries.length;
+
+  return (
+    <aside className="inspector">
+      <div className="inspector-head">
+        <div>
+          <span className="eyebrow">Chunk inspector</span>
+          <h2>{node.level === 0 ? 'Leaf node' : `Internal node · level ${node.level}`}</h2>
+        </div>
+        <button className="icon-button" onClick={onClose} aria-label="Close inspector">×</button>
+      </div>
+      <dl className="facts">
+        <div><dt>Content address</dt><dd className="full-hash">{node.hash}</dd></div>
+        <div><dt>Encoded size</dt><dd>{node.size.toLocaleString()} bytes</dd></div>
+        <div><dt>Key range</dt><dd>{node.minKey ?? 'empty'} → {node.maxKey ?? 'empty'}</dd></div>
+        <div><dt>Entries</dt><dd>{node.entries.length}</dd></div>
+      </dl>
+      <div className="entry-list">
+        <div className="entry-list-head">
+          <span>{node.level === 0 ? 'decoded key → value' : 'lower bound → child address'}</span>
+        </div>
+        {visibleEntries.map((entry, index) => (
+          <div className="entry-row" key={`${entry.keyHex}-${index}`}>
+            <span className="entry-key">{String(entry.key)}</span>
+            <span className="entry-arrow">→</span>
+            <span className={entry.childHash ? 'entry-value full-hash' : 'entry-value'}>
+              {entry.childHash ?? rowMap.get(Number(entry.key)) ?? `${entry.valueHex.slice(0, 24)}…`}
+            </span>
+            {entry.subtreeCount !== undefined && <span className="entry-count">{entry.subtreeCount} rows</span>}
+          </div>
+        ))}
+        {hiddenEntries > 0 && <div className="entry-more">and {hiddenEntries.toLocaleString()} more entries</div>}
+      </div>
+    </aside>
+  );
+}

--- a/3rd/prolly-tree-visualizer/src/components/TreeCanvas.test.ts
+++ b/3rd/prolly-tree-visualizer/src/components/TreeCanvas.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { missingKeyLabel, rangeKeysForNode, routeKeyForLookup, shownKeys } from './TreeCanvas';
+import type { ProllyNode } from '../types';
+
+function leaf(keys: number[]): ProllyNode {
+  return {
+    hash: '1'.repeat(40),
+    level: 0,
+    size: 100,
+    flags: 1,
+    entries: keys.map((key) => ({ key, keyHex: '', valueHex: '' })),
+    children: [],
+    minKey: keys[0],
+    maxKey: keys.at(-1)!,
+  };
+}
+
+describe('tree key labels', () => {
+  it('keeps a looked-up key visible inside a compressed leaf', () => {
+    expect(shownKeys(leaf([1, 2, 3, 4, 5, 6, 7, 8, 9]), [6])).toEqual([
+      { text: '1', match: false },
+      { text: '…', match: false },
+      { text: '6', match: true },
+      { text: '…', match: false },
+      { text: '9', match: false },
+    ]);
+  });
+
+  it('compresses wide keys even when the leaf has six entries', () => {
+    expect(shownKeys(leaf([12347, 12348, 12349, 12350, 12351, 12352]))).toEqual([
+      { text: '12347', match: false },
+      { text: '12348', match: false },
+      { text: '…', match: false },
+      { text: '12351', match: false },
+      { text: '12352', match: false },
+    ]);
+  });
+
+  it('places a missing key between its surrounding keys', () => {
+    expect(missingKeyLabel(leaf([1, 4, 8, 12]), 6)).toEqual([
+      { text: '4', match: false },
+      { text: 'key 6 not found', match: false, missing: true },
+      { text: '8', match: false },
+    ]);
+  });
+
+  it('selects the last lower-bound delimiter at or below the lookup key', () => {
+    expect(routeKeyForLookup(leaf([10, 20, 30]), 17)).toBe(10);
+    expect(routeKeyForLookup(leaf([10, 20, 30]), 40)).toBe(30);
+  });
+
+  it('selects the first and last returned keys in a leaf range', () => {
+    expect(rangeKeysForNode(leaf([1, 4, 8, 12, 16]), 3, 13)).toEqual([4, 12]);
+  });
+});

--- a/3rd/prolly-tree-visualizer/src/components/TreeCanvas.tsx
+++ b/3rd/prolly-tree-visualizer/src/components/TreeCanvas.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useMemo, useRef, type CSSProperties } from 'react';
+import { groupRowDiffsByLeaf } from '../prolly';
+import type { LookupResult, ProllyNode, RowDiff, TreeSnapshot } from '../types';
+
+interface Point {
+  x: number;
+  y: number;
+  node: ProllyNode;
+}
+
+const NODE_WIDTH = 282;
+const NODE_HEIGHT = 126;
+const X_GAP = 34;
+const Y_GAP = 184;
+
+interface KeyLabelPart {
+  text: string;
+  match: boolean;
+  missing?: boolean;
+}
+
+const KEY_PREVIEW_CHARACTERS = 34;
+
+function partsForIndexes(keys: string[], indexes: number[], matchIndexes: number[]) {
+  return indexes.flatMap((index, position): KeyLabelPart[] => {
+    const previousIndex = indexes[position - 1];
+    const omitted = position > 0 && index - previousIndex > 1
+      ? [{ text: '…', match: false }]
+      : [];
+    return [...omitted, { text: keys[index], match: matchIndexes.includes(index) }];
+  });
+}
+
+function previewLength(parts: KeyLabelPart[]) {
+  return parts.reduce((length, part) => length + part.text.length, 0) + Math.max(0, parts.length - 1) * 3;
+}
+
+function layout(root: ProllyNode, minimumWidth: number) {
+  const positions = new Map<string, Point>();
+  let leafIndex = 0;
+
+  const place = (node: ProllyNode): number => {
+    let center: number;
+    if (node.children.length === 0) {
+      center = leafIndex * (NODE_WIDTH + X_GAP) + NODE_WIDTH / 2 + 38;
+      leafIndex += 1;
+    } else {
+      const childCenters = node.children.map(place);
+      center = (childCenters[0] + childCenters.at(-1)!) / 2;
+    }
+    positions.set(node.hash, {
+      x: center - NODE_WIDTH / 2,
+      y: (root.level - node.level) * Y_GAP + 38,
+      node,
+    });
+    return center;
+  };
+
+  const rootCenter = place(root);
+  const contentWidth = Math.max(leafIndex * (NODE_WIDTH + X_GAP) + 42, NODE_WIDTH + 76);
+  if (leafIndex === 1) {
+    const offset = Math.max(0, minimumWidth / 2 - rootCenter);
+    for (const point of positions.values()) point.x += offset;
+  }
+  return {
+    positions,
+    width: Math.max(minimumWidth, contentWidth),
+    height: (root.level + 1) * Y_GAP + 30,
+  };
+}
+
+export function shownKeys(node: ProllyNode, lookupKeys: number[] = []): KeyLabelPart[] {
+  const keys = node.entries.map((entry) => String(entry.key));
+  const lookupKeySet = new Set(lookupKeys);
+  const matchIndexes = node.entries.flatMap((entry, index) => lookupKeySet.has(Number(entry.key)) ? [index] : []);
+  const allIndexes = keys.map((_, index) => index);
+  const allParts = partsForIndexes(keys, allIndexes, matchIndexes);
+  if (matchIndexes.length === 0 && previewLength(allParts) <= KEY_PREVIEW_CHARACTERS) return allParts;
+
+  if (matchIndexes.length > 0) {
+    const withEdges = [...new Set([0, ...matchIndexes, keys.length - 1])].sort((left, right) => left - right);
+    const edgeParts = partsForIndexes(keys, withEdges, matchIndexes);
+    if (previewLength(edgeParts) <= KEY_PREVIEW_CHARACTERS) return edgeParts;
+    if (matchIndexes.length === 1) {
+      const match = matchIndexes[0];
+      const nearby = [match - 1, match, match + 1].filter((index) => index >= 0 && index < keys.length);
+      const nearbyParts = partsForIndexes(keys, nearby, matchIndexes);
+      if (previewLength(nearbyParts) <= KEY_PREVIEW_CHARACTERS) return nearbyParts;
+    }
+    return partsForIndexes(keys, matchIndexes, matchIndexes);
+  }
+
+  const outsideIndexes = [...new Set([0, 1, keys.length - 2, keys.length - 1])]
+    .filter((index) => index >= 0 && index < keys.length)
+    .sort((left, right) => left - right);
+  const outsideParts = partsForIndexes(keys, outsideIndexes, matchIndexes);
+  if (previewLength(outsideParts) <= KEY_PREVIEW_CHARACTERS) return outsideParts;
+  return partsForIndexes(keys, [0, keys.length - 1], matchIndexes);
+}
+
+export function missingKeyLabel(node: ProllyNode, lookupKey: number): KeyLabelPart[] {
+  const keys = node.entries.map((entry) => Number(entry.key));
+  const insertionIndex = keys.findIndex((key) => key > lookupKey);
+  if (insertionIndex > 0) {
+    return [
+      { text: String(keys[insertionIndex - 1]), match: false },
+      { text: `key ${lookupKey} not found`, match: false, missing: true },
+      { text: String(keys[insertionIndex]), match: false },
+    ];
+  }
+  if (insertionIndex === 0) {
+    return [
+      { text: `key ${lookupKey} not found`, match: false, missing: true },
+      ...keys.slice(0, 2).map((key) => ({ text: String(key), match: false })),
+    ];
+  }
+  return [
+    ...keys.slice(-2).map((key) => ({ text: String(key), match: false })),
+    { text: `key ${lookupKey} not found`, match: false, missing: true },
+  ];
+}
+
+export function routeKeyForLookup(node: ProllyNode, lookupKey: number) {
+  const entry = node.entries.findLast((candidate) => Number(candidate.key) <= lookupKey) ?? node.entries[0];
+  return entry === undefined ? undefined : Number(entry.key);
+}
+
+export function rangeKeysForNode(node: ProllyNode, start: number, end: number) {
+  const low = Math.min(start, end);
+  const high = Math.max(start, end);
+  if (node.level > 0) {
+    return node.children.flatMap((child, index) => {
+      const childMin = Number(child.minKey);
+      const childMax = Number(child.maxKey);
+      return childMax >= low && childMin <= high ? [Number(node.entries[index].key)] : [];
+    });
+  }
+  const matches = node.entries.map((entry) => Number(entry.key)).filter((key) => key >= low && key <= high);
+  return matches.length <= 1 ? matches : [matches[0], matches.at(-1)!];
+}
+
+function shownChanges(changes: RowDiff[]) {
+  if (changes.length === 1) {
+    const change = changes[0];
+    return `key ${change.key} ${change.kind === 'modified' ? 'updated' : change.kind}`;
+  }
+  const keys = changes.slice(0, 3).map((change) => change.key).join(', ');
+  return `${changes.length} changed rows · ${keys}${changes.length > 3 ? ', …' : ''}`;
+}
+
+interface TreeCanvasProps {
+  snapshot: TreeSnapshot;
+  baseline?: TreeSnapshot;
+  trace: Set<string>;
+  activeTraceHash?: string;
+  diffHighlight: Set<string>;
+  activeDiffHashes?: Set<string>;
+  diffSkipped?: Set<string>;
+  activeDiffSkipped?: Set<string>;
+  rowDiffs: RowDiff[];
+  lookup?: LookupResult;
+  compact?: boolean;
+  selectedHash?: string;
+  onSelect(hash: string): void;
+}
+
+export function TreeCanvas({ snapshot, baseline, trace, activeTraceHash, diffHighlight, activeDiffHashes, diffSkipped, activeDiffSkipped, rowDiffs, lookup, compact = false, selectedHash, onSelect }: TreeCanvasProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const treeLayout = useMemo(() => layout(snapshot.root, compact ? 586 : 900), [compact, snapshot]);
+  const rowDiffsByLeaf = useMemo(() => groupRowDiffsByLeaf(snapshot.root, rowDiffs), [snapshot, rowDiffs]);
+  const baselineHashes = baseline?.nodes;
+
+  useEffect(() => {
+    const scroll = scrollRef.current;
+    const activeDiff = activeDiffHashes && activeDiffHashes.size > 0
+      ? [...activeDiffHashes]
+      : activeDiffSkipped ? [...activeDiffSkipped] : [];
+    const focusHashes = activeTraceHash ? [activeTraceHash] : activeDiff;
+    const points = focusHashes.flatMap((hash) => {
+      const point = treeLayout.positions.get(hash);
+      return point ? [point] : [];
+    });
+    if (!scroll || points.length === 0 || scroll.scrollWidth <= scroll.clientWidth) return;
+    const left = Math.min(...points.map((point) => point.x));
+    const right = Math.max(...points.map((point) => point.x + NODE_WIDTH));
+    scroll.scrollTo({
+      left: Math.max(0, (left + right) / 2 - scroll.clientWidth / 2),
+      behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
+    });
+  }, [activeDiffHashes, activeDiffSkipped, activeTraceHash, treeLayout]);
+
+  return (
+    <div
+      ref={scrollRef}
+      className="tree-scroll"
+      aria-label="Prolly tree visualization"
+      style={{ '--focus-delay': snapshot.nodes.size > 100 ? '1.2s' : snapshot.nodes.size > 20 ? '.6s' : '.3s' } as CSSProperties}
+    >
+      <svg className="tree-svg" width={treeLayout.width} height={treeLayout.height} role="img">
+        <title>Prolly tree rooted at {snapshot.rootHash}</title>
+        <g className="tree-edges">
+          {[...treeLayout.positions.values()].flatMap((point) =>
+            point.node.children.map((child) => {
+              const childPoint = treeLayout.positions.get(child.hash)!;
+              const changed = baselineHashes ? !baselineHashes.has(child.hash) : false;
+              const highlighted = diffHighlight.has(child.hash);
+              const skipped = diffSkipped?.has(child.hash);
+              const traced = trace.has(point.node.hash) && trace.has(child.hash);
+              return (
+                <path
+                  key={`${point.node.hash}-${child.hash}`}
+                  className={highlighted ? 'edge edge-diff' : skipped ? 'edge edge-skip' : traced ? 'edge edge-trace' : changed ? 'edge edge-new' : 'edge'}
+                  d={`M ${point.x + NODE_WIDTH / 2} ${point.y + NODE_HEIGHT} C ${point.x + NODE_WIDTH / 2} ${point.y + NODE_HEIGHT + 42}, ${childPoint.x + NODE_WIDTH / 2} ${childPoint.y - 42}, ${childPoint.x + NODE_WIDTH / 2} ${childPoint.y}`}
+                />
+              );
+            }),
+          )}
+        </g>
+        {[...treeLayout.positions.values()].map(({ node, x, y }) => {
+          const nodeRowDiffs = diffHighlight.has(node.hash) ? rowDiffsByLeaf.get(node.hash) ?? [] : [];
+          const isTrace = trace.has(node.hash);
+          const isActiveTrace = activeTraceHash === node.hash;
+          const isDiff = diffHighlight.has(node.hash);
+          const isSkipped = Boolean(diffSkipped?.has(node.hash));
+          const isActiveSkipped = Boolean(activeDiffSkipped?.has(node.hash));
+          const isNew = Boolean(baselineHashes && !baselineHashes.has(node.hash));
+          const lookupKeys = lookup && isTrace
+            ? lookup.kind === 'range'
+              ? rangeKeysForNode(node, lookup.start, lookup.end)
+              : node.level === 0 && lookup.found
+                ? [lookup.key]
+                : node.level > 0
+                  ? [routeKeyForLookup(node, lookup.key)].filter((key): key is number => key !== undefined)
+                  : []
+            : [];
+          const keyParts = lookup?.kind === 'key' && !lookup.found && node.level === 0 && isTrace
+            ? missingKeyLabel(node, lookup.key)
+            : shownKeys(node, lookupKeys);
+          const className = [
+            'tree-node',
+            node.level === 0 ? 'leaf-node' : 'internal-node',
+            isNew ? 'node-new' : '',
+            isTrace ? 'node-trace' : '',
+            isDiff ? 'node-diff' : '',
+            isSkipped ? 'node-skip' : '',
+            isActiveSkipped ? 'node-skip-active' : '',
+            selectedHash === node.hash ? 'node-selected' : '',
+          ].filter(Boolean).join(' ');
+          return (
+            <g
+              key={node.hash}
+              className={className}
+              transform={`translate(${x} ${y})`}
+              tabIndex={0}
+              role="button"
+              aria-label={`${node.level === 0 ? 'Leaf' : `Level ${node.level}`} node ${node.hash}`}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => onSelect(node.hash)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') onSelect(node.hash);
+              }}
+            >
+              <rect width={NODE_WIDTH} height={NODE_HEIGHT} rx="14" />
+              <text className="node-kind" x="15" y="24">
+                {isSkipped ? 'SHARED · SKIP' : node.level === 0 ? 'LEAF CHUNK' : `INTERNAL · LEVEL ${node.level}`}
+              </text>
+              <text className="node-count" x={NODE_WIDTH - 15} y="24" textAnchor="end">
+                {node.entries.length} {node.entries.length === 1 ? 'entry' : 'entries'}
+              </text>
+              <line x1="14" x2={NODE_WIDTH - 14} y1="36" y2="36" />
+              <text className={nodeRowDiffs.length ? 'node-keys node-row-change' : 'node-keys'} x="15" y="61">
+                {nodeRowDiffs.length ? shownChanges(nodeRowDiffs) : keyParts.map((part, index) => (
+                  <tspan key={`${part.text}-${index}`} className={part.match ? isActiveTrace ? 'node-key-match' : 'node-key-route' : part.missing ? isActiveTrace ? 'node-key-missing' : 'node-key-missing-static' : undefined}>{index > 0 ? '  ·  ' : ''}{part.text}</tspan>
+                ))}
+              </text>
+              <text className="node-range" x="15" y="84">
+                {node.size.toLocaleString()} bytes
+              </text>
+              <text className={activeDiffHashes?.has(node.hash) ? 'node-hash node-hash-active' : isActiveSkipped ? 'node-hash node-hash-skip-active' : 'node-hash'} x="15" y="108">{node.hash}</text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/3rd/prolly-tree-visualizer/src/diffTraversal.test.ts
+++ b/3rd/prolly-tree-visualizer/src/diffTraversal.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { buildDiffTraversal } from './diffTraversal';
+import type { ProllyNode, TreeSnapshot } from './types';
+
+function leaf(hash: string, keys: number[]): ProllyNode {
+  return {
+    hash,
+    level: 0,
+    size: 100,
+    flags: 0,
+    entries: keys.map((key) => ({ key, keyHex: '', valueHex: '' })),
+    children: [],
+    minKey: keys[0],
+    maxKey: keys.at(-1) ?? null,
+  };
+}
+
+function snapshot(id: number, root: ProllyNode): TreeSnapshot {
+  const nodes = new Map<string, ProllyNode>();
+  const visit = (node: ProllyNode) => {
+    nodes.set(node.hash, node);
+    node.children.forEach(visit);
+  };
+  visit(root);
+  const rows = [...nodes.values()].filter((node) => node.level === 0).flatMap((node) => node.entries.map((entry) => ({ key: Number(entry.key), value: `v${entry.key}` })));
+  return { id, label: '', rootHash: root.hash, root, rows, nodes, chunksInStore: nodes.size, databaseBytes: 0, timestamp: 0 };
+}
+
+function root(hash: string, children: ProllyNode[]): ProllyNode {
+  return {
+    hash,
+    level: 1,
+    size: 100,
+    flags: 0,
+    entries: children.map((child) => ({ key: Number(child.maxKey), keyHex: '', valueHex: '', childHash: child.hash })),
+    children,
+    minKey: children[0].minKey,
+    maxKey: children.at(-1)?.maxKey ?? null,
+  };
+}
+
+describe('buildDiffTraversal', () => {
+  it('stops at shared children and counts their rows', () => {
+    const shared = leaf('shared', [1, 2, 3]);
+    const before = snapshot(1, root('before-root', [shared, leaf('old', [4])]));
+    const after = snapshot(2, root('after-root', [shared, leaf('new', [4])]));
+    const frames = buildDiffTraversal(after, before, [{ key: 4, before: 'old', after: 'new', kind: 'modified' }]);
+
+    expect(frames.at(-1)).toMatchObject({
+      addressesChecked: 3,
+      nodesVisited: 2,
+      skippedSubtrees: 1,
+      skippedRows: 3,
+      revealedRows: true,
+    });
+    expect(frames[1].activeSkippedHashes).toEqual(['shared']);
+  });
+
+  it('skips the whole tree when root addresses match', () => {
+    const tree = snapshot(1, leaf('same', [1, 2]));
+    expect(buildDiffTraversal(tree, tree, [])).toEqual([expect.objectContaining({
+      addressesChecked: 1,
+      nodesVisited: 0,
+      skippedSubtrees: 1,
+      skippedRows: 2,
+      revealedRows: true,
+    })]);
+  });
+});

--- a/3rd/prolly-tree-visualizer/src/diffTraversal.ts
+++ b/3rd/prolly-tree-visualizer/src/diffTraversal.ts
@@ -1,0 +1,111 @@
+import type { ProllyNode, RowDiff, TreeSnapshot } from './types';
+
+export interface DiffTraversalFrame {
+  message: string;
+  changedHashes: string[];
+  skippedHashes: string[];
+  activeChangedHashes: string[];
+  activeSkippedHashes: string[];
+  addressesChecked: number;
+  nodesVisited: number;
+  skippedSubtrees: number;
+  skippedRows: number;
+  revealedRows: boolean;
+}
+
+function rowCount(node: ProllyNode): number {
+  return node.level === 0
+    ? node.entries.length
+    : node.children.reduce((total, child) => total + rowCount(child), 0);
+}
+
+export function buildDiffTraversal(current: TreeSnapshot, baseline: TreeSnapshot, rowDiffs: RowDiff[]) {
+  if (current.rootHash === baseline.rootHash) {
+    return [{
+      message: 'Root addresses match · entire tree skipped',
+      changedHashes: [],
+      skippedHashes: [current.rootHash],
+      activeChangedHashes: [],
+      activeSkippedHashes: [current.rootHash],
+      addressesChecked: 1,
+      nodesVisited: 0,
+      skippedSubtrees: 1,
+      skippedRows: current.rows.length,
+      revealedRows: true,
+    } satisfies DiffTraversalFrame];
+  }
+
+  const changed = new Set<string>([current.rootHash]);
+  const skipped = new Set<string>();
+  let addressesChecked = 1;
+  let nodesVisited = 1;
+  let skippedRows = 0;
+  let frontier = [current.root];
+  const frames: DiffTraversalFrame[] = [{
+    message: 'Root addresses differ · opening the new root',
+    changedHashes: [...changed],
+    skippedHashes: [],
+    activeChangedHashes: [current.rootHash],
+    activeSkippedHashes: [],
+    addressesChecked,
+    nodesVisited,
+    skippedSubtrees: 0,
+    skippedRows,
+    revealedRows: false,
+  }];
+
+  while (frontier.some((node) => node.children.length > 0)) {
+    const children = frontier.flatMap((node) => node.children);
+    const nextChanged: ProllyNode[] = [];
+    const nextSkipped: ProllyNode[] = [];
+    for (const child of children) {
+      addressesChecked += 1;
+      if (baseline.nodes.has(child.hash)) {
+        skipped.add(child.hash);
+        nextSkipped.push(child);
+        skippedRows += rowCount(child);
+      } else {
+        changed.add(child.hash);
+        nextChanged.push(child);
+        nodesVisited += 1;
+      }
+    }
+    const descent = nextChanged.length === 0
+      ? 'no changed children to open'
+      : `opening ${nextChanged.length} changed ${nextChanged.length === 1 ? 'child' : 'children'}`;
+    const avoided = nextSkipped.length === 0
+      ? ''
+      : ` · skipped ${nextSkipped.length} shared ${nextSkipped.length === 1 ? 'subtree' : 'subtrees'}`;
+    frames.push({
+      message: `${descent}${avoided}`,
+      changedHashes: [...changed],
+      skippedHashes: [...skipped],
+      activeChangedHashes: nextChanged.map((node) => node.hash),
+      activeSkippedHashes: nextSkipped.map((node) => node.hash),
+      addressesChecked,
+      nodesVisited,
+      skippedSubtrees: skipped.size,
+      skippedRows,
+      revealedRows: false,
+    });
+    frontier = nextChanged;
+    if (frontier.length === 0) break;
+  }
+
+  const changedLeaves = [...changed].filter((hash) => current.nodes.get(hash)?.level === 0);
+  frames.push({
+    message: rowDiffs.length === 0
+      ? 'Leaf comparison complete · rows are equal'
+      : `${rowDiffs.length} row ${rowDiffs.length === 1 ? 'difference' : 'differences'} emitted`,
+    changedHashes: [...changed],
+    skippedHashes: [...skipped],
+    activeChangedHashes: changedLeaves,
+    activeSkippedHashes: [],
+    addressesChecked,
+    nodesVisited,
+    skippedSubtrees: skipped.size,
+    skippedRows,
+    revealedRows: true,
+  });
+  return frames;
+}

--- a/3rd/prolly-tree-visualizer/src/engine.ts
+++ b/3rd/prolly-tree-visualizer/src/engine.ts
@@ -1,0 +1,345 @@
+import {
+  loadProllyWasm,
+  type ProllyWasmModule,
+  type WasmEntryRecord,
+  type WasmProllyEngineInstance,
+  type WasmTree,
+  type WasmTreeDebugViewRecord,
+} from '@trail/prolly-wasm';
+import { bootstrapKeys, deterministicShuffle } from './bootstrap';
+import { buildTreeFromDebug, leafNodes, toHex } from './prolly';
+import type { RowValue, TreeSnapshot } from './types';
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+function decodeI64Key(bytes: Uint8Array) {
+  let encoded = 0n;
+  for (const byte of bytes) encoded = (encoded << 8n) | BigInt(byte);
+  const decoded = BigInt.asIntN(64, encoded ^ (1n << 63n));
+  const number = Number(decoded);
+  if (!Number.isSafeInteger(number)) throw new Error(`integer key ${decoded} is outside JavaScript's safe range`);
+  return number;
+}
+
+function rowsFromEntries(entries: WasmEntryRecord[]): RowValue[] {
+  return entries.map((entry) => ({
+    key: decodeI64Key(entry.key),
+    value: textDecoder.decode(entry.value),
+  }));
+}
+
+function sumSizes(sizes: Map<string, number>) {
+  let total = 0;
+  for (const size of sizes.values()) total += size;
+  return total;
+}
+
+export interface GrowthResult {
+  before: TreeSnapshot;
+  after: TreeSnapshot;
+  added: number;
+}
+
+export interface GarbageCollectionResult {
+  head: TreeSnapshot;
+  message: string;
+  beforeChunks: number;
+  afterChunks: number;
+  beforeBytes: number;
+  afterBytes: number;
+}
+
+export interface InsertionOrderBuild {
+  order: number[];
+  updates: number[];
+  rootHash: string;
+  nodeHashes: string[];
+  snapshot: TreeSnapshot;
+}
+
+export interface InsertionOrderSource {
+  rootHash: string;
+  nodeHashes: string[];
+  snapshot: TreeSnapshot;
+}
+
+export interface InsertionOrderResult {
+  current: InsertionOrderSource;
+  rebuilt: InsertionOrderBuild;
+  identicalRoot: boolean;
+  identicalChunks: boolean;
+  rowCount: number;
+}
+
+export class ProllyEngine {
+  private readonly wasm: ProllyWasmModule;
+  private runtime: WasmProllyEngineInstance;
+  private tree: WasmTree;
+  private snapshotId = 0;
+  private storedNodeSizes = new Map<string, number>();
+  readonly version = '@trail/prolly-wasm 0.1.0';
+
+  private constructor(wasm: ProllyWasmModule) {
+    this.wasm = wasm;
+    this.runtime = wasm.WasmProllyEngine.memory();
+    this.tree = this.runtime.create();
+  }
+
+  static async create() {
+    return new ProllyEngine(await loadProllyWasm());
+  }
+
+  private key(key: number) {
+    if (!Number.isSafeInteger(key)) throw new Error('keys must be safe integers');
+    return this.wasm.i64Key(String(key));
+  }
+
+  private entry(row: RowValue) {
+    return { key: this.key(row.key), value: textEncoder.encode(row.value) };
+  }
+
+  private rows(runtime = this.runtime, tree = this.tree): RowValue[] {
+    return rowsFromEntries(runtime.range(tree, new Uint8Array()));
+  }
+
+  private replaceTree(next: WasmTree) {
+    this.tree.free();
+    this.tree = next;
+  }
+
+  private replaceRuntime(runtime: WasmProllyEngineInstance, tree: WasmTree) {
+    this.tree.free();
+    this.runtime.free();
+    this.runtime = runtime;
+    this.tree = tree;
+  }
+
+  private snapshotFrom(
+    runtime: WasmProllyEngineInstance,
+    tree: WasmTree,
+    rows: RowValue[],
+    label: string,
+    id: number,
+    storedNodeSizes?: Map<string, number>,
+  ): TreeSnapshot {
+    const debug = runtime.debugTree(tree) as WasmTreeDebugViewRecord;
+    const { root, nodes } = buildTreeFromDebug(debug, rows);
+    const rootBytes = tree.root as Uint8Array | number[] | null;
+    if (!rootBytes) throw new Error('the prolly tree is empty');
+    const rootHash = toHex(rootBytes);
+    if (root.hash !== rootHash) throw new Error('debug tree root does not match the engine root');
+
+    const physicalSizes = storedNodeSizes ?? new Map<string, number>();
+    for (const [hash, node] of nodes) physicalSizes.set(hash, node.size);
+    return {
+      id,
+      label,
+      rootHash,
+      root,
+      rows,
+      nodes,
+      chunksInStore: physicalSizes.size,
+      databaseBytes: sumSizes(physicalSizes),
+      timestamp: Date.now(),
+    };
+  }
+
+  seed(count = 240) {
+    const rows = bootstrapKeys(count).map((key) => ({ key, value: `value-${key}` }));
+    this.replaceTree(this.runtime.buildFromSortedEntries(rows.map((row) => this.entry(row))));
+    return this.capture(`Built ${rows.length} sparse rows`);
+  }
+
+  capture(label: string): TreeSnapshot {
+    return this.snapshotFrom(
+      this.runtime,
+      this.tree,
+      this.rows(),
+      label,
+      this.snapshotId++,
+      this.storedNodeSizes,
+    );
+  }
+
+  put(key: number, value: string) {
+    const encodedKey = this.key(key);
+    const exists = this.runtime.get(this.tree, encodedKey) !== null;
+    this.replaceTree(this.runtime.put(this.tree, encodedKey, textEncoder.encode(value)));
+    return this.capture(`${exists ? 'Updated' : 'Inserted'} key ${key}`);
+  }
+
+  remove(key: number) {
+    this.replaceTree(this.runtime.delete(this.tree, this.key(key)));
+    return this.capture(`Deleted key ${key}`);
+  }
+
+  addSequential(count: number) {
+    const rows = this.rows();
+    const first = (rows.at(-1)?.key ?? 0) + 1;
+    this.insertSequential(first, count, 'value');
+    return this.capture(`Appended ${count} sequential rows`);
+  }
+
+  private insertSequential(first: number, count: number, prefix: string) {
+    const amount = Math.max(1, Math.trunc(count));
+    const mutations = Array.from({ length: amount }, (_, index) => {
+      const key = first + index;
+      return { kind: 'upsert', key: this.key(key), value: textEncoder.encode(`${prefix}-${key}`) };
+    });
+    this.replaceTree(this.runtime.appendBatch(this.tree, mutations));
+  }
+
+  addRandom() {
+    const rows = this.rows();
+    if (rows.length > 0 && Math.random() < 0.5) {
+      const row = rows[Math.floor(Math.random() * rows.length)];
+      return this.put(row.key, `random-update-${row.key}-${this.snapshotId}`);
+    }
+    const maxKey = rows.at(-1)?.key ?? 0;
+    const key = maxKey + Math.floor(Math.random() * Math.max(160, maxKey)) + 1;
+    return this.put(key, `random-${key}`);
+  }
+
+  growUntilSplit(limit = 512, batchSize = 16): GrowthResult {
+    const before = this.capture('Before split search');
+    const leafCount = leafNodes(before.root).length;
+    let next = (before.rows.at(-1)?.key ?? 0) + 1;
+    let candidate = before;
+    for (let added = 0; added < limit;) {
+      const amount = Math.min(batchSize, limit - added);
+      this.insertSequential(next, amount, 'split');
+      added += amount;
+      next += amount;
+      candidate = this.capture(`Split after appending ${added} rows`);
+      if (leafNodes(candidate.root).length > leafCount) return { before, after: candidate, added };
+    }
+    candidate.label = `No split after ${limit} inserts`;
+    return { before, after: candidate, added: limit };
+  }
+
+  growUntilNextLevel(): GrowthResult {
+    const before = this.capture('Before level growth');
+    const rootLevel = before.root.level;
+    if (rootLevel >= 2) throw new Error('Four-level trees exceed the full-node browser rendering limit');
+    const limit = rootLevel === 0 ? 2_048 : 48_000;
+    const batchSize = rootLevel === 0 ? 256 : 2_000;
+    let next = (before.rows.at(-1)?.key ?? 0) + 1;
+    let candidate = before;
+    for (let added = 0; added < limit;) {
+      const amount = Math.min(batchSize, limit - added);
+      this.insertSequential(next, amount, 'level');
+      added += amount;
+      next += amount;
+      candidate = this.capture(`Reached level ${rootLevel + 1} after appending ${added} rows`);
+      if (candidate.root.level > rootLevel) return { before, after: candidate, added };
+    }
+    candidate.label = `No new level after ${limit} inserts`;
+    return { before, after: candidate, added: limit };
+  }
+
+  garbageCollect(): GarbageCollectionResult {
+    const beforeChunks = this.storedNodeSizes.size;
+    const beforeBytes = sumSizes(this.storedNodeSizes);
+    const rows = this.rows();
+    const previousRoot = toHex(this.tree.root as Uint8Array | number[]);
+    const replacementRuntime = this.wasm.WasmProllyEngine.memory();
+    const empty = replacementRuntime.create();
+    const replacementTree = replacementRuntime.buildFromSortedEntries(rows.map((row) => this.entry(row)));
+    empty.free();
+    const replacementRoot = toHex(replacementTree.root as Uint8Array | number[]);
+    if (replacementRoot !== previousRoot) {
+      replacementTree.free();
+      replacementRuntime.free();
+      throw new Error('HEAD root changed during garbage collection');
+    }
+
+    this.replaceRuntime(replacementRuntime, replacementTree);
+    this.storedNodeSizes = new Map();
+    const head = this.capture('Garbage collected');
+    return {
+      head,
+      message: `${Math.max(0, beforeChunks - head.chunksInStore)} chunks removed, ${head.chunksInStore} chunks kept`,
+      beforeChunks,
+      afterChunks: head.chunksInStore,
+      beforeBytes,
+      afterBytes: head.databaseBytes,
+    };
+  }
+
+  reset(count = 240) {
+    const runtime = this.wasm.WasmProllyEngine.memory();
+    const tree = runtime.create();
+    this.replaceRuntime(runtime, tree);
+    this.snapshotId = 0;
+    this.storedNodeSizes = new Map();
+    return this.seed(count);
+  }
+
+  compareInsertionOrder(snapshot: TreeSnapshot): InsertionOrderResult {
+    const rows = snapshot.rows;
+    const build = (ordered: RowValue[], draftKeys = new Set<number>()): InsertionOrderBuild => {
+      const runtime = this.wasm.WasmProllyEngine.memory();
+      let tree = runtime.create();
+      const pending: RowValue[] = [];
+      const updates: number[] = [];
+      try {
+        for (let index = 0; index < ordered.length; index += 1) {
+          const row = ordered[index];
+          const draft = draftKeys.has(row.key);
+          const next = runtime.put(tree, this.key(row.key), textEncoder.encode(draft ? `draft-${row.key}` : row.value));
+          tree.free();
+          tree = next;
+          if (draft) pending.push(row);
+          if (index % 5 === 4 && pending.length > 0) {
+            const update = pending.shift()!;
+            const updated = runtime.put(tree, this.key(update.key), textEncoder.encode(update.value));
+            tree.free();
+            tree = updated;
+            updates.push(update.key);
+          }
+        }
+        for (const update of pending) {
+          const updated = runtime.put(tree, this.key(update.key), textEncoder.encode(update.value));
+          tree.free();
+          tree = updated;
+          updates.push(update.key);
+        }
+        const finalRows = rowsFromEntries(runtime.range(tree, new Uint8Array()));
+        const rebuiltSnapshot = this.snapshotFrom(runtime, tree, finalRows, 'History independence build', -1);
+        return {
+          order: ordered.map((row) => row.key),
+          updates,
+          rootHash: rebuiltSnapshot.rootHash,
+          nodeHashes: [...rebuiltSnapshot.nodes.keys()].sort(),
+          snapshot: rebuiltSnapshot,
+        };
+      } finally {
+        tree.free();
+        runtime.free();
+      }
+    };
+
+    const current: InsertionOrderSource = {
+      rootHash: snapshot.rootHash,
+      nodeHashes: [...snapshot.nodes.keys()].sort(),
+      snapshot,
+    };
+    const shuffledRows = deterministicShuffle(rows);
+    const draftKeys = new Set(shuffledRows.filter((_, index) => index % 6 === 0).map((row) => row.key));
+    const rebuilt = build(shuffledRows, draftKeys);
+    return {
+      current,
+      rebuilt,
+      identicalRoot: current.rootHash === rebuilt.rootHash,
+      identicalChunks: current.nodeHashes.length === rebuilt.nodeHashes.length
+        && current.nodeHashes.every((hash, index) => hash === rebuilt.nodeHashes[index]),
+      rowCount: rows.length,
+    };
+  }
+
+  close() {
+    this.tree.free();
+    this.runtime.free();
+  }
+}

--- a/3rd/prolly-tree-visualizer/src/main.tsx
+++ b/3rd/prolly-tree-visualizer/src/main.tsx
@@ -1,0 +1,5 @@
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/3rd/prolly-tree-visualizer/src/mutationCost.test.ts
+++ b/3rd/prolly-tree-visualizer/src/mutationCost.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { calculateMutationCost } from './mutationCost';
+import type { ProllyNode, RowDiff } from './types';
+
+function nodes(entries: [string, number, number][]) {
+  return new Map(entries.map(([hash, level, size]) => [hash, { level, size } as ProllyNode]));
+}
+
+describe('calculateMutationCost', () => {
+  it('separates rewritten leaves and ancestors', () => {
+    const previous = { nodes: nodes([['root-old', 1, 140], ['leaf-old', 0, 900], ['leaf-shared', 0, 700]]) };
+    const current = { nodes: nodes([['root-new', 1, 150], ['leaf-new', 0, 960], ['leaf-shared', 0, 700]]) };
+    const rows: RowDiff[] = [{ key: 42, after: 'new-value', kind: 'modified' }];
+
+    expect(calculateMutationCost(current, previous, rows)).toEqual({
+      rowChanges: 1,
+      mutationBytes: 17,
+      leafHashes: ['leaf-new'],
+      leafBytes: 960,
+      internalHashes: ['root-new'],
+      internalBytes: 150,
+      changedHashes: ['root-new', 'leaf-new'],
+      changedBytes: 1110,
+      sharedNodes: 1,
+      retiredNodes: 2,
+      amplification: 1110 / 17,
+    });
+  });
+
+  it('reports no amplification for a no-op', () => {
+    const version = { nodes: nodes([['root', 0, 200]]) };
+    expect(calculateMutationCost(version, version, [])).toMatchObject({
+      rowChanges: 0,
+      mutationBytes: 0,
+      changedBytes: 0,
+      amplification: undefined,
+    });
+  });
+});

--- a/3rd/prolly-tree-visualizer/src/mutationCost.ts
+++ b/3rd/prolly-tree-visualizer/src/mutationCost.ts
@@ -1,0 +1,45 @@
+import type { ProllyNode, RowDiff } from './types';
+
+interface CostVersion {
+  nodes: Map<string, Pick<ProllyNode, 'level' | 'size'>>;
+}
+
+export interface MutationCost {
+  rowChanges: number;
+  mutationBytes: number;
+  leafHashes: string[];
+  leafBytes: number;
+  internalHashes: string[];
+  internalBytes: number;
+  changedHashes: string[];
+  changedBytes: number;
+  sharedNodes: number;
+  retiredNodes: number;
+  amplification?: number;
+}
+
+function valueBytes(value?: string) {
+  return value === undefined ? 0 : new TextEncoder().encode(value).length;
+}
+
+export function calculateMutationCost(current: CostVersion, previous: CostVersion, rowDiffs: RowDiff[]): MutationCost {
+  const changed = [...current.nodes].filter(([hash]) => !previous.nodes.has(hash));
+  const leaf = changed.filter(([, node]) => node.level === 0);
+  const internal = changed.filter(([, node]) => node.level > 0);
+  const mutationBytes = rowDiffs.reduce((total, row) => total + 8 + (row.kind === 'deleted' ? 0 : valueBytes(row.after)), 0);
+  const changedBytes = changed.reduce((total, [, node]) => total + node.size, 0);
+  const sharedNodes = [...current.nodes.keys()].filter((hash) => previous.nodes.has(hash)).length;
+  return {
+    rowChanges: rowDiffs.length,
+    mutationBytes,
+    leafHashes: leaf.map(([hash]) => hash),
+    leafBytes: leaf.reduce((total, [, node]) => total + node.size, 0),
+    internalHashes: internal.map(([hash]) => hash),
+    internalBytes: internal.reduce((total, [, node]) => total + node.size, 0),
+    changedHashes: changed.map(([hash]) => hash),
+    changedBytes,
+    sharedNodes,
+    retiredNodes: [...previous.nodes.keys()].filter((hash) => !current.nodes.has(hash)).length,
+    amplification: mutationBytes === 0 ? undefined : changedBytes / mutationBytes,
+  };
+}

--- a/3rd/prolly-tree-visualizer/src/prolly.test.ts
+++ b/3rd/prolly-tree-visualizer/src/prolly.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import type { WasmTreeDebugViewRecord } from '@trail/prolly-wasm';
+import {
+  buildTreeFromDebug,
+  diffRows,
+  estimateMutationSplitProbability,
+  groupRowDiffsByLeaf,
+  traceRange,
+  traceSearch,
+} from './prolly';
+
+function intKey(value: number) {
+  let encoded = BigInt.asUintN(64, BigInt(value)) ^ (1n << 63n);
+  const bytes = new Uint8Array(8);
+  for (let index = 7; index >= 0; index -= 1) {
+    bytes[index] = Number(encoded & 0xffn);
+    encoded >>= 8n;
+  }
+  return bytes;
+}
+
+function cid(byte: number) {
+  return Uint8Array.from({ length: 32 }, () => byte);
+}
+
+function debugTree(): WasmTreeDebugViewRecord {
+  return {
+    levels: [
+      {
+        level: 1,
+        nodes: [{
+          cid: cid(3),
+          leaf: false,
+          level: 1,
+          entry_count: 2,
+          max_entries: 1_048_576,
+          fill_factor: 2 / 1_048_576,
+          encoded_bytes: 100,
+          first_key: intKey(1),
+          last_key: intKey(7),
+        }],
+      },
+      {
+        level: 0,
+        nodes: [
+          {
+            cid: cid(1),
+            leaf: true,
+            level: 0,
+            entry_count: 2,
+            max_entries: 1_048_576,
+            fill_factor: 2 / 1_048_576,
+            encoded_bytes: 80,
+            first_key: intKey(1),
+            last_key: intKey(3),
+          },
+          {
+            cid: cid(2),
+            leaf: true,
+            level: 0,
+            entry_count: 2,
+            max_entries: 1_048_576,
+            fill_factor: 2 / 1_048_576,
+            encoded_bytes: 80,
+            first_key: intKey(7),
+            last_key: intKey(9),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const rows = [1, 3, 7, 9].map((key) => ({ key, value: `value-${key}` }));
+
+describe('prolly WASM debug adapter', () => {
+  it('builds child links and lower-bound lookup paths', () => {
+    const tree = buildTreeFromDebug(debugTree(), rows);
+    const rootHash = '03'.repeat(32);
+    const leftHash = '01'.repeat(32);
+    const rightHash = '02'.repeat(32);
+
+    expect(tree.root.hash).toBe(rootHash);
+    expect(tree.root.children).toHaveLength(2);
+    expect(tree.root.entries.map((entry) => entry.key)).toEqual([1, 7]);
+    expect(traceSearch(tree.root, 2)).toEqual([rootHash, leftHash]);
+    expect(traceSearch(tree.root, 8)).toEqual([rootHash, rightHash]);
+    expect(traceRange(tree.root, 2, 8)).toEqual([rootHash, leftHash, rightHash]);
+    expect(traceRange(tree.root, 7, 8)).toEqual([rootHash, rightHash]);
+  });
+
+  it('rejects debug metadata that does not match the returned rows', () => {
+    expect(() => buildTreeFromDebug(debugTree(), rows.slice(0, 3))).toThrow('reports 2 entries');
+  });
+});
+
+describe('row diff', () => {
+  it('classifies additions, edits, and deletes', () => {
+    expect(diffRows(
+      [{ key: 1, value: 'old' }, { key: 2, value: 'gone' }],
+      [{ key: 1, value: 'new' }, { key: 3, value: 'added' }],
+    )).toEqual([
+      { key: 1, before: 'old', after: 'new', kind: 'modified' },
+      { key: 2, before: 'gone', kind: 'deleted' },
+      { key: 3, after: 'added', kind: 'added' },
+    ]);
+  });
+
+  it('maps changed rows to their current leaf', () => {
+    const tree = buildTreeFromDebug(debugTree(), rows);
+    const diffs = [
+      { key: 2, after: 'added', kind: 'added' as const },
+      { key: 7, before: 'old', after: 'new', kind: 'modified' as const },
+      { key: 8, before: 'gone', kind: 'deleted' as const },
+    ];
+
+    expect(groupRowDiffsByLeaf(tree.root, diffs)).toEqual(new Map([
+      ['01'.repeat(32), [diffs[0]]],
+      ['02'.repeat(32), [diffs[1], diffs[2]]],
+    ]));
+  });
+});
+
+describe('split probability', () => {
+  it('uses prolly-map default hash-threshold chunking', () => {
+    const tree = buildTreeFromDebug(debugTree(), rows);
+    expect(estimateMutationSplitProbability(tree.root.children[0])).toBe(0);
+    tree.root.children[0].entries.push({ key: 4, keyHex: '', valueHex: '' });
+    expect(estimateMutationSplitProbability(tree.root.children[0])).toBe(1 / 128);
+  });
+});

--- a/3rd/prolly-tree-visualizer/src/prolly.ts
+++ b/3rd/prolly-tree-visualizer/src/prolly.ts
@@ -1,0 +1,208 @@
+import type { WasmTreeDebugNodeRecord, WasmTreeDebugViewRecord } from '@trail/prolly-wasm';
+import type { ProllyEntry, ProllyNode, RowDiff, RowValue } from './types';
+
+const DEFAULT_MIN_CHUNK_ENTRIES = 4;
+const DEFAULT_BOUNDARY_FACTOR = 128;
+
+type Bytes = Uint8Array | number[];
+
+function asBytes(value: Bytes) {
+  return value instanceof Uint8Array ? value : Uint8Array.from(value);
+}
+
+export function toHex(value: Bytes) {
+  return [...asBytes(value)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function decodeI64Key(value: Bytes) {
+  let encoded = 0n;
+  for (const byte of asBytes(value)) encoded = (encoded << 8n) | BigInt(byte);
+  const decoded = BigInt.asIntN(64, encoded ^ (1n << 63n));
+  const number = Number(decoded);
+  return Number.isSafeInteger(number) ? number : decoded.toString();
+}
+
+function encodeI64KeyHex(value: number) {
+  let encoded = BigInt.asUintN(64, BigInt(value)) ^ (1n << 63n);
+  const bytes = new Uint8Array(8);
+  for (let index = bytes.length - 1; index >= 0; index -= 1) {
+    bytes[index] = Number(encoded & 0xffn);
+    encoded >>= 8n;
+  }
+  return toHex(bytes);
+}
+
+function debugHash(node: WasmTreeDebugNodeRecord) {
+  return toHex(node.cid as unknown as Bytes);
+}
+
+function debugKey(value: Uint8Array | number[] | null | undefined) {
+  return value == null ? null : decodeI64Key(value);
+}
+
+function valueHex(value: string) {
+  return toHex(new TextEncoder().encode(value));
+}
+
+function leafFromDebug(node: WasmTreeDebugNodeRecord, rows: RowValue[]): ProllyNode {
+  const minKey = debugKey(node.first_key as Uint8Array | number[] | null | undefined);
+  const maxKey = debugKey(node.last_key as Uint8Array | number[] | null | undefined);
+  const entries = rows
+    .filter((row) => Number(minKey) <= row.key && row.key <= Number(maxKey))
+    .map((row): ProllyEntry => ({
+      key: row.key,
+      keyHex: encodeI64KeyHex(row.key),
+      valueHex: valueHex(row.value),
+    }));
+  if (entries.length !== node.entry_count) {
+    throw new Error(`leaf ${debugHash(node)} reports ${node.entry_count} entries but exposes ${entries.length} rows`);
+  }
+  return {
+    hash: debugHash(node),
+    level: node.level,
+    size: node.encoded_bytes,
+    flags: 0,
+    entries,
+    children: [],
+    minKey,
+    maxKey,
+  };
+}
+
+/**
+ * Reconstruct the renderable hierarchy from the Rust engine's debug view.
+ *
+ * Debug levels are emitted in deterministic breadth-first order. Internal
+ * entries are lower-bound separators, so each parent's next `entry_count`
+ * nodes in the following level are its direct children.
+ */
+export function buildTreeFromDebug(view: WasmTreeDebugViewRecord, rows: RowValue[]) {
+  if (view.levels.length === 0) throw new Error('cannot visualize an empty prolly tree');
+  const metadataByLevel = new Map(view.levels.map((level) => [level.level, level.nodes]));
+  const nodesByLevel = new Map<number, ProllyNode[]>();
+  const leafMetadata = metadataByLevel.get(0);
+  if (!leafMetadata) throw new Error('prolly debug view has no leaf level');
+  nodesByLevel.set(0, leafMetadata.map((node) => leafFromDebug(node, rows)));
+
+  const rootLevel = Math.max(...view.levels.map((level) => level.level));
+  for (let level = 1; level <= rootLevel; level += 1) {
+    const metadata = metadataByLevel.get(level);
+    const children = nodesByLevel.get(level - 1);
+    if (!metadata || !children) throw new Error(`prolly debug view is missing level ${level}`);
+    let childCursor = 0;
+    const parents = metadata.map((node): ProllyNode => {
+      const directChildren = children.slice(childCursor, childCursor + node.entry_count);
+      childCursor += node.entry_count;
+      if (directChildren.length !== node.entry_count) {
+        throw new Error(`internal node ${debugHash(node)} references missing children`);
+      }
+      const entries = directChildren.map((child): ProllyEntry => ({
+        key: child.minKey ?? '',
+        keyHex: typeof child.minKey === 'number' ? encodeI64KeyHex(child.minKey) : '',
+        valueHex: child.hash,
+        childHash: child.hash,
+        subtreeCount: leafNodes(child).reduce((total, leaf) => total + leaf.entries.length, 0),
+      }));
+      const reportedFirst = debugKey(node.first_key as Uint8Array | number[] | null | undefined);
+      const reportedLast = debugKey(node.last_key as Uint8Array | number[] | null | undefined);
+      if (entries[0]?.key !== reportedFirst || entries.at(-1)?.key !== reportedLast) {
+        throw new Error(`internal node ${debugHash(node)} separators do not match its children`);
+      }
+      return {
+        hash: debugHash(node),
+        level: node.level,
+        size: node.encoded_bytes,
+        flags: 0,
+        entries,
+        children: directChildren,
+        minKey: directChildren[0]?.minKey ?? null,
+        maxKey: directChildren.at(-1)?.maxKey ?? null,
+      };
+    });
+    if (childCursor !== children.length) throw new Error(`level ${level} leaves ${children.length - childCursor} children unclaimed`);
+    nodesByLevel.set(level, parents);
+  }
+
+  const roots = nodesByLevel.get(rootLevel)!;
+  if (roots.length !== 1) throw new Error(`prolly debug view has ${roots.length} roots`);
+  const nodes = new Map<string, ProllyNode>();
+  for (const levelNodes of nodesByLevel.values()) {
+    for (const node of levelNodes) nodes.set(node.hash, node);
+  }
+  return { root: roots[0], nodes };
+}
+
+export function traceSearch(root: ProllyNode, key: number) {
+  const trace: string[] = [];
+  let node: ProllyNode | undefined = root;
+  while (node) {
+    trace.push(node.hash);
+    if (node.level === 0) break;
+    let index = node.entries.findLastIndex((entry) => Number(entry.key) <= key);
+    if (index < 0) index = 0;
+    node = node.children[index];
+  }
+  return trace;
+}
+
+export function traceRange(root: ProllyNode, start: number, end: number) {
+  const low = Math.min(start, end);
+  const high = Math.max(start, end);
+  const trace: string[] = [];
+  const visit = (node: ProllyNode) => {
+    const min = Number(node.minKey);
+    const max = Number(node.maxKey);
+    if (!Number.isFinite(min) || !Number.isFinite(max) || max < low || min > high) return;
+    trace.push(node.hash);
+    node.children.forEach(visit);
+  };
+  visit(root);
+  return trace;
+}
+
+export function diffRows(before: RowValue[], after: RowValue[]): RowDiff[] {
+  const left = new Map(before.map((row) => [row.key, row.value]));
+  const right = new Map(after.map((row) => [row.key, row.value]));
+  const keys = [...new Set([...left.keys(), ...right.keys()])].sort((a, b) => a - b);
+  return keys.flatMap((key): RowDiff[] => {
+    const oldValue = left.get(key);
+    const newValue = right.get(key);
+    if (oldValue === newValue) return [];
+    if (oldValue === undefined) return [{ key, after: newValue, kind: 'added' }];
+    if (newValue === undefined) return [{ key, before: oldValue, kind: 'deleted' }];
+    return [{ key, before: oldValue, after: newValue, kind: 'modified' }];
+  });
+}
+
+export function groupRowDiffsByLeaf(root: ProllyNode, diffs: RowDiff[]) {
+  const grouped = new Map<string, RowDiff[]>();
+  for (const diff of diffs) {
+    const leafHash = traceSearch(root, diff.key).at(-1);
+    if (!leafHash) continue;
+    const existing = grouped.get(leafHash);
+    if (existing) existing.push(diff);
+    else grouped.set(leafHash, [diff]);
+  }
+  return grouped;
+}
+
+export function leafNodes(root: ProllyNode) {
+  const leaves: ProllyNode[] = [];
+  const visit = (node: ProllyNode) => {
+    if (node.level === 0) leaves.push(node);
+    else node.children.forEach(visit);
+  };
+  visit(root);
+  return leaves;
+}
+
+export function countSharedNodes(left: Map<string, ProllyNode>, right: Map<string, ProllyNode>) {
+  let shared = 0;
+  for (const hash of left.keys()) if (right.has(hash)) shared += 1;
+  return shared;
+}
+
+export function estimateMutationSplitProbability(node: ProllyNode) {
+  if (node.level !== 0 || node.entries.length + 1 < DEFAULT_MIN_CHUNK_ENTRIES) return 0;
+  return 1 / DEFAULT_BOUNDARY_FACTOR;
+}

--- a/3rd/prolly-tree-visualizer/src/serverConfig.test.ts
+++ b/3rd/prolly-tree-visualizer/src/serverConfig.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import type { UserConfig } from 'vite';
+import viteConfig from '../vite.config';
+
+describe('Vite development server', () => {
+  it('serves the linked prolly WASM package from the repository workspace', () => {
+    const repositoryRoot = decodeURIComponent(new URL('../../..', import.meta.url).pathname).replace(/\/$/, '');
+    const config = viteConfig as UserConfig;
+
+    expect(config.server?.fs?.allow).toContain(repositoryRoot);
+  });
+});

--- a/3rd/prolly-tree-visualizer/src/storage.test.ts
+++ b/3rd/prolly-tree-visualizer/src/storage.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { calculateVersionStorage, countHistoricalTreeChunks } from './storage';
+
+describe('calculateVersionStorage', () => {
+  it('counts shared addresses once across versions', () => {
+    const metrics = calculateVersionStorage([
+      { nodes: new Map([['root-a', null], ['leaf-a', null], ['leaf-shared', null]]) },
+      { nodes: new Map([['root-b', null], ['leaf-b', null], ['leaf-shared', null]]) },
+      { nodes: new Map([['root-c', null], ['leaf-b', null], ['leaf-shared', null]]) },
+    ]);
+
+    expect(metrics).toEqual({
+      versions: 3,
+      withoutSharing: 9,
+      withSharing: 6,
+      savedChunks: 3,
+      savedFraction: 1 / 3,
+    });
+  });
+
+  it('handles an empty history', () => {
+    expect(calculateVersionStorage([])).toEqual({
+      versions: 0,
+      withoutSharing: 0,
+      withSharing: 0,
+      savedChunks: 0,
+      savedFraction: 0,
+    });
+  });
+
+  it('counts every older root, internal, and leaf address not shared with HEAD', () => {
+    const versions = [
+      { nodes: new Map([['root-a', null], ['internal-a', null], ['leaf-shared', null]]) },
+      { nodes: new Map([['root-b', null], ['internal-a', null], ['leaf-old', null], ['leaf-shared', null]]) },
+      { nodes: new Map([['root-c', null], ['internal-c', null], ['leaf-shared', null]]) },
+    ];
+
+    expect(countHistoricalTreeChunks(versions)).toBe(4);
+  });
+});

--- a/3rd/prolly-tree-visualizer/src/storage.ts
+++ b/3rd/prolly-tree-visualizer/src/storage.ts
@@ -1,0 +1,32 @@
+interface VersionNodes {
+  nodes: Map<string, unknown>;
+}
+
+export interface VersionStorageMetrics {
+  versions: number;
+  withoutSharing: number;
+  withSharing: number;
+  savedChunks: number;
+  savedFraction: number;
+}
+
+export function calculateVersionStorage(versions: VersionNodes[]): VersionStorageMetrics {
+  const withoutSharing = versions.reduce((total, version) => total + version.nodes.size, 0);
+  const addresses = new Set(versions.flatMap((version) => [...version.nodes.keys()]));
+  const savedChunks = withoutSharing - addresses.size;
+  return {
+    versions: versions.length,
+    withoutSharing,
+    withSharing: addresses.size,
+    savedChunks,
+    savedFraction: withoutSharing === 0 ? 0 : savedChunks / withoutSharing,
+  };
+}
+
+export function countHistoricalTreeChunks(versions: VersionNodes[]) {
+  const head = versions.at(-1);
+  if (!head) return 0;
+  const historical = new Set(versions.slice(0, -1).flatMap((version) => [...version.nodes.keys()]));
+  for (const hash of head.nodes.keys()) historical.delete(hash);
+  return historical.size;
+}

--- a/3rd/prolly-tree-visualizer/src/styles.css
+++ b/3rd/prolly-tree-visualizer/src/styles.css
@@ -1,0 +1,422 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Manrope:wght@400;500;600;700;800&display=swap');
+
+:root {
+  color: #182134;
+  background: #f1f3f8;
+  font-family: Manrope, ui-sans-serif, system-ui, sans-serif;
+  font-synthesis: none;
+  --ink: #182134;
+  --muted: #5d6280;
+  --paper: #fff;
+  --line: #d7d8df;
+  --brand: #3d91f0;
+  --brand-soft: #eaf4ff;
+  --accent: #51cbee;
+  --green: #149566;
+  --green-soft: #defbec;
+  --lime: #51cbee;
+  --orange: #ff820f;
+  --orange-soft: #fbede1;
+  --blue: #805edd;
+  --blue-soft: #f0ecfb;
+  --mono: 'DM Mono', ui-monospace, SFMono-Regular, monospace;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; min-width: 320px; min-height: 100vh; background: #f1f3f8; }
+button, input { font: inherit; }
+button { color: inherit; }
+button:focus-visible, input:focus-visible, a:focus-visible, [tabindex]:focus-visible { outline: 3px solid rgba(66, 103, 203, .25); outline-offset: 2px; }
+code { font-family: var(--mono); }
+
+.info-tip { display: inline-flex; width: 15px; height: 15px; margin-left: 4px; align-items: center; justify-content: center; vertical-align: -2px; border: 1px solid #a9b0c1; border-radius: 50%; color: var(--muted); cursor: help; font: 800 11px/1 Manrope, ui-sans-serif, system-ui, sans-serif; letter-spacing: 0; text-transform: none; }
+.info-tip.dark { border-color: #64708e; color: #bdc7df; }
+.info-tip-content { position: fixed; z-index: 1000; width: max-content; max-width: min(260px, calc(100vw - 24px)); padding: 9px 11px; border: 1px solid #3b4b72; border-radius: 7px; background: var(--ink); box-shadow: 0 8px 22px rgba(5, 11, 48, .22); color: #eef2fa; font: 500 11px/1.5 Manrope, ui-sans-serif, system-ui, sans-serif; letter-spacing: 0; pointer-events: none; text-align: left; text-transform: none; transform: translateX(-50%); white-space: normal; }
+.info-tip-content.above { transform: translate(-50%, -100%); }
+.info-tip-content::before { position: absolute; bottom: 100%; left: 50%; width: 7px; height: 7px; border-top: 1px solid #3b4b72; border-left: 1px solid #3b4b72; background: var(--ink); content: ''; transform: translate(-50%, 4px) rotate(45deg); }
+.info-tip-content.above::before { top: 100%; bottom: auto; border: 0; border-right: 1px solid #3b4b72; border-bottom: 1px solid #3b4b72; transform: translate(-50%, -4px) rotate(45deg); }
+
+.app-shell { min-height: 100vh; }
+.topbar { height: 76px; padding: 0 4vw; display: flex; align-items: center; gap: 24px; border-bottom: 1px solid #1f2942; background: rgba(5, 11, 48, .96); color: #fff; position: sticky; top: 0; z-index: 30; backdrop-filter: blur(14px); }
+.brand { display: flex; align-items: center; gap: 12px; margin-right: auto; }
+.brand strong { display: block; font-size: 16px; letter-spacing: -.02em; }
+.brand-mark { width: 40px; height: 40px; flex: 0 0 auto; border: 1px solid #3b4b72; border-radius: 10px; background: #182134; }
+.brand-tree-link { fill: none; stroke: #7a96ab; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }
+.brand-root-node { fill: var(--accent); }
+.brand-leaf-node { fill: #0c1a32; stroke: var(--brand); stroke-width: 1.5; }
+.brand-hash-line { fill: none; stroke: #fff; stroke-width: 1.2; stroke-linecap: round; }
+.runtime-pill { display: flex; align-items: center; gap: 9px; border: 1px solid #3b4b72; background: #182134; border-radius: 999px; padding: 8px 12px; color: #9cadd0; font-family: var(--mono); font-size: 11px; text-decoration: none; }
+.runtime-pill:hover { border-color: var(--accent); }
+.runtime-pill img { display: block; width: 86px; height: auto; }
+.runtime-pill strong { color: #fff; font-size: 12px; }
+.runtime-pill b { border-left: 1px solid #3b4b72; padding-left: 9px; color: var(--accent); font-weight: 500; }
+
+.database-summary { padding: 28px 4vw 18px; }
+.eyebrow { display: block; color: var(--brand); font-size: 11px; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+.root-card { border-radius: 13px; background: var(--ink); color: #fff; padding: 18px 21px; box-shadow: 0 10px 30px rgba(32, 40, 39, .1); display: grid; grid-template-columns: auto minmax(260px, 1fr) auto; align-items: center; gap: 24px; }
+.root-card > span { display: flex; align-items: center; color: #aab4b1; font-size: 11px; text-transform: uppercase; letter-spacing: .12em; }
+.root-card code { color: var(--accent); font-size: 12px; overflow-wrap: anywhere; line-height: 1.6; }
+.root-card div { color: #b8c0be; font-size: 11px; text-align: right; }
+.root-card b { color: #fff; font-weight: 600; }
+.root-card i { display: inline-block; height: 12px; width: 1px; background: #58615f; margin: 0 9px -2px; }
+
+.control-deck { margin: 0 4vw 28px; border: 1px solid var(--line); border-radius: 16px; background: var(--paper); overflow: hidden; box-shadow: 0 8px 30px rgba(37, 47, 44, .04); }
+.control-tabs { display: flex; gap: 4px; padding: 7px; border-bottom: 1px solid var(--line); background: #f1f3f8; }
+.control-row { display: grid; align-items: stretch; }
+.modify-row { grid-template-columns: minmax(440px, 1.25fr) minmax(190px, .5fr) minmax(390px, 1.2fr); }
+.lookup-row { grid-template-columns: minmax(220px, .7fr) minmax(360px, 1fr) minmax(220px, .65fr); }
+.control-section { min-width: 0; padding: 13px 14px 14px; border-left: 1px solid var(--line); }
+.control-section:first-child { border-left: 0; }
+.control-section label { display: block; color: var(--muted); font-size: 11px; font-weight: 700; letter-spacing: .09em; text-transform: uppercase; }
+.control-fields { min-height: 42px; margin-top: 7px; display: flex; align-items: center; gap: 8px; }
+.control-section input { min-width: 0; width: 92px; height: 42px; border: 1px solid #cfd4ce; background: #fff; border-radius: 9px; padding: 0 11px; font-family: var(--mono); font-size: 12px; }
+.put-section .value-input { width: auto; flex: 1; }
+.range-lookup-section input { width: 88px; }
+.range-arrow { color: var(--muted); font-size: 11px; }
+.control-deck button { height: 42px; border: 1px solid #cfd4ce; background: #fff; border-radius: 9px; padding: 0 14px; cursor: pointer; font-size: 11px; font-weight: 700; white-space: nowrap; }
+.control-deck .control-tab { height: 34px; min-width: 92px; border: 0; border-radius: 8px; background: transparent; color: var(--muted); }
+.control-deck .control-tab.active { background: #fff; color: var(--ink); box-shadow: 0 1px 4px rgba(24, 33, 52, .12); }
+.control-deck button:hover:not(:disabled) { border-color: #9ca6a1; transform: translateY(-1px); }
+.control-deck button:disabled { opacity: .5; cursor: wait; }
+.control-deck button[title]:disabled { cursor: not-allowed; }
+.control-deck .primary-button { color: #fff; background: var(--brand); border-color: var(--brand); }
+.control-deck .danger-quiet { color: #a44734; }
+.bulk-actions { flex-wrap: wrap; }
+.control-deck .reset-button { color: var(--muted); border-style: dashed; }
+.diff-lookup-button { color: #334f9e; border-color: #a9b9e7 !important; background: var(--blue-soft) !important; }
+.diff-lookup-button.active { color: #fff; border-color: var(--blue) !important; background: var(--blue) !important; }
+
+.workbench-layout { margin: 0 4vw 40px; display: grid; grid-template-columns: minmax(0, 1fr) 340px; align-items: start; gap: 20px; }
+.workbench-layout.order-mode { grid-template-columns: minmax(0, 1fr); }
+.workbench-main { min-width: 0; }
+.tabs { padding: 0; display: flex; gap: 28px; border-bottom: 1px solid var(--line); }
+.tabs button { border: 0; border-bottom: 3px solid transparent; background: none; padding: 15px 1px 13px; cursor: pointer; color: var(--muted); font-size: 12px; font-weight: 700; }
+.tabs button.active { border-color: var(--brand); color: var(--ink); }
+.workspace { min-height: 520px; background: var(--paper); border: 1px solid var(--line); border-top: 0; border-radius: 0 0 18px 18px; overflow: hidden; }
+.view-toolbar { min-height: 60px; border-bottom: 1px solid var(--line); display: flex; align-items: center; justify-content: space-between; padding: 0 20px; gap: 18px; }
+.legend { display: flex; flex-wrap: wrap; gap: 19px; color: var(--muted); font-size: 11px; }
+.legend > span { display: inline-flex; align-items: center; }
+.legend i { display: inline-block; width: 10px; height: 10px; border-radius: 3px; margin-right: 5px; }
+.legend-new { background: var(--green-soft); border: 1px solid var(--green); }
+.legend-trace { background: var(--blue-soft); border: 1px solid var(--blue); }
+.legend-diff { background: var(--orange-soft); border: 1px solid var(--orange); }
+.legend-skip { background: #f1f3f8; border: 1px dashed #74809d; }
+.change-summary { display: flex; gap: 14px; align-items: center; color: var(--muted); font-family: var(--mono); font-size: 11px; }
+.change-summary strong { background: var(--orange-soft); color: #ac4f25; padding: 6px 9px; border-radius: 6px; }
+.change-summary strong.no-content-change { background: #eef1f6; color: var(--muted); }
+.change-summary strong.chunk-combine { background: var(--green-soft); color: var(--green); }
+.tree-storage-note { border-bottom: 1px solid var(--line); background: #f8faff; padding: 11px 20px; color: var(--muted); font-size: 12px; line-height: 1.55; }
+
+.mutation-cost { border-top: 1px solid var(--line); background: #f8faff; padding: 16px 20px 15px; }
+.mutation-cost-head { display: flex; align-items: center; justify-content: space-between; gap: 18px; margin-bottom: 12px; }
+.mutation-cost-head > div { display: flex; align-items: baseline; gap: 12px; min-width: 0; }
+.mutation-cost-head span { color: var(--brand); font-size: 11px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.mutation-cost-head strong { overflow: hidden; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+.mutation-cost-head em { border-radius: 999px; background: var(--orange-soft); color: #ad512b; padding: 4px 8px; font-size: 11px; font-style: normal; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
+.mutation-flow { display: grid; grid-template-columns: minmax(125px, .8fr) 18px minmax(125px, 1fr) 18px minmax(125px, 1fr) 18px minmax(175px, 1.25fr); align-items: stretch; gap: 7px; }
+.mutation-flow > i { display: grid; place-items: center; color: #a4aaa7; font: 500 16px var(--mono); font-style: normal; }
+.mutation-stage { min-width: 0; min-height: 88px; border: 1px solid var(--line); border-radius: 10px; background: #fff; padding: 12px 13px; text-align: left; }
+button.mutation-stage { color: var(--ink); cursor: pointer; }
+button.mutation-stage:hover:not(:disabled) { border-color: var(--blue); transform: translateY(-1px); }
+button.mutation-stage:disabled { cursor: default; }
+.mutation-stage > span, .mutation-stage > b, .mutation-stage > small { display: block; }
+.mutation-stage > span { color: var(--muted); font-size: 11px; }
+.mutation-stage > b { margin: 7px 0 4px; font: 500 18px var(--mono); }
+.mutation-stage > small { color: var(--muted); font-size: 11px; line-height: 1.4; }
+.mutation-stage > small .info-tip { vertical-align: -3px; }
+.mutation-total { border-color: #b9c8f3; background: var(--blue-soft); }
+.diff-skip-stage { border-style: dashed; border-color: #9da6bc; background: #f3f5f9; }
+.lookup-details-panel .mutation-cost-head em { background: var(--blue-soft); color: #334f9e; }
+.lookup-details-panel .mutation-cost-bar span { background: var(--blue); }
+.mutation-cost-foot { display: flex; align-items: center; justify-content: flex-end; gap: 14px; margin-top: 11px; color: var(--muted); font: 500 11px var(--mono); }
+.mutation-cost-ratio { display: flex; width: min(285px, 32%); align-items: center; gap: 5px; margin-right: auto; }
+.mutation-cost-bar { flex: 1; height: 7px; overflow: hidden; border-radius: 999px; background: #dfe3e8; }
+.mutation-cost-bar span { display: block; height: 100%; border-radius: inherit; background: var(--orange); }
+
+.tree-with-inspector { display: grid; grid-template-columns: minmax(0, 1fr) 0; transition: grid-template-columns .25s ease; }
+.tree-with-inspector.open { grid-template-columns: minmax(0, 1fr) minmax(330px, 26vw); }
+.tree-scroll { min-width: 0; overflow: auto; min-height: 500px; background-color: #fbfcff; background-image: radial-gradient(#dfe6f0 1px, transparent 1px); background-size: 18px 18px; }
+.tree-svg { display: block; margin: 0 auto; }
+.edge { fill: none; stroke: #c6ccc6; stroke-width: 1.5; }
+.edge-new { stroke: #73b7a1; stroke-width: 2; stroke-dasharray: 4 4; }
+.edge-trace { stroke: var(--blue); stroke-width: 2.5; stroke-dasharray: 8 5; animation: trace-edge .45s ease-out; }
+.edge-diff { stroke: var(--orange); stroke-width: 2.5; animation: diff-edge .45s ease-out; }
+.edge-skip { stroke: #74809d; stroke-width: 2; stroke-dasharray: 3 5; }
+.tree-node { cursor: pointer; }
+.tree-node:focus-visible { outline: none; }
+.tree-node:focus-visible rect { stroke: var(--blue); stroke-width: 3; }
+.tree-node rect { fill: #fff; stroke: #b9c1bc; stroke-width: 1.2; filter: drop-shadow(0 5px 6px rgba(32, 40, 39, .07)); transition: all .16s ease; }
+.tree-node:hover rect { stroke: #66716d; transform: translateY(-2px); }
+.tree-node line { stroke: #e4e7e2; }
+.tree-node text { pointer-events: none; }
+.node-kind, .node-count { font-size: 11px; fill: #78817e; font-weight: 700; letter-spacing: .08em; }
+.node-keys { font: 500 11px var(--mono); fill: var(--ink); }
+.node-keys tspan, .node-hash { transition: font-size .18s ease, fill .18s ease; }
+.node-key-match { fill: var(--blue); stroke: var(--blue-soft); stroke-width: 5px; paint-order: stroke; font-size: 13px; font-weight: 900; }
+.node-key-route { fill: var(--blue); font-weight: 600; }
+.node-key-missing { fill: #ad512b; stroke: var(--orange-soft); stroke-width: 5px; paint-order: stroke; font-size: 13px; font-weight: 900; }
+.node-key-missing-static { fill: #ad512b; font-weight: 600; }
+.node-row-change { fill: #ad512b; font-weight: 800; }
+.node-range { font: 400 11px var(--mono); fill: #69736f; }
+.node-hash { font: 500 10px var(--mono); fill: var(--brand); }
+.node-hash-active { fill: var(--orange); stroke: var(--orange-soft); stroke-width: 4px; paint-order: stroke; font-size: 11px; font-weight: 900; }
+.node-hash-skip-active { fill: #52607f; stroke: #eef0f6; stroke-width: 4px; paint-order: stroke; font-size: 11px; font-weight: 900; }
+.internal-node rect { fill: #f1f3f8; }
+.node-new rect { fill: #eff9f5; stroke: var(--green); stroke-width: 2; }
+.node-new .node-kind { fill: var(--green); }
+.node-trace rect { fill: var(--blue-soft); stroke: var(--blue); stroke-width: 2.5; }
+.node-trace rect { transform-box: fill-box; transform-origin: center; animation: trace-node .35s var(--focus-delay, .3s) ease-out; }
+.node-diff rect { fill: var(--orange-soft); stroke: var(--orange); stroke-width: 3; }
+.node-diff rect { transform-box: fill-box; transform-origin: center; animation: diff-node .35s var(--focus-delay, .3s) ease-out; }
+.node-diff .node-kind { fill: #ad512b; }
+.node-skip rect { fill: #f3f5f9; stroke: #74809d; stroke-width: 2px; stroke-dasharray: 5 4; }
+.node-skip .node-kind { fill: #52607f; }
+.node-skip-active rect { transform-box: fill-box; transform-origin: center; animation: skip-node .55s var(--focus-delay, .3s) ease-out; }
+.node-selected rect, .node-selected:focus-visible rect { stroke: var(--ink); stroke-width: 3; }
+
+.inspector { min-width: 0; overflow: hidden; border-left: 1px solid var(--line); background: #fff; padding: 24px; }
+.inspector-head { display: flex; gap: 10px; align-items: flex-start; justify-content: space-between; }
+.inspector h2 { margin: 7px 0 0; font-size: 22px; letter-spacing: -.035em; }
+.icon-button { width: 31px; height: 31px; border-radius: 50%; border: 1px solid var(--line); background: #fff; cursor: pointer; font-size: 20px; }
+.facts { margin: 23px 0; border: 1px solid var(--line); border-radius: 10px; overflow: hidden; }
+.facts > div { padding: 10px 12px; border-bottom: 1px solid var(--line); }
+.facts > div:last-child { border-bottom: 0; }
+.facts dt { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
+.facts dd { margin: 4px 0 0; font-size: 11px; }
+.full-hash { color: var(--brand); font: 500 10px/1.5 var(--mono); overflow-wrap: anywhere; }
+.facts dd.full-hash { font-size: 10px; }
+.entry-list { border-top: 1px solid var(--line); }
+.entry-list-head { padding: 12px 0; color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
+.entry-row { display: grid; grid-template-columns: auto 15px minmax(0, 1fr); align-items: start; gap: 5px; border-top: 1px solid #eceeea; padding: 9px 0; font-size: 11px; }
+.entry-key { font: 500 11px var(--mono); background: #f1f3f8; border-radius: 5px; padding: 3px 5px; }
+.entry-arrow { color: #a3aaa6; padding-top: 3px; }
+.entry-value { padding-top: 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.entry-count { grid-column: 3; color: var(--muted); font-size: 11px; }
+.entry-more { border-top: 1px solid #eceeea; padding: 12px 0; color: var(--muted); font-size: 11px; }
+
+.panel-view { padding: 44px clamp(24px, 5vw, 74px) 60px; }
+.data-view-head { display: flex; align-items: center; justify-content: space-between; gap: 25px; }
+.data-view-head h2 { margin: 0; font-size: 28px; letter-spacing: -.045em; }
+.data-view-head h2, .history-order-head h2, .timeline-head h2 { display: flex; align-items: center; }
+.diff-version-picker { display: flex; align-items: center; gap: 10px; color: var(--muted); font-size: 11px; }
+.diff-version-picker label { color: var(--ink); font-weight: 700; }
+.diff-version-picker select { min-width: 260px; max-width: 480px; height: 38px; border: 1px solid #cfd4ce; border-radius: 8px; background: #fff; padding: 0 32px 0 10px; color: var(--ink); font: 500 11px var(--mono); }
+.diff-metrics { margin: 25px 0; display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+.diff-metrics div { background: #f1f3f8; border-radius: 12px; padding: 21px; }
+.diff-metrics b { display: block; font: 500 30px var(--mono); }
+.diff-metrics span { color: var(--muted); font-size: 11px; }
+.hash-compare { display: grid; grid-template-columns: 1fr 50px 1fr; align-items: center; gap: 15px; margin: 26px 0; }
+.hash-compare div { min-width: 0; background: var(--ink); padding: 16px; border-radius: 10px; }
+.hash-compare small { color: #9da7a4; display: block; font-size: 11px; margin-bottom: 7px; }
+.hash-compare code { color: var(--accent); font-size: 10px; overflow-wrap: anywhere; }
+.hash-compare > span { text-align: center; font-size: 25px; font-weight: 700; }
+.changed-root { color: var(--orange); }
+.same-root { color: var(--green); }
+.row-diff-table { border: 1px solid var(--line); border-radius: 12px; overflow: hidden; }
+.row-diff { display: grid; grid-template-columns: 32px 70px 1fr 24px 1fr 80px; gap: 8px; padding: 11px 14px; border-bottom: 1px solid var(--line); align-items: center; font-size: 11px; }
+.row-diff:last-child { border-bottom: 0; }
+.row-diff code { font-weight: 600; }
+.row-diff em { font-style: normal; text-align: right; color: var(--muted); font-size: 11px; text-transform: uppercase; }
+.row-diff.added { background: #f1faf6; }
+.row-diff.deleted { background: #fff4ef; }
+.row-diff.modified { background: #fffaf0; }
+.diff-sign { font: 500 17px var(--mono); color: var(--green); }
+.deleted .diff-sign { color: #bd4f35; }
+.modified .diff-sign { color: #b27d14; }
+.empty-state { padding: 35px; text-align: center; color: var(--muted); font-size: 12px; }
+
+.chunk-summary { display: flex; align-items: center; gap: 20px; color: var(--muted); font-size: 11px; }
+.chunk-summary span { padding-left: 20px; border-left: 1px solid var(--line); }
+.chunk-summary b { color: var(--ink); font: 500 13px var(--mono); }
+.chunk-strip { display: flex; align-items: stretch; gap: 5px; margin: 25px 0 30px; min-height: 170px; overflow-x: auto; }
+.chunk-strip button { min-width: 145px; border: 1px solid #9cc6b8; background: var(--green-soft); border-radius: 9px; padding: 16px; text-align: left; cursor: pointer; }
+.chunk-strip button:nth-child(even) { background: #ebf5cf; border-color: #b5cb75; }
+.chunk-strip span, .chunk-strip small, .chunk-strip code, .chunk-strip em { display: block; }
+.chunk-strip span { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .1em; }
+.chunk-strip b { display: block; font: 500 22px var(--mono); margin: 20px 0 8px; }
+.chunk-strip small { color: var(--muted); font-size: 11px; }
+.chunk-strip code { margin-top: 18px; color: var(--brand); font-size: 10px; overflow-wrap: anywhere; }
+.chunk-strip em { margin-top: 10px; color: var(--ink); font: 500 11px var(--mono); font-style: normal; }
+.chunk-table { border: 1px solid var(--line); border-radius: 10px; overflow: hidden; }
+.chunk-row { width: 100%; display: grid; grid-template-columns: 45px 1fr 80px 80px 100px 2fr; gap: 12px; border: 0; border-bottom: 1px solid var(--line); background: #fff; padding: 12px 14px; text-align: left; font-size: 11px; cursor: pointer; }
+.chunk-row:last-child { border-bottom: 0; }
+.chunk-row:hover:not(.chunk-head) { background: #f2f7fd; }
+.chunk-row code { color: var(--brand); font-size: 10px; overflow-wrap: anywhere; }
+.chunk-row strong { font-family: var(--mono); font-weight: 500; }
+.chunk-head { background: #f1f2ed; color: var(--muted); text-transform: uppercase; letter-spacing: .07em; font-size: 11px; cursor: default; }
+
+.storage-head > div:first-child > span { display: block; margin-top: 6px; color: var(--muted); font-size: 11px; }
+.storage-actions { display: flex; align-items: center; gap: 12px; }
+.storage-actions > span { display: flex; align-items: center; color: var(--muted); font-size: 11px; }
+.storage-actions button { height: 42px; border: 1px solid #b74f39; border-radius: 9px; background: #fff; color: #a44734; padding: 0 15px; cursor: pointer; font-size: 11px; font-weight: 800; }
+.storage-actions button:hover:not(:disabled) { background: #fff4ef; }
+.storage-actions button:disabled { opacity: .5; cursor: wait; }
+.storage-comparison { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; margin-top: 28px; }
+.storage-comparison article { min-width: 0; border: 1px solid var(--line); border-radius: 12px; background: #f1f3f8; padding: 20px; }
+.storage-comparison article.shared-storage-card { border-color: #9cc6b8; background: var(--green-soft); }
+.storage-comparison article.saved-storage-card { border-color: #b9c8f3; background: var(--blue-soft); }
+.storage-comparison article > span { display: flex; min-height: 30px; align-items: flex-start; justify-content: space-between; gap: 8px; color: var(--muted); font-size: 11px; font-weight: 700; }
+.storage-comparison article > span em { border: 1px solid #c7cbd6; border-radius: 999px; padding: 2px 6px; font-size: 11px; font-style: normal; letter-spacing: .06em; text-transform: uppercase; }
+.storage-comparison article > b { display: block; margin: 11px 0 7px; font: 500 34px var(--mono); }
+.storage-comparison article > small { color: var(--muted); font-size: 11px; line-height: 1.5; }
+.storage-ratio { height: 9px; margin: 15px 2px 28px; overflow: hidden; border-radius: 999px; background: #dfe2e9; }
+.storage-ratio span { display: block; height: 100%; border-radius: inherit; background: var(--green); transition: width .3s ease; }
+.physical-storage { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); overflow: hidden; border: 1px solid var(--line); border-radius: 11px; }
+.physical-storage div { display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 15px 17px; }
+.physical-storage div + div { border-left: 1px solid var(--line); }
+.physical-storage span { color: var(--muted); font-size: 11px; }
+.physical-storage b { font: 500 12px var(--mono); }
+.chunk-makeup { margin-top: 12px; border: 1px solid var(--line); border-radius: 11px; padding: 15px 17px 17px; }
+.chunk-makeup-head { display: flex; align-items: center; justify-content: space-between; gap: 20px; }
+.chunk-makeup-head > span { color: var(--muted); font-size: 11px; }
+.chunk-makeup-head small { font: 500 11px var(--mono); }
+.chunk-makeup-bar { display: flex; height: 13px; margin-top: 13px; overflow: hidden; border-radius: 999px; background: #e1e4e9; }
+.chunk-makeup-bar span { height: 100%; }
+.makeup-live { background: var(--brand); }
+.makeup-history { background: var(--orange); }
+.makeup-metadata { background: #8b93a7; }
+.chunk-makeup-legend { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; margin-top: 14px; }
+.chunk-makeup-legend > span { display: grid; grid-template-columns: 10px minmax(0, 1fr) auto; align-items: center; gap: 7px; color: var(--muted); font-size: 11px; }
+.chunk-makeup-legend i { width: 9px; height: 9px; border-radius: 3px; }
+.chunk-makeup-legend > span > span { display: flex; align-items: center; min-width: 0; }
+.chunk-makeup-legend b { color: var(--ink); font: 500 11px var(--mono); }
+.gc-report { margin-top: 20px; overflow: hidden; border: 1px solid #9cc6b8; border-radius: 12px; background: #f1faf6; }
+.gc-report-head { display: flex; align-items: center; justify-content: space-between; gap: 20px; border-bottom: 1px solid #b8d8cd; padding: 13px 15px; }
+.gc-report-head span { color: var(--green); font-size: 11px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.gc-report-head strong { font: 500 11px var(--mono); }
+.gc-deltas { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.gc-deltas div { display: grid; grid-template-columns: 1fr auto; gap: 8px; border-right: 1px solid #cce2da; padding: 15px; }
+.gc-deltas div:last-child { border-right: 0; }
+.gc-deltas span { grid-column: 1 / 3; color: var(--muted); font-size: 11px; }
+.gc-deltas b { overflow-wrap: anywhere; font: 500 11px var(--mono); }
+.gc-deltas em { color: var(--green); font: 500 11px var(--mono); font-style: normal; text-align: right; }
+.gc-report > small { display: block; border-top: 1px solid #cce2da; padding: 11px 15px; color: var(--muted); font-size: 11px; }
+
+.history-order-head { display: flex; align-items: center; justify-content: space-between; gap: 30px; }
+.history-order-head h2 { margin: 0; font-size: 28px; letter-spacing: -.045em; }
+.history-order-head p { margin: 7px 0 0; color: var(--muted); font-size: 11px; }
+.run-order-button { flex: 0 0 auto; height: 44px; border: 1px solid var(--brand); border-radius: 9px; background: var(--brand); color: #fff; padding: 0 18px; cursor: pointer; font-size: 11px; font-weight: 800; }
+.run-order-button:disabled { opacity: .5; cursor: wait; }
+.history-match { display: flex; align-items: center; gap: 13px; margin-top: 25px; border: 1px solid var(--line); border-radius: 9px; background: #fff; padding: 11px 13px; font-size: 11px; }
+.history-match code { min-width: 0; margin-right: auto; color: var(--brand); font-size: 10px; overflow-wrap: anywhere; }
+.history-match span { border-left: 1px solid var(--line); padding-left: 13px; color: var(--muted); white-space: nowrap; }
+.history-match.fail { border-color: #edb39c; background: var(--orange-soft); }
+.history-trees { display: grid; grid-template-columns: minmax(0, 1fr); gap: 14px; margin-top: 14px; }
+.history-tree { min-width: 0; overflow: hidden; border: 1px solid var(--line); border-radius: 12px; background: #fff; }
+.history-tree header { min-height: 105px; padding: 15px 17px; border-bottom: 1px solid var(--line); }
+.history-tree header > div { display: flex; align-items: baseline; gap: 10px; }
+.history-tree header span { color: var(--brand); font: 500 11px var(--mono); letter-spacing: .08em; }
+.history-tree header h3 { margin: 0; font-size: 15px; }
+.history-tree header > code { display: block; margin-top: 12px; color: var(--muted); font-size: 11px; line-height: 1.6; overflow-wrap: anywhere; }
+.history-tree-canvas .tree-scroll { min-height: 398px; }
+.history-node-hint { margin: 12px 0 0; color: var(--muted); font-size: 11px; text-align: center; }
+.history-empty { min-height: 390px; margin-top: 25px; display: grid; place-items: center; border: 1px dashed #bdc4bf; border-radius: 12px; color: var(--muted); font-size: 11px; }
+
+.timeline-section { position: sticky; top: 92px; height: calc(100vh - 112px); min-height: 420px; display: flex; flex-direction: column; overflow: hidden; border: 1px solid #1f2942; border-radius: 16px; background: #050b30; color: #fff; }
+.timeline-head { flex: 0 0 auto; display: flex; justify-content: space-between; align-items: end; gap: 20px; padding: 21px 20px 17px; border-bottom: 1px solid #263253; }
+.timeline-head h2 { margin: 0; font-size: 22px; letter-spacing: -.04em; }
+.timeline { flex: 1; min-height: 0; display: flex; flex-direction: column; overflow-y: auto; padding: 16px 14px 22px 43px; }
+.timeline button { position: relative; flex: 0 0 auto; width: 100%; min-height: 116px; margin: 0 0 10px; border: 1px solid #3b4b72; background: #0c1a32; color: #fff; border-radius: 11px; text-align: left; padding: 13px 14px; cursor: pointer; }
+.timeline button::before { content: ''; position: absolute; left: -25px; top: 22px; bottom: -33px; width: 2px; background: #3b4b72; }
+.timeline button:last-child::before { display: none; }
+.timeline button::after { content: ''; position: absolute; left: -30px; top: 16px; width: 10px; height: 10px; border: 2px solid #7382a5; border-radius: 50%; background: #050b30; }
+.timeline button:hover:not(:disabled), .timeline button.selected { border-color: var(--accent); background: #1f2942; }
+.timeline button.selected::after { border-color: var(--accent); background: var(--accent); box-shadow: 0 0 0 4px rgba(81, 203, 238, .14); }
+.timeline button:disabled { cursor: default; }
+.timeline button > span, .timeline button b, .timeline button code, .timeline button small { display: block; }
+.timeline button > span { color: var(--accent); font: 500 11px var(--mono); }
+.timeline button > span em { float: right; border: 1px solid #3b4b72; border-radius: 999px; padding: 2px 6px; color: #aebbd6; font-size: 11px; font-style: normal; text-transform: uppercase; letter-spacing: .08em; }
+.timeline button b { margin: 10px 0; font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.timeline button code { color: #b9c5c1; font-size: 10px; line-height: 1.45; white-space: nowrap; }
+.timeline button small { color: #899592; margin-top: 8px; font-size: 11px; }
+
+footer { padding: 19px 4vw; display: flex; justify-content: space-between; gap: 20px; color: var(--muted); font-size: 11px; border-top: 1px solid var(--line); }
+footer a { color: var(--brand); font-weight: 700; text-decoration: none; }
+footer a:hover { text-decoration: underline; }
+.busy-bar { position: fixed; z-index: 50; top: 84px; left: 50%; transform: translateX(-50%); background: var(--ink); color: #fff; border-radius: 999px; padding: 10px 16px; font-size: 11px; box-shadow: 0 12px 30px rgba(0,0,0,.2); }
+.busy-bar span { display: inline-block; width: 8px; height: 8px; border: 2px solid var(--lime); border-top-color: transparent; border-radius: 50%; margin-right: 7px; vertical-align: -1px; animation: spin .8s linear infinite; }
+.error-banner { margin: -12px 4vw 20px; background: #fff0ea; border: 1px solid #edb39c; border-radius: 10px; padding: 12px 15px; display: flex; gap: 12px; font-size: 11px; }
+.error-banner button { margin-left: auto; border: 0; background: none; cursor: pointer; }
+.history-view-banner { margin: -12px 4vw 20px; background: var(--blue-soft); border: 1px solid #b9c8f3; border-radius: 10px; padding: 11px 14px; display: flex; align-items: center; justify-content: space-between; gap: 18px; color: #334f9e; font-size: 11px; }
+.history-view-banner button { border: 1px solid #91a6e1; border-radius: 7px; background: #fff; color: #334f9e; padding: 7px 10px; cursor: pointer; font-size: 11px; font-weight: 700; white-space: nowrap; }
+.loading-screen { min-height: 100vh; display: grid; place-content: center; text-align: center; background: var(--ink); color: #fff; }
+.loading-screen p { color: #aab5b1; font-size: 12px; }
+.loader-mark { display: flex; gap: 6px; justify-content: center; }
+.loader-mark span { width: 12px; height: 12px; border-radius: 3px; background: var(--lime); animation: pulse 1s ease-in-out infinite alternate; }
+.loader-mark span:nth-child(2) { animation-delay: .18s; }
+.loader-mark span:nth-child(3) { animation-delay: .36s; }
+@keyframes spin { to { transform: rotate(360deg); } }
+@keyframes pulse { to { transform: translateY(-9px); opacity: .45; } }
+@keyframes trace-edge { from { opacity: .2; stroke-dashoffset: 42; } }
+@keyframes trace-node { from { transform: scale(.97); stroke-width: 5; } }
+@keyframes diff-edge { from { opacity: .2; stroke-dashoffset: 42; } }
+@keyframes diff-node { from { transform: scale(.97); stroke-width: 5; } }
+@keyframes skip-node { 50% { transform: scale(1.025); stroke-width: 4; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .edge-trace, .node-trace rect, .edge-diff, .node-diff rect, .node-skip-active rect { animation: none; }
+}
+
+@media (max-width: 1700px) {
+  .workbench-layout { grid-template-columns: 1fr; }
+  .timeline-section { position: static; height: auto; min-height: 0; }
+  .timeline { flex-direction: row; overflow-x: auto; overflow-y: hidden; padding: 40px 20px 22px; }
+  .timeline button { flex: 0 0 280px; width: 280px; margin: 0 10px 0 0; }
+  .timeline button::before { left: 24px; top: -20px; bottom: auto; width: calc(100% + 10px); height: 2px; }
+  .timeline button::after { left: 19px; top: -25px; }
+}
+
+@media (max-width: 1200px) {
+  .modify-row, .lookup-row { grid-template-columns: minmax(0, 1fr) minmax(210px, .55fr); }
+  .bulk-section, .diff-lookup-section { grid-column: 1 / 3; }
+  .bulk-section, .diff-lookup-section { border-top: 1px solid var(--line); }
+}
+
+@media (max-width: 1050px) {
+  .tree-with-inspector.open { grid-template-columns: 1fr; }
+  .inspector { border-left: 0; border-top: 1px solid var(--line); }
+}
+
+@media (max-width: 700px) {
+  .topbar { padding: 0 16px; }
+  .runtime-pill { display: none; }
+  .database-summary { padding: 18px 12px 12px; }
+  .root-card { grid-template-columns: 1fr; gap: 7px; }
+  .root-card div { text-align: left; margin-top: 5px; }
+  .control-deck { margin-left: 12px; margin-right: 12px; }
+  .workbench-layout { margin-left: 12px; margin-right: 12px; }
+  .modify-row, .lookup-row { grid-template-columns: 1fr; }
+  .bulk-section, .diff-lookup-section { grid-column: auto; }
+  .control-section { border-left: 0; border-top: 1px solid var(--line); }
+  .control-fields { flex-wrap: wrap; }
+  .tabs { gap: 18px; overflow-x: auto; }
+  .view-toolbar { align-items: flex-start; flex-direction: column; padding: 14px; }
+  .mutation-flow { grid-template-columns: 1fr; }
+  .mutation-flow > i { display: none; }
+  .mutation-cost-head > div, .mutation-cost-foot { align-items: flex-start; flex-direction: column; }
+  .mutation-cost-ratio { width: 100%; }
+  .change-summary { flex-wrap: wrap; }
+  .panel-view { padding: 34px 18px 45px; }
+  .data-view-head { align-items: flex-start; flex-direction: column; }
+  .chunk-summary { width: 100%; justify-content: space-between; gap: 8px; }
+  .chunk-summary span { padding-left: 8px; }
+  .diff-metrics { grid-template-columns: 1fr; }
+  .diff-version-picker { align-items: flex-start; flex-direction: column; }
+  .diff-version-picker select { width: 100%; min-width: 0; }
+  .hash-compare { grid-template-columns: 1fr; }
+  .row-diff { grid-template-columns: 28px 50px 1fr 18px 1fr; }
+  .row-diff em { display: none; }
+  .chunk-row { grid-template-columns: 30px 1fr 60px; }
+  .chunk-row > :nth-child(4), .chunk-row > :nth-child(5), .chunk-row > :nth-child(6) { display: none; }
+  .storage-head, .storage-actions { align-items: flex-start; flex-direction: column; }
+  .storage-comparison, .physical-storage, .gc-deltas { grid-template-columns: 1fr; }
+  .chunk-makeup-legend { grid-template-columns: 1fr; }
+  .physical-storage div + div { border-top: 1px solid var(--line); border-left: 0; }
+  .gc-deltas div { border-right: 0; border-bottom: 1px solid #cce2da; }
+  .gc-deltas div:last-child { border-bottom: 0; }
+  .history-order-head { align-items: flex-start; flex-direction: column; }
+  .history-match { align-items: flex-start; flex-direction: column; }
+  .history-match span { border-left: 0; padding-left: 0; white-space: normal; }
+  .history-trees { grid-template-columns: 1fr; }
+  footer { align-items: flex-start; flex-direction: column; }
+}

--- a/3rd/prolly-tree-visualizer/src/types.ts
+++ b/3rd/prolly-tree-visualizer/src/types.ts
@@ -1,0 +1,48 @@
+export interface RowValue {
+  key: number;
+  value: string;
+}
+
+export interface ProllyEntry {
+  key: number | string;
+  keyHex: string;
+  valueHex: string;
+  childHash?: string;
+  subtreeCount?: number;
+}
+
+export interface ProllyNode {
+  hash: string;
+  level: number;
+  size: number;
+  flags: number;
+  entries: ProllyEntry[];
+  children: ProllyNode[];
+  minKey: number | string | null;
+  maxKey: number | string | null;
+}
+
+export interface TreeSnapshot {
+  id: number;
+  label: string;
+  rootHash: string;
+  root: ProllyNode;
+  rows: RowValue[];
+  nodes: Map<string, ProllyNode>;
+  chunksInStore: number;
+  databaseBytes: number;
+  timestamp: number;
+}
+
+export type NodeChange = 'new' | 'shared' | 'neutral' | 'trace';
+
+export interface RowDiff {
+  key: number;
+  before?: string;
+  after?: string;
+  kind: 'added' | 'modified' | 'deleted';
+}
+
+export type LookupResult =
+  | { kind: 'key'; key: number; found: boolean }
+  | { kind: 'range'; start: number; end: number };

--- a/3rd/prolly-tree-visualizer/src/vite-env.d.ts
+++ b/3rd/prolly-tree-visualizer/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/3rd/prolly-tree-visualizer/tsconfig.app.json
+++ b/3rd/prolly-tree-visualizer/tsconfig.app.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/3rd/prolly-tree-visualizer/tsconfig.json
+++ b/3rd/prolly-tree-visualizer/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/3rd/prolly-tree-visualizer/tsconfig.node.json
+++ b/3rd/prolly-tree-visualizer/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/3rd/prolly-tree-visualizer/vite.config.ts
+++ b/3rd/prolly-tree-visualizer/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+const repositoryRoot = decodeURIComponent(new URL('../..', import.meta.url).pathname).replace(/\/$/, '');
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    fs: {
+      allow: [repositoryRoot],
+    },
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+    },
+  },
+  preview: {
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+    },
+  },
+});

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Native approximate nearest-neighbor indexing is documented in
 Breaking changes and release qualification are recorded in
 [`CHANGELOG.md`](CHANGELOG.md).
 
+## Interactive visualizer
+
+The browser app in
+[`3rd/prolly-tree-visualizer`](3rd/prolly-tree-visualizer/README.md) executes
+mutations against this repository's real `@trail/prolly-wasm` binding and
+renders the resulting content-addressed tree, lookup paths, structural diffs,
+and storage history.
+
 For application builders who want a Git-like repository layer on top of prolly
 trees, see the proposed [`prolly-vcs` design](docs/prolly-vcs-design.md). It
 keeps `prolly-map` focused on immutable ordered maps while outlining a separate

--- a/bindings/wasm/src/index.ts
+++ b/bindings/wasm/src/index.ts
@@ -654,10 +654,15 @@ export type ProllyWasmModule = Omit<RawProllyWasmModule, "WasmProllyEngine"> & {
 };
 
 export async function loadProllyWasm(
-  modulePath = "../pkg/prolly_wasm.js",
+  modulePath?: string,
   wasmInput?: WebAssembly.Module | BufferSource,
 ): Promise<ProllyWasmModule> {
-  const module = (await import(modulePath)) as ProllyWasmModule;
+  // Keep the default import statically visible so browser bundlers include the
+  // generated JavaScript shim and its WebAssembly asset. Explicit alternate
+  // module paths remain runtime-resolved for tests and custom deployments.
+  const module = (modulePath
+    ? await import(/* @vite-ignore */ modulePath)
+    : await import("../pkg/prolly_wasm.js")) as ProllyWasmModule;
   if (wasmInput && "initSync" in module) {
     module.initSync({ module: wasmInput });
     return module;

--- a/bindings/wasm/test/wasm.test.ts
+++ b/bindings/wasm/test/wasm.test.ts
@@ -39,6 +39,8 @@ try {
 test("wasm package declares browser memory-scope API", () => {
   const source = readFileSync(resolve(import.meta.dirname, "../src/index.ts"), "utf8");
   assert.match(source, /loadProllyWasm/);
+  assert.match(source, /await import\("\.\.\/pkg\/prolly_wasm\.js"\)/);
+  assert.doesNotMatch(source, /modulePath\s*=\s*"\.\.\/pkg\/prolly_wasm\.js"/);
   assert.match(source, /WasmEntryRecord/);
   assert.match(source, /WasmOptionalEntryRecord/);
   assert.match(source, /WasmProllyEngineInstance/);


### PR DESCRIPTION
## Summary

- vendor the adapted tree visualizer under `3rd/prolly-tree-visualizer`
- replace its DoltLite SQL/VFS adapter with this repository's real `@trail/prolly-wasm` memory engine
- render actual debug-tree records, lower-bound internal separators, content-addressed node IDs, lookup paths, structural diffs, mutation costs, and storage history
- make the default generated WASM import statically discoverable by Vite/Rollup while retaining runtime-resolved custom module paths
- allow the visualizer's Vite server to serve the linked binding from the enclosing repository
- document the visualizer from the repository README and include focused regression and smoke coverage

The vendored visualizer corresponds to the adaptation proposed upstream in [`timsehn/prolly-tree-visualizer#1`](https://github.com/timsehn/prolly-tree-visualizer/pull/1).

## Root cause

The previous visualizer checkout was coupled to DoltLite's SQL and virtual-filesystem formats, so it could not inspect this engine's native nodes or routing semantics. The WASM loader also placed its default relative module path in a variable before calling `import()`, preventing browser bundlers from statically discovering the generated JavaScript and WASM assets.

A clean binding rebuild showed that earlier versioned-batch and append-stat failures came from stale generated artifacts; current Rust source and freshly generated bindings pass the full suite, so no Rust accounting change is included.

## Validation

- `npm --prefix bindings/wasm test` — 34/34 passed
- `npm --prefix bindings/wasm run check:rust`
- clean `npm --prefix bindings/wasm run build:wasm` before binding runtime tests
- `npm ci` in `3rd/prolly-tree-visualizer`
- `npm test` in the visualizer — 7 files, 20 tests passed
- `npm run build` in the visualizer — TypeScript and Vite production build passed
- `npm run smoke:wasm` — built and inspected a 240-row real prolly tree
- manually verified the visualizer in a browser against the local WASM engine
