### PR TITLE
Add typed GlueSQL merge and runnable integration examples

### DIFF
--- a/integrations/prolly-gluesql/Cargo.toml
+++ b/integrations/prolly-gluesql/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/prolly-gluesql"
 readme = "README.md"
 keywords = ["sql", "database", "versioned", "prolly-tree", "gluesql"]
 categories = ["database-implementations"]
-include = ["/Cargo.toml", "/README.md", "/src/**", "/tests/**"]
+include = ["/Cargo.toml", "/README.md", "/examples/**", "/src/**", "/tests/**"]
 
 [lib]
 name = "prolly_gluesql"
@@ -47,3 +47,7 @@ unsafe_code = "forbid"
 name = "prolly-sql"
 path = "src/bin/prolly-sql.rs"
 required-features = ["cli"]
+
+[[example]]
+name = "sqlite_durable"
+required-features = ["sqlite"]

--- a/integrations/prolly-gluesql/README.md
+++ b/integrations/prolly-gluesql/README.md
@@ -20,7 +20,7 @@ logical diffs, and optimistic conflict detection for concurrent writers.
 - Explicit transactions and GlueSQL autocommit with atomic catalog-and-data
   publication.
 - Named branches, immutable version handles, historical reads, logical diffs,
-  and compare-and-swap resets.
+  typed three-way merges, and compare-and-swap resets.
 - In-memory storage by default and durable SQLite storage behind the `sqlite`
   feature.
 - An optional `prolly-sql` command-line client behind the `cli` feature.
@@ -126,6 +126,53 @@ Keep important states reachable through a branch before running store garbage
 collection. The adapter intentionally does not invent SQL syntax for branch
 operations.
 
