### PR TITLE
Use Crabbuild package namespace and compact visualizer IDs

### DIFF
--- a/3rd/README.md
+++ b/3rd/README.md
@@ -12,5 +12,5 @@ repository. Credit goes to Tim Sehn and the original contributors for the
 visualizer's design and implementation.
 
 The version vendored here replaces the original DoltLite backend with this
-repository's `@trail/prolly-wasm` binding so it can render the actual trees,
+repository's `@crabbuild/prolly-wasm` binding so it can render the actual trees,
 content IDs, lookups, diffs, and storage behavior produced by `prolly-map`.

--- a/3rd/prolly-tree-visualizer/README.md
+++ b/3rd/prolly-tree-visualizer/README.md
@@ -3,7 +3,7 @@
 An interactive browser visualizer for the real trees produced by this
 repository's Rust `prolly-map` engine. The interaction model is inspired by
 [btree.app](https://btree.app/), but mutations execute in the
-`@trail/prolly-wasm` binding rather than in a JavaScript tree simulation.
+`@crabbuild/prolly-wasm` binding rather than in a JavaScript tree simulation.
 
 The visualizer demonstrates:
 
@@ -40,7 +40,7 @@ npm --prefix 3rd/prolly-tree-visualizer run preview
 
 ```text
 browser control
-  → @trail/prolly-wasm
+  → @crabbuild/prolly-wasm
   → Rust prolly-map mutation
   → content-addressed in-memory node store
   → typed Rust debug traversal and real node CIDs

--- a/3rd/prolly-tree-visualizer/package-lock.json
+++ b/3rd/prolly-tree-visualizer/package-lock.json
@@ -8,7 +8,7 @@
       "name": "prolly-tree-visualizer",
       "version": "0.1.0",
       "dependencies": {
-        "@trail/prolly-wasm": "file:../../bindings/wasm",
+        "@crabbuild/prolly-wasm": "file:../../bindings/wasm",
         "react": "19.1.1",
         "react-dom": "19.1.1"
       },
@@ -22,7 +22,7 @@
       }
     },
     "../../bindings/wasm": {
-      "name": "@trail/prolly-wasm",
+      "name": "@crabbuild/prolly-wasm",
       "version": "0.1.0"
     },
     "node_modules/@babel/code-frame": {
@@ -1215,7 +1215,7 @@
         "win32"
       ]
     },
-    "node_modules/@trail/prolly-wasm": {
+    "node_modules/@crabbuild/prolly-wasm": {
       "resolved": "../../bindings/wasm",
       "link": true
     },

--- a/3rd/prolly-tree-visualizer/package.json
+++ b/3rd/prolly-tree-visualizer/package.json
@@ -12,7 +12,7 @@
     "smoke:wasm": "node scripts/smoke-wasm.mjs"
   },
   "dependencies": {
-    "@trail/prolly-wasm": "file:../../bindings/wasm",
+    "@crabbuild/prolly-wasm": "file:../../bindings/wasm",
     "react": "19.1.1",
     "react-dom": "19.1.1"
   },

--- a/3rd/prolly-tree-visualizer/scripts/smoke-wasm.mjs
+++ b/3rd/prolly-tree-visualizer/scripts/smoke-wasm.mjs
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { loadProllyWasm } from '@trail/prolly-wasm';
+import { loadProllyWasm } from '@crabbuild/prolly-wasm';
 
 const wasmBytes = readFileSync(new URL('../../../bindings/wasm/pkg/prolly_wasm_bg.wasm', import.meta.url));
 const prolly = await loadProllyWasm(undefined, wasmBytes);

--- a/3rd/prolly-tree-visualizer/src/App.tsx
+++ b/3rd/prolly-tree-visualizer/src/App.tsx
@@ -10,7 +10,7 @@ import { DiffPlaybackPanel } from './components/DiffPlaybackPanel';
 import { LookupDetailsPanel, type LookupDetails } from './components/LookupDetailsPanel';
 import { MutationCostPanel } from './components/MutationCostPanel';
 import { NodeInspector } from './components/NodeInspector';
-import { TreeCanvas } from './components/TreeCanvas';
+import { compactNodeId, TreeCanvas } from './components/TreeCanvas';
 
 type Tab = 'tree' | 'diff' | 'chunks' | 'storage' | 'order';
 type ControlMode = 'modify' | 'lookup';
@@ -815,7 +815,9 @@ function App() {
                 <button key={snapshot.id} className={snapshot.id === current.id ? 'selected' : ''} onClick={() => { resetTreeState(); setViewId(snapshot.id); setInsertionOrderResult(undefined); }} disabled={snapshot.id === current.id}>
                   <span>Version {String(index + 1).padStart(2, '0')}{index === snapshots.length - 1 && <em>latest</em>}</span>
                   <b>{snapshot.label}</b>
-                  <code>{snapshot.rootHash}</code>
+                  <code title={`Full content address: ${snapshot.rootHash}`} aria-label={`Content address ${snapshot.rootHash}`}>
+                    {compactNodeId(snapshot.rootHash)}
+                  </code>
                   <small>{snapshot.rows.length} rows · {snapshot.nodes.size} nodes</small>
                 </button>
               );

--- a/3rd/prolly-tree-visualizer/src/components/TreeCanvas.test.ts
+++ b/3rd/prolly-tree-visualizer/src/components/TreeCanvas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { missingKeyLabel, rangeKeysForNode, routeKeyForLookup, shownKeys } from './TreeCanvas';
+import { compactNodeId, missingKeyLabel, rangeKeysForNode, routeKeyForLookup, shownKeys } from './TreeCanvas';
 import type { ProllyNode } from '../types';
 
 function leaf(keys: number[]): ProllyNode {
@@ -16,6 +16,12 @@ function leaf(keys: number[]): ProllyNode {
 }
 
 describe('tree key labels', () => {
+  it('compacts long node IDs while preserving distinguishing ends', () => {
+    expect(compactNodeId('0058c97f1e48bcd2441721d6c63421d3f70093c3475e36ce4627780918f3e253'))
+      .toBe('0058c97f1e48…18f3e253');
+    expect(compactNodeId('short-node-id')).toBe('short-node-id');
+  });
+
   it('keeps a looked-up key visible inside a compressed leaf', () => {
     expect(shownKeys(leaf([1, 2, 3, 4, 5, 6, 7, 8, 9]), [6])).toEqual([
       { text: '1', match: false },

--- a/3rd/prolly-tree-visualizer/src/components/TreeCanvas.test.ts
+++ b/3rd/prolly-tree-visualizer/src/components/TreeCanvas.test.ts
@@ -18,7 +18,7 @@ function leaf(keys: number[]): ProllyNode {
 describe('tree key labels', () => {
   it('compacts long node IDs while preserving distinguishing ends', () => {
     expect(compactNodeId('0058c97f1e48bcd2441721d6c63421d3f70093c3475e36ce4627780918f3e253'))
-      .toBe('0058c97f1e48…18f3e253');
+      .toBe('0058c97f1e48bcd2…780918f3e253');
     expect(compactNodeId('short-node-id')).toBe('short-node-id');
   });
 

--- a/3rd/prolly-tree-visualizer/src/components/TreeCanvas.tsx
+++ b/3rd/prolly-tree-visualizer/src/components/TreeCanvas.tsx
@@ -20,8 +20,8 @@ interface KeyLabelPart {
 }
 
 const KEY_PREVIEW_CHARACTERS = 34;
-const NODE_ID_PREFIX_CHARACTERS = 12;
-const NODE_ID_SUFFIX_CHARACTERS = 8;
+const NODE_ID_PREFIX_CHARACTERS = 16;
+const NODE_ID_SUFFIX_CHARACTERS = 12;
 
 export function compactNodeId(nodeId: string) {
   const visibleCharacters = NODE_ID_PREFIX_CHARACTERS + NODE_ID_SUFFIX_CHARACTERS;

--- a/3rd/prolly-tree-visualizer/src/components/TreeCanvas.tsx
+++ b/3rd/prolly-tree-visualizer/src/components/TreeCanvas.tsx
@@ -20,6 +20,14 @@ interface KeyLabelPart {
 }
 
 const KEY_PREVIEW_CHARACTERS = 34;
+const NODE_ID_PREFIX_CHARACTERS = 12;
+const NODE_ID_SUFFIX_CHARACTERS = 8;
+
+export function compactNodeId(nodeId: string) {
+  const visibleCharacters = NODE_ID_PREFIX_CHARACTERS + NODE_ID_SUFFIX_CHARACTERS;
+  if (nodeId.length <= visibleCharacters + 1) return nodeId;
+  return `${nodeId.slice(0, NODE_ID_PREFIX_CHARACTERS)}…${nodeId.slice(-NODE_ID_SUFFIX_CHARACTERS)}`;
+}
 
 function partsForIndexes(keys: string[], indexes: number[], matchIndexes: number[]) {
   return indexes.flatMap((index, position): KeyLabelPart[] => {
@@ -276,7 +284,10 @@ export function TreeCanvas({ snapshot, baseline, trace, activeTraceHash, diffHig
               <text className="node-range" x="15" y="84">
                 {node.size.toLocaleString()} bytes
               </text>
-              <text className={activeDiffHashes?.has(node.hash) ? 'node-hash node-hash-active' : isActiveSkipped ? 'node-hash node-hash-skip-active' : 'node-hash'} x="15" y="108">{node.hash}</text>
+              <text className={activeDiffHashes?.has(node.hash) ? 'node-hash node-hash-active' : isActiveSkipped ? 'node-hash node-hash-skip-active' : 'node-hash'} x="15" y="108">
+                <title>Full content address: {node.hash}</title>
+                {compactNodeId(node.hash)}
+              </text>
             </g>
           );
         })}

--- a/3rd/prolly-tree-visualizer/src/engine.ts
+++ b/3rd/prolly-tree-visualizer/src/engine.ts
@@ -5,7 +5,7 @@ import {
   type WasmProllyEngineInstance,
   type WasmTree,
   type WasmTreeDebugViewRecord,
-} from '@trail/prolly-wasm';
+} from '@crabbuild/prolly-wasm';
 import { bootstrapKeys, deterministicShuffle } from './bootstrap';
 import { buildTreeFromDebug, leafNodes, toHex } from './prolly';
 import type { RowValue, TreeSnapshot } from './types';
@@ -78,7 +78,7 @@ export class ProllyEngine {
   private tree: WasmTree;
   private snapshotId = 0;
   private storedNodeSizes = new Map<string, number>();
-  readonly version = '@trail/prolly-wasm 0.1.0';
+  readonly version = '@crabbuild/prolly-wasm 0.1.0';
 
   private constructor(wasm: ProllyWasmModule) {
     this.wasm = wasm;

--- a/3rd/prolly-tree-visualizer/src/prolly.test.ts
+++ b/3rd/prolly-tree-visualizer/src/prolly.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { WasmTreeDebugViewRecord } from '@trail/prolly-wasm';
+import type { WasmTreeDebugViewRecord } from '@crabbuild/prolly-wasm';
 import {
   buildTreeFromDebug,
   diffRows,

--- a/3rd/prolly-tree-visualizer/src/prolly.ts
+++ b/3rd/prolly-tree-visualizer/src/prolly.ts
@@ -1,4 +1,4 @@
-import type { WasmTreeDebugNodeRecord, WasmTreeDebugViewRecord } from '@trail/prolly-wasm';
+import type { WasmTreeDebugNodeRecord, WasmTreeDebugViewRecord } from '@crabbuild/prolly-wasm';
 import type { ProllyEntry, ProllyNode, RowDiff, RowValue } from './types';
 
 const DEFAULT_MIN_CHUNK_ENTRIES = 4;

--- a/3rd/prolly-tree-visualizer/src/styles.css
+++ b/3rd/prolly-tree-visualizer/src/styles.css
@@ -327,7 +327,7 @@ button.mutation-stage:disabled { cursor: default; }
 .timeline button > span { color: var(--accent); font: 500 11px var(--mono); }
 .timeline button > span em { float: right; border: 1px solid #3b4b72; border-radius: 999px; padding: 2px 6px; color: #aebbd6; font-size: 11px; font-style: normal; text-transform: uppercase; letter-spacing: .08em; }
 .timeline button b { margin: 10px 0; font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.timeline button code { color: #b9c5c1; font-size: 10px; line-height: 1.45; white-space: nowrap; }
+.timeline button code { min-width: 0; overflow: hidden; color: #b9c5c1; font-size: 10px; line-height: 1.45; text-overflow: ellipsis; white-space: nowrap; }
 .timeline button small { color: #899592; margin-top: 8px; font-size: 11px; }
 
 footer { padding: 19px 4vw; display: flex; justify-content: space-between; gap: 20px; color: var(--muted); font-size: 11px; border-top: 1px solid var(--line); }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Breaking changes and release qualification are recorded in
 
 The browser app in
 [`3rd/prolly-tree-visualizer`](3rd/prolly-tree-visualizer/README.md) executes
-mutations against this repository's real `@trail/prolly-wasm` binding and
+mutations against this repository's real `@crabbuild/prolly-wasm` binding and
 renders the resulting content-addressed tree, lookup paths, structural diffs,
 and storage history.
 

--- a/bindings/api/idiomatic-equivalents.json
+++ b/bindings/api/idiomatic-equivalents.json
@@ -23,7 +23,7 @@
         "java": "build.crab.prolly.javaapi KeyCodec/ValueCodec contract ({rust})",
         "ruby": "Prolly codec contract ({rust})",
         "swift": "ProllyAPI KeyCodec/ValueCodec contract ({rust})",
-        "wasm": "@trail/prolly-wasm Codec<T> contract ({rust})"
+        "wasm": "@crabbuild/prolly-wasm Codec<T> contract ({rust})"
       },
       "tests": [
         "portable-parity::typed-codec-round-trip"
@@ -247,7 +247,7 @@
         "java": "build.crab.prolly package namespace ({rust})",
         "ruby": "Prolly module namespace ({rust})",
         "swift": "Prolly/ProllyAPI module namespace ({rust})",
-        "wasm": "@trail/prolly-wasm export namespace ({rust})"
+        "wasm": "@crabbuild/prolly-wasm export namespace ({rust})"
       },
       "tests": [
         "portable-parity::public-export-surface"

--- a/bindings/api/idiomatic-equivalents.json
+++ b/bindings/api/idiomatic-equivalents.json
@@ -18,7 +18,7 @@
       "language_symbols": {
         "python": "prolly.api.KeyCodec/ValueCodec contract ({rust})",
         "go": "prolly.KeyCodec/ValueCodec contract ({rust})",
-        "node": "@trail/prolly-node Codec<T> contract ({rust})",
+        "node": "@crabbuild/prolly-node Codec<T> contract ({rust})",
         "kotlin": "build.crab.prolly.api KeyCodec/ValueCodec contract ({rust})",
         "java": "build.crab.prolly.javaapi KeyCodec/ValueCodec contract ({rust})",
         "ruby": "Prolly codec contract ({rust})",
@@ -242,7 +242,7 @@
       "language_symbols": {
         "python": "prolly package namespace ({rust})",
         "go": "prolly package namespace ({rust})",
-        "node": "@trail/prolly-node export namespace ({rust})",
+        "node": "@crabbuild/prolly-node export namespace ({rust})",
         "kotlin": "build.crab.prolly package namespace ({rust})",
         "java": "build.crab.prolly package namespace ({rust})",
         "ruby": "Prolly module namespace ({rust})",

--- a/bindings/api/parity.json
+++ b/bindings/api/parity.json
@@ -7151,7 +7151,7 @@
       "languages": {
         "python": "prolly.api.BytesKeyCodec",
         "go": "prolly.BytesKeyCodec",
-        "node": "@trail/prolly-node.BytesKeyCodec",
+        "node": "@crabbuild/prolly-node.BytesKeyCodec",
         "kotlin": "build.crab.prolly.api.BytesKeyCodec",
         "java": "build.crab.prolly.javaapi.BytesKeyCodec",
         "ruby": "Prolly::BytesKeyCodec",
@@ -15756,7 +15756,7 @@
       "languages": {
         "python": "prolly.api.KeyCodec",
         "go": "prolly.KeyCodec",
-        "node": "@trail/prolly-node.KeyCodec",
+        "node": "@crabbuild/prolly-node.KeyCodec",
         "kotlin": "build.crab.prolly.api.KeyCodec",
         "java": "build.crab.prolly.javaapi.KeyCodec",
         "ruby": "Prolly key codec protocol",
@@ -17215,7 +17215,7 @@
       "languages": {
         "python": "prolly.api.MapSnapshot.export",
         "go": "prolly.(*MapSnapshot).Export",
-        "node": "@trail/prolly-node.MapSnapshot.export",
+        "node": "@crabbuild/prolly-node.MapSnapshot.export",
         "kotlin": "build.crab.prolly.api.MapSnapshot.export",
         "java": "build.crab.prolly.javaapi.MapSnapshot.export",
         "ruby": "Prolly::MapSnapshot#export",
@@ -37103,7 +37103,7 @@
       "languages": {
         "python": "prolly.api.StringKeyCodec",
         "go": "prolly.StringKeyCodec",
-        "node": "@trail/prolly-node.StringKeyCodec",
+        "node": "@crabbuild/prolly-node.StringKeyCodec",
         "kotlin": "build.crab.prolly.api.StringKeyCodec",
         "java": "build.crab.prolly.javaapi.StringKeyCodec",
         "ruby": "Prolly::StringKeyCodec",
@@ -39362,7 +39362,7 @@
       "languages": {
         "python": "prolly.api.TypedMigrationResult",
         "go": "prolly.TypedMigrationResult",
-        "node": "@trail/prolly-node.TypedMigrationResult",
+        "node": "@crabbuild/prolly-node.TypedMigrationResult",
         "kotlin": "build.crab.prolly.api.TypedMigrationResult",
         "java": "build.crab.prolly.javaapi.TypedMigrationResult",
         "ruby": "Prolly::TypedMigrationResult",
@@ -39454,7 +39454,7 @@
       "languages": {
         "python": "prolly.api.TypedVersionedMap",
         "go": "prolly.TypedVersionedMap",
-        "node": "@trail/prolly-node.TypedVersionedMap",
+        "node": "@crabbuild/prolly-node.TypedVersionedMap",
         "kotlin": "build.crab.prolly.api.TypedVersionedMap",
         "java": "build.crab.prolly.javaapi.TypedVersionedMap",
         "ruby": "Prolly::TypedVersionedMap",
@@ -39743,7 +39743,7 @@
       "languages": {
         "python": "prolly.api.ValueCodec",
         "go": "prolly.ValueCodec",
-        "node": "@trail/prolly-node.ValueCodec",
+        "node": "@crabbuild/prolly-node.ValueCodec",
         "kotlin": "build.crab.prolly.api.ValueCodec",
         "java": "build.crab.prolly.javaapi.ValueCodec",
         "ruby": "Prolly value codec protocol",
@@ -40845,7 +40845,7 @@
       "languages": {
         "python": "prolly.api.VersionedMap.get_large_value",
         "go": "prolly.(*VersionedMap).GetLargeValue",
-        "node": "@trail/prolly-node.VersionedMap.getLargeValue",
+        "node": "@crabbuild/prolly-node.VersionedMap.getLargeValue",
         "kotlin": "build.crab.prolly.api.VersionedMap.getLargeValue",
         "java": "build.crab.prolly.javaapi.VersionedMap.getLargeValue",
         "ruby": "Prolly::VersionedMap#get_large_value",
@@ -41171,7 +41171,7 @@
       "languages": {
         "python": "prolly.api.VersionedMap.head_name",
         "go": "prolly.(*VersionedMap).HeadName",
-        "node": "@trail/prolly-node.VersionedMap.headName",
+        "node": "@crabbuild/prolly-node.VersionedMap.headName",
         "kotlin": "build.crab.prolly.api.VersionedMap.headName",
         "java": "build.crab.prolly.javaapi.VersionedMap.headName",
         "ruby": "Prolly::VersionedMap#head_name",
@@ -41239,7 +41239,7 @@
       "languages": {
         "python": "prolly.api.VersionedMap.import_as_head",
         "go": "prolly.(*VersionedMap).ImportAsHead",
-        "node": "@trail/prolly-node.VersionedMap.importAsHead",
+        "node": "@crabbuild/prolly-node.VersionedMap.importAsHead",
         "kotlin": "build.crab.prolly.api.VersionedMap.importAsHead",
         "java": "build.crab.prolly.javaapi.VersionedMap.importAsHead",
         "ruby": "Prolly::VersionedMap#import_as_head",
@@ -41268,7 +41268,7 @@
       "languages": {
         "python": "prolly.api.VersionedMap.import_as_head_at_millis",
         "go": "prolly.(*VersionedMap).ImportAsHeadAtMillis",
-        "node": "@trail/prolly-node.VersionedMap.importAsHeadAtMillis",
+        "node": "@crabbuild/prolly-node.VersionedMap.importAsHeadAtMillis",
         "kotlin": "build.crab.prolly.api.VersionedMap.importAsHead(bundle,timestampMillis)",
         "java": "build.crab.prolly.javaapi.VersionedMap.importAsHead(bundle,timestampMillis)",
         "ruby": "Prolly::VersionedMap#import_as_head_at_millis",
@@ -41649,7 +41649,7 @@
       "languages": {
         "python": "prolly.api.VersionedMap.plan_blob_gc",
         "go": "prolly.(*VersionedMap).PlanBlobGC",
-        "node": "@trail/prolly-node.VersionedMap.planBlobGc",
+        "node": "@crabbuild/prolly-node.VersionedMap.planBlobGc",
         "kotlin": "build.crab.prolly.api.VersionedMap.planBlobGc",
         "java": "build.crab.prolly.javaapi.VersionedMap.planBlobGc",
         "ruby": "Prolly::VersionedMap#plan_blob_gc",
@@ -42031,7 +42031,7 @@
       "languages": {
         "python": "prolly.api.VersionedMap.put_large_value",
         "go": "prolly.(*VersionedMap).PutLargeValue",
-        "node": "@trail/prolly-node.VersionedMap.putLargeValue",
+        "node": "@crabbuild/prolly-node.VersionedMap.putLargeValue",
         "kotlin": "build.crab.prolly.api.VersionedMap.putLargeValue",
         "java": "build.crab.prolly.javaapi.VersionedMap.putLargeValue",
         "ruby": "Prolly::VersionedMap#put_large_value",
@@ -42060,7 +42060,7 @@
       "languages": {
         "python": "prolly.api.VersionedMap.put_large_value_if",
         "go": "prolly.(*VersionedMap).PutLargeValueIf",
-        "node": "@trail/prolly-node.VersionedMap.putLargeValueIf",
+        "node": "@crabbuild/prolly-node.VersionedMap.putLargeValueIf",
         "kotlin": "build.crab.prolly.api.VersionedMap.putLargeValueIf",
         "java": "build.crab.prolly.javaapi.VersionedMap.putLargeValueIf",
         "ruby": "Prolly::VersionedMap#put_large_value_if",
@@ -42761,7 +42761,7 @@
       "languages": {
         "python": "prolly.api.VersionedMap.sweep_blob_gc",
         "go": "prolly.(*VersionedMap).SweepBlobGC",
-        "node": "@trail/prolly-node.VersionedMap.sweepBlobGc",
+        "node": "@crabbuild/prolly-node.VersionedMap.sweepBlobGc",
         "kotlin": "build.crab.prolly.api.VersionedMap.sweepBlobGc",
         "java": "build.crab.prolly.javaapi.VersionedMap.sweepBlobGc",
         "ruby": "Prolly::VersionedMap#sweep_blob_gc",
@@ -42989,7 +42989,7 @@
       "languages": {
         "python": "prolly.api.VersionedMap.versions_prefix",
         "go": "prolly.(*VersionedMap).VersionsPrefix",
-        "node": "@trail/prolly-node.VersionedMap.versionsPrefix",
+        "node": "@crabbuild/prolly-node.VersionedMap.versionsPrefix",
         "kotlin": "build.crab.prolly.api.VersionedMap.versionsPrefix",
         "java": "build.crab.prolly.javaapi.VersionedMap.versionsPrefix",
         "ruby": "Prolly::VersionedMap#versions_prefix",
@@ -44340,7 +44340,7 @@
       "languages": {
         "python": "prolly package namespace (prolly::chunking)",
         "go": "prolly package namespace (prolly::chunking)",
-        "node": "@trail/prolly-node export namespace (prolly::chunking)",
+        "node": "@crabbuild/prolly-node export namespace (prolly::chunking)",
         "kotlin": "build.crab.prolly package namespace (prolly::chunking)",
         "java": "build.crab.prolly package namespace (prolly::chunking)",
         "ruby": "Prolly module namespace (prolly::chunking)",
@@ -44809,7 +44809,7 @@
       "languages": {
         "python": "prolly package namespace (prolly::remote_conformance)",
         "go": "prolly package namespace (prolly::remote_conformance)",
-        "node": "@trail/prolly-node export namespace (prolly::remote_conformance)",
+        "node": "@crabbuild/prolly-node export namespace (prolly::remote_conformance)",
         "kotlin": "build.crab.prolly package namespace (prolly::remote_conformance)",
         "java": "build.crab.prolly package namespace (prolly::remote_conformance)",
         "ruby": "Prolly module namespace (prolly::remote_conformance)",
@@ -44876,7 +44876,7 @@
       "languages": {
         "python": "prolly package namespace (prolly::resolver)",
         "go": "prolly package namespace (prolly::resolver)",
-        "node": "@trail/prolly-node export namespace (prolly::resolver)",
+        "node": "@crabbuild/prolly-node export namespace (prolly::resolver)",
         "kotlin": "build.crab.prolly package namespace (prolly::resolver)",
         "java": "build.crab.prolly package namespace (prolly::resolver)",
         "ruby": "Prolly module namespace (prolly::resolver)",

--- a/bindings/api/parity.json
+++ b/bindings/api/parity.json
@@ -7156,7 +7156,7 @@
         "java": "build.crab.prolly.javaapi.BytesKeyCodec",
         "ruby": "Prolly::BytesKeyCodec",
         "swift": "ProllyAPI.BytesKeyCodec",
-        "wasm": "@trail/prolly-wasm.BytesKeyCodec"
+        "wasm": "@crabbuild/prolly-wasm.BytesKeyCodec"
       },
       "exclusions": {},
       "tests": [
@@ -15761,7 +15761,7 @@
         "java": "build.crab.prolly.javaapi.KeyCodec",
         "ruby": "Prolly key codec protocol",
         "swift": "ProllyAPI.KeyCodec",
-        "wasm": "@trail/prolly-wasm.KeyCodec"
+        "wasm": "@crabbuild/prolly-wasm.KeyCodec"
       },
       "exclusions": {},
       "tests": [
@@ -17220,7 +17220,7 @@
         "java": "build.crab.prolly.javaapi.MapSnapshot.export",
         "ruby": "Prolly::MapSnapshot#export",
         "swift": "ProllyAPI.MapSnapshot.export",
-        "wasm": "@trail/prolly-wasm.WasmMapSnapshot.export"
+        "wasm": "@crabbuild/prolly-wasm.WasmMapSnapshot.export"
       },
       "exclusions": {},
       "tests": [
@@ -37108,7 +37108,7 @@
         "java": "build.crab.prolly.javaapi.StringKeyCodec",
         "ruby": "Prolly::StringKeyCodec",
         "swift": "ProllyAPI.StringKeyCodec",
-        "wasm": "@trail/prolly-wasm.StringKeyCodec"
+        "wasm": "@crabbuild/prolly-wasm.StringKeyCodec"
       },
       "exclusions": {},
       "tests": [
@@ -39367,7 +39367,7 @@
         "java": "build.crab.prolly.javaapi.TypedMigrationResult",
         "ruby": "Prolly::TypedMigrationResult",
         "swift": "ProllyAPI.TypedMigrationResult",
-        "wasm": "@trail/prolly-wasm.TypedMigrationResult"
+        "wasm": "@crabbuild/prolly-wasm.TypedMigrationResult"
       },
       "exclusions": {},
       "tests": [
@@ -39459,7 +39459,7 @@
         "java": "build.crab.prolly.javaapi.TypedVersionedMap",
         "ruby": "Prolly::TypedVersionedMap",
         "swift": "ProllyAPI.TypedVersionedMap",
-        "wasm": "@trail/prolly-wasm.TypedVersionedMap"
+        "wasm": "@crabbuild/prolly-wasm.TypedVersionedMap"
       },
       "exclusions": {},
       "tests": [
@@ -39748,7 +39748,7 @@
         "java": "build.crab.prolly.javaapi.ValueCodec",
         "ruby": "Prolly value codec protocol",
         "swift": "ProllyAPI.ValueCodec",
-        "wasm": "@trail/prolly-wasm.ValueCodec"
+        "wasm": "@crabbuild/prolly-wasm.ValueCodec"
       },
       "exclusions": {},
       "tests": [
@@ -40850,7 +40850,7 @@
         "java": "build.crab.prolly.javaapi.VersionedMap.getLargeValue",
         "ruby": "Prolly::VersionedMap#get_large_value",
         "swift": "ProllyAPI.VersionedMap.getLargeValue",
-        "wasm": "@trail/prolly-wasm.WasmVersionedMap.getLargeValue"
+        "wasm": "@crabbuild/prolly-wasm.WasmVersionedMap.getLargeValue"
       },
       "exclusions": {},
       "tests": [
@@ -41176,7 +41176,7 @@
         "java": "build.crab.prolly.javaapi.VersionedMap.headName",
         "ruby": "Prolly::VersionedMap#head_name",
         "swift": "ProllyAPI.VersionedMap.headName",
-        "wasm": "@trail/prolly-wasm.WasmVersionedMap.headName"
+        "wasm": "@crabbuild/prolly-wasm.WasmVersionedMap.headName"
       },
       "exclusions": {},
       "tests": [
@@ -41244,7 +41244,7 @@
         "java": "build.crab.prolly.javaapi.VersionedMap.importAsHead",
         "ruby": "Prolly::VersionedMap#import_as_head",
         "swift": "ProllyAPI.VersionedMap.importAsHead",
-        "wasm": "@trail/prolly-wasm.WasmVersionedMap.importAsHead"
+        "wasm": "@crabbuild/prolly-wasm.WasmVersionedMap.importAsHead"
       },
       "exclusions": {},
       "tests": [
@@ -41273,7 +41273,7 @@
         "java": "build.crab.prolly.javaapi.VersionedMap.importAsHead(bundle,timestampMillis)",
         "ruby": "Prolly::VersionedMap#import_as_head_at_millis",
         "swift": "ProllyAPI.VersionedMap.importAsHead(_:timestampMillis:)",
-        "wasm": "@trail/prolly-wasm.WasmVersionedMap.importAsHeadAtMillis"
+        "wasm": "@crabbuild/prolly-wasm.WasmVersionedMap.importAsHeadAtMillis"
       },
       "exclusions": {},
       "tests": [
@@ -41654,7 +41654,7 @@
         "java": "build.crab.prolly.javaapi.VersionedMap.planBlobGc",
         "ruby": "Prolly::VersionedMap#plan_blob_gc",
         "swift": "ProllyAPI.VersionedMap.planBlobGC",
-        "wasm": "@trail/prolly-wasm.WasmVersionedMap.planBlobGc"
+        "wasm": "@crabbuild/prolly-wasm.WasmVersionedMap.planBlobGc"
       },
       "exclusions": {},
       "tests": [
@@ -42036,7 +42036,7 @@
         "java": "build.crab.prolly.javaapi.VersionedMap.putLargeValue",
         "ruby": "Prolly::VersionedMap#put_large_value",
         "swift": "ProllyAPI.VersionedMap.putLargeValue",
-        "wasm": "@trail/prolly-wasm.WasmVersionedMap.putLargeValue"
+        "wasm": "@crabbuild/prolly-wasm.WasmVersionedMap.putLargeValue"
       },
       "exclusions": {},
       "tests": [
@@ -42065,7 +42065,7 @@
         "java": "build.crab.prolly.javaapi.VersionedMap.putLargeValueIf",
         "ruby": "Prolly::VersionedMap#put_large_value_if",
         "swift": "ProllyAPI.VersionedMap.putLargeValueIf",
-        "wasm": "@trail/prolly-wasm.WasmVersionedMap.putLargeValueIf"
+        "wasm": "@crabbuild/prolly-wasm.WasmVersionedMap.putLargeValueIf"
       },
       "exclusions": {},
       "tests": [
@@ -42766,7 +42766,7 @@
         "java": "build.crab.prolly.javaapi.VersionedMap.sweepBlobGc",
         "ruby": "Prolly::VersionedMap#sweep_blob_gc",
         "swift": "ProllyAPI.VersionedMap.sweepBlobGC",
-        "wasm": "@trail/prolly-wasm.WasmVersionedMap.sweepBlobGc"
+        "wasm": "@crabbuild/prolly-wasm.WasmVersionedMap.sweepBlobGc"
       },
       "exclusions": {},
       "tests": [
@@ -42994,7 +42994,7 @@
         "java": "build.crab.prolly.javaapi.VersionedMap.versionsPrefix",
         "ruby": "Prolly::VersionedMap#versions_prefix",
         "swift": "ProllyAPI.VersionedMap.versionsPrefix",
-        "wasm": "@trail/prolly-wasm.WasmVersionedMap.versionsPrefix"
+        "wasm": "@crabbuild/prolly-wasm.WasmVersionedMap.versionsPrefix"
       },
       "exclusions": {},
       "tests": [
@@ -44345,7 +44345,7 @@
         "java": "build.crab.prolly package namespace (prolly::chunking)",
         "ruby": "Prolly module namespace (prolly::chunking)",
         "swift": "Prolly/ProllyAPI module namespace (prolly::chunking)",
-        "wasm": "@trail/prolly-wasm export namespace (prolly::chunking)"
+        "wasm": "@crabbuild/prolly-wasm export namespace (prolly::chunking)"
       },
       "exclusions": {},
       "tests": [
@@ -44814,7 +44814,7 @@
         "java": "build.crab.prolly package namespace (prolly::remote_conformance)",
         "ruby": "Prolly module namespace (prolly::remote_conformance)",
         "swift": "Prolly/ProllyAPI module namespace (prolly::remote_conformance)",
-        "wasm": "@trail/prolly-wasm export namespace (prolly::remote_conformance)"
+        "wasm": "@crabbuild/prolly-wasm export namespace (prolly::remote_conformance)"
       },
       "exclusions": {},
       "tests": [
@@ -44881,7 +44881,7 @@
         "java": "build.crab.prolly package namespace (prolly::resolver)",
         "ruby": "Prolly module namespace (prolly::resolver)",
         "swift": "Prolly/ProllyAPI module namespace (prolly::resolver)",
-        "wasm": "@trail/prolly-wasm export namespace (prolly::resolver)"
+        "wasm": "@crabbuild/prolly-wasm export namespace (prolly::resolver)"
       },
       "exclusions": {},
       "tests": [

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -107,28 +107,28 @@ only gives JavaScript code a familiar scheduling model.
 
 ## Async Store Providers
 
-Database adapters are separate packages, so installing `@trail/prolly-node`
+Database adapters are separate packages, so installing `@crabbuild/prolly-node`
 does not install a database SDK. Each adapter accepts a caller-owned SDK client,
 pool, database, or container and never closes it. Initialize or validate the
 physical schema explicitly before opening a remote engine.
 
 | Provider package | Minimal construction | Required preparation |
 | --- | --- | --- |
-| `@trail/prolly-store-sqlite` | `new SqliteStore(database)` | `await store.initializeSchema()` |
-| `@trail/prolly-store-postgres` | `new PostgresStore(pool)` | `await store.initializeSchema()` |
-| `@trail/prolly-store-mysql` | `new MysqlStore(pool)` | `await store.initializeSchema()` |
-| `@trail/prolly-store-redis` | `new RedisStore(client)` | connect the binary Redis client |
-| `@trail/prolly-store-dynamodb` | `new DynamoDbStore(client, { tableName: "prolly" })` | `await store.initializeTable()` |
-| `@trail/prolly-store-cosmosdb` | `new CosmosDbStore(container)` | create with `/kind`, then `await store.validateContainer()` |
-| `@trail/prolly-store-spanner` | `new SpannerStore(database)` | apply the exported `SPANNER_DDL` statements |
-| `@trail/prolly-store-pglite` | `new PGliteStore(database)` | `await store.initializeSchema()` |
+| `@crabbuild/prolly-store-sqlite` | `new SqliteStore(database)` | `await store.initializeSchema()` |
+| `@crabbuild/prolly-store-postgres` | `new PostgresStore(pool)` | `await store.initializeSchema()` |
+| `@crabbuild/prolly-store-mysql` | `new MysqlStore(pool)` | `await store.initializeSchema()` |
+| `@crabbuild/prolly-store-redis` | `new RedisStore(client)` | connect the binary Redis client |
+| `@crabbuild/prolly-store-dynamodb` | `new DynamoDbStore(client, { tableName: "prolly" })` | `await store.initializeTable()` |
+| `@crabbuild/prolly-store-cosmosdb` | `new CosmosDbStore(container)` | create with `/kind`, then `await store.validateContainer()` |
+| `@crabbuild/prolly-store-spanner` | `new SpannerStore(database)` | apply the exported `SPANNER_DDL` statements |
+| `@crabbuild/prolly-store-pglite` | `new PGliteStore(database)` | `await store.initializeSchema()` |
 
 Import the constructor from the provider package and create the injected value
 with its official SDK. For example:
 
 ```ts
 import { Pool } from "pg";
-import { PostgresStore } from "@trail/prolly-store-postgres";
+import { PostgresStore } from "@crabbuild/prolly-store-postgres";
 
 const pool = new Pool(); // standard PG* environment variables or explicit options
 const store = new PostgresStore(pool);

--- a/bindings/node/index.cjs
+++ b/bindings/node/index.cjs
@@ -37,7 +37,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./index.android-arm64.node')
           } else {
-            nativeBinding = require('@trail/prolly-node-android-arm64')
+            nativeBinding = require('@crabbuild/prolly-node-android-arm64')
           }
         } catch (e) {
           loadError = e
@@ -49,7 +49,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./index.android-arm-eabi.node')
           } else {
-            nativeBinding = require('@trail/prolly-node-android-arm-eabi')
+            nativeBinding = require('@crabbuild/prolly-node-android-arm-eabi')
           }
         } catch (e) {
           loadError = e
@@ -69,7 +69,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./index.win32-x64-msvc.node')
           } else {
-            nativeBinding = require('@trail/prolly-node-win32-x64-msvc')
+            nativeBinding = require('@crabbuild/prolly-node-win32-x64-msvc')
           }
         } catch (e) {
           loadError = e
@@ -83,7 +83,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./index.win32-ia32-msvc.node')
           } else {
-            nativeBinding = require('@trail/prolly-node-win32-ia32-msvc')
+            nativeBinding = require('@crabbuild/prolly-node-win32-ia32-msvc')
           }
         } catch (e) {
           loadError = e
@@ -97,7 +97,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./index.win32-arm64-msvc.node')
           } else {
-            nativeBinding = require('@trail/prolly-node-win32-arm64-msvc')
+            nativeBinding = require('@crabbuild/prolly-node-win32-arm64-msvc')
           }
         } catch (e) {
           loadError = e
@@ -113,7 +113,7 @@ switch (platform) {
       if (localFileExisted) {
         nativeBinding = require('./index.darwin-universal.node')
       } else {
-        nativeBinding = require('@trail/prolly-node-darwin-universal')
+        nativeBinding = require('@crabbuild/prolly-node-darwin-universal')
       }
       break
     } catch {}
@@ -124,7 +124,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./index.darwin-x64.node')
           } else {
-            nativeBinding = require('@trail/prolly-node-darwin-x64')
+            nativeBinding = require('@crabbuild/prolly-node-darwin-x64')
           }
         } catch (e) {
           loadError = e
@@ -138,7 +138,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./index.darwin-arm64.node')
           } else {
-            nativeBinding = require('@trail/prolly-node-darwin-arm64')
+            nativeBinding = require('@crabbuild/prolly-node-darwin-arm64')
           }
         } catch (e) {
           loadError = e
@@ -157,7 +157,7 @@ switch (platform) {
       if (localFileExisted) {
         nativeBinding = require('./index.freebsd-x64.node')
       } else {
-        nativeBinding = require('@trail/prolly-node-freebsd-x64')
+        nativeBinding = require('@crabbuild/prolly-node-freebsd-x64')
       }
     } catch (e) {
       loadError = e
@@ -174,7 +174,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./index.linux-x64-musl.node')
             } else {
-              nativeBinding = require('@trail/prolly-node-linux-x64-musl')
+              nativeBinding = require('@crabbuild/prolly-node-linux-x64-musl')
             }
           } catch (e) {
             loadError = e
@@ -187,7 +187,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./index.linux-x64-gnu.node')
             } else {
-              nativeBinding = require('@trail/prolly-node-linux-x64-gnu')
+              nativeBinding = require('@crabbuild/prolly-node-linux-x64-gnu')
             }
           } catch (e) {
             loadError = e
@@ -203,7 +203,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./index.linux-arm64-musl.node')
             } else {
-              nativeBinding = require('@trail/prolly-node-linux-arm64-musl')
+              nativeBinding = require('@crabbuild/prolly-node-linux-arm64-musl')
             }
           } catch (e) {
             loadError = e
@@ -216,7 +216,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./index.linux-arm64-gnu.node')
             } else {
-              nativeBinding = require('@trail/prolly-node-linux-arm64-gnu')
+              nativeBinding = require('@crabbuild/prolly-node-linux-arm64-gnu')
             }
           } catch (e) {
             loadError = e
@@ -232,7 +232,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./index.linux-arm-musleabihf.node')
             } else {
-              nativeBinding = require('@trail/prolly-node-linux-arm-musleabihf')
+              nativeBinding = require('@crabbuild/prolly-node-linux-arm-musleabihf')
             }
           } catch (e) {
             loadError = e
@@ -245,7 +245,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./index.linux-arm-gnueabihf.node')
             } else {
-              nativeBinding = require('@trail/prolly-node-linux-arm-gnueabihf')
+              nativeBinding = require('@crabbuild/prolly-node-linux-arm-gnueabihf')
             }
           } catch (e) {
             loadError = e
@@ -261,7 +261,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./index.linux-riscv64-musl.node')
             } else {
-              nativeBinding = require('@trail/prolly-node-linux-riscv64-musl')
+              nativeBinding = require('@crabbuild/prolly-node-linux-riscv64-musl')
             }
           } catch (e) {
             loadError = e
@@ -274,7 +274,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./index.linux-riscv64-gnu.node')
             } else {
-              nativeBinding = require('@trail/prolly-node-linux-riscv64-gnu')
+              nativeBinding = require('@crabbuild/prolly-node-linux-riscv64-gnu')
             }
           } catch (e) {
             loadError = e
@@ -289,7 +289,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./index.linux-s390x-gnu.node')
           } else {
-            nativeBinding = require('@trail/prolly-node-linux-s390x-gnu')
+            nativeBinding = require('@crabbuild/prolly-node-linux-s390x-gnu')
           }
         } catch (e) {
           loadError = e

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@trail/prolly-node",
+  "name": "@crabbuild/prolly-node",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@trail/prolly-node",
+      "name": "@crabbuild/prolly-node",
       "version": "0.1.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trail/prolly-node",
+  "name": "@crabbuild/prolly-node",
   "version": "0.1.0",
   "type": "module",
   "private": true,

--- a/bindings/node/stores/cosmosdb/README.md
+++ b/bindings/node/stores/cosmosdb/README.md
@@ -1,4 +1,4 @@
-# `@trail/prolly-store-cosmosdb`
+# `@crabbuild/prolly-store-cosmosdb`
 
 Cosmos DB implementation of the shared async store protocol using the official `@azure/cosmos` SDK. Construct it with a caller-owned `Container`; the adapter never closes the surrounding client.
 

--- a/bindings/node/stores/cosmosdb/package-lock.json
+++ b/bindings/node/stores/cosmosdb/package-lock.json
@@ -1,31 +1,31 @@
 {
-  "name": "@trail/prolly-store-cosmosdb",
+  "name": "@crabbuild/prolly-store-cosmosdb",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@trail/prolly-store-cosmosdb",
+      "name": "@crabbuild/prolly-store-cosmosdb",
       "version": "0.1.0",
       "dependencies": {
         "@azure/cosmos": "4.9.3",
-        "@trail/prolly-node": "file:../.."
+        "@crabbuild/prolly-node": "file:../.."
       },
       "devDependencies": {
-        "@trail/prolly-storetest": "file:../../storetest",
+        "@crabbuild/prolly-storetest": "file:../../storetest",
         "@types/node": "20.19.25",
         "typescript": "5.9.3"
       }
     },
     "../..": {
-      "name": "@trail/prolly-node",
+      "name": "@crabbuild/prolly-node",
       "version": "0.1.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"
       }
     },
     "../../storetest": {
-      "name": "@trail/prolly-storetest",
+      "name": "@crabbuild/prolly-storetest",
       "version": "0.1.0",
       "dev": true
     },
