### PR TITLE
Add redb storage to the GlueSQL adapter

### DIFF
--- a/integrations/prolly-gluesql/Cargo.lock
+++ b/integrations/prolly-gluesql/Cargo.lock
@@ -20,6 +20,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -610,13 +611,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -1095,6 +1108,7 @@ dependencies = [
  "gluesql-core",
  "gluesql-test-suite",
  "prolly-map",
+ "prolly-store-redb",
  "prolly-store-sqlite",
  "serde",
  "serde_json",
@@ -1116,6 +1130,17 @@ dependencies = [
  "serde_json",
  "sha2",
  "xxhash-rust",
+]
+
+[[package]]
+name = "prolly-store-redb"
+version = "0.5.0"
+dependencies = [
+ "ahash 0.8.12",
+ "lz4_flex",
+ "parking_lot",
+ "prolly-map",
+ "redb",
 ]
 
 [[package]]
@@ -1157,6 +1182,12 @@ checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1229,6 +1260,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redb"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1749,6 +1789,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +1919,12 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wyz"

--- a/integrations/prolly-gluesql/Cargo.toml
+++ b/integrations/prolly-gluesql/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/lib.rs"
 [features]
 default = []
 sqlite = ["dep:prolly-store-sqlite"]
+redb = ["dep:prolly-store-redb"]
 cli = ["sqlite", "dep:clap", "dep:serde_json", "dep:tokio"]
 
 [dependencies]
@@ -29,6 +30,7 @@ clap = { version = "4.5", features = ["derive"], optional = true }
 futures = "0.3"
 gluesql-core = "0.19.0"
 prolly = { package = "prolly-map", path = "../..", version = "0.7.0" }
+prolly-store-redb = { path = "../../stores/prolly-store-redb", version = "0.5.0", optional = true }
 prolly-store-sqlite = { path = "../../stores/prolly-store-sqlite", version = "0.5.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
@@ -51,3 +53,7 @@ required-features = ["cli"]
 [[example]]
 name = "sqlite_durable"
 required-features = ["sqlite"]
+
+[[example]]
+name = "redb_durable"
+required-features = ["redb"]

--- a/integrations/prolly-gluesql/README.md
+++ b/integrations/prolly-gluesql/README.md
@@ -21,8 +21,8 @@ logical diffs, and optimistic conflict detection for concurrent writers.
   publication.
 - Named branches, immutable version handles, historical reads, logical diffs,
   typed three-way merges, and compare-and-swap resets.
-- In-memory storage by default and durable SQLite storage behind the `sqlite`
-  feature.
+- In-memory storage by default, durable pure-Rust redb storage behind the
+  `redb` feature, and durable SQLite storage behind the `sqlite` feature.
 - An optional `prolly-sql` command-line client behind the `cli` feature.
 - A versioned record envelope that detects incompatible or corrupt data.
 
@@ -74,6 +74,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+Enable `redb` for a process-durable, pure-Rust single-file database:
+
+```toml
+prolly-gluesql = { version = "0.1", features = ["redb"] }
+```
+
+```rust,no_run
+use prolly_gluesql::{Glue, RedbProllyStorage};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let storage = RedbProllyStorage::open_redb("database.prolly.redb")?;
+    let mut db = Glue::new(storage);
+    let payloads = db.execute("SELECT * FROM users;").await?;
+    println!("{payloads:#?}");
+    Ok(())
+}
+```
+
+Redb permits one writable database handle per file. For multiple GlueSQL
+connections, open one `prolly_store_redb::RedbStore`, wrap it in `Arc`, and
+pass clones to `RedbProllyStorage::new`. This preserves independent SQL
+transaction state while sharing redb's database handle. See the
+[`redb_durable`](examples/redb_durable.rs) example for the complete pattern.
+Applications using this shared-handle pattern should also add
+`prolly-store-redb = "0.5"` as a direct dependency.
+
 Any custom backend implementing both `prolly::Store` and
 `prolly::ManifestStore` can be passed to `ProllyStorage::new`.
 
@@ -88,6 +115,7 @@ cargo run --example concurrent_writers
 cargo run --example versions_and_branches
 cargo run --example merge_clean
 cargo run --example merge_conflicts
+cargo run --features redb --example redb_durable
 cargo run --features sqlite --example sqlite_durable
 ```
 
@@ -96,7 +124,8 @@ external service or input. They cover SQL execution, transactions, indexes,
 custom functions, shared custom stores, optimistic writer conflicts, typed
 diffs, historical reads, branch isolation, clean merges, every typed conflict
 category, constraint conflicts, CAS publication, and durable SQLite reopen
-behavior.
+behavior. The redb example additionally demonstrates sharing one backend
+between connections and reopening durable branch heads.
 
 ## Versions and branches
 
@@ -267,9 +296,9 @@ have different ownership and execution models.
 
 The integration runs GlueSQL's published storage conformance suite plus tests
 for rollback, branch isolation, historical reads, reset, typed merge conflicts,
-merge constraint validation, derived-state rebuilding, SQLite reopen,
-secondary-index durability, custom-function durability, and concurrent-writer
-conflicts:
+merge constraint validation, derived-state rebuilding, redb and SQLite reopen,
+secondary-index durability, custom-function durability, durable branch
+isolation, and concurrent-writer conflicts:
 
 ```sh
 cargo test --all-features --all-targets

--- a/integrations/prolly-gluesql/examples/README.md
+++ b/integrations/prolly-gluesql/examples/README.md
@@ -9,6 +9,7 @@ Run these commands from `integrations/prolly-gluesql`.
 | [`versions_and_branches.rs`](versions_and_branches.rs) | `cargo run --example versions_and_branches` | Opaque versions, typed diffs, durable branches, branch isolation, historical checkout, and CAS reset. |
 | [`merge_clean.rs`](merge_clean.rs) | `cargo run --example merge_clean` | An explicit-base three-way merge, structural combination of disjoint changes, rebuilt indexes, and the returned logical diff. |
 | [`merge_conflicts.rs`](merge_conflicts.rs) | `cargo run --example merge_conflicts` | Decoded row, schema, function, unique-column, and foreign-key conflicts without changing the target branch. |
+| [`redb_durable.rs`](redb_durable.rs) | `cargo run --features redb --example redb_durable` | A self-cleaning pure-Rust redb store, shared GlueSQL connections, durable versions and branches, and reopening both branch heads. |
 | [`sqlite_durable.rs`](sqlite_durable.rs) | `cargo run --features sqlite --example sqlite_durable` | A self-cleaning temporary SQLite store, durable versions and branches, and reopening both branch heads. |
 
 Every example is self-contained: it creates its own database state, validates

--- a/integrations/prolly-gluesql/examples/redb_durable.rs
+++ b/integrations/prolly-gluesql/examples/redb_durable.rs
@@ -1,0 +1,95 @@
+//! Durable redb-backed versions, shared connections, and branch reopen.
+//!
+//! Run with: `cargo run --features redb --example redb_durable`
+
+use {
+    prolly_gluesql::{gluesql_core::prelude::Value, Glue, Payload, RedbProllyStorage},
+    prolly_store_redb::RedbStore,
+    std::{
+        error::Error,
+        path::{Path, PathBuf},
+        sync::Arc,
+        time::{SystemTime, UNIX_EPOCH},
+    },
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let path = temporary_database_path();
+    let result = run(&path).await;
+    let _ = std::fs::remove_file(&path);
+    result
+}
+
+async fn run(path: &Path) -> Result<(), Box<dyn Error>> {
+    let (main_id, snapshot_id) = {
+        // Redb permits one writable database handle per file. Share that handle
+        // when an application needs multiple GlueSQL connections.
+        let backend = Arc::new(RedbStore::open(path)?);
+        let storage = RedbProllyStorage::new(Arc::clone(&backend))?;
+        let mut db = Glue::new(storage);
+        db.execute("CREATE TABLE events (id INTEGER PRIMARY KEY, message TEXT NOT NULL);")
+            .await?;
+        db.execute("INSERT INTO events VALUES (1, 'persisted');")
+            .await?;
+        let snapshot = db.storage.create_branch("snapshot")?;
+        let snapshot_id = snapshot.id().unwrap().to_string();
+
+        let mut reader = Glue::new(RedbProllyStorage::new(Arc::clone(&backend))?);
+        assert_eq!(select_messages(&mut reader).await?.len(), 1);
+
+        db.execute("INSERT INTO events VALUES (2, 'main only');")
+            .await?;
+        assert_eq!(select_messages(&mut reader).await?.len(), 2);
+        let main_id = db.storage.head()?.unwrap().id().unwrap().to_string();
+        (main_id, snapshot_id)
+    };
+
+    {
+        let storage = RedbProllyStorage::open_redb(path)?;
+        let mut db = Glue::new(storage);
+        assert_eq!(db.storage.head()?.unwrap().id().unwrap().as_str(), main_id);
+        assert_eq!(select_messages(&mut db).await?.len(), 2);
+    }
+
+    {
+        let storage = RedbProllyStorage::open_redb_with_branch(path, "snapshot")?;
+        let mut db = Glue::new(storage);
+        assert_eq!(
+            db.storage.head()?.unwrap().id().unwrap().as_str(),
+            snapshot_id
+        );
+        assert_eq!(
+            select_messages(&mut db).await?,
+            vec![vec![Value::I64(1), Value::Str("persisted".to_owned())]]
+        );
+    }
+
+    println!("reopened redb database: {}", path.display());
+    println!("main version:     {main_id}");
+    println!("snapshot version: {snapshot_id}");
+    Ok(())
+}
+
+async fn select_messages(
+    db: &mut Glue<RedbProllyStorage>,
+) -> Result<Vec<Vec<Value>>, Box<dyn Error>> {
+    let payloads = db
+        .execute("SELECT id, message FROM events ORDER BY id;")
+        .await?;
+    let Payload::Select { rows, .. } = &payloads[0] else {
+        return Err("expected a SELECT payload".into());
+    };
+    Ok(rows.clone())
+}
+
+fn temporary_database_path() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is after the Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "prolly-gluesql-example-{}-{nonce}.redb",
+        std::process::id()
+    ))
+}

