### PR TITLE
Fix visualizer random controls and enable four-level trees

### DIFF
--- a/3rd/prolly-tree-visualizer/package-lock.json
+++ b/3rd/prolly-tree-visualizer/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "19.1.1"
       },
       "devDependencies": {
+        "@types/node": "24.10.1",
         "@types/react": "19.1.9",
         "@types/react-dom": "19.1.7",
         "@vitejs/plugin-react": "4.7.0",
@@ -306,6 +307,10 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@crabbuild/prolly-wasm": {
+      "resolved": "../../bindings/wasm",
+      "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -1215,10 +1220,6 @@
         "win32"
       ]
     },
-    "node_modules/@crabbuild/prolly-wasm": {
-      "resolved": "../../bindings/wasm",
-      "link": true
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1288,6 +1289,16 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.9",
@@ -2111,6 +2122,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.3.0",

--- a/3rd/prolly-tree-visualizer/package.json
+++ b/3rd/prolly-tree-visualizer/package.json
@@ -17,6 +17,7 @@
     "react-dom": "19.1.1"
   },
   "devDependencies": {
+    "@types/node": "24.10.1",
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
     "@vitejs/plugin-react": "4.7.0",

--- a/3rd/prolly-tree-visualizer/src/App.tsx
+++ b/3rd/prolly-tree-visualizer/src/App.tsx
@@ -489,7 +489,23 @@ function App() {
                   },
                 );
               }}>Put row</button>
-              <button title="Randomly insert a new key or update an existing row" disabled={busy || viewingHistorical} onClick={() => run((engine) => engine.addRandom())}>Random</button>
+              <button title="Randomly insert a new key or update an existing row" disabled={busy || viewingHistorical} onClick={() => {
+                let randomKey: number | undefined;
+                let randomValue: string | undefined;
+                run(
+                  (engine) => {
+                    const result = engine.addRandom();
+                    randomKey = result.key;
+                    randomValue = result.value;
+                    return result.snapshot;
+                  },
+                  () => {
+                    if (randomKey === undefined || randomValue === undefined) return;
+                    setKeyInput(String(randomKey));
+                    setValueInput(randomValue);
+                  },
+                );
+              }}>Random</button>
             </div>
           </div>
           <div className="control-section delete-section">

--- a/3rd/prolly-tree-visualizer/src/App.tsx
+++ b/3rd/prolly-tree-visualizer/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { ProllyEngine, type GrowthResult, type InsertionOrderResult } from './engine';
+import { canGrowTree, MAX_TREE_LEVELS, ProllyEngine, type GrowthResult, type InsertionOrderResult } from './engine';
 import { countSharedNodes, diffRows, estimateMutationSplitProbability, leafNodes, traceRange, traceSearch } from './prolly';
 import { calculateVersionStorage, countHistoricalTreeChunks } from './storage';
 import { calculateMutationCost } from './mutationCost';
@@ -259,16 +259,16 @@ function App() {
     }, 20);
   };
 