@@ -219,11 +219,11 @@
         "node": ">=22.0.0"
       }
     },
-    "node_modules/@trail/prolly-node": {
+    "node_modules/@crabbuild/prolly-node": {
       "resolved": "../..",
       "link": true
     },
-    "node_modules/@trail/prolly-storetest": {
+    "node_modules/@crabbuild/prolly-storetest": {
       "resolved": "../../storetest",
       "link": true
     },

--- a/bindings/node/stores/cosmosdb/package.json
+++ b/bindings/node/stores/cosmosdb/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@trail/prolly-store-cosmosdb",
+  "name": "@crabbuild/prolly-store-cosmosdb",
   "version": "0.1.0",
   "type": "module",
   "files": ["src", "README.md"],
   "scripts": {"check": "tsc --noEmit", "test": "node --test test/*.test.ts"},
-  "dependencies": {"@azure/cosmos": "4.9.3", "@trail/prolly-node": "file:../.."},
-  "devDependencies": {"@trail/prolly-storetest": "file:../../storetest", "@types/node": "20.19.25", "typescript": "5.9.3"},
+  "dependencies": {"@azure/cosmos": "4.9.3", "@crabbuild/prolly-node": "file:../.."},
+  "devDependencies": {"@crabbuild/prolly-storetest": "file:../../storetest", "@types/node": "20.19.25", "typescript": "5.9.3"},
   "exports": "./src/index.ts"
 }

--- a/bindings/node/stores/cosmosdb/src/index.ts
+++ b/bindings/node/stores/cosmosdb/src/index.ts
@@ -22,7 +22,7 @@ import {
   type RootWrite,
   type StoreDescriptor,
   type StoreTransactionResult,
-} from "@trail/prolly-node/remote-store";
+} from "@crabbuild/prolly-node/remote-store";
 
 const TRANSACTION_LIMIT = 100;
 const NODE = Buffer.from("node:");