--- a/integrations/prolly-gluesql/src/error.rs
+++ b/integrations/prolly-gluesql/src/error.rs
@@ -39,6 +39,11 @@ pub enum Error {
     #[error("merge materialization failed: {0}")]
     Merge(String),
 
+    /// A redb-backed storage engine could not be opened.
+    #[cfg(feature = "redb")]
+    #[error("redb store failed: {0}")]
+    Redb(#[from] prolly_store_redb::RedbStoreError),
+
     /// A SQLite-backed storage engine could not be opened.
     #[cfg(feature = "sqlite")]
     #[error("sqlite store failed: {0}")]

--- a/integrations/prolly-gluesql/src/lib.rs
+++ b/integrations/prolly-gluesql/src/lib.rs
@@ -14,6 +14,9 @@ pub use storage::{
     Version, VersionId,
 };
 
+#[cfg(feature = "redb")]
+pub use storage::RedbProllyStorage;
+
 #[cfg(feature = "sqlite")]
 pub use storage::SqliteProllyStorage;
 

--- a/integrations/prolly-gluesql/src/storage.rs
+++ b/integrations/prolly-gluesql/src/storage.rs
@@ -1192,6 +1192,31 @@ impl ProllyStorage<prolly::MemStore> {
     }
 }
 
+/// A durable redb-backed GlueSQL storage engine.
+///
+/// The shared handle lets multiple GlueSQL connections use one redb database,
+/// as redb permits only one open writable database handle per file.
+#[cfg(feature = "redb")]
+pub type RedbProllyStorage = ProllyStorage<std::sync::Arc<prolly_store_redb::RedbStore>>;
+
+#[cfg(feature = "redb")]
+impl ProllyStorage<std::sync::Arc<prolly_store_redb::RedbStore>> {
+    /// Open or create a durable redb-backed Prolly SQL database.
+    pub fn open_redb(path: impl AsRef<std::path::Path>) -> Result<Self> {
+        let store = prolly_store_redb::RedbStore::open(path)?;
+        Self::new(std::sync::Arc::new(store))
+    }
+
+    /// Open or create a durable redb-backed database on the selected branch.
+    pub fn open_redb_with_branch(
+        path: impl AsRef<std::path::Path>,
+        branch: impl Into<String>,
+    ) -> Result<Self> {
+        let store = prolly_store_redb::RedbStore::open(path)?;
+        Self::with_branch(std::sync::Arc::new(store), branch)
+    }
+}
+
 #[cfg(feature = "sqlite")]
 pub type SqliteProllyStorage = ProllyStorage<prolly_store_sqlite::SqliteStore>;
 

--- a/integrations/prolly-gluesql/tests/redb_durability.rs
+++ b/integrations/prolly-gluesql/tests/redb_durability.rs
@@ -1,0 +1,131 @@
+#![cfg(feature = "redb")]
+
+use {
+    gluesql_core::{data::Value, executor::Payload, prelude::Glue},
+    prolly_gluesql::RedbProllyStorage,
+    prolly_store_redb::RedbStore,
+    std::sync::Arc,
+    tempfile::TempDir,
+};
+
+fn database_path() -> (TempDir, std::path::PathBuf) {
+    let directory = TempDir::new().expect("create temporary directory");
+    let path = directory.path().join("database.redb");
+    (directory, path)
+}
+
+#[tokio::test]
+async fn redb_reopen_preserves_catalog_rows_indexes_and_functions() {
+    let (_directory, path) = database_path();
+    {
+        let storage = RedbProllyStorage::open_redb(&path).unwrap();
+        let mut glue = Glue::new(storage);
+        glue.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT);")
+            .await
+            .unwrap();
+        glue.execute("CREATE INDEX users_email ON users (email);")
+            .await
+            .unwrap();
+        glue.execute("INSERT INTO users VALUES (1, 'ada@example.com');")
+            .await
+            .unwrap();
+        glue.execute("CREATE FUNCTION plus_one(n INT) RETURN n + 1;")
+            .await
+            .unwrap();
+    }
+
+    let storage = RedbProllyStorage::open_redb(&path).unwrap();
+    let mut glue = Glue::new(storage);
+    let payloads = glue
+        .execute("SELECT id FROM users WHERE email = 'ada@example.com';")
+        .await
+        .unwrap();
+    assert!(matches!(
+        &payloads[0],
+        Payload::Select { rows, .. } if rows == &vec![vec![Value::I64(1)]]
+    ));
+    let function_result = glue.execute("SELECT plus_one(41);").await.unwrap();
+    assert!(matches!(
+        &function_result[0],
+        Payload::Select { rows, .. } if rows == &vec![vec![Value::I64(42)]]
+    ));
+}
+
+#[tokio::test]
+async fn shared_redb_connections_get_a_serialization_conflict() {
+    let (_directory, path) = database_path();
+    let backend = Arc::new(RedbStore::open(&path).unwrap());
+    let mut first = Glue::new(RedbProllyStorage::new(Arc::clone(&backend)).unwrap());
+    first
+        .execute("CREATE TABLE counter (id INTEGER PRIMARY KEY, value INTEGER);")
+        .await
+        .unwrap();
+    first
+        .execute("INSERT INTO counter VALUES (1, 0);")
+        .await
+        .unwrap();
+
+    let mut second = Glue::new(RedbProllyStorage::new(Arc::clone(&backend)).unwrap());
+    first.execute("START TRANSACTION;").await.unwrap();
+    second.execute("START TRANSACTION;").await.unwrap();
+    first
+        .execute("UPDATE counter SET value = 1 WHERE id = 1;")
+        .await
+        .unwrap();
+    second
+        .execute("UPDATE counter SET value = 2 WHERE id = 1;")
+        .await
+        .unwrap();
+    first.execute("COMMIT;").await.unwrap();
+    let conflict = second.execute("COMMIT;").await.unwrap_err();
+    assert!(conflict.to_string().contains("serialization conflict"));
+
+    let payloads = first.execute("SELECT value FROM counter;").await.unwrap();
+    assert!(matches!(
+        &payloads[0],
+        Payload::Select { rows, .. } if rows == &vec![vec![Value::I64(1)]]
+    ));
+}
+
+#[tokio::test]
+async fn redb_branches_remain_isolated_after_reopen() {
+    let (_directory, path) = database_path();
+    {
+        let storage = RedbProllyStorage::open_redb(&path).unwrap();
+        let mut glue = Glue::new(storage);
+        glue.execute("CREATE TABLE settings (id INTEGER PRIMARY KEY, value TEXT);")
+            .await
+            .unwrap();
+        glue.execute("INSERT INTO settings VALUES (1, 'main');")
+            .await
+            .unwrap();
+        glue.storage.create_branch("experiment").unwrap();
+    }
+
+    {
+        let storage = RedbProllyStorage::open_redb_with_branch(&path, "experiment").unwrap();
+        let mut glue = Glue::new(storage);
+        glue.execute("UPDATE settings SET value = 'experiment' WHERE id = 1;")
+            .await
+            .unwrap();
+    }
+
+    let experiment_rows = {
+        let storage = RedbProllyStorage::open_redb_with_branch(&path, "experiment").unwrap();
+        let mut glue = Glue::new(storage);
+        glue.execute("SELECT value FROM settings;").await.unwrap()
+    };
+    let main_rows = {
+        let storage = RedbProllyStorage::open_redb(&path).unwrap();
+        let mut glue = Glue::new(storage);
+        glue.execute("SELECT value FROM settings;").await.unwrap()
+    };
+    assert!(matches!(
+        &experiment_rows[0],
+        Payload::Select { rows, .. } if rows == &vec![vec![Value::Str("experiment".to_owned())]]
+    ));
+    assert!(matches!(
+        &main_rows[0],
+        Payload::Select { rows, .. } if rows == &vec![vec![Value::Str("main".to_owned())]]
+    ));
+}