-  const runGrowth = (operation: (engine: ProllyEngine) => GrowthResult) => {
+  const runGrowth = (operation: (engine: ProllyEngine) => GrowthResult | Promise<GrowthResult>) => {
     const engine = engineRef.current;
     if (!engine || operationPendingRef.current) return;
     operationPendingRef.current = true;
     resetTreeState();
     setBusy(true);
     setError(undefined);
-    window.setTimeout(() => {
+    window.setTimeout(async () => {
       try {
-        const result = operation(engine);
+        const result = await operation(engine);
         appendSnapshot(result.after);
       } catch (cause) {
         setError(cause instanceof Error ? cause.message : String(cause));
@@ -523,7 +523,13 @@ function App() {
             <div className="control-fields bulk-actions">
               <button disabled={busy || viewingHistorical} onClick={() => run((engine) => engine.addSequential(25))}>+ 25 rows</button>
               <button disabled={busy || viewingHistorical} onClick={() => runGrowth((engine) => engine.growUntilSplit())}>Next split</button>
-              <button title={current.root.level >= 2 ? 'Three levels is the browser demo limit' : undefined} disabled={busy || viewingHistorical || current.root.level >= 2} onClick={() => runGrowth((engine) => engine.growUntilNextLevel())}>{current.root.level >= 2 ? 'Three levels reached' : 'Next tree level'}</button>
+              <button
+                title={!canGrowTree(current.root.level) ? `${MAX_TREE_LEVELS} levels is the browser demo limit` : undefined}
+                disabled={busy || viewingHistorical || !canGrowTree(current.root.level)}
+                onClick={() => runGrowth((engine) => engine.growUntilNextLevel())}
+              >
+                {!canGrowTree(current.root.level) ? `${MAX_TREE_LEVELS} levels reached` : 'Next tree level'}
+              </button>
               <button className="reset-button" disabled={busy || viewingHistorical} onClick={() => {
                 const engine = engineRef.current;
                 if (!engine) return;

--- a/3rd/prolly-tree-visualizer/src/engine.test.ts
+++ b/3rd/prolly-tree-visualizer/src/engine.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ProllyEngine } from './engine';
+
+const wasmBytes = Uint8Array.from(readFileSync(
+  new URL('../../../bindings/wasm/pkg/prolly_wasm_bg.wasm', import.meta.url),
+)).buffer;
+
+describe('random mutations', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reports the exact inserted key and value for the controls', async () => {
+    const engine = await ProllyEngine.create(wasmBytes);
+    try {
+      const seeded = engine.seed();
+      const maxKey = seeded.rows.at(-1)!.key;
+      vi.spyOn(Math, 'random')
+        .mockReturnValueOnce(0.75)
+        .mockReturnValueOnce(0);
+
+      const result = engine.addRandom();
+
+      expect(result.key).toBe(maxKey + 1);
+      expect(result.value).toBe(`random-${maxKey + 1}`);
+      expect(result.snapshot.rows).toContainEqual({
+        key: result.key,
+        value: result.value,
+      });
+    } finally {
+      engine.close();
+    }
+  });
+
+  it('reports the exact updated key and value for the controls', async () => {
+    const engine = await ProllyEngine.create(wasmBytes);
+    try {
+      const seeded = engine.seed();
+      const firstKey = seeded.rows[0].key;
+      vi.spyOn(Math, 'random')
+        .mockReturnValueOnce(0.25)
+        .mockReturnValueOnce(0);
+
+      const result = engine.addRandom();
+
+      expect(result.key).toBe(firstKey);
+      expect(result.value).toBe(`random-update-${firstKey}-1`);
+      expect(result.snapshot.rows).toContainEqual({
+        key: result.key,
+        value: result.value,
+      });
+    } finally {
+      engine.close();
+    }
+  });
+});

--- a/3rd/prolly-tree-visualizer/src/engine.test.ts
+++ b/3rd/prolly-tree-visualizer/src/engine.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { ProllyEngine } from './engine';
+import { canGrowTree, MAX_TREE_LEVELS, ProllyEngine } from './engine';
 
 const wasmBytes = Uint8Array.from(readFileSync(
   new URL('../../../bindings/wasm/pkg/prolly_wasm_bg.wasm', import.meta.url),
@@ -53,5 +53,13 @@ describe('random mutations', () => {
     } finally {
       engine.close();
     }
+  });
+});
+
+describe('tree level growth', () => {
+  it('allows growth from three displayed levels to four', () => {
+    expect(MAX_TREE_LEVELS).toBe(4);
+    expect(canGrowTree(2)).toBe(true);
+    expect(canGrowTree(3)).toBe(false);
   });
 });

--- a/3rd/prolly-tree-visualizer/src/engine.ts
+++ b/3rd/prolly-tree-visualizer/src/engine.ts
@@ -41,6 +41,12 @@ export interface GrowthResult {
   added: number;
 }
 
+export interface RandomMutationResult {
+  snapshot: TreeSnapshot;
+  key: number;
+  value: string;
+}
+
 export interface GarbageCollectionResult {
   head: TreeSnapshot;
   message: string;
@@ -86,8 +92,8 @@ export class ProllyEngine {
     this.tree = this.runtime.create();
   }
 
-  static async create() {
-    return new ProllyEngine(await loadProllyWasm());
+  static async create(wasmInput?: WebAssembly.Module | BufferSource) {
+    return new ProllyEngine(await loadProllyWasm(undefined, wasmInput));
   }
 
   private key(key: number) {
@@ -190,15 +196,17 @@ export class ProllyEngine {
     this.replaceTree(this.runtime.appendBatch(this.tree, mutations));
   }
 
-  addRandom() {
+  addRandom(): RandomMutationResult {
     const rows = this.rows();
     if (rows.length > 0 && Math.random() < 0.5) {
       const row = rows[Math.floor(Math.random() * rows.length)];
-      return this.put(row.key, `random-update-${row.key}-${this.snapshotId}`);
+      const value = `random-update-${row.key}-${this.snapshotId}`;
+      return { snapshot: this.put(row.key, value), key: row.key, value };
     }
     const maxKey = rows.at(-1)?.key ?? 0;
     const key = maxKey + Math.floor(Math.random() * Math.max(160, maxKey)) + 1;
-    return this.put(key, `random-${key}`);
+    const value = `random-${key}`;
+    return { snapshot: this.put(key, value), key, value };
   }
 
   growUntilSplit(limit = 512, batchSize = 16): GrowthResult {

--- a/3rd/prolly-tree-visualizer/src/engine.ts
+++ b/3rd/prolly-tree-visualizer/src/engine.ts
@@ -5,6 +5,7 @@ import {
   type WasmProllyEngineInstance,
   type WasmTree,
   type WasmTreeDebugViewRecord,
+  type WasmTreeStatsRecord,
 } from '@crabbuild/prolly-wasm';
 import { bootstrapKeys, deterministicShuffle } from './bootstrap';
 import { buildTreeFromDebug, leafNodes, toHex } from './prolly';
@@ -12,6 +13,12 @@ import type { RowValue, TreeSnapshot } from './types';
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
+
+export const MAX_TREE_LEVELS = 4;
+
+export function canGrowTree(rootLevel: number) {
+  return rootLevel + 1 < MAX_TREE_LEVELS;
+}
 
 function decodeI64Key(bytes: Uint8Array) {
   let encoded = 0n;
@@ -226,24 +233,33 @@ export class ProllyEngine {
     return { before, after: candidate, added: limit };
   }
 
-  growUntilNextLevel(): GrowthResult {
+  async growUntilNextLevel(): Promise<GrowthResult> {
     const before = this.capture('Before level growth');
     const rootLevel = before.root.level;
-    if (rootLevel >= 2) throw new Error('Four-level trees exceed the full-node browser rendering limit');
-    const limit = rootLevel === 0 ? 2_048 : 48_000;
-    const batchSize = rootLevel === 0 ? 256 : 2_000;
+    if (!canGrowTree(rootLevel)) throw new Error(`${MAX_TREE_LEVELS} levels is the browser demo limit`);
+    const limit = rootLevel === 0 ? 2_048 : rootLevel === 1 ? 48_000 : 1_000_000;
+    const batchSize = rootLevel === 0 ? 256 : rootLevel === 1 ? 2_000 : 20_000;
     let next = (before.rows.at(-1)?.key ?? 0) + 1;
-    let candidate = before;
     for (let added = 0; added < limit;) {
       const amount = Math.min(batchSize, limit - added);
       this.insertSequential(next, amount, 'level');
       added += amount;
       next += amount;
-      candidate = this.capture(`Reached level ${rootLevel + 1} after appending ${added} rows`);
-      if (candidate.root.level > rootLevel) return { before, after: candidate, added };
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      const stats = this.runtime.collectStats(this.tree) as WasmTreeStatsRecord;
+      if (stats.tree_height > rootLevel + 1) {
+        return {
+          before,
+          after: this.capture(`Reached level ${rootLevel + 1} after appending ${added} rows`),
+          added,
+        };
+      }
     }
-    candidate.label = `No new level after ${limit} inserts`;
-    return { before, after: candidate, added: limit };
+    return {
+      before,
+      after: this.capture(`No new level after ${limit} inserts`),
+      added: limit,
+    };
   }
 
   garbageCollect(): GarbageCollectionResult {


### PR DESCRIPTION
## What changed

- Keep the insert/update controls synchronized with the exact key and value produced by a Random mutation.
- Allow the visualizer to grow from three displayed tree levels to four.
- Use tree statistics while searching for the next level instead of materializing a complete snapshot after every batch.
- Yield between large growth batches so the browser can continue painting the busy state.
- Add regression coverage for Random mutations and the four-level growth limit.

## Why

The Random action mutated the prolly tree but left stale values in the controls. Separately, the visualizer disabled level growth as soon as a three-level tree was reached, even though the prolly WASM engine supports deeper trees. Four-level growth also magnifies the cost of rebuilding complete snapshots during every search batch.

## Impact

Random actions now show the mutation that was actually applied. Users can grow and inspect a four-level prolly tree; the level-growth control is disabled only after four levels are reached.

## Validation

- `npm test` (24 tests)
- `npm run build`
- `npm run smoke:wasm`
- Real WASM growth check through four levels (~1.05 million rows / ~8,000 live nodes)