--- a/bindings/node/stores/cosmosdb/test/cosmosdb.test.ts
+++ b/bindings/node/stores/cosmosdb/test/cosmosdb.test.ts
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { CosmosClient } from "@azure/cosmos";
-import { StoreError, missingBytes, presentBytes, upsertNode } from "@trail/prolly-node/remote-store";
-import { runStoreConformance } from "@trail/prolly-storetest";
+import { StoreError, missingBytes, presentBytes, upsertNode } from "@crabbuild/prolly-node/remote-store";
+import { runStoreConformance } from "@crabbuild/prolly-storetest";
 
 import { CosmosDbStore, type CosmosBatchOperation, type CosmosBatchResponse, type CosmosDocument, type CosmosItemClient, type CosmosReadResult } from "../src/index.ts";
 

--- a/bindings/node/stores/dynamodb/README.md
+++ b/bindings/node/stores/dynamodb/README.md
@@ -1,4 +1,4 @@
-# `@trail/prolly-store-dynamodb`
+# `@crabbuild/prolly-store-dynamodb`
 
 DynamoDB implementation of the shared async store protocol using the official AWS SDK. It borrows a configured `DynamoDBClient`; `close()` drains adapter operations but never destroys the client.
 

--- a/bindings/node/stores/dynamodb/package-lock.json
+++ b/bindings/node/stores/dynamodb/package-lock.json
@@ -1,31 +1,31 @@
 {
-  "name": "@trail/prolly-store-dynamodb",
+  "name": "@crabbuild/prolly-store-dynamodb",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@trail/prolly-store-dynamodb",
+      "name": "@crabbuild/prolly-store-dynamodb",
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.1089.0",
-        "@trail/prolly-node": "file:../.."
+        "@crabbuild/prolly-node": "file:../.."
       },
       "devDependencies": {
-        "@trail/prolly-storetest": "file:../../storetest",
+        "@crabbuild/prolly-storetest": "file:../../storetest",
         "@types/node": "20.19.25",
         "typescript": "5.9.3"
       }
     },
     "../..": {
-      "name": "@trail/prolly-node",
+      "name": "@crabbuild/prolly-node",
       "version": "0.1.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"
       }
     },
     "../../storetest": {
-      "name": "@trail/prolly-storetest",
+      "name": "@crabbuild/prolly-storetest",
       "version": "0.1.0",
       "dev": true
     },