### PR DESCRIPTION
## Summary

- add an optional `redb` feature backed by the existing `prolly-store-redb` adapter
- expose the typed `RedbProllyStorage` alias with `open_redb` and `open_redb_with_branch` constructors
- share redb through `Arc<RedbStore>` so multiple GlueSQL connections keep independent transaction state while using one writable database handle
- add reopen, index, custom-function, branch-isolation, and serialization-conflict coverage
- add a self-contained `redb_durable` example and document both single-connection and shared-handle usage

## User impact

Applications can enable `prolly-gluesql` with the `redb` feature and open a durable pure-Rust single-file SQL database without SQLite or a native database dependency:

```rust
let storage = RedbProllyStorage::open_redb("database.prolly.redb")?;
let mut db = Glue::new(storage);
```

Redb versions, branches, indexes, rows, schemas, metadata, and custom functions survive close/reopen. Multiple connections share one `Arc<RedbStore>`; stale concurrent commits return the existing typed serialization error and do not overwrite the winner.

## Validation

- ran all seven self-contained examples successfully
- `cargo test --package prolly-gluesql --all-features --no-fail-fast`: 236 passed
- `cargo clippy --package prolly-gluesql --all-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --package prolly-gluesql --all-features --no-deps`
- `cargo package --package prolly-gluesql --allow-dirty`
- verified the packaged crate includes the redb example and durability tests