+## Merging branches
+
+`merge` performs a typed three-way merge. The selected branch is the current
+side, `incoming` is the version being merged, and `base` is their common
+ancestor. The base is explicit because `Version` is a database snapshot rather
+than a commit with parent history.
+
+```rust,ignore
+use prolly_gluesql::{MergeConflict, MergeResult};
+
+let base = db.storage.head()?.unwrap();
+db.storage.create_branch("feature")?;
+
+// Make changes on main and feature, then retain the feature head.
+db.storage.checkout_branch("feature")?;
+db.execute("UPDATE users SET name = 'Feature' WHERE id = 1;")
+    .await?;
+let incoming = db.storage.head()?.unwrap();
+db.storage.checkout_branch("main")?;
+
+match db.storage.merge(&base, &incoming).await? {
+    MergeResult::Applied { version, changes } => {
+        println!("published {} logical changes at {:?}", changes.len(), version.id());
+    }
+    MergeResult::Conflicted { conflicts } => {
+        for conflict in conflicts {
+            match conflict {
+                MergeConflict::Row { table, key, base, current, incoming } => {
+                    // All values are decoded GlueSQL records; no raw Prolly bytes leak.
+                }
+                MergeConflict::Schema { .. }
+                | MergeConflict::Function { .. }
+                | MergeConflict::Constraint { .. } => { /* present for resolution */ }
+            }
+        }
+    }
+}
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Clean changes are combined with Prolly's structural prefix merge. The adapter
+then validates row shape, types, nullability, primary keys, unique columns, and
+foreign keys. Covering indexes, generated-key sequences, and metadata are
+rebuilt internally before the selected branch is moved with compare-and-swap.
+Conflicts and validation failures leave the branch unchanged; a concurrent
+head update returns a serialization conflict.
+
 ## Transaction and concurrency model
 
 At `BEGIN`, the connection resolves the selected branch once. Mutations build
@@ -186,9 +233,9 @@ before upgrading between pre-1.0 releases.
 SQL parsing, execution semantics, and supported SQL syntax come from GlueSQL
 0.19. This adapter provides versioned storage rather than a Git-like commit
 graph: it has branch heads and immutable roots, but no author metadata,
-reflogs, semantic SQL merge, or automatic history retention. Those can be
-layered above `Version`, typed diffs, and durable branches when an application
-needs them.
+reflogs, automatic common-ancestor discovery, or automatic history retention.
+Those can be layered above `Version`, typed diffs, typed merges, and durable
+branches when an application needs them.
 
 The adapter currently targets synchronous Prolly stores. Remote
 `AsyncStore`/`AsyncManifestStore` backends would require a separate async
@@ -198,7 +245,8 @@ have different ownership and execution models.
 ## Verification
 
 The integration runs GlueSQL's published storage conformance suite plus tests
-for rollback, branch isolation, historical reads, reset, SQLite reopen,
+for rollback, branch isolation, historical reads, reset, typed merge conflicts,
+merge constraint validation, derived-state rebuilding, SQLite reopen,
 secondary-index durability, custom-function durability, and concurrent-writer
 conflicts:
 

--- a/integrations/prolly-gluesql/README.md
+++ b/integrations/prolly-gluesql/README.md
@@ -77,6 +77,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 Any custom backend implementing both `prolly::Store` and
 `prolly::ManifestStore` can be passed to `ProllyStorage::new`.
 
+## Runnable examples
+
+The [`examples`](examples/README.md) directory contains complete programs. Run
+them from this crate directory:
+
+```sh
+cargo run --example basic_sql
+cargo run --example concurrent_writers
+cargo run --example versions_and_branches
+cargo run --example merge_clean
+cargo run --example merge_conflicts
+cargo run --features sqlite --example sqlite_durable
+```
+
+Each example creates its own state, checks its expected results, and needs no
+external service or input. They cover SQL execution, transactions, indexes,
+custom functions, shared custom stores, optimistic writer conflicts, typed
+diffs, historical reads, branch isolation, clean merges, every typed conflict
+category, constraint conflicts, CAS publication, and durable SQLite reopen
+behavior.
+
 ## Versions and branches
 
 `head` returns an immutable handle to the selected branch state. A branch is a

--- a/integrations/prolly-gluesql/examples/README.md
+++ b/integrations/prolly-gluesql/examples/README.md
@@ -1,0 +1,16 @@
+# Runnable integration examples
+
+Run these commands from `integrations/prolly-gluesql`.
+
+| Example | Command | Demonstrates |
+| --- | --- | --- |
+| [`basic_sql.rs`](basic_sql.rs) | `cargo run --example basic_sql` | In-memory setup, schema, foreign keys, transactions, rollback, a covering index, a custom function, and typed GlueSQL payloads. |
+| [`concurrent_writers.rs`](concurrent_writers.rs) | `cargo run --example concurrent_writers` | A shared custom Prolly backend, two GlueSQL connections, optimistic transactions, and a serialization conflict that preserves the winning commit. |
+| [`versions_and_branches.rs`](versions_and_branches.rs) | `cargo run --example versions_and_branches` | Opaque versions, typed diffs, durable branches, branch isolation, historical checkout, and CAS reset. |
+| [`merge_clean.rs`](merge_clean.rs) | `cargo run --example merge_clean` | An explicit-base three-way merge, structural combination of disjoint changes, rebuilt indexes, and the returned logical diff. |
+| [`merge_conflicts.rs`](merge_conflicts.rs) | `cargo run --example merge_conflicts` | Decoded row, schema, function, unique-column, and foreign-key conflicts without changing the target branch. |
+| [`sqlite_durable.rs`](sqlite_durable.rs) | `cargo run --features sqlite --example sqlite_durable` | A self-cleaning temporary SQLite store, durable versions and branches, and reopening both branch heads. |
+
+Every example is self-contained: it creates its own database state, validates
+the result with assertions, and prints the important typed output. No external
+database server is required.

--- a/integrations/prolly-gluesql/examples/basic_sql.rs
+++ b/integrations/prolly-gluesql/examples/basic_sql.rs
@@ -1,0 +1,78 @@
+//! End-to-end in-memory SQL, transaction, index, and function example.
+//!
+//! Run with: `cargo run --example basic_sql`
+
+use {
+    prolly_gluesql::{gluesql_core::prelude::Value, Glue, Payload, ProllyStorage},
+    std::error::Error,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let storage = ProllyStorage::in_memory()?;
+    let mut db = Glue::new(storage);
+
+    db.execute(
+        "CREATE TABLE projects (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE
+        );",
+    )
+    .await?;
+    db.execute(
+        "CREATE TABLE tasks (
+            id INTEGER PRIMARY KEY,
+            project_id INTEGER NOT NULL,
+            title TEXT NOT NULL,
+            done BOOLEAN NOT NULL,
+            FOREIGN KEY (project_id) REFERENCES projects (id)
+        );",
+    )
+    .await?;
+    db.execute("CREATE INDEX tasks_done ON tasks (done);")
+        .await?;
+    db.execute("CREATE FUNCTION next_id(n INT) RETURN n + 1;")
+        .await?;
+
+    db.execute("START TRANSACTION;").await?;
+    db.execute("INSERT INTO projects VALUES (1, 'Prolly GlueSQL');")
+        .await?;
+    db.execute(
+        "INSERT INTO tasks VALUES
+            (1, 1, 'build typed storage', false),
+            (2, 1, 'ship examples', false);",
+    )
+    .await?;
+    db.execute("COMMIT;").await?;
+
+    db.execute("START TRANSACTION;").await?;
+    db.execute("UPDATE tasks SET done = true WHERE id = 1;")
+        .await?;
+    db.execute("ROLLBACK;").await?;
+
+    let payloads = db
+        .execute(
+            "SELECT next_id(id), title
+             FROM tasks
+             WHERE done = false
+             ORDER BY id;",
+        )
+        .await?;
+    let Payload::Select { rows, .. } = &payloads[0] else {
+        return Err("expected a SELECT payload".into());
+    };
+    assert_eq!(
+        rows,
+        &vec![
+            vec![Value::I64(2), Value::Str("build typed storage".to_owned())],
+            vec![Value::I64(3), Value::Str("ship examples".to_owned())],
+        ]
+    );
+
+    println!("selected rows through the covering index and custom function:");
+    for row in rows {
+        println!("  {row:?}");
+    }
+    println!("rollback preserved both unfinished tasks");
+    Ok(())
+}

--- a/integrations/prolly-gluesql/examples/concurrent_writers.rs
+++ b/integrations/prolly-gluesql/examples/concurrent_writers.rs
@@ -1,0 +1,49 @@
+//! Shared backend connections and optimistic serialization conflicts.
+//!
+//! Run with: `cargo run --example concurrent_writers`
+
+use {
+    prolly::{ManifestStore, MemStore, Store},
+    prolly_gluesql::{gluesql_core::prelude::Value, Glue, Payload, ProllyStorage},
+    std::{error::Error, sync::Arc},
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // ProllyStorage accepts any backend implementing Store + ManifestStore.
+    let backend = Arc::new(MemStore::new());
+    assert_backend(&backend);
+    let mut first = Glue::new(ProllyStorage::new(Arc::clone(&backend))?);
+    first
+        .execute("CREATE TABLE counters (id INTEGER PRIMARY KEY, value INTEGER NOT NULL);")
+        .await?;
+    first.execute("INSERT INTO counters VALUES (1, 0);").await?;
+
+    let mut second = Glue::new(ProllyStorage::new(Arc::clone(&backend))?);
+    first.execute("START TRANSACTION;").await?;
+    second.execute("START TRANSACTION;").await?;
+    first
+        .execute("UPDATE counters SET value = 1 WHERE id = 1;")
+        .await?;
+    second
+        .execute("UPDATE counters SET value = 2 WHERE id = 1;")
+        .await?;
+
+    first.execute("COMMIT;").await?;
+    let conflict = second
+        .execute("COMMIT;")
+        .await
+        .expect_err("the stale writer must lose compare-and-swap");
+    assert!(conflict.to_string().contains("serialization conflict"));
+
+    let payloads = first.execute("SELECT value FROM counters;").await?;
+    assert!(matches!(
+        &payloads[0],
+        Payload::Select { rows, .. } if rows == &vec![vec![Value::I64(1)]]
+    ));
+    println!("second writer rejected: {conflict}");
+    println!("the first writer's value remains committed");
+    Ok(())
+}
+
+fn assert_backend<S: Store + ManifestStore>(_backend: &S) {}

--- a/integrations/prolly-gluesql/examples/merge_clean.rs
+++ b/integrations/prolly-gluesql/examples/merge_clean.rs
@@ -1,0 +1,67 @@
+//! A clean, typed three-way merge with rebuilt derived state.
+//!
+//! Run with: `cargo run --example merge_clean`
+
+use {
+    prolly_gluesql::{gluesql_core::prelude::Value, Glue, MergeResult, Payload, ProllyStorage},
+    std::error::Error,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let storage = ProllyStorage::in_memory()?;
+    let mut db = Glue::new(storage);
+
+    db.execute(
+        "CREATE TABLE tickets (
+            id INTEGER PRIMARY KEY,
+            status TEXT NOT NULL,
+            title TEXT NOT NULL
+        );",
+    )
+    .await?;
+    db.execute("INSERT INTO tickets VALUES (1, 'open', 'base ticket');")
+        .await?;
+    let base = db.storage.head()?.unwrap();
+    db.storage.create_branch("feature")?;
+
+    // Current/main changes one row and adds an index.
+    db.execute("UPDATE tickets SET title = 'edited on main' WHERE id = 1;")
+        .await?;
+    db.execute("CREATE INDEX tickets_status ON tickets (status);")
+        .await?;
+
+    // Incoming/feature adds a disjoint row from the same base.
+    db.storage.checkout_branch("feature")?;
+    db.execute("INSERT INTO tickets VALUES (2, 'open', 'added on feature');")
+        .await?;
+    let incoming = db.storage.head()?.unwrap();
+
+    db.storage.checkout_branch("main")?;
+    let result = db.storage.merge(&base, &incoming).await?;
+    let MergeResult::Applied { version, changes } = result else {
+        return Err("disjoint changes should merge cleanly".into());
+    };
+    assert_eq!(changes.rows.len(), 1);
+    assert!(changes.schemas.is_empty());
+
+    // This predicate uses the main-side index, rebuilt with the incoming row.
+    let payloads = db
+        .execute("SELECT id, title FROM tickets WHERE status = 'open' ORDER BY id;")
+        .await?;
+    let Payload::Select { rows, .. } = &payloads[0] else {
+        return Err("expected a SELECT payload".into());
+    };
+    assert_eq!(
+        rows,
+        &vec![
+            vec![Value::I64(1), Value::Str("edited on main".to_owned())],
+            vec![Value::I64(2), Value::Str("added on feature".to_owned())],
+        ]
+    );
+
+    println!("merged version: {}", version.id().unwrap());
+    println!("changes applied to main: {changes:#?}");
+    println!("merged indexed rows: {rows:#?}");
+    Ok(())
+}

--- a/integrations/prolly-gluesql/examples/merge_conflicts.rs
+++ b/integrations/prolly-gluesql/examples/merge_conflicts.rs
@@ -1,0 +1,146 @@
+//! Typed merge-conflict payloads and unchanged target branches.
+//!
+//! Run with: `cargo run --example merge_conflicts`
+
+use {
+    prolly_gluesql::{Glue, MergeConflict, MergeResult, ProllyStorage},
+    std::error::Error,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    row_conflict().await?;
+    schema_and_function_conflicts().await?;
+    unique_constraint_conflict().await?;
+    foreign_key_conflict().await?;
+    Ok(())
+}
+
+async fn row_conflict() -> Result<(), Box<dyn Error>> {
+    let mut db = Glue::new(ProllyStorage::in_memory()?);
+    db.execute("CREATE TABLE settings (id INTEGER PRIMARY KEY, value TEXT NOT NULL);")
+        .await?;
+    db.execute("INSERT INTO settings VALUES (1, 'base');")
+        .await?;
+    let base = db.storage.head()?.unwrap();
+    db.storage.create_branch("feature")?;
+
+    db.execute("UPDATE settings SET value = 'current' WHERE id = 1;")
+        .await?;
+    let current = db.storage.head()?.unwrap();
+    db.storage.checkout_branch("feature")?;
+    db.execute("UPDATE settings SET value = 'incoming' WHERE id = 1;")
+        .await?;
+    let incoming = db.storage.head()?.unwrap();
+
+    db.storage.checkout_branch("main")?;
+    let result = db.storage.merge(&base, &incoming).await?;
+    assert!(matches!(result.conflicts(), [MergeConflict::Row { .. }]));
+    assert_eq!(db.storage.head()?.unwrap().id(), current.id());
+    println!("row conflict: {:#?}", result.conflicts()[0]);
+    Ok(())
+}
+
+async fn schema_and_function_conflicts() -> Result<(), Box<dyn Error>> {
+    let mut db = Glue::new(ProllyStorage::in_memory()?);
+    db.execute("CREATE TABLE items (id INTEGER PRIMARY KEY);")
+        .await?;
+    db.execute("CREATE FUNCTION transform(n INT) RETURN n;")
+        .await?;
+    let base = db.storage.head()?.unwrap();
+    db.storage.create_branch("feature")?;
+
+    db.execute("ALTER TABLE items ADD COLUMN current_value TEXT NULL;")
+        .await?;
+    db.execute("DROP FUNCTION transform;").await?;
+    db.execute("CREATE FUNCTION transform(n INT) RETURN n + 1;")
+        .await?;
+    let current = db.storage.head()?.unwrap();
+
+    db.storage.checkout_branch("feature")?;
+    db.execute("ALTER TABLE items ADD COLUMN incoming_value TEXT NULL;")
+        .await?;
+    db.execute("DROP FUNCTION transform;").await?;
+    db.execute("CREATE FUNCTION transform(n INT) RETURN n + 2;")
+        .await?;
+    let incoming = db.storage.head()?.unwrap();
+
+    db.storage.checkout_branch("main")?;
+    let result = db.storage.merge(&base, &incoming).await?;
+    assert!(result
+        .conflicts()
+        .iter()
+        .any(|conflict| matches!(conflict, MergeConflict::Schema { .. })));
+    assert!(result
+        .conflicts()
+        .iter()
+        .any(|conflict| matches!(conflict, MergeConflict::Function { .. })));
+    assert_eq!(db.storage.head()?.unwrap().id(), current.id());
+    println!("schema and function conflicts: {:#?}", result.conflicts());
+    Ok(())
+}
+
+async fn unique_constraint_conflict() -> Result<(), Box<dyn Error>> {
+    let mut db = Glue::new(ProllyStorage::in_memory()?);
+    db.execute(
+        "CREATE TABLE users (
+            id INTEGER PRIMARY KEY,
+            email TEXT NOT NULL UNIQUE
+        );",
+    )
+    .await?;
+    let base = db.storage.head()?.unwrap();
+    db.storage.create_branch("feature")?;
+
+    db.execute("INSERT INTO users VALUES (1, 'same@example.com');")
+        .await?;
+    let current = db.storage.head()?.unwrap();
+    db.storage.checkout_branch("feature")?;
+    db.execute("INSERT INTO users VALUES (2, 'same@example.com');")
+        .await?;
+    let incoming = db.storage.head()?.unwrap();
+
+    db.storage.checkout_branch("main")?;
+    let result = db.storage.merge(&base, &incoming).await?;
+    assert!(matches!(
+        result,
+        MergeResult::Conflicted { ref conflicts }
+            if matches!(conflicts.as_slice(), [MergeConflict::Constraint { reason, .. }] if reason.contains("unique column"))
+    ));
+    assert_eq!(db.storage.head()?.unwrap().id(), current.id());
+    println!("unique constraint conflict: {:#?}", result.conflicts()[0]);
+    Ok(())
+}
+
+async fn foreign_key_conflict() -> Result<(), Box<dyn Error>> {
+    let mut db = Glue::new(ProllyStorage::in_memory()?);
+    db.execute("CREATE TABLE parents (id INTEGER PRIMARY KEY);")
+        .await?;
+    db.execute(
+        "CREATE TABLE children (
+            id INTEGER PRIMARY KEY,
+            parent_id INTEGER,
+            FOREIGN KEY (parent_id) REFERENCES parents (id)
+        );",
+    )
+    .await?;
+    db.execute("INSERT INTO parents VALUES (1);").await?;
+    let base = db.storage.head()?.unwrap();
+    db.storage.create_branch("feature")?;
+
+    db.execute("DELETE FROM parents WHERE id = 1;").await?;
+    let current = db.storage.head()?.unwrap();
+    db.storage.checkout_branch("feature")?;
+    db.execute("INSERT INTO children VALUES (1, 1);").await?;
+    let incoming = db.storage.head()?.unwrap();
+
+    db.storage.checkout_branch("main")?;
+    let result = db.storage.merge(&base, &incoming).await?;
+    assert!(matches!(
+        result.conflicts(),
+        [MergeConflict::Constraint { reason, .. }] if reason.contains("foreign key")
+    ));
+    assert_eq!(db.storage.head()?.unwrap().id(), current.id());
+    println!("foreign-key conflict: {:#?}", result.conflicts()[0]);
+    Ok(())
+}

--- a/integrations/prolly-gluesql/examples/sqlite_durable.rs
+++ b/integrations/prolly-gluesql/examples/sqlite_durable.rs
@@ -1,0 +1,83 @@
+//! Durable SQLite-backed versions and branches with reopen verification.
+//!
+//! Run with: `cargo run --features sqlite --example sqlite_durable`
+
+use {
+    prolly_gluesql::{gluesql_core::prelude::Value, Glue, Payload, SqliteProllyStorage},
+    std::{
+        error::Error,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    },
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let path = temporary_database_path();
+    let result = run(&path).await;
+    let _ = std::fs::remove_file(&path);
+    result
+}
+
+async fn run(path: &Path) -> Result<(), Box<dyn Error>> {
+    let (main_id, snapshot_id) = {
+        let storage = SqliteProllyStorage::open_sqlite(path)?;
+        let mut db = Glue::new(storage);
+        db.execute("CREATE TABLE events (id INTEGER PRIMARY KEY, message TEXT NOT NULL);")
+            .await?;
+        db.execute("INSERT INTO events VALUES (1, 'persisted');")
+            .await?;
+        let snapshot = db.storage.create_branch("snapshot")?;
+        let snapshot_id = snapshot.id().unwrap().to_string();
+
+        db.execute("INSERT INTO events VALUES (2, 'main only');")
+            .await?;
+        let main_id = db.storage.head()?.unwrap().id().unwrap().to_string();
+        (main_id, snapshot_id)
+    };
+
+    {
+        let storage = SqliteProllyStorage::open_sqlite(path)?;
+        let mut db = Glue::new(storage);
+        assert_eq!(db.storage.head()?.unwrap().id().unwrap().as_str(), main_id);
+        assert_eq!(select_messages(&mut db).await?.len(), 2);
+
+        db.storage.checkout_branch("snapshot")?;
+        assert_eq!(
+            db.storage.head()?.unwrap().id().unwrap().as_str(),
+            snapshot_id
+        );
+        assert_eq!(
+            select_messages(&mut db).await?,
+            vec![vec![Value::I64(1), Value::Str("persisted".to_owned())]]
+        );
+    }
+
+    println!("reopened SQLite database: {}", path.display());
+    println!("main version:     {main_id}");
+    println!("snapshot version: {snapshot_id}");
+    Ok(())
+}
+
+async fn select_messages(
+    db: &mut Glue<SqliteProllyStorage>,
+) -> Result<Vec<Vec<Value>>, Box<dyn Error>> {
+    let payloads = db
+        .execute("SELECT id, message FROM events ORDER BY id;")
+        .await?;
+    let Payload::Select { rows, .. } = &payloads[0] else {
+        return Err("expected a SELECT payload".into());
+    };
+    Ok(rows.clone())
+}
+
+fn temporary_database_path() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is after the Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "prolly-gluesql-example-{}-{nonce}.sqlite",
+        std::process::id()
+    ))
+}

--- a/integrations/prolly-gluesql/examples/versions_and_branches.rs
+++ b/integrations/prolly-gluesql/examples/versions_and_branches.rs
@@ -1,0 +1,93 @@
+//! Opaque versions, typed diffs, branches, historical reads, and reset.
+//!
+//! Run with: `cargo run --example versions_and_branches`
+
+use {
+    prolly_gluesql::{
+        gluesql_core::prelude::{Key, Value},
+        Glue, Payload, ProllyStorage, RowChange,
+    },
+    std::error::Error,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let storage = ProllyStorage::in_memory()?;
+    let mut db = Glue::new(storage);
+
+    db.execute("CREATE TABLE accounts (id INTEGER PRIMARY KEY, balance INTEGER NOT NULL);")
+        .await?;
+    db.execute("INSERT INTO accounts VALUES (1, 100);").await?;
+    let base = db.storage.head()?.expect("main has been published");
+    db.storage.create_branch("experiment")?;
+
+    db.execute("UPDATE accounts SET balance = 125 WHERE id = 1;")
+        .await?;
+    let updated_main = db.storage.head()?.unwrap();
+    let diff = db.storage.diff(&base, &updated_main)?;
+    assert!(matches!(
+        diff.rows.as_slice(),
+        [RowChange::Modified {
+            table,
+            key: Key::I64(1),
+            before,
+            after,
+        }] if table == "accounts"
+            && before == &prolly_gluesql::gluesql_core::store::DataRow::Vec(vec![
+                Value::I64(1),
+                Value::I64(100),
+            ])
+            && after == &prolly_gluesql::gluesql_core::store::DataRow::Vec(vec![
+                Value::I64(1),
+                Value::I64(125),
+            ])
+    ));
+
+    db.storage.checkout_branch("experiment")?;
+    db.execute("INSERT INTO accounts VALUES (2, 50);").await?;
+    let experiment = db.storage.head()?.unwrap();
+
+    db.storage.checkout_branch("main")?;
+    assert_eq!(
+        selected_rows(
+            &db.execute("SELECT id, balance FROM accounts ORDER BY id;")
+                .await?
+        )?,
+        vec![vec![Value::I64(1), Value::I64(125)]]
+    );
+
+    // Historical checkout opens a transaction pinned to the immutable version.
+    db.storage.checkout(&base)?;
+    assert_eq!(
+        selected_rows(
+            &db.execute("SELECT id, balance FROM accounts ORDER BY id;")
+                .await?
+        )?,
+        vec![vec![Value::I64(1), Value::I64(100)]]
+    );
+    db.execute("ROLLBACK;").await?;
+
+    // Reset and restore demonstrate compare-and-swap branch movement.
+    db.storage.reset(&base)?;
+    assert_eq!(
+        selected_rows(
+            &db.execute("SELECT id, balance FROM accounts ORDER BY id;")
+                .await?
+        )?,
+        vec![vec![Value::I64(1), Value::I64(100)]]
+    );
+    db.storage.reset(&updated_main)?;
+
+    println!("base:       {}", base.id().unwrap());
+    println!("main:       {}", updated_main.id().unwrap());
+    println!("experiment: {}", experiment.id().unwrap());
+    println!("typed row change: {:#?}", diff.rows[0]);
+    Ok(())
+}
+
+fn selected_rows(payloads: &[Payload]) -> Result<Vec<Vec<Value>>, Box<dyn Error>> {
+    let Payload::Select { rows, .. } = &payloads[0] else {
+        return Err("expected a SELECT payload".into());
+    };
+    Ok(rows.clone())
+}

--- a/integrations/prolly-gluesql/src/error.rs
+++ b/integrations/prolly-gluesql/src/error.rs
@@ -35,6 +35,10 @@ pub enum Error {
     #[error("branch operation failed: {0}")]
     Branch(String),
 
+    /// A merged logical state could not be materialized as SQL storage records.
+    #[error("merge materialization failed: {0}")]
+    Merge(String),
+
     /// A SQLite-backed storage engine could not be opened.
     #[cfg(feature = "sqlite")]
     #[error("sqlite store failed: {0}")]

--- a/integrations/prolly-gluesql/src/layout.rs
+++ b/integrations/prolly-gluesql/src/layout.rs
@@ -53,6 +53,14 @@ pub(crate) fn all_schemas_prefix() -> Vec<u8> {
     kind_prefix(KIND_SCHEMA)
 }
 
+pub(crate) fn all_rows_prefix() -> Vec<u8> {
+    kind_prefix(KIND_ROW)
+}
+
+pub(crate) fn all_sequences_prefix() -> Vec<u8> {
+    kind_prefix(KIND_SEQUENCE)
+}
+
 pub(crate) fn schema_key(table_name: &str) -> Vec<u8> {
     let mut key = all_schemas_prefix();
     push_segment(&mut key, table_name.as_bytes());
@@ -130,6 +138,10 @@ pub(crate) fn metadata_key(table_name: &str) -> Vec<u8> {
 
 pub(crate) fn functions_prefix() -> Vec<u8> {
     kind_prefix(KIND_FUNCTION)
+}
+
+pub(crate) fn all_indexes_prefix() -> Vec<u8> {
+    kind_prefix(KIND_INDEX)
 }
 
 pub(crate) fn function_key(function_name: &str) -> Vec<u8> {

--- a/integrations/prolly-gluesql/src/lib.rs
+++ b/integrations/prolly-gluesql/src/lib.rs
@@ -10,7 +10,8 @@ mod storage;
 
 pub use error::{Error, Result};
 pub use storage::{
-    Diff, FunctionChange, ProllyStorage, RowChange, SchemaChange, Version, VersionId,
+    Diff, FunctionChange, MergeConflict, MergeResult, ProllyStorage, RowChange, SchemaChange,
+    Version, VersionId,
 };
 
 #[cfg(feature = "sqlite")]

--- a/integrations/prolly-gluesql/src/storage.rs
+++ b/integrations/prolly-gluesql/src/storage.rs
@@ -2,17 +2,18 @@ use {
     crate::{
         error::glue_error,
         layout::{
-            all_schemas_prefix, branch_root_name, decode_record, encode_record, function_key,
-            functions_prefix, index_key, index_prefix, index_value_prefix, key_kind, metadata_key,
-            metadata_prefix, row_key, row_key_parts, row_key_payload, row_prefix, schema_key,
-            sequence_key, KIND_FUNCTION, KIND_ROW, KIND_SCHEMA,
+            all_indexes_prefix, all_rows_prefix, all_schemas_prefix, all_sequences_prefix,
+            branch_root_name, decode_record, encode_record, function_key, functions_prefix,
+            index_key, index_prefix, index_value_prefix, key_kind, metadata_key, metadata_prefix,
+            row_key, row_key_parts, row_key_payload, row_prefix, schema_key, sequence_key,
+            KIND_FUNCTION, KIND_ROW, KIND_SCHEMA,
         },
         Error, Result,
     },
     async_trait::async_trait,
     futures::stream,
     gluesql_core::{
-        ast::{IndexOperator, OrderByExpr, Statement},
+        ast::{ColumnUniqueOption, IndexOperator, OrderByExpr, Statement},
         chrono::Utc,
         data::{CustomFunction as GlueFunction, Key, Schema, SchemaIndex, SchemaIndexOrd, Value},
         error::Result as GlueResult,
@@ -27,7 +28,7 @@ use {
     serde::{de::DeserializeOwned, Deserialize, Serialize},
     std::{
         cmp::Ordering,
-        collections::{BTreeMap, HashMap},
+        collections::{BTreeMap, BTreeSet, HashMap},
     },
 };
 
@@ -36,7 +37,7 @@ use {
 pub struct Version {
     branch: String,
     id: Option<VersionId>,
-    tree: Tree,
+    tree: Box<Tree>,
 }
 
 /// A stable, printable identifier for an immutable database state.
@@ -127,6 +128,71 @@ pub enum FunctionChange {
     Modified {
         before: GlueFunction,
         after: GlueFunction,
+    },
+}
+
+/// Outcome of merging an incoming version into the selected branch.
+#[derive(Clone, Debug, PartialEq)]
+pub enum MergeResult {
+    /// The selected branch now points to the merged database state.
+    Applied {
+        /// Newly published version, or the unchanged head for a no-op merge.
+        version: Version,
+        /// Logical changes applied to the selected branch head.
+        changes: Diff,
+    },
+    /// The branch was not changed because manual resolution is required.
+    Conflicted {
+        /// All logical conflicts found during the merge.
+        conflicts: Vec<MergeConflict>,
+    },
+}
+
+impl MergeResult {
+    /// Return whether the merge completed without logical conflicts.
+    pub fn is_applied(&self) -> bool {
+        matches!(self, Self::Applied { .. })
+    }
+
+    /// Return conflicts when the merge requires manual resolution.
+    pub fn conflicts(&self) -> &[MergeConflict] {
+        match self {
+            Self::Applied { .. } => &[],
+            Self::Conflicted { conflicts } => conflicts,
+        }
+    }
+}
+
+/// A decoded SQL-level conflict produced by a three-way merge.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum MergeConflict {
+    /// Both sides changed the same table definition differently.
+    Schema {
+        table: String,
+        base: Option<Schema>,
+        current: Option<Schema>,
+        incoming: Option<Schema>,
+    },
+    /// Both sides changed the same row differently.
+    Row {
+        table: String,
+        key: Key,
+        base: Option<DataRow>,
+        current: Option<DataRow>,
+        incoming: Option<DataRow>,
+    },
+    /// Both sides changed the same custom function differently.
+    Function {
+        name: String,
+        base: Option<GlueFunction>,
+        current: Option<GlueFunction>,
+        incoming: Option<GlueFunction>,
+    },
+    /// Individually valid changes combine into an invalid SQL database state.
+    Constraint {
+        table: String,
+        key: Option<Key>,
+        reason: String,
     },
 }
 
@@ -229,7 +295,11 @@ impl Version {
                     .collect(),
             )
         });
-        Self { branch, id, tree }
+        Self {
+            branch,
+            id,
+            tree: Box::new(tree),
+        }
     }
 
     /// Return the branch from which this state was resolved.
@@ -250,7 +320,7 @@ struct ActiveTransaction {
     functions_before: HashMap<String, GlueFunction>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 enum StoredRow {
     Vec(Vec<Value>),
     Map(BTreeMap<String, Value>),
@@ -279,6 +349,53 @@ struct IndexEntry {
     primary_key: Key,
     index_value: Value,
     row: StoredRow,
+}
+
+#[derive(Default)]
+struct LogicalState {
+    schemas: BTreeMap<String, Schema>,
+    rows: BTreeMap<(String, Key), StoredRow>,
+    functions: BTreeMap<String, GlueFunction>,
+}
+
+fn merge_maps<K, V, F>(
+    base: &BTreeMap<K, V>,
+    current: &BTreeMap<K, V>,
+    incoming: &BTreeMap<K, V>,
+    mut conflict: F,
+) -> (BTreeMap<K, V>, Vec<MergeConflict>)
+where
+    K: Clone + Ord,
+    V: Clone + PartialEq,
+    F: FnMut(&K, Option<&V>, Option<&V>, Option<&V>) -> MergeConflict,
+{
+    let keys = base
+        .keys()
+        .chain(current.keys())
+        .chain(incoming.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut merged = BTreeMap::new();
+    let mut conflicts = Vec::new();
+    for key in keys {
+        let base_value = base.get(&key);
+        let current_value = current.get(&key);
+        let incoming_value = incoming.get(&key);
+        let selected = if current_value == incoming_value {
+            current_value
+        } else if current_value == base_value {
+            incoming_value
+        } else if incoming_value == base_value {
+            current_value
+        } else {
+            conflicts.push(conflict(&key, base_value, current_value, incoming_value));
+            current_value
+        };
+        if let Some(value) = selected {
+            merged.insert(key, value.clone());
+        }
+    }
+    (merged, conflicts)
 }
 
 /// A GlueSQL storage engine whose complete database state is one Prolly tree.
@@ -350,7 +467,7 @@ where
     pub fn create_branch(&self, name: &str) -> Result<Version> {
         let source = self
             .head()?
-            .map_or_else(|| self.engine.create(), |version| version.tree);
+            .map_or_else(|| self.engine.create(), |version| *version.tree);
         let target_name = branch_root_name(name)?;
         match self
             .engine
@@ -393,8 +510,8 @@ where
         self.head_name = branch_root_name(&version.branch)?;
         self.functions = self.load_functions_from_tree(&version.tree)?;
         self.transaction = Some(ActiveTransaction {
-            base: Some(version.tree.clone()),
-            tree: version.tree.clone(),
+            base: Some(version.tree.as_ref().clone()),
+            tree: version.tree.as_ref().clone(),
             dirty: false,
             functions_before: self.functions.clone(),
         });
@@ -429,6 +546,53 @@ where
         Ok(result)
     }
 
+    /// Merge `incoming` into the selected branch using `base` as their common ancestor.
+    ///
+    /// The current branch head is the left side of the three-way merge. Logical
+    /// schema, row, and function conflicts are returned as decoded SQL values.
+    /// Secondary indexes, sequences, and metadata remain private implementation
+    /// details and are rebuilt before the new version is atomically published.
+    ///
+    /// The selected branch is changed only when there are no conflicts and its
+    /// head has not advanced since the merge began.
+    pub async fn merge(&mut self, base: &Version, incoming: &Version) -> Result<MergeResult> {
+        if self.transaction.is_some() {
+            return Err(Error::TransactionState("cannot merge during a transaction"));
+        }
+
+        let current_root = self.load_head_tree()?;
+        let current_tree = current_root.clone().unwrap_or_else(|| self.engine.create());
+        let current = Version::new(self.branch.clone(), current_tree.clone());
+
+        if current.tree == incoming.tree || incoming.tree == base.tree {
+            self.reload_function_cache()?;
+            return Ok(MergeResult::Applied {
+                version: current,
+                changes: Diff::default(),
+            });
+        }
+        if current.tree == base.tree {
+            return self.publish_merge(current_root, current, incoming.tree.as_ref().clone());
+        }
+
+        let base_state = self.load_logical_state(&base.tree)?;
+        let current_state = self.load_logical_state(&current.tree)?;
+        let incoming_state = self.load_logical_state(&incoming.tree)?;
+        let (merged_state, mut conflicts) =
+            Self::merge_logical_states(&base_state, &current_state, &incoming_state);
+        if conflicts.is_empty() {
+            conflicts = Self::validate_logical_state(&merged_state);
+        }
+        if !conflicts.is_empty() {
+            return Ok(MergeResult::Conflicted { conflicts });
+        }
+
+        let merged_tree = self
+            .materialize_logical_state(&base.tree, &current.tree, &incoming.tree, &merged_state)
+            .await?;
+        self.publish_merge(current_root, current, merged_tree)
+    }
+
     /// Atomically move the selected branch to an earlier or otherwise pinned version.
     pub fn reset(&mut self, version: &Version) -> Result<()> {
         if self.transaction.is_some() {
@@ -445,6 +609,357 @@ where
             prolly::NamedRootUpdate::Applied => self.reload_function_cache(),
             prolly::NamedRootUpdate::Conflict { .. } => Err(Error::SerializationConflict),
         }
+    }
+
+    fn publish_merge(
+        &mut self,
+        expected_root: Option<Tree>,
+        current: Version,
+        merged_tree: Tree,
+    ) -> Result<MergeResult> {
+        if current.tree.as_ref() == &merged_tree {
+            return Ok(MergeResult::Applied {
+                version: current,
+                changes: Diff::default(),
+            });
+        }
+        let merged = Version::new(self.branch.clone(), merged_tree);
+        let changes = self.diff(&current, &merged)?;
+        match self.engine.compare_and_swap_named_root(
+            &self.head_name,
+            expected_root.as_ref(),
+            Some(&merged.tree),
+        )? {
+            prolly::NamedRootUpdate::Applied => {
+                self.reload_function_cache()?;
+                Ok(MergeResult::Applied {
+                    version: merged,
+                    changes,
+                })
+            }
+            prolly::NamedRootUpdate::Conflict { .. } => Err(Error::SerializationConflict),
+        }
+    }
+
+    fn load_logical_state(&self, tree: &Tree) -> Result<LogicalState> {
+        let schemas = self
+            .scan_tree_records::<Schema>(tree, &all_schemas_prefix())?
+            .into_iter()
+            .map(|(_, schema)| (schema.table_name.clone(), schema))
+            .collect();
+        let rows = self
+            .scan_tree_records::<StoredRow>(tree, &all_rows_prefix())?
+            .into_iter()
+            .map(|(physical_key, row)| Ok((decode_row_identity(&physical_key)?, row)))
+            .collect::<Result<_>>()?;
+        let functions = self
+            .scan_tree_records::<GlueFunction>(tree, &functions_prefix())?
+            .into_iter()
+            .map(|(_, function)| (function.func_name.to_uppercase(), function))
+            .collect();
+        Ok(LogicalState {
+            schemas,
+            rows,
+            functions,
+        })
+    }
+
+    fn merge_logical_states(
+        base: &LogicalState,
+        current: &LogicalState,
+        incoming: &LogicalState,
+    ) -> (LogicalState, Vec<MergeConflict>) {
+        let (schemas, mut conflicts) = merge_maps(
+            &base.schemas,
+            &current.schemas,
+            &incoming.schemas,
+            |table, base, current, incoming| MergeConflict::Schema {
+                table: table.clone(),
+                base: base.cloned(),
+                current: current.cloned(),
+                incoming: incoming.cloned(),
+            },
+        );
+        let (rows, row_conflicts) = merge_maps(
+            &base.rows,
+            &current.rows,
+            &incoming.rows,
+            |(table, key), base, current, incoming| MergeConflict::Row {
+                table: table.clone(),
+                key: key.clone(),
+                base: base.cloned().map(DataRow::from),
+                current: current.cloned().map(DataRow::from),
+                incoming: incoming.cloned().map(DataRow::from),
+            },
+        );
+        conflicts.extend(row_conflicts);
+        let (functions, function_conflicts) = merge_maps(
+            &base.functions,
+            &current.functions,
+            &incoming.functions,
+            |name, base, current, incoming| MergeConflict::Function {
+                name: name.clone(),
+                base: base.cloned(),
+                current: current.cloned(),
+                incoming: incoming.cloned(),
+            },
+        );
+        conflicts.extend(function_conflicts);
+        (
+            LogicalState {
+                schemas,
+                rows,
+                functions,
+            },
+            conflicts,
+        )
+    }
+
+    fn validate_logical_state(state: &LogicalState) -> Vec<MergeConflict> {
+        let mut conflicts = Vec::new();
+        let mut unique_values = BTreeMap::<(String, String, Key), Key>::new();
+
+        for ((table, key), row) in &state.rows {
+            let Some(schema) = state.schemas.get(table) else {
+                conflicts.push(MergeConflict::Constraint {
+                    table: table.clone(),
+                    key: Some(key.clone()),
+                    reason: "row belongs to a table that was removed".to_owned(),
+                });
+                continue;
+            };
+            let (Some(column_defs), StoredRow::Vec(values)) = (&schema.column_defs, row) else {
+                if !matches!((&schema.column_defs, row), (None, StoredRow::Map(_))) {
+                    conflicts.push(MergeConflict::Constraint {
+                        table: table.clone(),
+                        key: Some(key.clone()),
+                        reason: "row representation does not match the merged schema".to_owned(),
+                    });
+                }
+                continue;
+            };
+            if values.len() != column_defs.len() {
+                conflicts.push(MergeConflict::Constraint {
+                    table: table.clone(),
+                    key: Some(key.clone()),
+                    reason: format!(
+                        "row has {} values but the merged schema has {} columns",
+                        values.len(),
+                        column_defs.len()
+                    ),
+                });
+                continue;
+            }
+            for (column, value) in column_defs.iter().zip(values) {
+                if let Err(error) = value
+                    .validate_type(&column.data_type)
+                    .and_then(|()| value.validate_null(column.nullable))
+                {
+                    conflicts.push(MergeConflict::Constraint {
+                        table: table.clone(),
+                        key: Some(key.clone()),
+                        reason: format!("column {:?}: {error}", column.name),
+                    });
+                    continue;
+                }
+                let Some(unique) = column.unique else {
+                    continue;
+                };
+                let Ok(value_key) = Key::try_from(value.clone()) else {
+                    conflicts.push(MergeConflict::Constraint {
+                        table: table.clone(),
+                        key: Some(key.clone()),
+                        reason: format!(
+                            "unique column {:?} cannot be represented as a key",
+                            column.name
+                        ),
+                    });
+                    continue;
+                };
+                if unique == (ColumnUniqueOption { is_primary: true }) && &value_key != key {
+                    conflicts.push(MergeConflict::Constraint {
+                        table: table.clone(),
+                        key: Some(key.clone()),
+                        reason: format!(
+                            "primary-key column {:?} does not match the stored row key",
+                            column.name
+                        ),
+                    });
+                }
+                if matches!(value_key, Key::None) {
+                    continue;
+                }
+                let identity = (table.clone(), column.name.clone(), value_key);
+                if let Some(existing_key) = unique_values.insert(identity, key.clone()) {
+                    if existing_key != *key {
+                        conflicts.push(MergeConflict::Constraint {
+                            table: table.clone(),
+                            key: Some(key.clone()),
+                            reason: format!(
+                                "unique column {:?} duplicates row key {existing_key:?}",
+                                column.name
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+
+        for ((table, key), row) in &state.rows {
+            let Some(schema) = state.schemas.get(table) else {
+                continue;
+            };
+            let (Some(column_defs), StoredRow::Vec(values)) = (&schema.column_defs, row) else {
+                continue;
+            };
+            for foreign_key in &schema.foreign_keys {
+                let Some(column_index) = column_defs
+                    .iter()
+                    .position(|column| column.name == foreign_key.referencing_column_name)
+                else {
+                    conflicts.push(MergeConflict::Constraint {
+                        table: table.clone(),
+                        key: Some(key.clone()),
+                        reason: format!(
+                            "foreign key {:?} references a missing local column",
+                            foreign_key.name
+                        ),
+                    });
+                    continue;
+                };
+                let Some(value) = values.get(column_index) else {
+                    continue;
+                };
+                if matches!(value, Value::Null) {
+                    continue;
+                }
+                let Ok(referenced_key) = Key::try_from(value.clone()) else {
+                    conflicts.push(MergeConflict::Constraint {
+                        table: table.clone(),
+                        key: Some(key.clone()),
+                        reason: format!(
+                            "foreign-key column {:?} cannot be represented as a key",
+                            foreign_key.referencing_column_name
+                        ),
+                    });
+                    continue;
+                };
+                if !state.rows.contains_key(&(
+                    foreign_key.referenced_table_name.clone(),
+                    referenced_key.clone(),
+                )) {
+                    conflicts.push(MergeConflict::Constraint {
+                        table: table.clone(),
+                        key: Some(key.clone()),
+                        reason: format!(
+                            "foreign key {:?} cannot find {:?} in table {:?}",
+                            foreign_key.name, referenced_key, foreign_key.referenced_table_name
+                        ),
+                    });
+                }
+            }
+        }
+
+        conflicts
+    }
+
+    async fn materialize_logical_state(
+        &self,
+        base: &Tree,
+        current: &Tree,
+        incoming: &Tree,
+        state: &LogicalState,
+    ) -> Result<Tree> {
+        let merged =
+            self.engine
+                .merge_prefix(base, current, incoming, &all_schemas_prefix(), None)?;
+        let merged = self
+            .engine
+            .merge_prefix(base, &merged, incoming, &all_rows_prefix(), None)?;
+        let merged =
+            self.engine
+                .merge_prefix(base, &merged, incoming, &functions_prefix(), None)?;
+        let mut mutations = BTreeMap::<Vec<u8>, Mutation>::new();
+        for prefix in [
+            all_sequences_prefix(),
+            metadata_prefix(),
+            all_indexes_prefix(),
+        ] {
+            let (start, end) = prefix_range(&prefix);
+            for entry in self.engine.range(&merged, &start, end.as_deref())? {
+                let (key, _) = entry?;
+                mutations.insert(key.clone(), Mutation::Delete { key });
+            }
+        }
+
+        for schema in state.schemas.values() {
+            let metadata_key = metadata_key(&schema.table_name);
+            let metadata = self
+                .read_tree_record::<BTreeMap<String, Value>>(current, &metadata_key)?
+                .or(self.read_tree_record(incoming, &metadata_key)?)
+                .or(self.read_tree_record(base, &metadata_key)?)
+                .unwrap_or_else(|| {
+                    BTreeMap::from([(
+                        "CREATED".to_owned(),
+                        Value::Timestamp(Utc::now().naive_utc()),
+                    )])
+                });
+            mutations.insert(
+                metadata_key.clone(),
+                Mutation::Upsert {
+                    key: metadata_key,
+                    val: encode_record(&metadata)?,
+                },
+            );
+
+            let sequence_key = sequence_key(&schema.table_name);
+            let mut sequence = [base, current, incoming]
+                .into_iter()
+                .map(|tree| self.read_tree_record::<i64>(tree, &sequence_key))
+                .collect::<Result<Vec<_>>>()?
+                .into_iter()
+                .flatten()
+                .max()
+                .unwrap_or(0);
+            sequence = state
+                .rows
+                .keys()
+                .filter_map(|(table, key)| {
+                    (table == &schema.table_name)
+                        .then_some(key)
+                        .and_then(|key| match key {
+                            Key::I64(value) => Some(*value),
+                            _ => None,
+                        })
+                })
+                .fold(sequence, i64::max);
+            if sequence > 0 {
+                mutations.insert(
+                    sequence_key.clone(),
+                    Mutation::Upsert {
+                        key: sequence_key,
+                        val: encode_record(&sequence)?,
+                    },
+                );
+            }
+
+            for ((table, primary_key), stored_row) in &state.rows {
+                if table != &schema.table_name {
+                    continue;
+                }
+                let row = DataRow::from(stored_row.clone());
+                for index in &schema.indexes {
+                    let mutation = Self::index_mutation(schema, index, primary_key, &row, false)
+                        .await
+                        .map_err(|error| Error::Merge(error.to_string()))?;
+                    mutations.insert(mutation.key().to_vec(), mutation);
+                }
+            }
+        }
+
+        Ok(self
+            .engine
+            .batch(&merged, mutations.into_values().collect())?)
     }
 
     fn load_head_tree(&self) -> Result<Option<Tree>> {
@@ -465,6 +980,28 @@ where
             .get(&self.current_tree()?, key)?
             .map(|bytes| decode_record(&bytes))
             .transpose()
+    }
+
+    fn read_tree_record<T: DeserializeOwned>(&self, tree: &Tree, key: &[u8]) -> Result<Option<T>> {
+        self.engine
+            .get(tree, key)?
+            .map(|bytes| decode_record(&bytes))
+            .transpose()
+    }
+
+    fn scan_tree_records<T: DeserializeOwned>(
+        &self,
+        tree: &Tree,
+        prefix: &[u8],
+    ) -> Result<Vec<(Vec<u8>, T)>> {
+        let (start, end) = prefix_range(prefix);
+        self.engine
+            .range(tree, &start, end.as_deref())?
+            .map(|entry| {
+                let (key, bytes) = entry?;
+                Ok((key, decode_record(&bytes)?))
+            })
+            .collect()
     }
 
     fn scan_records<T: DeserializeOwned>(&self, prefix: &[u8]) -> Result<Vec<(Vec<u8>, T)>> {
@@ -1233,6 +1770,277 @@ mod tests {
             Payload::Select { rows, .. }
                 if rows == &vec![vec![Value::Str("before".to_owned())]]
         ));
+    }
+
+    #[tokio::test]
+    async fn clean_merge_rebuilds_indexes_and_advances_sequences() {
+        let storage = ProllyStorage::in_memory().unwrap();
+        let mut glue = Glue::new(storage);
+        glue.execute("CREATE TABLE notes (value TEXT NOT NULL);")
+            .await
+            .unwrap();
+        glue.execute("INSERT INTO notes VALUES ('base');")
+            .await
+            .unwrap();
+        let base = glue.storage.head().unwrap().unwrap();
+        glue.storage.create_branch("feature").unwrap();
+
+        glue.execute("CREATE INDEX notes_value ON notes (value);")
+            .await
+            .unwrap();
+        glue.storage.checkout_branch("feature").unwrap();
+        glue.execute("INSERT INTO notes VALUES ('incoming');")
+            .await
+            .unwrap();
+        let incoming = glue.storage.head().unwrap().unwrap();
+
+        glue.storage.checkout_branch("main").unwrap();
+        let result = glue.storage.merge(&base, &incoming).await.unwrap();
+        let MergeResult::Applied { version, changes } = result else {
+            panic!("disjoint changes should merge cleanly");
+        };
+        assert_eq!(version.branch(), "main");
+        assert_eq!(changes.rows.len(), 1);
+        assert!(changes.schemas.is_empty());
+
+        let selected = glue
+            .execute("SELECT value FROM notes WHERE value = 'incoming';")
+            .await
+            .unwrap();
+        assert!(matches!(
+            &selected[0],
+            Payload::Select { rows, .. }
+                if rows == &vec![vec![Value::Str("incoming".to_owned())]]
+        ));
+
+        glue.execute("INSERT INTO notes VALUES ('after');")
+            .await
+            .unwrap();
+        let keys = glue
+            .storage
+            .scan_data_inner("notes")
+            .unwrap()
+            .into_iter()
+            .map(|(key, _)| key)
+            .collect::<Vec<_>>();
+        assert_eq!(keys, vec![Key::I64(1), Key::I64(2), Key::I64(3)]);
+    }
+
+    #[tokio::test]
+    async fn merge_returns_typed_row_conflicts_without_moving_head() {
+        let storage = ProllyStorage::in_memory().unwrap();
+        let mut glue = Glue::new(storage);
+        glue.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, value TEXT);")
+            .await
+            .unwrap();
+        glue.execute("INSERT INTO t VALUES (1, 'base');")
+            .await
+            .unwrap();
+        let base = glue.storage.head().unwrap().unwrap();
+        glue.storage.create_branch("feature").unwrap();
+
+        glue.execute("UPDATE t SET value = 'current' WHERE id = 1;")
+            .await
+            .unwrap();
+        let current = glue.storage.head().unwrap().unwrap();
+        glue.storage.checkout_branch("feature").unwrap();
+        glue.execute("UPDATE t SET value = 'incoming' WHERE id = 1;")
+            .await
+            .unwrap();
+        let incoming = glue.storage.head().unwrap().unwrap();
+
+        glue.storage.checkout_branch("main").unwrap();
+        let result = glue.storage.merge(&base, &incoming).await.unwrap();
+        assert!(!result.is_applied());
+        assert!(matches!(
+            result.conflicts(),
+            [MergeConflict::Row {
+                table,
+                key: Key::I64(1),
+                base: Some(DataRow::Vec(base)),
+                current: Some(DataRow::Vec(current)),
+                incoming: Some(DataRow::Vec(incoming)),
+            }] if table == "t"
+                && base[1] == Value::Str("base".to_owned())
+                && current[1] == Value::Str("current".to_owned())
+                && incoming[1] == Value::Str("incoming".to_owned())
+        ));
+        assert_eq!(glue.storage.head().unwrap().unwrap().id(), current.id());
+    }
+
+    #[tokio::test]
+    async fn merge_reports_cross_branch_unique_constraint_conflicts() {
+        let storage = ProllyStorage::in_memory().unwrap();
+        let mut glue = Glue::new(storage);
+        glue.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT NOT NULL UNIQUE);")
+            .await
+            .unwrap();
+        let base = glue.storage.head().unwrap().unwrap();
+        glue.storage.create_branch("feature").unwrap();
+
+        glue.execute("INSERT INTO users VALUES (1, 'same@example.com');")
+            .await
+            .unwrap();
+        let current = glue.storage.head().unwrap().unwrap();
+        glue.storage.checkout_branch("feature").unwrap();
+        glue.execute("INSERT INTO users VALUES (2, 'same@example.com');")
+            .await
+            .unwrap();
+        let incoming = glue.storage.head().unwrap().unwrap();
+
+        glue.storage.checkout_branch("main").unwrap();
+        let result = glue.storage.merge(&base, &incoming).await.unwrap();
+        assert!(matches!(
+            result.conflicts(),
+            [MergeConflict::Constraint { table, reason, .. }]
+                if table == "users" && reason.contains("unique column")
+        ));
+        assert_eq!(glue.storage.head().unwrap().unwrap().id(), current.id());
+    }
+
+    #[tokio::test]
+    async fn merge_reports_cross_branch_foreign_key_conflicts() {
+        let storage = ProllyStorage::in_memory().unwrap();
+        let mut glue = Glue::new(storage);
+        glue.execute("CREATE TABLE parents (id INTEGER PRIMARY KEY);")
+            .await
+            .unwrap();
+        glue.execute(
+            "CREATE TABLE children (
+                id INTEGER PRIMARY KEY,
+                parent_id INTEGER,
+                FOREIGN KEY (parent_id) REFERENCES parents (id)
+            );",
+        )
+        .await
+        .unwrap();
+        glue.execute("INSERT INTO parents VALUES (1);")
+            .await
+            .unwrap();
+        let base = glue.storage.head().unwrap().unwrap();
+        glue.storage.create_branch("feature").unwrap();
+
+        glue.execute("DELETE FROM parents WHERE id = 1;")
+            .await
+            .unwrap();
+        let current = glue.storage.head().unwrap().unwrap();
+        glue.storage.checkout_branch("feature").unwrap();
+        glue.execute("INSERT INTO children VALUES (1, 1);")
+            .await
+            .unwrap();
+        let incoming = glue.storage.head().unwrap().unwrap();
+
+        glue.storage.checkout_branch("main").unwrap();
+        let result = glue.storage.merge(&base, &incoming).await.unwrap();
+        assert!(matches!(
+            result.conflicts(),
+            [MergeConflict::Constraint { table, reason, .. }]
+                if table == "children" && reason.contains("foreign key")
+        ));
+        assert_eq!(glue.storage.head().unwrap().unwrap().id(), current.id());
+    }
+
+    #[tokio::test]
+    async fn merge_reports_schema_and_function_conflicts() {
+        let storage = ProllyStorage::in_memory().unwrap();
+        let mut glue = Glue::new(storage);
+        glue.execute("CREATE TABLE t (id INTEGER PRIMARY KEY);")
+            .await
+            .unwrap();
+        glue.execute("CREATE FUNCTION transform(n INT) RETURN n;")
+            .await
+            .unwrap();
+        let base = glue.storage.head().unwrap().unwrap();
+        glue.storage.create_branch("feature").unwrap();
+
+        glue.execute("ALTER TABLE t ADD COLUMN current_value TEXT NULL;")
+            .await
+            .unwrap();
+        glue.execute("DROP FUNCTION transform;").await.unwrap();
+        glue.execute("CREATE FUNCTION transform(n INT) RETURN n + 1;")
+            .await
+            .unwrap();
+        glue.storage.checkout_branch("feature").unwrap();
+        glue.execute("ALTER TABLE t ADD COLUMN incoming_value TEXT NULL;")
+            .await
+            .unwrap();
+        glue.execute("DROP FUNCTION transform;").await.unwrap();
+        glue.execute("CREATE FUNCTION transform(n INT) RETURN n + 2;")
+            .await
+            .unwrap();
+        let incoming = glue.storage.head().unwrap().unwrap();
+
+        glue.storage.checkout_branch("main").unwrap();
+        let result = glue.storage.merge(&base, &incoming).await.unwrap();
+        assert_eq!(result.conflicts().len(), 2);
+        assert!(result.conflicts().iter().any(
+            |conflict| matches!(conflict, MergeConflict::Schema { table, .. } if table == "t")
+        ));
+        assert!(result.conflicts().iter().any(
+            |conflict| matches!(conflict, MergeConflict::Function { name, .. } if name == "TRANSFORM")
+        ));
+    }
+
+    #[tokio::test]
+    async fn merge_publication_rejects_a_stale_branch_head() {
+        let store = std::sync::Arc::new(prolly::MemStore::new());
+        let mut primary = Glue::new(ProllyStorage::new(store.clone()).unwrap());
+        primary
+            .execute("CREATE TABLE t (id INTEGER PRIMARY KEY);")
+            .await
+            .unwrap();
+        let base = primary.storage.head().unwrap().unwrap();
+        primary.storage.create_branch("feature").unwrap();
+        primary.storage.checkout_branch("feature").unwrap();
+        primary.execute("INSERT INTO t VALUES (1);").await.unwrap();
+        let incoming = primary.storage.head().unwrap().unwrap();
+        primary.storage.checkout_branch("main").unwrap();
+
+        let expected_root = primary.storage.load_head_tree().unwrap();
+        let expected = Version::new("main".to_owned(), expected_root.clone().unwrap());
+        let mut concurrent = Glue::new(ProllyStorage::new(store).unwrap());
+        concurrent
+            .execute("INSERT INTO t VALUES (2);")
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            primary
+                .storage
+                .publish_merge(expected_root, expected, *incoming.tree),
+            Err(Error::SerializationConflict)
+        ));
+        assert_eq!(
+            concurrent.storage.head().unwrap().unwrap().id(),
+            primary.storage.head().unwrap().unwrap().id()
+        );
+        assert_ne!(primary.storage.head().unwrap().unwrap().id(), base.id());
+    }
+
+    #[tokio::test]
+    async fn merge_fast_forwards_and_rejects_active_transactions() {
+        let storage = ProllyStorage::in_memory().unwrap();
+        let mut glue = Glue::new(storage);
+        glue.execute("CREATE TABLE t (id INTEGER PRIMARY KEY);")
+            .await
+            .unwrap();
+        let base = glue.storage.head().unwrap().unwrap();
+        glue.storage.create_branch("feature").unwrap();
+        glue.storage.checkout_branch("feature").unwrap();
+        glue.execute("INSERT INTO t VALUES (1);").await.unwrap();
+        let incoming = glue.storage.head().unwrap().unwrap();
+
+        glue.storage.checkout_branch("main").unwrap();
+        let result = glue.storage.merge(&base, &incoming).await.unwrap();
+        assert!(result.is_applied());
+        assert_eq!(glue.storage.head().unwrap().unwrap().id(), incoming.id());
+
+        glue.execute("START TRANSACTION;").await.unwrap();
+        assert!(matches!(
+            glue.storage.merge(&base, &incoming).await,
+            Err(Error::TransactionState("cannot merge during a transaction"))
+        ));
+        glue.execute("ROLLBACK;").await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add an async typed three-way merge API using an explicit common base and the selected branch as the current side
- expose decoded schema, row, function, and SQL constraint conflicts without leaking raw Prolly keys or values
- structurally merge authoritative records, then rebuild indexes, generated-key sequences, and metadata before atomic CAS publication
- add six self-contained runnable examples covering SQL, transactions, custom backends, concurrent writers, versions, branches, typed diffs, clean and conflicting merges, and SQLite durability
- package and document every example with exact commands

## User impact

API users can merge an incoming `Version` into the selected branch with `storage.merge(&base, &incoming).await`. Clean merges return `MergeResult::Applied` with the published `Version` and logical `Diff`. Conflicts return serializable `MergeConflict` payloads and leave the branch unchanged.

The examples under `integrations/prolly-gluesql/examples` create their own state, assert the expected behavior, and require no external service. The SQLite example creates and removes its own temporary database.

`Version` remains opaque; raw trees, conflict records, indexes, sequences, and metadata remain internal.

## Validation

- ran all six examples successfully, including SQLite close/reopen
- `cargo test --package prolly-gluesql --all-features --all-targets --no-fail-fast`: 233 passed
- `cargo clippy --package prolly-gluesql --all-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --package prolly-gluesql --all-features --no-deps`
- `cargo package --package prolly-gluesql --allow-dirty`
- verified all six examples are included in the crate package