@@ -428,11 +428,11 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@trail/prolly-node": {
+    "node_modules/@crabbuild/prolly-node": {
       "resolved": "../..",
       "link": true
     },
-    "node_modules/@trail/prolly-storetest": {
+    "node_modules/@crabbuild/prolly-storetest": {
       "resolved": "../../storetest",
       "link": true
     },

--- a/bindings/node/stores/dynamodb/package.json
+++ b/bindings/node/stores/dynamodb/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@trail/prolly-store-dynamodb",
+  "name": "@crabbuild/prolly-store-dynamodb",
   "version": "0.1.0",
   "type": "module",
   "files": ["src", "README.md"],
   "scripts": {"check": "tsc --noEmit", "test": "node --test test/*.test.ts"},
-  "dependencies": {"@aws-sdk/client-dynamodb": "3.1089.0", "@trail/prolly-node": "file:../.."},
-  "devDependencies": {"@trail/prolly-storetest": "file:../../storetest", "@types/node": "20.19.25", "typescript": "5.9.3"},
+  "dependencies": {"@aws-sdk/client-dynamodb": "3.1089.0", "@crabbuild/prolly-node": "file:../.."},
+  "devDependencies": {"@crabbuild/prolly-storetest": "file:../../storetest", "@types/node": "20.19.25", "typescript": "5.9.3"},
   "exports": "./src/index.ts"
 }

--- a/bindings/node/stores/dynamodb/src/index.ts
+++ b/bindings/node/stores/dynamodb/src/index.ts
@@ -37,7 +37,7 @@ import {
   type RootWrite,
   type StoreDescriptor,
   type StoreTransactionResult,
-} from "@trail/prolly-node/remote-store";
+} from "@crabbuild/prolly-node/remote-store";
 
 const BATCH_GET_LIMIT = 100;
 const BATCH_WRITE_LIMIT = 25;

--- a/bindings/node/stores/dynamodb/test/dynamodb.test.ts
+++ b/bindings/node/stores/dynamodb/test/dynamodb.test.ts
@@ -13,9 +13,9 @@ import {
   GetItemCommand,
   ListTablesCommand,
 } from "@aws-sdk/client-dynamodb";
-import { RemoteAsyncProllyEngine } from "@trail/prolly-node/remote-async";
-import { StoreError, missingBytes, presentBytes, upsertNode } from "@trail/prolly-node/remote-store";
-import { runStoreConformance } from "@trail/prolly-storetest";
+import { RemoteAsyncProllyEngine } from "@crabbuild/prolly-node/remote-async";
+import { StoreError, missingBytes, presentBytes, upsertNode } from "@crabbuild/prolly-node/remote-store";
+import { runStoreConformance } from "@crabbuild/prolly-storetest";
 
 import { DynamoDbStore } from "../src/index.ts";
 

--- a/bindings/node/stores/mysql/README.md
+++ b/bindings/node/stores/mysql/README.md
@@ -1,10 +1,10 @@
-# @trail/prolly-store-mysql
+# @crabbuild/prolly-store-mysql
 
 MySQL implementation of the Prolly version 1 asynchronous store protocol.
 
 ```ts
 import { createPool } from "mysql2/promise";
-import { MysqlStore } from "@trail/prolly-store-mysql";
+import { MysqlStore } from "@crabbuild/prolly-store-mysql";
 
 const pool = createPool(process.env.DATABASE_URL!);
 const store = new MysqlStore(pool);

--- a/bindings/node/stores/mysql/package-lock.json
+++ b/bindings/node/stores/mysql/package-lock.json
@@ -1,39 +1,39 @@
 {
-  "name": "@trail/prolly-store-mysql",
+  "name": "@crabbuild/prolly-store-mysql",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@trail/prolly-store-mysql",
+      "name": "@crabbuild/prolly-store-mysql",
       "version": "0.1.0",
       "dependencies": {
-        "@trail/prolly-node": "file:../..",
+        "@crabbuild/prolly-node": "file:../..",
         "mysql2": "3.23.0"
       },
       "devDependencies": {
-        "@trail/prolly-storetest": "file:../../storetest",
+        "@crabbuild/prolly-storetest": "file:../../storetest",
         "@types/node": "20.19.25",
         "typescript": "5.9.3"
       }
     },
     "../..": {
-      "name": "@trail/prolly-node",
+      "name": "@crabbuild/prolly-node",
       "version": "0.1.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"
       }
     },
     "../../storetest": {
-      "name": "@trail/prolly-storetest",
+      "name": "@crabbuild/prolly-storetest",
       "version": "0.1.0",
       "dev": true
     },
-    "node_modules/@trail/prolly-node": {
+    "node_modules/@crabbuild/prolly-node": {
       "resolved": "../..",
       "link": true
     },
-    "node_modules/@trail/prolly-storetest": {
+    "node_modules/@crabbuild/prolly-storetest": {
       "resolved": "../../storetest",
       "link": true
     },

--- a/bindings/node/stores/mysql/package.json
+++ b/bindings/node/stores/mysql/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trail/prolly-store-mysql",
+  "name": "@crabbuild/prolly-store-mysql",
   "version": "0.1.0",
   "type": "module",
   "files": ["src", "README.md"],
@@ -8,11 +8,11 @@
     "test": "node --test test/*.test.ts"
   },
   "dependencies": {
-    "@trail/prolly-node": "file:../..",
+    "@crabbuild/prolly-node": "file:../..",
     "mysql2": "3.23.0"
   },
   "devDependencies": {
-    "@trail/prolly-storetest": "file:../../storetest",
+    "@crabbuild/prolly-storetest": "file:../../storetest",
     "@types/node": "20.19.25",
     "typescript": "5.9.3"
   },

--- a/bindings/node/stores/mysql/src/index.ts
+++ b/bindings/node/stores/mysql/src/index.ts
@@ -27,7 +27,7 @@ import {
   type RootWrite,
   type StoreDescriptor,
   type StoreTransactionResult,
-} from "@trail/prolly-node/remote-store";
+} from "@crabbuild/prolly-node/remote-store";
 
 const CREATE_SCHEMA = [
   "CREATE TABLE IF NOT EXISTS prolly_nodes (cid VARBINARY(32) PRIMARY KEY, node LONGBLOB NOT NULL)",

--- a/bindings/node/stores/mysql/test/mysql.test.ts
+++ b/bindings/node/stores/mysql/test/mysql.test.ts
@@ -5,9 +5,9 @@ import test from "node:test";
 import { promisify } from "node:util";
 
 import { createPool, type Pool, type RowDataPacket } from "mysql2/promise";
-import { RemoteAsyncProllyEngine } from "@trail/prolly-node/remote-async";
-import { missingBytes, presentBytes, StoreError, upsertNode } from "@trail/prolly-node/remote-store";
-import { runStoreConformance } from "@trail/prolly-storetest";
+import { RemoteAsyncProllyEngine } from "@crabbuild/prolly-node/remote-async";
+import { missingBytes, presentBytes, StoreError, upsertNode } from "@crabbuild/prolly-node/remote-store";
+import { runStoreConformance } from "@crabbuild/prolly-storetest";
 
 import { MysqlStore } from "../src/index.ts";
 

--- a/bindings/node/stores/pglite/README.md
+++ b/bindings/node/stores/pglite/README.md
@@ -1,4 +1,4 @@
-# `@trail/prolly-store-pglite`
+# `@crabbuild/prolly-store-pglite`
 
 Browser-native PostgreSQL/WASM implementation of the shared async store
 protocol using a caller-owned `PGlite` database. It uses the same three-table

--- a/bindings/node/stores/pglite/package-lock.json
+++ b/bindings/node/stores/pglite/package-lock.json
@@ -1,31 +1,31 @@
 {
-  "name": "@trail/prolly-store-pglite",
+  "name": "@crabbuild/prolly-store-pglite",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@trail/prolly-store-pglite",
+      "name": "@crabbuild/prolly-store-pglite",
       "version": "0.1.0",
       "dependencies": {
         "@electric-sql/pglite": "0.5.4",
-        "@trail/prolly-node": "file:../.."
+        "@crabbuild/prolly-node": "file:../.."
       },
       "devDependencies": {
-        "@trail/prolly-storetest": "file:../../storetest",
+        "@crabbuild/prolly-storetest": "file:../../storetest",
         "@types/node": "20.19.25",
         "typescript": "5.9.3"
       }
     },
     "../..": {
-      "name": "@trail/prolly-node",
+      "name": "@crabbuild/prolly-node",
       "version": "0.1.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"
       }
     },
     "../../storetest": {
-      "name": "@trail/prolly-storetest",
+      "name": "@crabbuild/prolly-storetest",
       "version": "0.1.0",
       "dev": true
     },
@@ -35,11 +35,11 @@
       "integrity": "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g==",
       "license": "Apache-2.0"
     },
-    "node_modules/@trail/prolly-node": {
+    "node_modules/@crabbuild/prolly-node": {
       "resolved": "../..",
       "link": true
     },
-    "node_modules/@trail/prolly-storetest": {
+    "node_modules/@crabbuild/prolly-storetest": {
       "resolved": "../../storetest",
       "link": true
     },

--- a/bindings/node/stores/pglite/package.json
+++ b/bindings/node/stores/pglite/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@trail/prolly-store-pglite",
+  "name": "@crabbuild/prolly-store-pglite",
   "version": "0.1.0",
   "type": "module",
   "files": ["src", "README.md"],
   "scripts": {"check": "tsc --noEmit", "test": "node --test test/*.test.ts"},
-  "dependencies": {"@electric-sql/pglite": "0.5.4", "@trail/prolly-node": "file:../.."},
-  "devDependencies": {"@trail/prolly-storetest": "file:../../storetest", "@types/node": "20.19.25", "typescript": "5.9.3"},
+  "dependencies": {"@electric-sql/pglite": "0.5.4", "@crabbuild/prolly-node": "file:../.."},
+  "devDependencies": {"@crabbuild/prolly-storetest": "file:../../storetest", "@types/node": "20.19.25", "typescript": "5.9.3"},
   "exports": "./src/index.ts"
 }

--- a/bindings/node/stores/pglite/src/index.ts
+++ b/bindings/node/stores/pglite/src/index.ts
@@ -22,7 +22,7 @@ import {
   type RootWrite,
   type StoreDescriptor,
   type StoreTransactionResult,
-} from "@trail/prolly-node/remote-store";
+} from "@crabbuild/prolly-node/remote-store";
 
 export const PGLITE_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS prolly_nodes (

--- a/bindings/node/stores/pglite/test/pglite.test.ts
+++ b/bindings/node/stores/pglite/test/pglite.test.ts
@@ -5,8 +5,8 @@ import { join } from "node:path";
 import test from "node:test";
 
 import { PGlite } from "@electric-sql/pglite";
-import { StoreError, missingBytes, presentBytes, upsertNode } from "@trail/prolly-node/remote-store";
-import { runStoreConformance } from "@trail/prolly-storetest";
+import { StoreError, missingBytes, presentBytes, upsertNode } from "@crabbuild/prolly-node/remote-store";
+import { runStoreConformance } from "@crabbuild/prolly-storetest";
 
 import { PGliteStore } from "../src/index.ts";
 

--- a/bindings/node/stores/postgres/README.md
+++ b/bindings/node/stores/postgres/README.md
@@ -1,10 +1,10 @@
-# @trail/prolly-store-postgres
+# @crabbuild/prolly-store-postgres
 
 PostgreSQL implementation of the Prolly version 1 asynchronous store protocol.
 
 ```ts
 import { Pool } from "pg";
-import { PostgresStore } from "@trail/prolly-store-postgres";
+import { PostgresStore } from "@crabbuild/prolly-store-postgres";
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 const store = new PostgresStore(pool);

--- a/bindings/node/stores/postgres/package-lock.json
+++ b/bindings/node/stores/postgres/package-lock.json
@@ -1,40 +1,40 @@
 {
-  "name": "@trail/prolly-store-postgres",
+  "name": "@crabbuild/prolly-store-postgres",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@trail/prolly-store-postgres",
+      "name": "@crabbuild/prolly-store-postgres",
       "version": "0.1.0",
       "dependencies": {
-        "@trail/prolly-node": "file:../..",
+        "@crabbuild/prolly-node": "file:../..",
         "pg": "8.22.0"
       },
       "devDependencies": {
-        "@trail/prolly-storetest": "file:../../storetest",
+        "@crabbuild/prolly-storetest": "file:../../storetest",
         "@types/node": "20.19.25",
         "@types/pg": "8.20.0",
         "typescript": "5.9.3"
       }
     },
     "../..": {
-      "name": "@trail/prolly-node",
+      "name": "@crabbuild/prolly-node",
       "version": "0.1.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"
       }
     },
     "../../storetest": {
-      "name": "@trail/prolly-storetest",
+      "name": "@crabbuild/prolly-storetest",
       "version": "0.1.0",
       "dev": true
     },
-    "node_modules/@trail/prolly-node": {
+    "node_modules/@crabbuild/prolly-node": {
       "resolved": "../..",
       "link": true
     },
-    "node_modules/@trail/prolly-storetest": {
+    "node_modules/@crabbuild/prolly-storetest": {
       "resolved": "../../storetest",
       "link": true
     },

--- a/bindings/node/stores/postgres/package.json
+++ b/bindings/node/stores/postgres/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trail/prolly-store-postgres",
+  "name": "@crabbuild/prolly-store-postgres",
   "version": "0.1.0",
   "type": "module",
   "files": [
@@ -11,11 +11,11 @@
     "test": "node --test test/*.test.ts"
   },
   "dependencies": {
-    "@trail/prolly-node": "file:../..",
+    "@crabbuild/prolly-node": "file:../..",
     "pg": "8.22.0"
   },
   "devDependencies": {
-    "@trail/prolly-storetest": "file:../../storetest",
+    "@crabbuild/prolly-storetest": "file:../../storetest",
     "@types/node": "20.19.25",
     "@types/pg": "8.20.0",
     "typescript": "5.9.3"

--- a/bindings/node/stores/postgres/src/index.ts
+++ b/bindings/node/stores/postgres/src/index.ts
@@ -28,7 +28,7 @@ import {
   type RootWrite,
   type StoreDescriptor,
   type StoreTransactionResult,
-} from "@trail/prolly-node/remote-store";
+} from "@crabbuild/prolly-node/remote-store";
 
 const CREATE_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS prolly_nodes (

--- a/bindings/node/stores/postgres/test/postgres.test.ts
+++ b/bindings/node/stores/postgres/test/postgres.test.ts
@@ -5,14 +5,14 @@ import test from "node:test";
 import { promisify } from "node:util";
 
 import { Pool } from "pg";
-import { RemoteAsyncProllyEngine } from "@trail/prolly-node/remote-async";
+import { RemoteAsyncProllyEngine } from "@crabbuild/prolly-node/remote-async";
 import {
   missingBytes,
   presentBytes,
   StoreError,
   upsertNode,
-} from "@trail/prolly-node/remote-store";
-import { runStoreConformance } from "@trail/prolly-storetest";
+} from "@crabbuild/prolly-node/remote-store";
+import { runStoreConformance } from "@crabbuild/prolly-storetest";
 
 import { PostgresStore } from "../src/index.ts";
 

--- a/bindings/node/stores/redis/README.md
+++ b/bindings/node/stores/redis/README.md
@@ -1,10 +1,10 @@
-# `@trail/prolly-store-redis`
+# `@crabbuild/prolly-store-redis`
 
 Redis implementation of the shared async store protocol for Node.js. It accepts an already-connected official `redis` client and never closes or destroys that caller-owned client.
 
 ```ts
 import { createClient } from "redis";
-import { RedisStore } from "@trail/prolly-store-redis";
+import { RedisStore } from "@crabbuild/prolly-store-redis";
 
 const client = createClient({ url: process.env.REDIS_URL });
 await client.connect();

--- a/bindings/node/stores/redis/package-lock.json
+++ b/bindings/node/stores/redis/package-lock.json
@@ -1,31 +1,31 @@
 {
-  "name": "@trail/prolly-store-redis",
+  "name": "@crabbuild/prolly-store-redis",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@trail/prolly-store-redis",
+      "name": "@crabbuild/prolly-store-redis",
       "version": "0.1.0",
       "dependencies": {
-        "@trail/prolly-node": "file:../..",
+        "@crabbuild/prolly-node": "file:../..",
         "redis": "6.1.0"
       },
       "devDependencies": {
-        "@trail/prolly-storetest": "file:../../storetest",
+        "@crabbuild/prolly-storetest": "file:../../storetest",
         "@types/node": "20.19.25",
         "typescript": "5.9.3"
       }
     },
     "../..": {
-      "name": "@trail/prolly-node",
+      "name": "@crabbuild/prolly-node",
       "version": "0.1.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"
       }
     },
     "../../storetest": {
-      "name": "@trail/prolly-storetest",
+      "name": "@crabbuild/prolly-storetest",
       "version": "0.1.0",
       "dev": true
     },
@@ -101,11 +101,11 @@
         "@redis/client": "^6.1.0"
       }
     },
-    "node_modules/@trail/prolly-node": {
+    "node_modules/@crabbuild/prolly-node": {
       "resolved": "../..",
       "link": true
     },
-    "node_modules/@trail/prolly-storetest": {
+    "node_modules/@crabbuild/prolly-storetest": {
       "resolved": "../../storetest",
       "link": true
     },

--- a/bindings/node/stores/redis/package.json
+++ b/bindings/node/stores/redis/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@trail/prolly-store-redis",
+  "name": "@crabbuild/prolly-store-redis",
   "version": "0.1.0",
   "type": "module",
   "files": ["src", "README.md"],
   "scripts": {"check": "tsc --noEmit", "test": "node --test test/*.test.ts"},
-  "dependencies": {"@trail/prolly-node": "file:../..", "redis": "6.1.0"},
-  "devDependencies": {"@trail/prolly-storetest": "file:../../storetest", "@types/node": "20.19.25", "typescript": "5.9.3"},
+  "dependencies": {"@crabbuild/prolly-node": "file:../..", "redis": "6.1.0"},
+  "devDependencies": {"@crabbuild/prolly-storetest": "file:../../storetest", "@types/node": "20.19.25", "typescript": "5.9.3"},
   "exports": "./src/index.ts"
 }

--- a/bindings/node/stores/redis/src/index.ts
+++ b/bindings/node/stores/redis/src/index.ts
@@ -22,7 +22,7 @@ import {
   type RootWrite,
   type StoreDescriptor,
   type StoreTransactionResult,
-} from "@trail/prolly-node/remote-store";
+} from "@crabbuild/prolly-node/remote-store";
 
 const CAS_SCRIPT = `
 local current = redis.call('GET', KEYS[1])

--- a/bindings/node/stores/redis/test/redis.test.ts
+++ b/bindings/node/stores/redis/test/redis.test.ts
@@ -6,9 +6,9 @@ import test from "node:test";
 import { promisify } from "node:util";
 
 import { createClient, RESP_TYPES, type RedisClientType } from "redis";
-import { RemoteAsyncProllyEngine } from "@trail/prolly-node/remote-async";
-import { missingBytes, presentBytes, StoreError, upsertNode } from "@trail/prolly-node/remote-store";
-import { runStoreConformance } from "@trail/prolly-storetest";
+import { RemoteAsyncProllyEngine } from "@crabbuild/prolly-node/remote-async";
+import { missingBytes, presentBytes, StoreError, upsertNode } from "@crabbuild/prolly-node/remote-store";
+import { runStoreConformance } from "@crabbuild/prolly-storetest";
 
 import { RedisStore } from "../src/index.ts";
 

--- a/bindings/node/stores/spanner/README.md
+++ b/bindings/node/stores/spanner/README.md
@@ -1,4 +1,4 @@
-# `@trail/prolly-store-spanner`
+# `@crabbuild/prolly-store-spanner`
 
 Cloud Spanner implementation of the shared async store protocol using the
 official `@google-cloud/spanner` SDK. Construct it with a caller-owned

--- a/bindings/node/stores/spanner/package-lock.json
+++ b/bindings/node/stores/spanner/package-lock.json
@@ -1,31 +1,31 @@
 {
-  "name": "@trail/prolly-store-spanner",
+  "name": "@crabbuild/prolly-store-spanner",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@trail/prolly-store-spanner",
+      "name": "@crabbuild/prolly-store-spanner",
       "version": "0.1.0",
       "dependencies": {
         "@google-cloud/spanner": "8.0.0",
-        "@trail/prolly-node": "file:../.."
+        "@crabbuild/prolly-node": "file:../.."
       },
       "devDependencies": {
-        "@trail/prolly-storetest": "file:../../storetest",
+        "@crabbuild/prolly-storetest": "file:../../storetest",
         "@types/node": "20.19.25",
         "typescript": "5.9.3"
       }
     },
     "../..": {
-      "name": "@trail/prolly-node",
+      "name": "@crabbuild/prolly-node",
       "version": "0.1.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"
       }
     },
     "../../storetest": {
-      "name": "@trail/prolly-storetest",
+      "name": "@crabbuild/prolly-storetest",
       "version": "0.1.0",
       "dev": true
     },
@@ -323,11 +323,11 @@
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@trail/prolly-node": {
+    "node_modules/@crabbuild/prolly-node": {
       "resolved": "../..",
       "link": true
     },
-    "node_modules/@trail/prolly-storetest": {
+    "node_modules/@crabbuild/prolly-storetest": {
       "resolved": "../../storetest",
       "link": true
     },

--- a/bindings/node/stores/spanner/package.json
+++ b/bindings/node/stores/spanner/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trail/prolly-store-spanner",
+  "name": "@crabbuild/prolly-store-spanner",
   "version": "0.1.0",
   "type": "module",
   "files": [
@@ -12,10 +12,10 @@
   },
   "dependencies": {
     "@google-cloud/spanner": "8.0.0",
-    "@trail/prolly-node": "file:../.."
+    "@crabbuild/prolly-node": "file:../.."
   },
   "devDependencies": {
-    "@trail/prolly-storetest": "file:../../storetest",
+    "@crabbuild/prolly-storetest": "file:../../storetest",
     "@types/node": "20.19.25",
     "typescript": "5.9.3"
   },

--- a/bindings/node/stores/spanner/src/index.ts
+++ b/bindings/node/stores/spanner/src/index.ts
@@ -21,7 +21,7 @@ import {
   type RootWrite,
   type StoreDescriptor,
   type StoreTransactionResult,
-} from "@trail/prolly-node/remote-store";
+} from "@crabbuild/prolly-node/remote-store";
 
 export const SPANNER_DDL = [
   "CREATE TABLE ProllyNodes (\n  Cid BYTES(32) NOT NULL,\n  Node BYTES(MAX) NOT NULL\n) PRIMARY KEY (Cid)",

--- a/bindings/node/stores/spanner/test/spanner.test.ts
+++ b/bindings/node/stores/spanner/test/spanner.test.ts
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { Spanner } from "@google-cloud/spanner";
-import { StoreError, missingBytes, presentBytes, upsertNode } from "@trail/prolly-node/remote-store";
-import { runStoreConformance } from "@trail/prolly-storetest";
+import { StoreError, missingBytes, presentBytes, upsertNode } from "@crabbuild/prolly-node/remote-store";
+import { runStoreConformance } from "@crabbuild/prolly-storetest";
 
 import { SPANNER_DDL, SpannerStore, type SpannerItemClient, type SpannerMutation, type SpannerRootRecord, type SpannerTransaction } from "../src/index.ts";
 

--- a/bindings/node/stores/sqlite/README.md
+++ b/bindings/node/stores/sqlite/README.md
@@ -1,12 +1,12 @@
 # Node SQLite remote store
 
-`@trail/prolly-store-sqlite` implements store protocol version 2 with an
+`@crabbuild/prolly-store-sqlite` implements store protocol version 2 with an
 application-owned `better-sqlite3` database.
 
 ```ts
 import Database from "better-sqlite3";
-import { RemoteAsyncProllyEngine } from "@trail/prolly-node/remote-async";
-import { SqliteStore } from "@trail/prolly-store-sqlite";
+import { RemoteAsyncProllyEngine } from "@crabbuild/prolly-node/remote-async";
+import { SqliteStore } from "@crabbuild/prolly-store-sqlite";
 
 const database = new Database("prolly.db");
 const store = new SqliteStore(database);

--- a/bindings/node/stores/sqlite/package-lock.json
+++ b/bindings/node/stores/sqlite/package-lock.json
@@ -1,40 +1,40 @@
 {
-  "name": "@trail/prolly-store-sqlite",
+  "name": "@crabbuild/prolly-store-sqlite",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@trail/prolly-store-sqlite",
+      "name": "@crabbuild/prolly-store-sqlite",
       "version": "0.1.0",
       "dependencies": {
-        "@trail/prolly-node": "file:../..",
+        "@crabbuild/prolly-node": "file:../..",
         "better-sqlite3": "12.11.1"
       },
       "devDependencies": {
-        "@trail/prolly-storetest": "file:../../storetest",
+        "@crabbuild/prolly-storetest": "file:../../storetest",
         "@types/better-sqlite3": "7.6.13",
         "@types/node": "20.19.25",
         "typescript": "5.9.3"
       }
     },
     "../..": {
-      "name": "@trail/prolly-node",
+      "name": "@crabbuild/prolly-node",
       "version": "0.1.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"
       }
     },
     "../../storetest": {
-      "name": "@trail/prolly-storetest",
+      "name": "@crabbuild/prolly-storetest",
       "version": "0.1.0",
       "dev": true
     },
-    "node_modules/@trail/prolly-node": {
+    "node_modules/@crabbuild/prolly-node": {
       "resolved": "../..",
       "link": true
     },
-    "node_modules/@trail/prolly-storetest": {
+    "node_modules/@crabbuild/prolly-storetest": {
       "resolved": "../../storetest",
       "link": true
     },

--- a/bindings/node/stores/sqlite/package.json
+++ b/bindings/node/stores/sqlite/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trail/prolly-store-sqlite",
+  "name": "@crabbuild/prolly-store-sqlite",
   "version": "0.1.0",
   "type": "module",
   "files": [
@@ -11,11 +11,11 @@
     "test": "node --test test/*.test.ts"
   },
   "dependencies": {
-    "@trail/prolly-node": "file:../..",
+    "@crabbuild/prolly-node": "file:../..",
     "better-sqlite3": "12.11.1"
   },
   "devDependencies": {
-    "@trail/prolly-storetest": "file:../../storetest",
+    "@crabbuild/prolly-storetest": "file:../../storetest",
     "@types/better-sqlite3": "7.6.13",
     "@types/node": "20.19.25",
     "typescript": "5.9.3"

--- a/bindings/node/stores/sqlite/src/index.ts
+++ b/bindings/node/stores/sqlite/src/index.ts
@@ -22,7 +22,7 @@ import {
   type RootWrite,
   type StoreDescriptor,
   type StoreTransactionResult,
-} from "@trail/prolly-node/remote-store";
+} from "@crabbuild/prolly-node/remote-store";
 
 const CREATE_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS prolly_nodes (

--- a/bindings/node/stores/sqlite/test/sqlite.test.ts
+++ b/bindings/node/stores/sqlite/test/sqlite.test.ts
@@ -8,9 +8,9 @@ import test from "node:test";
 import { promisify } from "node:util";
 
 import Database from "better-sqlite3";
-import { RemoteAsyncProllyEngine } from "@trail/prolly-node/remote-async";
-import { missingBytes, presentBytes } from "@trail/prolly-node/remote-store";
-import { runStoreConformance } from "@trail/prolly-storetest";
+import { RemoteAsyncProllyEngine } from "@crabbuild/prolly-node/remote-async";
+import { missingBytes, presentBytes } from "@crabbuild/prolly-node/remote-store";
+import { runStoreConformance } from "@crabbuild/prolly-storetest";
 
 import { SqliteStore } from "../src/index.ts";
 

--- a/bindings/node/storetest/package.json
+++ b/bindings/node/storetest/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trail/prolly-storetest",
+  "name": "@crabbuild/prolly-storetest",
   "version": "0.1.0",
   "type": "module",
   "private": true,

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.10,<2.0", "uniffi-bindgen==0.31.0"]
 build-backend = "maturin"
 
 [project]
-name = "trail-prolly-binding"
+name = "crabbuild-prolly-binding"
 version = "0.1.0"
 description = "Python binding compatibility harness for prolly-map fixtures"
 requires-python = ">=3.10"

--- a/bindings/python/stores/cosmosdb/pyproject.toml
+++ b/bindings/python/stores/cosmosdb/pyproject.toml
@@ -3,10 +3,10 @@ requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "trail-prolly-store-cosmosdb"
+name = "crabbuild-prolly-store-cosmosdb"
 version = "0.1.0"
 requires-python = ">=3.10"
-dependencies = ["trail-prolly-binding==0.1.0", "azure-cosmos==4.16.1"]
+dependencies = ["crabbuild-prolly-binding==0.1.0", "azure-cosmos==4.16.1"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/bindings/python/stores/dynamodb/pyproject.toml
+++ b/bindings/python/stores/dynamodb/pyproject.toml
@@ -3,10 +3,10 @@ requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "trail-prolly-store-dynamodb"
+name = "crabbuild-prolly-store-dynamodb"
 version = "0.1.0"
 requires-python = ">=3.10"
-dependencies = ["trail-prolly-binding==0.1.0", "aioboto3==15.5.0"]
+dependencies = ["crabbuild-prolly-binding==0.1.0", "aioboto3==15.5.0"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/bindings/python/stores/mysql/pyproject.toml
+++ b/bindings/python/stores/mysql/pyproject.toml
@@ -3,10 +3,10 @@ requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "trail-prolly-store-mysql"
+name = "crabbuild-prolly-store-mysql"
 version = "0.1.0"
 requires-python = ">=3.10"
-dependencies = ["trail-prolly-binding==0.1.0", "aiomysql==0.3.2"]
+dependencies = ["crabbuild-prolly-binding==0.1.0", "aiomysql==0.3.2"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/bindings/python/stores/postgres/pyproject.toml
+++ b/bindings/python/stores/postgres/pyproject.toml
@@ -3,11 +3,11 @@ requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "trail-prolly-store-postgres"
+name = "crabbuild-prolly-store-postgres"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-  "trail-prolly-binding==0.1.0",
+  "crabbuild-prolly-binding==0.1.0",
   "psycopg[binary,pool]==3.3.4",
 ]
 

--- a/bindings/python/stores/redis/README.md
+++ b/bindings/python/stores/redis/README.md
@@ -1,6 +1,6 @@
 # Python Redis store
 
-`trail-prolly-store-redis` adapts a caller-owned `redis.asyncio.Redis` client
+`crabbuild-prolly-store-redis` adapts a caller-owned `redis.asyncio.Redis` client
 to Prolly's version-1 asynchronous store protocol. Closing the adapter does not
 close the injected client.
 

--- a/bindings/python/stores/redis/pyproject.toml
+++ b/bindings/python/stores/redis/pyproject.toml
@@ -3,10 +3,10 @@ requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "trail-prolly-store-redis"
+name = "crabbuild-prolly-store-redis"
 version = "0.1.0"
 requires-python = ">=3.10"
-dependencies = ["trail-prolly-binding==0.1.0", "redis==8.0.1"]
+dependencies = ["crabbuild-prolly-binding==0.1.0", "redis==8.0.1"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/bindings/python/stores/spanner/pyproject.toml
+++ b/bindings/python/stores/spanner/pyproject.toml
@@ -3,10 +3,10 @@ requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "trail-prolly-store-spanner"
+name = "crabbuild-prolly-store-spanner"
 version = "0.1.0"
 requires-python = ">=3.10"
-dependencies = ["trail-prolly-binding==0.1.0", "google-cloud-spanner==3.69.0"]
+dependencies = ["crabbuild-prolly-binding==0.1.0", "google-cloud-spanner==3.69.0"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/bindings/python/stores/sqlite/README.md
+++ b/bindings/python/stores/sqlite/README.md
@@ -1,6 +1,6 @@
 # Python SQLite store
 
-`trail-prolly-store-sqlite` implements async store protocol major 2 over a
+`crabbuild-prolly-store-sqlite` implements async store protocol major 2 over a
 caller-owned `sqlite3.Connection`. Open the connection with
 `check_same_thread=False`, inject a bounded executor if desired, and call
 `await store.initialize_schema()` explicitly. Closing the adapter never closes

--- a/bindings/python/stores/sqlite/pyproject.toml
+++ b/bindings/python/stores/sqlite/pyproject.toml
@@ -3,10 +3,10 @@ requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "trail-prolly-store-sqlite"
+name = "crabbuild-prolly-store-sqlite"
 version = "0.1.0"
 requires-python = ">=3.10"
-dependencies = ["trail-prolly-binding==0.1.0"]
+dependencies = ["crabbuild-prolly-binding==0.1.0"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/bindings/ruby/prolly.gemspec
+++ b/bindings/ruby/prolly.gemspec
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |spec|
-  spec.name = 'trail-prolly'
+  spec.name = 'crabbuild-prolly'
   spec.version = '0.1.0'
   spec.summary = 'Ruby bindings for prolly-map'
-  spec.authors = ['Trail Contributors']
+  spec.authors = ['Crabbuild Contributors']
   spec.email = ['opensource@crab.build']
   spec.license = 'MIT OR Apache-2.0'
   spec.required_ruby_version = '>= 2.6'

--- a/bindings/ruby/stores/dynamodb/Gemfile
+++ b/bindings/ruby/stores/dynamodb/Gemfile
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 gemspec
-gem 'trail-prolly', path: '../..'
+gem 'crabbuild-prolly', path: '../..'

--- a/bindings/ruby/stores/dynamodb/prolly-store-dynamodb.gemspec
+++ b/bindings/ruby/stores/dynamodb/prolly-store-dynamodb.gemspec
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 Gem::Specification.new do |spec|
-  spec.name = 'trail-prolly-store-dynamodb'
+  spec.name = 'crabbuild-prolly-store-dynamodb'
   spec.version = '0.1.0'
   spec.summary = 'DynamoDB remote-store adapter for Prolly'
-  spec.authors = ['Trail Contributors']
+  spec.authors = ['Crabbuild Contributors']
   spec.license = 'MIT OR Apache-2.0'
   spec.required_ruby_version = '>= 3.2'
   spec.files = Dir['lib/**/*.rb'] + ['README.md']
   spec.require_paths = ['lib']
-  spec.add_runtime_dependency 'trail-prolly', '= 0.1.0'
+  spec.add_runtime_dependency 'crabbuild-prolly', '= 0.1.0'
   spec.add_runtime_dependency 'aws-sdk-dynamodb', '= 1.169.0'
 end

--- a/bindings/ruby/stores/mysql/Gemfile
+++ b/bindings/ruby/stores/mysql/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-gem 'trail-prolly', path: '../..'
+gem 'crabbuild-prolly', path: '../..'
 gemspec

--- a/bindings/ruby/stores/mysql/prolly-store-mysql.gemspec
+++ b/bindings/ruby/stores/mysql/prolly-store-mysql.gemspec
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |spec|
-  spec.name = 'trail-prolly-store-mysql'
+  spec.name = 'crabbuild-prolly-store-mysql'
   spec.version = '0.1.0'
   spec.summary = 'MySQL async remote-store adapter for Prolly'
-  spec.authors = ['Trail Contributors']
+  spec.authors = ['Crabbuild Contributors']
   spec.license = 'MIT OR Apache-2.0'
   spec.required_ruby_version = '>= 3.2'
   spec.files = Dir['lib/**/*.rb'] + ['README.md']
   spec.require_paths = ['lib']
-  spec.add_runtime_dependency 'trail-prolly', '= 0.1.0'
+  spec.add_runtime_dependency 'crabbuild-prolly', '= 0.1.0'
   spec.add_runtime_dependency 'mysql2', '= 0.5.7'
 end

--- a/bindings/ruby/stores/postgres/Gemfile
+++ b/bindings/ruby/stores/postgres/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-gem 'trail-prolly', path: '../..'
+gem 'crabbuild-prolly', path: '../..'
 gemspec

--- a/bindings/ruby/stores/postgres/prolly-store-postgres.gemspec
+++ b/bindings/ruby/stores/postgres/prolly-store-postgres.gemspec
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |spec|
-  spec.name = 'trail-prolly-store-postgres'
+  spec.name = 'crabbuild-prolly-store-postgres'
   spec.version = '0.1.0'
   spec.summary = 'PostgreSQL async remote-store adapter for Prolly'
-  spec.authors = ['Trail Contributors']
+  spec.authors = ['Crabbuild Contributors']
   spec.license = 'MIT OR Apache-2.0'
   spec.required_ruby_version = '>= 3.2'
   spec.files = Dir['lib/**/*.rb'] + ['README.md']
   spec.require_paths = ['lib']
-  spec.add_runtime_dependency 'trail-prolly', '= 0.1.0'
+  spec.add_runtime_dependency 'crabbuild-prolly', '= 0.1.0'
   spec.add_runtime_dependency 'pg', '= 1.6.3'
 end

--- a/bindings/ruby/stores/redis/Gemfile
+++ b/bindings/ruby/stores/redis/Gemfile
@@ -2,4 +2,4 @@
 
 source 'https://rubygems.org'
 gemspec
-gem 'trail-prolly', path: '../..'
+gem 'crabbuild-prolly', path: '../..'

--- a/bindings/ruby/stores/redis/README.md
+++ b/bindings/ruby/stores/redis/README.md
@@ -1,6 +1,6 @@
 # Ruby Redis store
 
-`trail-prolly-store-redis` adapts a caller-owned `Redis` client to Prolly's
+`crabbuild-prolly-store-redis` adapts a caller-owned `Redis` client to Prolly's
 version-1 asynchronous store bridge. Closing the adapter does not close the
 client.
 

--- a/bindings/ruby/stores/redis/prolly-store-redis.gemspec
+++ b/bindings/ruby/stores/redis/prolly-store-redis.gemspec
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |spec|
-  spec.name = 'trail-prolly-store-redis'
+  spec.name = 'crabbuild-prolly-store-redis'
   spec.version = '0.1.0'
   spec.summary = 'Redis remote-store adapter for Prolly'
-  spec.authors = ['Trail Contributors']
+  spec.authors = ['Crabbuild Contributors']
   spec.license = 'MIT OR Apache-2.0'
   spec.required_ruby_version = '>= 3.2'
   spec.files = Dir['lib/**/*.rb'] + ['README.md']
   spec.require_paths = ['lib']
-  spec.add_runtime_dependency 'trail-prolly', '= 0.1.0'
+  spec.add_runtime_dependency 'crabbuild-prolly', '= 0.1.0'
   spec.add_runtime_dependency 'redis', '= 5.4.1'
 end

--- a/bindings/ruby/stores/spanner/Gemfile
+++ b/bindings/ruby/stores/spanner/Gemfile
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 gemspec
-gem 'trail-prolly', path: '../..'
+gem 'crabbuild-prolly', path: '../..'

--- a/bindings/ruby/stores/spanner/prolly-store-spanner.gemspec
+++ b/bindings/ruby/stores/spanner/prolly-store-spanner.gemspec
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 Gem::Specification.new do |spec|
-  spec.name = 'trail-prolly-store-spanner'
+  spec.name = 'crabbuild-prolly-store-spanner'
   spec.version = '0.1.0'
   spec.summary = 'Cloud Spanner remote-store adapter for Prolly'
-  spec.authors = ['Trail Contributors']
+  spec.authors = ['Crabbuild Contributors']
   spec.license = 'MIT OR Apache-2.0'
   spec.required_ruby_version = '>= 3.2'
   spec.files = Dir['lib/**/*.rb'] + ['README.md']
   spec.require_paths = ['lib']
-  spec.add_runtime_dependency 'trail-prolly', '= 0.1.0'
+  spec.add_runtime_dependency 'crabbuild-prolly', '= 0.1.0'
   spec.add_runtime_dependency 'google-cloud-spanner', '= 2.36.0'
   spec.add_runtime_dependency 'mutex_m', '= 0.3.0'
 end

--- a/bindings/ruby/stores/sqlite/Gemfile
+++ b/bindings/ruby/stores/sqlite/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-gem 'trail-prolly', path: '../..'
+gem 'crabbuild-prolly', path: '../..'
 gemspec

--- a/bindings/ruby/stores/sqlite/README.md
+++ b/bindings/ruby/stores/sqlite/README.md
@@ -1,5 +1,5 @@
 # Ruby SQLite store
 
-`trail-prolly-store-sqlite` implements protocol major 2 over a caller-owned
+`crabbuild-prolly-store-sqlite` implements protocol major 2 over a caller-owned
 `SQLite3::Database`. Call `initialize_schema` explicitly. The adapter serializes
 operations and uses immediate transactions, but never closes the database.

--- a/bindings/ruby/stores/sqlite/prolly-store-sqlite.gemspec
+++ b/bindings/ruby/stores/sqlite/prolly-store-sqlite.gemspec
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |spec|
-  spec.name = 'trail-prolly-store-sqlite'
+  spec.name = 'crabbuild-prolly-store-sqlite'
   spec.version = '0.1.0'
   spec.summary = 'SQLite async remote-store adapter for Prolly'
-  spec.authors = ['Trail Contributors']
+  spec.authors = ['Crabbuild Contributors']
   spec.license = 'MIT OR Apache-2.0'
   spec.required_ruby_version = '>= 3.2'
   spec.files = Dir['lib/**/*.rb'] + ['README.md']
   spec.require_paths = ['lib']
-  spec.add_runtime_dependency 'trail-prolly', '= 0.1.0'
+  spec.add_runtime_dependency 'crabbuild-prolly', '= 0.1.0'
   spec.add_runtime_dependency 'sqlite3', '= 2.9.5'
 end

--- a/bindings/uniffi/uniffi.toml
+++ b/bindings/uniffi/uniffi.toml
@@ -12,7 +12,7 @@ package_name = "build.crab.prolly"
 cdylib_name = "prolly_bindings"
 
 [bindings.node]
-package_name = "@trail/prolly-node"
+package_name = "@crabbuild/prolly-node"
 node_engine = ">=20"
 bundled_prebuilds = true
 manual_load = false

--- a/bindings/wasm/COOKBOOK.md
+++ b/bindings/wasm/COOKBOOK.md
@@ -35,7 +35,7 @@ Browser-safe application files include `batch-build.ts`,
 ## Create A Browser Snapshot
 
 ```ts
-import init, { WasmProllyEngine, WasmRangeCursor } from "@trail/prolly-wasm";
+import init, { WasmProllyEngine, WasmRangeCursor } from "@crabbuild/prolly-wasm";
 
 await init();
 

--- a/bindings/wasm/PROVENANCE.md
+++ b/bindings/wasm/PROVENANCE.md
@@ -2,7 +2,7 @@
 
 - Binding path: direct `wasm-bindgen` wrapper over `prolly-map`
 - Rust crate: `bindings/wasm`
-- Package: `@trail/prolly-wasm`
+- Package: `@crabbuild/prolly-wasm`
 - Generated artifacts: `pkg/` from `wasm-bindgen --target web --typescript`
 - Compiled artifacts checked in: none
 

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trail/prolly-wasm",
+  "name": "@crabbuild/prolly-wasm",
   "version": "0.1.0",
   "type": "module",
   "private": true,

--- a/bindings/wasm/stores/indexeddb/package-lock.json
+++ b/bindings/wasm/stores/indexeddb/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@trail/prolly-store-indexeddb",
       "version": "0.1.0",
       "dependencies": {
-        "@trail/prolly-wasm": "file:../.."
+        "@crabbuild/prolly-wasm": "file:../.."
       },
       "devDependencies": {
         "@types/node": "20.19.25",
@@ -17,10 +17,10 @@
       }
     },
     "../..": {
-      "name": "@trail/prolly-wasm",
+      "name": "@crabbuild/prolly-wasm",
       "version": "0.1.0"
     },
-    "node_modules/@trail/prolly-wasm": {
+    "node_modules/@crabbuild/prolly-wasm": {
       "resolved": "../..",
       "link": true
     },

--- a/bindings/wasm/stores/indexeddb/package-lock.json
+++ b/bindings/wasm/stores/indexeddb/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@trail/prolly-store-indexeddb",
+  "name": "@crabbuild/prolly-store-indexeddb",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@trail/prolly-store-indexeddb",
+      "name": "@crabbuild/prolly-store-indexeddb",
       "version": "0.1.0",
       "dependencies": {
         "@crabbuild/prolly-wasm": "file:../.."

--- a/bindings/wasm/stores/indexeddb/package.json
+++ b/bindings/wasm/stores/indexeddb/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "files": ["src", "README.md"],
   "scripts": {"check": "tsc --noEmit", "test": "node --test test/*.test.ts"},
-  "dependencies": {"@trail/prolly-wasm": "file:../.."},
+  "dependencies": {"@crabbuild/prolly-wasm": "file:../.."},
   "devDependencies": {"@types/node": "20.19.25", "fake-indexeddb": "6.2.4", "typescript": "5.9.3"},
   "exports": "./src/index.ts"
 }

--- a/bindings/wasm/stores/indexeddb/package.json
+++ b/bindings/wasm/stores/indexeddb/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trail/prolly-store-indexeddb",
+  "name": "@crabbuild/prolly-store-indexeddb",
   "version": "0.1.0",
   "type": "module",
   "files": ["src", "README.md"],

--- a/bindings/wasm/stores/indexeddb/src/index.ts
+++ b/bindings/wasm/stores/indexeddb/src/index.ts
@@ -3,7 +3,7 @@ import {
   publishNodesWithGeneralPath, throwIfAborted, validateStoreDescriptor,
   type NamedStoreRoot, type NodeEntry, type NodeMutation, type NodePublication, type OptionalBytes, type RemoteStore,
   type RootCasResult, type RootCondition, type RootWrite, type StoreDescriptor, type StoreTransactionResult,
-} from "@trail/prolly-wasm/remote-store";
+} from "@crabbuild/prolly-wasm/remote-store";
 
 const DATABASE_VERSION = 1;
 const NODES = "nodes";

--- a/bindings/wasm/stores/indexeddb/test/indexeddb.test.ts
+++ b/bindings/wasm/stores/indexeddb/test/indexeddb.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { indexedDB } from "fake-indexeddb";
-import { missingBytes, presentBytes } from "@trail/prolly-wasm/remote-store";
+import { missingBytes, presentBytes } from "@crabbuild/prolly-wasm/remote-store";
 import { IndexedDbStore, openIndexedDbDatabase } from "../src/index.ts";
 
 const bytes = (value: string): Uint8Array => new TextEncoder().encode(value);

--- a/bindings/wasm/stores/opfs/package-lock.json
+++ b/bindings/wasm/stores/opfs/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@trail/prolly-store-opfs",
+  "name": "@crabbuild/prolly-store-opfs",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@trail/prolly-store-opfs",
+      "name": "@crabbuild/prolly-store-opfs",
       "version": "0.1.0",
       "dependencies": {
         "@crabbuild/prolly-wasm": "file:../.."

--- a/bindings/wasm/stores/opfs/package-lock.json
+++ b/bindings/wasm/stores/opfs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@trail/prolly-store-opfs",
       "version": "0.1.0",
       "dependencies": {
-        "@trail/prolly-wasm": "file:../.."
+        "@crabbuild/prolly-wasm": "file:../.."
       },
       "devDependencies": {
         "@types/node": "20.19.25",
@@ -16,10 +16,10 @@
       }
     },
     "../..": {
-      "name": "@trail/prolly-wasm",
+      "name": "@crabbuild/prolly-wasm",
       "version": "0.1.0"
     },
-    "node_modules/@trail/prolly-wasm": {
+    "node_modules/@crabbuild/prolly-wasm": {
       "resolved": "../..",
       "link": true
     },

--- a/bindings/wasm/stores/opfs/package.json
+++ b/bindings/wasm/stores/opfs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trail/prolly-store-opfs",
+  "name": "@crabbuild/prolly-store-opfs",
   "version": "0.1.0",
   "type": "module",
   "files": ["src", "README.md"],

--- a/bindings/wasm/stores/opfs/package.json
+++ b/bindings/wasm/stores/opfs/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "files": ["src", "README.md"],
   "scripts": {"check": "tsc --noEmit", "test": "node --test test/*.test.ts"},
-  "dependencies": {"@trail/prolly-wasm": "file:../.."},
+  "dependencies": {"@crabbuild/prolly-wasm": "file:../.."},
   "devDependencies": {"@types/node": "20.19.25", "typescript": "5.9.3"},
   "exports": "./src/index.ts"
 }

--- a/bindings/wasm/stores/opfs/src/index.ts
+++ b/bindings/wasm/stores/opfs/src/index.ts
@@ -3,7 +3,7 @@ import {
   publishNodesWithGeneralPath, throwIfAborted, validateStoreDescriptor,
   type NamedStoreRoot, type NodeEntry, type NodeMutation, type NodePublication, type OptionalBytes, type RemoteStore,
   type RootCasResult, type RootCondition, type RootWrite, type StoreDescriptor, type StoreTransactionResult,
-} from "@trail/prolly-wasm/remote-store";
+} from "@crabbuild/prolly-wasm/remote-store";
 
 export interface OpfsWritableFile { write(data: string): Promise<void>; close(): Promise<void>; abort?(): Promise<void>; }
 export interface OpfsFileHandle { getFile(): Promise<{ text(): Promise<string> }>; createWritable(): Promise<OpfsWritableFile>; }

--- a/bindings/wasm/stores/opfs/test/opfs.test.ts
+++ b/bindings/wasm/stores/opfs/test/opfs.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { missingBytes, presentBytes } from "@trail/prolly-wasm/remote-store";
+import { missingBytes, presentBytes } from "@crabbuild/prolly-wasm/remote-store";
 import { OpfsStore, type OpfsDirectoryHandle } from "../src/index.ts";
 
 const bytes = (value: string): Uint8Array => new TextEncoder().encode(value);

--- a/bindings/wasm/stores/pglite/package-lock.json
+++ b/bindings/wasm/stores/pglite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@electric-sql/pglite": "0.5.4",
-        "@trail/prolly-wasm": "file:../.."
+        "@crabbuild/prolly-wasm": "file:../.."
       },
       "devDependencies": {
         "@types/node": "20.19.25",
@@ -18,7 +18,7 @@
       }
     },
     "../..": {
-      "name": "@trail/prolly-wasm",
+      "name": "@crabbuild/prolly-wasm",
       "version": "0.1.0"
     },
     "node_modules/@electric-sql/pglite": {
@@ -27,7 +27,7 @@
       "integrity": "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g==",
       "license": "Apache-2.0"
     },
-    "node_modules/@trail/prolly-wasm": {
+    "node_modules/@crabbuild/prolly-wasm": {
       "resolved": "../..",
       "link": true
     },

--- a/bindings/wasm/stores/pglite/package-lock.json
+++ b/bindings/wasm/stores/pglite/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@trail/prolly-browser-store-pglite",
+  "name": "@crabbuild/prolly-browser-store-pglite",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@trail/prolly-browser-store-pglite",
+      "name": "@crabbuild/prolly-browser-store-pglite",
       "version": "0.1.0",
       "dependencies": {
         "@electric-sql/pglite": "0.5.4",

--- a/bindings/wasm/stores/pglite/package.json
+++ b/bindings/wasm/stores/pglite/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trail/prolly-browser-store-pglite",
+  "name": "@crabbuild/prolly-browser-store-pglite",
   "version": "0.1.0",
   "type": "module",
   "files": ["src", "README.md"],

--- a/bindings/wasm/stores/pglite/package.json
+++ b/bindings/wasm/stores/pglite/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "files": ["src", "README.md"],
   "scripts": {"check": "tsc --noEmit", "test": "node --test test/*.test.ts"},
-  "dependencies": {"@electric-sql/pglite": "0.5.4", "@trail/prolly-wasm": "file:../.."},
+  "dependencies": {"@electric-sql/pglite": "0.5.4", "@crabbuild/prolly-wasm": "file:../.."},
   "devDependencies": {"@types/node": "20.19.25", "fake-indexeddb": "6.2.4", "typescript": "5.9.3"},
   "exports": "./src/index.ts"
 }

--- a/bindings/wasm/stores/pglite/src/index.ts
+++ b/bindings/wasm/stores/pglite/src/index.ts
@@ -4,7 +4,7 @@ import {
   presentBytes, publishNodesWithGeneralPath, throwIfAborted, validateStoreDescriptor,
   type NamedStoreRoot, type NodeEntry, type NodeMutation, type NodePublication, type OptionalBytes, type RemoteStore,
   type RootCasResult, type RootCondition, type RootWrite, type StoreDescriptor, type StoreTransactionResult,
-} from "@trail/prolly-wasm/remote-store";
+} from "@crabbuild/prolly-wasm/remote-store";
 
 export const PGLITE_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS prolly_nodes (cid bytea PRIMARY KEY, node bytea NOT NULL);

--- a/bindings/wasm/stores/pglite/test/pglite.test.ts
+++ b/bindings/wasm/stores/pglite/test/pglite.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import "fake-indexeddb/auto";
 import { PGlite } from "@electric-sql/pglite";
-import { missingBytes, presentBytes } from "@trail/prolly-wasm/remote-store";
+import { missingBytes, presentBytes } from "@crabbuild/prolly-wasm/remote-store";
 import { BrowserPGliteStore } from "../src/index.ts";
 
 const bytes = (value: string): Uint8Array => new TextEncoder().encode(value);

--- a/bindings/wasm/test/wasm.test.ts
+++ b/bindings/wasm/test/wasm.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 const fixturePath = resolve(import.meta.dirname, "../../../conformance/prolly-fixtures.v1.json");
+const packageManifestPath = resolve(import.meta.dirname, "../package.json");
 
 function fixtures(): any {
   return JSON.parse(readFileSync(fixturePath, "utf8"));
@@ -66,6 +67,11 @@ test("wasm package declares browser memory-scope API", () => {
   assert.match(source, /WasmRangeProofRecord/);
   assert.match(source, /WasmRangeProofVerificationRecord/);
   assert.match(source, /WasmSnapshotNamespaceKind/);
+});
+
+test("wasm artifacts use the Crabbuild package scope", () => {
+  const manifest = JSON.parse(readFileSync(packageManifestPath, "utf8"));
+  assert.equal(manifest.name, "@crabbuild/prolly-wasm");
 });
 
 test("wasm deleteRange uses raw-byte half-open bounds", { skip: !generatedPresent }, () => {

--- a/conformance/store-protocol-v1/compatibility.json
+++ b/conformance/store-protocol-v1/compatibility.json
@@ -4,7 +4,7 @@
     "node": {
       "sqlite": {
         "status": "supported",
-        "module": "@trail/prolly-store-sqlite",
+        "module": "@crabbuild/prolly-store-sqlite",
         "sdk_module": "better-sqlite3",
         "sdk_version": "12.11.1",
         "minimum_node": "20.0.0",
@@ -16,7 +16,7 @@
       },
       "postgresql": {
         "status": "supported",
-        "module": "@trail/prolly-store-postgres",
+        "module": "@crabbuild/prolly-store-postgres",
         "sdk_module": "pg",
         "sdk_version": "8.22.0",
         "minimum_node": "20.0.0",
@@ -28,7 +28,7 @@
       },
       "mysql": {
         "status": "supported",
-        "module": "@trail/prolly-store-mysql",
+        "module": "@crabbuild/prolly-store-mysql",
         "sdk_module": "mysql2",
         "sdk_version": "3.23.0",
         "minimum_node": "20.0.0",
@@ -40,7 +40,7 @@
       },
       "redis": {
         "status": "supported",
-        "module": "@trail/prolly-store-redis",
+        "module": "@crabbuild/prolly-store-redis",
         "sdk_module": "redis",
         "sdk_version": "6.1.0",
         "minimum_node": "20.0.0",
@@ -52,7 +52,7 @@
       },
       "dynamodb": {
         "status": "supported",
-        "module": "@trail/prolly-store-dynamodb",
+        "module": "@crabbuild/prolly-store-dynamodb",
         "sdk_module": "@aws-sdk/client-dynamodb",
         "sdk_version": "3.1089.0",
         "minimum_node": "20.0.0",
@@ -64,7 +64,7 @@
       },
       "cosmosdb": {
         "status": "supported",
-        "module": "@trail/prolly-store-cosmosdb",
+        "module": "@crabbuild/prolly-store-cosmosdb",
         "sdk_module": "@azure/cosmos",
         "sdk_version": "4.9.3",
         "minimum_node": "20.0.0",
@@ -76,7 +76,7 @@
       },
       "spanner": {
         "status": "supported",
-        "module": "@trail/prolly-store-spanner",
+        "module": "@crabbuild/prolly-store-spanner",
         "sdk_module": "@google-cloud/spanner",
         "sdk_version": "8.0.0",
         "minimum_node": "20.0.0",
@@ -88,7 +88,7 @@
       },
       "pglite": {
         "status": "supported",
-        "module": "@trail/prolly-store-pglite",
+        "module": "@crabbuild/prolly-store-pglite",
         "sdk_module": "@electric-sql/pglite",
         "sdk_version": "0.5.4",
         "minimum_node": "20.0.0",
@@ -360,7 +360,7 @@
     "python": {
       "sqlite": {
         "status": "supported",
-        "module": "trail-prolly-store-sqlite",
+        "module": "crabbuild-prolly-store-sqlite",
         "sdk_module": "sqlite3",
         "sdk_version": "stdlib",
         "minimum_python": "3.10",
@@ -372,7 +372,7 @@
       },
       "postgresql": {
         "status": "supported",
-        "module": "trail-prolly-store-postgres",
+        "module": "crabbuild-prolly-store-postgres",
         "sdk_module": "psycopg",
         "sdk_version": "3.3.4",
         "minimum_python": "3.10",
@@ -384,7 +384,7 @@
       },
       "mysql": {
         "status": "supported",
-        "module": "trail-prolly-store-mysql",
+        "module": "crabbuild-prolly-store-mysql",
         "sdk_module": "aiomysql",
         "sdk_version": "0.3.2",
         "minimum_python": "3.10",
@@ -396,7 +396,7 @@
       },
       "redis": {
         "status": "supported",
-        "module": "trail-prolly-store-redis",
+        "module": "crabbuild-prolly-store-redis",
         "sdk_module": "redis",
         "sdk_version": "8.0.1",
         "minimum_python": "3.10",
@@ -408,7 +408,7 @@
       },
       "dynamodb": {
         "status": "supported",
-        "module": "trail-prolly-store-dynamodb",
+        "module": "crabbuild-prolly-store-dynamodb",
         "sdk_module": "aioboto3",
         "sdk_version": "15.5.0",
         "minimum_python": "3.10",
@@ -420,7 +420,7 @@
       },
       "cosmosdb": {
         "status": "supported",
-        "module": "trail-prolly-store-cosmosdb",
+        "module": "crabbuild-prolly-store-cosmosdb",
         "sdk_module": "azure-cosmos",
         "sdk_version": "4.16.1",
         "minimum_python": "3.10",
@@ -432,7 +432,7 @@
       },
       "spanner": {
         "status": "supported",
-        "module": "trail-prolly-store-spanner",
+        "module": "crabbuild-prolly-store-spanner",
         "sdk_module": "google-cloud-spanner",
         "sdk_version": "3.69.0",
         "minimum_python": "3.10",
@@ -446,7 +446,7 @@
     "ruby": {
       "sqlite": {
         "status": "supported",
-        "module": "trail-prolly-store-sqlite",
+        "module": "crabbuild-prolly-store-sqlite",
         "sdk_module": "sqlite3",
         "sdk_version": "2.9.5",
         "minimum_ruby": "3.2",
@@ -458,7 +458,7 @@
       },
       "postgresql": {
         "status": "supported",
-        "module": "trail-prolly-store-postgres",
+        "module": "crabbuild-prolly-store-postgres",
         "sdk_module": "pg",
         "sdk_version": "1.6.3",
         "minimum_ruby": "3.2",
@@ -470,7 +470,7 @@
       },
       "mysql": {
         "status": "supported",
-        "module": "trail-prolly-store-mysql",
+        "module": "crabbuild-prolly-store-mysql",
         "sdk_module": "mysql2",
         "sdk_version": "0.5.7",
         "minimum_ruby": "3.2",
@@ -482,7 +482,7 @@
       },
       "redis": {
         "status": "supported",
-        "module": "trail-prolly-store-redis",
+        "module": "crabbuild-prolly-store-redis",
         "sdk_module": "redis",
         "sdk_version": "5.4.1",
         "minimum_ruby": "3.2",
@@ -494,7 +494,7 @@
       },
       "dynamodb": {
         "status": "supported",
-        "module": "trail-prolly-store-dynamodb",
+        "module": "crabbuild-prolly-store-dynamodb",
         "sdk_module": "aws-sdk-dynamodb",
         "sdk_version": "1.169.0",
         "minimum_ruby": "3.2",
@@ -507,7 +507,7 @@
       "cosmosdb": {"status":"unsupported","reason":"Microsoft does not publish a supported Cosmos DB Ruby client SDK"},
       "spanner": {
         "status": "supported",
-        "module": "trail-prolly-store-spanner",
+        "module": "crabbuild-prolly-store-spanner",
         "sdk_module": "google-cloud-spanner",
         "sdk_version": "2.36.0",
         "minimum_ruby": "3.2",
@@ -585,7 +585,7 @@
     "browser": {
       "indexeddb": {
         "status": "supported",
-        "module": "@trail/prolly-store-indexeddb",
+        "module": "@crabbuild/prolly-store-indexeddb",
         "sdk_module": "IndexedDB",
         "sdk_version": "browser-native",
         "minimum_browser": "IndexedDB 2.0",
@@ -597,7 +597,7 @@
       },
       "opfs": {
         "status": "supported",
-        "module": "@trail/prolly-store-opfs",
+        "module": "@crabbuild/prolly-store-opfs",
         "sdk_module": "Origin Private File System",
         "sdk_version": "browser-native",
         "minimum_browser": "File System Access API",
@@ -609,7 +609,7 @@
       },
       "pglite": {
         "status": "supported",
-        "module": "@trail/prolly-browser-store-pglite",
+        "module": "@crabbuild/prolly-browser-store-pglite",
         "sdk_module": "@electric-sql/pglite",
         "sdk_version": "0.5.4",
         "minimum_browser": "WebAssembly and IndexedDB",

--- a/docs/superpowers/plans/2026-07-17-node-jvm-async-store-bindings.md
+++ b/docs/superpowers/plans/2026-07-17-node-jvm-async-store-bindings.md
@@ -13,7 +13,7 @@
 - Protocol major is exactly `1`; provider schema version is exactly `1`.
 - Node, Kotlin, and Java support SQLite, PostgreSQL, MySQL, Redis, DynamoDB, Cosmos DB, and Spanner.
 - PGlite is Node-only; RocksDB and SlateDB remain Rust-only.
-- Provider SDK dependencies never enter `@trail/prolly-node`, `build.crab:prolly-kotlin`, or `build.crab:prolly-java`.
+- Provider SDK dependencies never enter `@crabbuild/prolly-node`, `build.crab:prolly-kotlin`, or `build.crab:prolly-java`.
 - Applications own injected clients and pools; adapters never close borrowed clients.
 - Missing bytes and present empty bytes remain distinct in every language.
 - Ordered batch reads preserve input length, order, duplicates, and missing positions.

--- a/docs/superpowers/specs/2026-07-16-language-native-store-bindings-design.md
+++ b/docs/superpowers/specs/2026-07-16-language-native-store-bindings-design.md
@@ -173,7 +173,7 @@ conformance/
 ```
 
 Artifacts preserve the repository's current ecosystem namespaces, including
-`@trail`, `build.crab`, and the existing Go module path. Every provider is a
+`@crabbuild`, `build.crab`, and the existing Go module path. Every provider is a
 separately installable artifact and declares:
 
 - the supported core binding version range;

--- a/stores/prolly-store-pglite/benches/pglite_scale_bench.rs
+++ b/stores/prolly-store-pglite/benches/pglite_scale_bench.rs
@@ -135,7 +135,7 @@ fn db_path() -> PathBuf {
         .unwrap()
         .as_nanos();
     std::env::temp_dir().join(format!(
-        "trail-prolly-pglite-scale-{}-{nanos}",
+        "crabbuild-prolly-pglite-scale-{}-{nanos}",
         std::process::id()
     ))
 }

--- a/stores/prolly-store-rocksdb/tests/rocksdb_store.rs
+++ b/stores/prolly-store-rocksdb/tests/rocksdb_store.rs
@@ -97,7 +97,7 @@ fn temp_db_path(label: &str) -> PathBuf {
         .unwrap()
         .as_nanos();
     std::env::temp_dir().join(format!(
-        "trail-prolly-rocksdb-{label}-{}-{nanos}",
+        "crabbuild-prolly-rocksdb-{label}-{}-{nanos}",
         std::process::id()
     ))
 }

--- a/stores/prolly-store-slatedb/benches/slatedb_ops_bench.rs
+++ b/stores/prolly-store-slatedb/benches/slatedb_ops_bench.rs
@@ -1144,7 +1144,7 @@ fn db_path() -> String {
     }
 
     let prefix = std::env::var("PROLLY_SLATEDB_PATH_PREFIX")
-        .unwrap_or_else(|_| "trail/prolly-bench".to_string());
+        .unwrap_or_else(|_| "crabbuild/prolly-bench".to_string());
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()

--- a/stores/prolly-store-slatedb/benches/slatedb_scale_bench.rs
+++ b/stores/prolly-store-slatedb/benches/slatedb_scale_bench.rs
@@ -161,7 +161,7 @@ fn db_path() -> String {
     }
 
     let prefix = std::env::var("PROLLY_SLATEDB_PATH_PREFIX")
-        .unwrap_or_else(|_| "trail/prolly-bench".to_string());
+        .unwrap_or_else(|_| "crabbuild/prolly-bench".to_string());
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()

--- a/stores/prolly-store-slatedb/benches/slatedb_workload_bench.rs
+++ b/stores/prolly-store-slatedb/benches/slatedb_workload_bench.rs
@@ -1431,7 +1431,7 @@ fn db_path() -> String {
     }
 
     let prefix = std::env::var("PROLLY_SLATEDB_PATH_PREFIX")
-        .unwrap_or_else(|_| "trail/prolly-workload".to_string());
+        .unwrap_or_else(|_| "crabbuild/prolly-workload".to_string());
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()

--- a/stores/prolly-store-sqlite/benches/sqlite_scale_bench.rs
+++ b/stores/prolly-store-sqlite/benches/sqlite_scale_bench.rs
@@ -130,7 +130,7 @@ fn db_path() -> PathBuf {
         .unwrap()
         .as_nanos();
     std::env::temp_dir().join(format!(
-        "trail-prolly-sqlite-scale-{}-{nanos}.db",
+        "crabbuild-prolly-sqlite-scale-{}-{nanos}.db",
         std::process::id()
     ))
 }

--- a/stores/prolly-store-sqlite/tests/sqlite_store.rs
+++ b/stores/prolly-store-sqlite/tests/sqlite_store.rs
@@ -175,7 +175,7 @@ fn temp_db_path(label: &str) -> PathBuf {
         .unwrap()
         .as_nanos();
     std::env::temp_dir().join(format!(
-        "trail-prolly-{label}-{}-{nanos}.db",
+        "crabbuild-prolly-{label}-{}-{nanos}.db",
         std::process::id()
     ))
 }


### PR DESCRIPTION
## Summary

- migrate legacy published package identities to Crabbuild across npm, Python, Ruby, UniFFI metadata, provider packages, lockfiles, conformance metadata, and documentation
- publish npm artifacts under `@crabbuild/*`, including `@crabbuild/prolly-wasm` and `@crabbuild/prolly-node`
- publish Python and Ruby artifacts with the `crabbuild-prolly*` prefix
- compact 64-character content addresses in tree and history cards to a stable 16-character prefix and 12-character suffix
- retain complete addresses in tooltips, accessibility labels, and the chunk inspector

## Why

The bindings and store providers still exposed the legacy Trail namespace even though the engine and repository are owned by Crabbuild. The visualizer also rendered complete SHA-256 addresses in fixed-width cards, allowing them to overflow their containers.

Protocol and fixture identifiers that affect encoded compatibility remain unchanged; this migration targets package, artifact, dependency, contributor, and repository identities.

## Validation

- Node native binding built successfully; all 60 Node tests passed
- all eight Node store providers type-checked and tested; live service suites skipped when services were not configured
- IndexedDB, OPFS, and browser PGlite packages type-checked and tested
- dry-run packaging confirmed all npm package IDs and tarballs use the Crabbuild namespace
- all Python TOML, Ruby gem, and changed JSON manifests parsed successfully
- repository audit found no remaining `@trail`, `trail-prolly`, `Trail Contributors`, or `trail/prolly` package identifiers
- `npm test` in `bindings/wasm` — 35 tests passed
- `npm test` in `3rd/prolly-tree-visualizer` — 7 files, 21 tests passed
- visualizer TypeScript/Vite production build and real-WASM smoke test passed
- browser verification confirmed tree and history card addresses remain within their containers
