### PR TITLE
Add high-throughput versioned DynamoDB write paths

### DIFF
--- a/benchmarks/dynamodb-client/README.md
+++ b/benchmarks/dynamodb-client/README.md
@@ -61,6 +61,27 @@ cannot silently produce acceptable evidence.
 Runner v14 also binds `BENCH_NODE_CACHE_MAX_BYTES` into the executable CLI,
 run manifest, and validator. It defaults to the client's 64-MiB retained
 serialized-node weight; zero disables caching. This is not a process-RSS cap.
+
+The executable also has a focused `bulk` workload for the one-version import
+path. It records latency, SDK/wire calls, request/response bytes, and physical
+transaction actions, then verifies that the imported table has exactly one
+version. For example, against an already-running DynamoDB Local instance:
+
+```bash
+cargo run --release --manifest-path benchmarks/dynamodb-client/Cargo.toml -- \
+  --workload bulk --records 1000000 --value-bytes 1024 --samples 1 \
+  --endpoint http://127.0.0.1:8000 \
+  --output performance-results/dynamodb-client-bulk-1m
+```
+
+This path consumes primary-key-sorted records and creates one commit for the
+entire import. It is distinct from compatible `BatchWriteItem`, which retains
+one commit per accepted item action.
+
+Use `--workload large` with the same size flags to profile an explicit
+`WriteSession` commit into an existing empty table. The timed row is
+`LargeWriteCommit`; table creation is outside that row, and the harness verifies
+that the session adds exactly one version.
 The result directory contains raw samples, a deterministic summary/report,
 machine and run manifests, dependency graph, binary digest, build log, DynamoDB
 artifact identity, raw BSD/GNU process timing, and normalized peak RSS. The raw

--- a/benchmarks/dynamodb-client/src/main.rs
+++ b/benchmarks/dynamodb-client/src/main.rs
@@ -17,9 +17,9 @@ use aws_smithy_runtime_api::client::interceptors::context::{
 use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_types::config_bag::ConfigBag;
 use prolly_dynamodb_client::{
-    Client, GcApplyOptions, GcPlanLimits, KeyAttribute, KeyKind, MaintenanceContext,
-    RetentionPolicy, SecondaryIndexDefinition, SecondaryIndexKind, SecondaryIndexProjection,
-    WithMetadata, MIN_MAINTENANCE_LEASE_MILLIS,
+    BulkImportOptions, Client, GcApplyOptions, GcPlanLimits, KeyAttribute, KeyKind,
+    LargeWriteOptions, MaintenanceContext, RetentionPolicy, SecondaryIndexDefinition,
+    SecondaryIndexKind, SecondaryIndexProjection, WithMetadata, MIN_MAINTENANCE_LEASE_MILLIS,
 };
 use prolly_store_dynamodb::DynamoDbBackend;
 use serde::Serialize;
@@ -62,6 +62,8 @@ struct Args {
 enum Workload {
     Full,
     History,
+    Bulk,
+    Large,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -339,6 +341,12 @@ async fn run(args: Result<Args, String>) -> Result<(), String> {
     backend.initialize_schema().await.map_err(error)?;
     if args.workload == Workload::History {
         return run_history_workload(&args, &metrics, &backend, &raw_path).await;
+    }
+    if args.workload == Workload::Bulk {
+        return run_bulk_workload(&args, &metrics, &backend, &raw_path).await;
+    }
+    if args.workload == Workload::Large {
+        return run_large_write_workload(&args, &metrics, &backend, &raw_path).await;
     }
     let client = Client::builder()
         .backend(backend.clone())
@@ -2064,6 +2072,195 @@ async fn run(args: Result<Args, String>) -> Result<(), String> {
     Ok(())
 }
 
+async fn run_large_write_workload(
+    args: &Args,
+    metrics: &PhysicalMetrics,
+    backend: &DynamoDbBackend,
+    raw_path: &std::path::Path,
+) -> Result<(), String> {
+    let mut writer = csv::Writer::from_path(raw_path).map_err(error)?;
+    for sample in 0..args.samples {
+        let mut sample_prefix = backend.key_prefix().to_vec();
+        sample_prefix.extend_from_slice(format!("large-sample-{sample}:").as_bytes());
+        let client = Client::builder()
+            .backend(backend.clone().with_key_prefix(sample_prefix))
+            .node_cache_max_bytes(args.node_cache_max_bytes)
+            .open()
+            .await
+            .map_err(error)?;
+        let table = format!("BenchmarkLarge{sample}");
+        client
+            .create_table()
+            .table_name(&table)
+            .attribute_definitions(
+                AttributeDefinition::builder()
+                    .attribute_name("id")
+                    .attribute_type(ScalarAttributeType::S)
+                    .build()
+                    .map_err(error)?,
+            )
+            .key_schema(
+                KeySchemaElement::builder()
+                    .attribute_name("id")
+                    .key_type(KeyType::Hash)
+                    .build()
+                    .map_err(error)?,
+            )
+            .send()
+            .await
+            .map_err(error)?;
+        let logical_bytes = logical_item_bytes("00000000000000000000", args.value_bytes)
+            .checked_mul(args.records)
+            .ok_or("large write logical byte count overflowed")?;
+        measure(
+            args,
+            metrics,
+            &mut writer,
+            "LargeWriteCommit",
+            "warm",
+            sample,
+            logical_bytes,
+            0,
+            true,
+            1,
+            async {
+                let mut session = client.table(&table).write_session().options(LargeWriteOptions {
+                    max_items: args.records,
+                    max_logical_bytes: logical_bytes.max(1),
+                    ..LargeWriteOptions::default()
+                });
+                for index in 0..args.records {
+                    session
+                        .put(HashMap::from([
+                            ("id".into(), AttributeValue::S(format!("{index:020}"))),
+                            (
+                                "payload".into(),
+                                AttributeValue::B(value(index, 0, args.value_bytes).into()),
+                            ),
+                        ]))
+                        .map_err(error)?;
+                }
+                let result = session.commit().await.map_err(error)?;
+                if result.transitions.len() != 1 || !result.transitions[0].applied {
+                    return Err("large write did not report one applied transition".into());
+                }
+                Ok(args.records)
+            },
+        )
+        .await?;
+        if client
+            .table(&table)
+            .collect_versions()
+            .await
+            .map_err(error)?
+            .len()
+            != 2
+        {
+            return Err("large write did not create exactly one version after table creation".into());
+        }
+    }
+    writer.flush().map_err(error)?;
+    writer.get_ref().sync_all().map_err(error)?;
+    if args.cleanup {
+        backend.clear_namespace().await.map_err(error)?;
+    }
+    println!(
+        "wrote {} validated large-write samples to {}",
+        args.samples,
+        raw_path.display()
+    );
+    Ok(())
+}
+
+async fn run_bulk_workload(
+    args: &Args,
+    metrics: &PhysicalMetrics,
+    backend: &DynamoDbBackend,
+    raw_path: &std::path::Path,
+) -> Result<(), String> {
+    let mut writer = csv::Writer::from_path(raw_path).map_err(error)?;
+    for sample in 0..args.samples {
+        let mut sample_prefix = backend.key_prefix().to_vec();
+        sample_prefix.extend_from_slice(format!("bulk-sample-{sample}:").as_bytes());
+        let client = Client::builder()
+            .backend(backend.clone().with_key_prefix(sample_prefix))
+            .node_cache_max_bytes(args.node_cache_max_bytes)
+            .open()
+            .await
+            .map_err(error)?;
+        let table = format!("BenchmarkBulk{sample}");
+        let logical_bytes = logical_item_bytes("00000000000000000000", args.value_bytes)
+            .checked_mul(args.records)
+            .ok_or("bulk import logical byte count overflowed")?;
+        measure(
+            args,
+            metrics,
+            &mut writer,
+            "BulkImportSorted",
+            "cold",
+            sample,
+            logical_bytes,
+            0,
+            true,
+            1,
+            async {
+                let items = (0..args.records).map(|index| {
+                    HashMap::from([
+                        ("id".into(), AttributeValue::S(format!("{index:020}"))),
+                        (
+                            "payload".into(),
+                            AttributeValue::B(value(index, 0, args.value_bytes).into()),
+                        ),
+                    ])
+                });
+                let result = client
+                    .bulk_import_sorted(
+                        &table,
+                        KeyAttribute {
+                            name: "id".into(),
+                            kind: KeyKind::String,
+                        },
+                        None,
+                        items,
+                        BulkImportOptions::default(),
+                    )
+                    .await
+                    .map_err(error)?;
+                if result.item_count != args.records {
+                    return Err(format!(
+                        "bulk import reported {} items; expected {}",
+                        result.item_count, args.records
+                    ));
+                }
+                Ok(result.item_count)
+            },
+        )
+        .await?;
+        let versions = client
+            .table(&table)
+            .collect_versions()
+            .await
+            .map_err(error)?;
+        if versions.len() != 1 {
+            return Err(format!(
+                "bulk import created {} versions; expected 1",
+                versions.len()
+            ));
+        }
+    }
+    writer.flush().map_err(error)?;
+    writer.get_ref().sync_all().map_err(error)?;
+    if args.cleanup {
+        backend.clear_namespace().await.map_err(error)?;
+    }
+    println!(
+        "wrote {} validated bulk-import samples to {}",
+        args.samples,
+        raw_path.display()
+    );
+    Ok(())
+}
+
 async fn run_history_workload(
     args: &Args,
     metrics: &PhysicalMetrics,
@@ -2498,6 +2695,8 @@ fn parse_args() -> Result<Args, String> {
                 args.workload = match take(&values, &mut index, flag)?.as_str() {
                     "full" => Workload::Full,
                     "history" => Workload::History,
+                    "bulk" => Workload::Bulk,
+                    "large" => Workload::Large,
                     value => return Err(format!("invalid --workload: {value}")),
                 }
             }

--- a/dynamodb/client/public-api.txt
+++ b/dynamodb/client/public-api.txt
@@ -1,8 +1,15 @@
 pub mod prolly_dynamodb_client
 pub use prolly_dynamodb_client::AttributeValue
+pub use prolly_dynamodb_client::BulkImportOptions
+pub use prolly_dynamodb_client::BulkImportResult
 pub use prolly_dynamodb_client::CancellationToken
 pub use prolly_dynamodb_client::Commit
 pub use prolly_dynamodb_client::CommitId
+pub use prolly_dynamodb_client::DEFAULT_BULK_IMPORT_MAX_BYTES
+pub use prolly_dynamodb_client::DEFAULT_BULK_IMPORT_MAX_ITEMS
+pub use prolly_dynamodb_client::DEFAULT_IMMUTABLE_UPLOAD_PARALLELISM
+pub use prolly_dynamodb_client::DEFAULT_LARGE_WRITE_MAX_BYTES
+pub use prolly_dynamodb_client::DEFAULT_LARGE_WRITE_MAX_ITEMS
 pub use prolly_dynamodb_client::DEFAULT_LOGICAL_RETRY_LIMIT
 pub use prolly_dynamodb_client::ImportAuditRecord
 pub use prolly_dynamodb_client::ImportPlan
@@ -14,7 +21,9 @@ pub use prolly_dynamodb_client::IndexReconfigurationPlanId
 pub use prolly_dynamodb_client::IndexReconfigurationResult
 pub use prolly_dynamodb_client::KeyAttribute
 pub use prolly_dynamodb_client::KeyKind
+pub use prolly_dynamodb_client::LargeWriteOptions
 pub use prolly_dynamodb_client::MAX_GC_PLAN_DELETES
+pub use prolly_dynamodb_client::MAX_IMMUTABLE_UPLOAD_PARALLELISM
 pub use prolly_dynamodb_client::MAX_LOGICAL_RETRY_LIMIT
 pub use prolly_dynamodb_client::MAX_MAINTENANCE_LEASE_MILLIS
 pub use prolly_dynamodb_client::MAX_RETENTION_PROTECTED_VERSIONS
@@ -563,6 +572,7 @@ pub fn prolly_dynamodb_client::Client::batch_get_item(&self) -> prolly_dynamodb_
 pub fn prolly_dynamodb_client::Client::batch_write_item(&self) -> prolly_dynamodb_client::operation::BatchWriteItem
 pub async fn prolly_dynamodb_client::Client::break_expired_maintenance_lease(&self, &prolly_dynamodb_core::database::MaintenanceLeaseId, prolly_dynamodb_core::database::MaintenanceContext) -> prolly_dynamodb_client::Result<prolly_dynamodb_core::database::MaintenanceLeaseRelease>
 pub fn prolly_dynamodb_client::Client::builder() -> prolly_dynamodb_client::ClientBuilder
+pub async fn prolly_dynamodb_client::Client::bulk_import_sorted<I>(&self, impl core::convert::Into<alloc::string::String>, prolly_dynamodb_core::model::table::KeyAttribute, core::option::Option<prolly_dynamodb_core::model::table::KeyAttribute>, I, prolly_dynamodb_core::database::BulkImportOptions) -> prolly_dynamodb_client::Result<prolly_dynamodb_core::database::BulkImportResult> where I: core::iter::traits::collect::IntoIterator<Item = std::collections::hash::map::HashMap<alloc::string::String, aws_sdk_dynamodb::types::_attribute_value::AttributeValue>>
 pub fn prolly_dynamodb_client::Client::cache_usage(&self) -> prolly::prolly::ProllyCacheUsage
 pub fn prolly_dynamodb_client::Client::capabilities(&self) -> &prolly_dynamodb_client::CapabilityReport
 pub fn prolly_dynamodb_client::Client::create_table(&self) -> prolly_dynamodb_client::operation::CreateTable
@@ -601,6 +611,7 @@ pub fn prolly_dynamodb_client::Client::transact_get_items(&self) -> prolly_dynam
 pub fn prolly_dynamodb_client::Client::transact_write_items(&self) -> prolly_dynamodb_client::operation::TransactWriteItems
 pub fn prolly_dynamodb_client::Client::update_item(&self) -> prolly_dynamodb_client::operation::UpdateItem
 pub fn prolly_dynamodb_client::Client::workers(&self) -> prolly_dynamodb_client::Workers
+pub fn prolly_dynamodb_client::Client::write_session(&self, impl core::convert::Into<alloc::string::String>) -> prolly_dynamodb_client::WriteSession
 impl prolly_dynamodb_client::Client
 pub async fn prolly_dynamodb_client::Client::apply_gc(&self, &prolly_dynamodb_client::GcPlan, prolly_dynamodb_core::database::MaintenanceContext, prolly_dynamodb_client::GcApplyOptions) -> prolly_dynamodb_client::Result<prolly_dynamodb_client::GcApplyResult>
 pub async fn prolly_dynamodb_client::Client::plan_gc(&self, &prolly_dynamodb_core::database::MaintenanceLeaseId, core::option::Option<&prolly_dynamodb_client::GcCursor>, prolly_dynamodb_client::GcPlanLimits) -> prolly_dynamodb_client::Result<prolly_dynamodb_client::GcPlan>
@@ -1045,6 +1056,7 @@ pub fn prolly_dynamodb_client::Table::retention(&self, prolly_dynamodb_core::dat
 pub async fn prolly_dynamodb_client::Table::retention_audit(&self, &prolly_dynamodb_core::database::RetentionPlanId) -> prolly_dynamodb_client::Result<core::option::Option<prolly_dynamodb_core::database::RetentionAuditRecord>>
 pub fn prolly_dynamodb_client::Table::update_item(&self) -> prolly_dynamodb_client::operation::UpdateItem
 pub fn prolly_dynamodb_client::Table::versions(&self) -> prolly_dynamodb_client::VersionsPaginator
+pub fn prolly_dynamodb_client::Table::write_session(&self) -> prolly_dynamodb_client::WriteSession
 impl core::clone::Clone for prolly_dynamodb_client::Table
 pub fn prolly_dynamodb_client::Table::clone(&self) -> prolly_dynamodb_client::Table
 impl core::marker::Freeze for prolly_dynamodb_client::Table
@@ -1196,6 +1208,23 @@ impl core::marker::Unpin for prolly_dynamodb_client::Workers
 impl core::marker::UnsafeUnpin for prolly_dynamodb_client::Workers
 impl !core::panic::unwind_safe::RefUnwindSafe for prolly_dynamodb_client::Workers
 impl !core::panic::unwind_safe::UnwindSafe for prolly_dynamodb_client::Workers
+pub struct prolly_dynamodb_client::WriteSession
+impl prolly_dynamodb_client::WriteSession
+pub async fn prolly_dynamodb_client::WriteSession::commit(self) -> prolly_dynamodb_client::Result<prolly_dynamodb_core::database::TransactWriteResult>
+pub fn prolly_dynamodb_client::WriteSession::delete(&mut self, std::collections::hash::map::HashMap<alloc::string::String, aws_sdk_dynamodb::types::_attribute_value::AttributeValue>) -> prolly_dynamodb_client::Result<&mut Self>
+pub fn prolly_dynamodb_client::WriteSession::if_head(self, prolly::prolly::versioned_map::MapVersionId) -> Self
+pub fn prolly_dynamodb_client::WriteSession::is_empty(&self) -> bool
+pub fn prolly_dynamodb_client::WriteSession::len(&self) -> usize
+pub fn prolly_dynamodb_client::WriteSession::options(self, prolly_dynamodb_core::database::LargeWriteOptions) -> Self
+pub fn prolly_dynamodb_client::WriteSession::put(&mut self, std::collections::hash::map::HashMap<alloc::string::String, aws_sdk_dynamodb::types::_attribute_value::AttributeValue>) -> prolly_dynamodb_client::Result<&mut Self>
+pub fn prolly_dynamodb_client::WriteSession::request_token(self, impl core::convert::Into<alloc::string::String>) -> Self
+impl core::marker::Freeze for prolly_dynamodb_client::WriteSession
+impl core::marker::Send for prolly_dynamodb_client::WriteSession
+impl core::marker::Sync for prolly_dynamodb_client::WriteSession
+impl core::marker::Unpin for prolly_dynamodb_client::WriteSession
+impl core::marker::UnsafeUnpin for prolly_dynamodb_client::WriteSession
+impl !core::panic::unwind_safe::RefUnwindSafe for prolly_dynamodb_client::WriteSession
+impl !core::panic::unwind_safe::UnwindSafe for prolly_dynamodb_client::WriteSession
 pub const prolly_dynamodb_client::DEFAULT_NODE_CACHE_MAX_BYTES: usize
 pub const prolly_dynamodb_client::MAX_GC_BLOB_DELETE_PARALLELISM: usize
 pub const prolly_dynamodb_client::MAX_WORKER_PAGE_ITEMS: usize

--- a/dynamodb/client/src/client.rs
+++ b/dynamodb/client/src/client.rs
@@ -1,8 +1,10 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use prolly::{ProllyCacheUsage, RemoteProllyStore, RemoteStoreConfig};
 use prolly_dynamodb_core::{
-    Clock, Database, IdGenerator, ImportAuditRecord, ImportPlanId, LargeValueConfig,
+    BulkImportOptions, BulkImportResult, Clock, Database, IdGenerator, ImportAuditRecord,
+    ImportPlanId, KeyAttribute, LargeValueConfig,
     MaintenanceContext, MaintenanceLease, MaintenanceLeaseId, MaintenanceLeaseRelease,
     StoragePublicationMode,
 };
@@ -17,7 +19,7 @@ use crate::operation::{
 };
 use crate::table::{Import, Table};
 use crate::worker::Workers;
-use crate::CapabilityReport;
+use crate::{CapabilityReport, WriteSession};
 
 type CoreDatabase = Database<DynamoDbStore>;
 
@@ -392,6 +394,41 @@ impl Client {
 
     pub fn table(&self, name: impl Into<String>) -> Table {
         Table::new(self.clone(), name.into())
+    }
+
+    /// Open an explicit large write session for one logical table.
+    pub fn write_session(&self, table_name: impl Into<String>) -> WriteSession {
+        WriteSession::new(self.clone(), table_name.into())
+    }
+
+    /// Create a table from strictly primary-key-sorted items as one initial
+    /// version. This administrative path deliberately does not emulate an AWS
+    /// operation builder and never changes `PutItem` or `BatchWriteItem`
+    /// commit semantics.
+    pub async fn bulk_import_sorted<I>(
+        &self,
+        table_name: impl Into<String>,
+        partition_key: KeyAttribute,
+        sort_key: Option<KeyAttribute>,
+        items: I,
+        options: BulkImportOptions,
+    ) -> crate::Result<BulkImportResult>
+    where
+        I: IntoIterator<Item = HashMap<String, aws_sdk_dynamodb::types::AttributeValue>>,
+    {
+        Ok(self
+            .core()
+            .bulk_import_sorted(
+                table_name,
+                partition_key,
+                sort_key,
+                items.into_iter().map(|item| {
+                    crate::conversion::item_from_aws(item)
+                        .map_err(|error| prolly_dynamodb_core::Error::Validation(error.to_string()))
+                }),
+                options,
+            )
+            .await?)
     }
 
     /// Construct explicit leased background workers. Merely opening a client

--- a/dynamodb/client/src/lib.rs
+++ b/dynamodb/client/src/lib.rs
@@ -11,6 +11,7 @@ mod metadata;
 pub mod operation;
 mod table;
 mod worker;
+mod write_session;
 
 pub use capabilities::{CapabilityReport, CompatibilityLevel, OperationCapability};
 pub use client::{Client, ClientBuilder, DEFAULT_NODE_CACHE_MAX_BYTES};
@@ -21,7 +22,8 @@ pub use gc::{
 };
 pub use metadata::{TableTransitionMetadata, WithMetadata};
 pub use prolly_dynamodb_core::{
-    CommitId, ImportAuditRecord, ImportPlan, ImportPlanId, ImportResult,
+    BulkImportOptions, BulkImportResult, CommitId, ImportAuditRecord, ImportPlan, ImportPlanId,
+    ImportResult, LargeWriteOptions,
     IndexReconfigurationAuditRecord, IndexReconfigurationPlan, IndexReconfigurationPlanId,
     IndexReconfigurationResult, KeyAttribute, KeyKind, MaintenanceContext, MaintenanceLease,
     MaintenanceLeaseId, MaintenanceLeaseRelease, RetentionAuditRecord, RetentionPlan,
@@ -32,7 +34,10 @@ pub use prolly_dynamodb_core::{
     WorkerLeaseRelease, WorkerProgress, DEFAULT_LOGICAL_RETRY_LIMIT, MAX_GC_PLAN_DELETES,
     MAX_LOGICAL_RETRY_LIMIT, MAX_MAINTENANCE_LEASE_MILLIS, MAX_RETENTION_PROTECTED_VERSIONS,
     MAX_RETENTION_REMOVALS, MAX_WORKER_LEASE_MILLIS, MIN_MAINTENANCE_LEASE_MILLIS,
-    MIN_WORKER_LEASE_MILLIS, TABLE_ARCHIVE_FORMAT_VERSION,
+    MIN_WORKER_LEASE_MILLIS, TABLE_ARCHIVE_FORMAT_VERSION, DEFAULT_BULK_IMPORT_MAX_BYTES,
+    DEFAULT_BULK_IMPORT_MAX_ITEMS, DEFAULT_IMMUTABLE_UPLOAD_PARALLELISM,
+    DEFAULT_LARGE_WRITE_MAX_BYTES, DEFAULT_LARGE_WRITE_MAX_ITEMS,
+    MAX_IMMUTABLE_UPLOAD_PARALLELISM,
 };
 pub use table::{
     ConditionalTable, DiffPaginator, Import, Indexes, Restore, RetentionPlanner, Snapshot, Table,
@@ -44,6 +49,7 @@ pub use worker::{
     TtlWorkerOptions, Worker, WorkerExit, Workers, MAX_WORKER_PAGE_ITEMS, MAX_WORKER_SLEEP,
     MIN_WORKER_SLEEP,
 };
+pub use write_session::WriteSession;
 
 pub use aws_sdk_dynamodb::types::AttributeValue;
 pub use prolly::ProllyCacheUsage;

--- a/dynamodb/client/src/table.rs
+++ b/dynamodb/client/src/table.rs
@@ -12,7 +12,7 @@ use prolly_dynamodb_core::{
 };
 
 use crate::operation::{DeleteItem, GetItem, PutItem, Query, Scan, UpdateItem};
-use crate::{Client, Error, Result, TableTransitionMetadata, WithMetadata};
+use crate::{Client, Error, Result, TableTransitionMetadata, WithMetadata, WriteSession};
 
 #[derive(Clone)]
 pub struct Table {
@@ -114,6 +114,11 @@ impl Table {
 
     pub fn update_item(&self) -> UpdateItem {
         self.client.update_item().table_name(&self.name)
+    }
+
+    /// Open an explicit large write session scoped to this table.
+    pub fn write_session(&self) -> WriteSession {
+        WriteSession::new(self.client.clone(), self.name.clone())
     }
 
     pub fn if_head(&self, version: MapVersionId) -> ConditionalTable {

--- a/dynamodb/client/src/write_session.rs
+++ b/dynamodb/client/src/write_session.rs
@@ -1,0 +1,95 @@
+use std::collections::{BTreeMap, HashMap};
+
+use aws_sdk_dynamodb::types::AttributeValue;
+use prolly::MapVersionId;
+use prolly_dynamodb_core::{LargeWriteOptions, TransactWriteAction};
+
+use crate::{Client, Commit, Result};
+
+/// Explicit, client-side large write session.
+///
+/// The session is inert until [`WriteSession::commit`]. A successful commit
+/// publishes every buffered action as one table version and one durable commit.
+/// Normal AWS-compatible write builders retain their original limits and
+/// per-operation commit behavior.
+pub struct WriteSession {
+    client: Client,
+    table_name: String,
+    actions: Vec<TransactWriteAction>,
+    expected_head: Option<MapVersionId>,
+    request_token: Option<String>,
+    options: LargeWriteOptions,
+}
+
+impl WriteSession {
+    pub(crate) fn new(client: Client, table_name: String) -> Self {
+        Self {
+            client,
+            table_name,
+            actions: Vec::new(),
+            expected_head: None,
+            request_token: None,
+            options: LargeWriteOptions::default(),
+        }
+    }
+
+    pub fn options(mut self, options: LargeWriteOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    pub fn if_head(mut self, version: MapVersionId) -> Self {
+        self.expected_head = Some(version);
+        self
+    }
+
+    pub fn request_token(mut self, token: impl Into<String>) -> Self {
+        self.request_token = Some(token.into());
+        self
+    }
+
+    pub fn put(&mut self, item: HashMap<String, AttributeValue>) -> Result<&mut Self> {
+        self.actions.push(TransactWriteAction::Put {
+            table_name: self.table_name.clone(),
+            item: crate::conversion::item_from_aws(item)?,
+            condition: None,
+            return_failure_old: false,
+        });
+        Ok(self)
+    }
+
+    pub fn delete(&mut self, key: HashMap<String, AttributeValue>) -> Result<&mut Self> {
+        self.actions.push(TransactWriteAction::Delete {
+            table_name: self.table_name.clone(),
+            key: crate::conversion::item_from_aws(key)?,
+            condition: None,
+            return_failure_old: false,
+        });
+        Ok(self)
+    }
+
+    pub fn len(&self) -> usize {
+        self.actions.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.actions.is_empty()
+    }
+
+    pub async fn commit(self) -> Result<Commit> {
+        let expected_heads = self
+            .expected_head
+            .map(|head| BTreeMap::from([(self.table_name.clone(), head)]))
+            .unwrap_or_default();
+        Ok(self
+            .client
+            .core()
+            .write_large(
+                self.actions,
+                self.request_token.as_deref(),
+                &expected_heads,
+                self.options,
+            )
+            .await?)
+    }
+}

--- a/dynamodb/client/tests/fluent_compile.rs
+++ b/dynamodb/client/tests/fluent_compile.rs
@@ -10,9 +10,10 @@ use aws_sdk_dynamodb::types::{
 };
 use prolly::MapVersionId;
 use prolly_dynamodb_client::{
-    Client, IndexReconfigurationPlan, KeyAttribute, KeyKind, MaintenanceContext, RetentionPolicy,
-    SecondaryIndexDefinition, SecondaryIndexKind, SecondaryIndexProjection, StreamWorkerOptions,
-    TableArchive, TableArchiveLimits, TtlWorkerOptions,
+    BulkImportOptions, Client, IndexReconfigurationPlan, KeyAttribute, KeyKind,
+    LargeWriteOptions, MaintenanceContext, RetentionPolicy, SecondaryIndexDefinition,
+    SecondaryIndexKind, SecondaryIndexProjection, StreamWorkerOptions, TableArchive,
+    TableArchiveLimits, TtlWorkerOptions,
 };
 
 #[allow(dead_code)]
@@ -201,6 +202,29 @@ fn advertised_fluent_chains_compile(
             .ttl(TtlWorkerOptions::new("Orders", "expiresAt", "worker-a")),
     );
     assert_send(client.workers().maintenance(context, 60_000));
+    let mut session = client
+        .table("Orders")
+        .write_session()
+        .options(LargeWriteOptions::default())
+        .if_head(version.clone())
+        .request_token("large-write");
+    session
+        .put(HashMap::from([(
+        "accountId".into(),
+        AttributeValue::S("acct-bulk".into()),
+        )]))
+        .unwrap();
+    assert_send(session.commit());
+    assert_send(client.bulk_import_sorted(
+        "ImportedOrders",
+        KeyAttribute {
+            name: "accountId".into(),
+            kind: KeyKind::String,
+        },
+        None,
+        Vec::<HashMap<String, AttributeValue>>::new(),
+        BulkImportOptions::default(),
+    ));
     assert_stream(
         client
             .table("Orders")

--- a/dynamodb/core/src/database.rs
+++ b/dynamodb/core/src/database.rs
@@ -5,11 +5,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use futures_util::{lock::Mutex, stream, StreamExt, TryStreamExt};
 use prolly::{
     AsyncManifestStore, AsyncManifestStoreScan, AsyncPreparedIndexedUpdate, AsyncProlly,
-    AsyncProllyTransaction, AsyncStore, AsyncTransactionalStore, AsyncVersionedMapsTransaction,
-    BlobRef, CollectionIndexPolicy, IndexedSnapshotId, IndexedSnapshotManifest, MapVersion,
-    MapVersionCursor, MapVersionId, MapVersionPage, Mutation, MutationBudget, NamedRootUpdate,
-    RootManifest, SnapshotExportLimits, StructuralDiffCursor, StructuralDiffPage,
-    TransactionUpdate, Tree, ValueRef, VersionedMapUpdate, DEFAULT_VERSIONED_MAP_RETRIES,
+    AsyncProllyTransaction, AsyncSortedBatchBuilder, AsyncStore, AsyncTransactionalStore,
+    AsyncVersionedMapsTransaction, BlobRef, CollectionIndexPolicy, IndexedSnapshotId,
+    IndexedSnapshotManifest, MapVersion, MapVersionCursor, MapVersionId, MapVersionPage, Mutation,
+    MutationBudget, NamedRootUpdate, RootManifest, SnapshotExportLimits, StructuralDiffCursor,
+    StructuralDiffPage, TransactionUpdate, Tree, ValueRef, VersionedMapUpdate,
+    DEFAULT_VERSIONED_MAP_RETRIES,
 };
 use serde::{Deserialize, Serialize};
 
@@ -60,6 +61,8 @@ const MAX_READ_PAGE_BYTES: usize = 1024 * 1024;
 const READ_CHUNK_ITEMS: usize = 128;
 const IMPORT_INDEX_BATCH_ITEMS: usize = 1_024;
 const IMPORT_INDEX_BATCH_BYTES: usize = 16 * 1024 * 1024;
+pub const DEFAULT_IMMUTABLE_UPLOAD_PARALLELISM: usize = 8;
+pub const MAX_IMMUTABLE_UPLOAD_PARALLELISM: usize = 64;
 /// DynamoDB TTL eligibility excludes timestamps older than five 365-day years.
 pub const TTL_MAX_PAST_SECONDS: u64 = 5 * 365 * 24 * 60 * 60;
 
@@ -69,6 +72,11 @@ pub const MAX_BATCH_GET_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 pub const MAX_BATCH_WRITE_ITEMS: usize = 25;
 pub const MAX_TRANSACTION_ITEMS: usize = 100;
 pub const MAX_TRANSACTION_BYTES: usize = 4 * 1024 * 1024;
+pub const DEFAULT_LARGE_WRITE_MAX_ITEMS: usize = 100_000;
+pub const DEFAULT_LARGE_WRITE_MAX_BYTES: usize = 256 * 1024 * 1024;
+/// Default safety envelope for one explicit bulk snapshot build.
+pub const DEFAULT_BULK_IMPORT_MAX_ITEMS: usize = 1_000_000;
+pub const DEFAULT_BULK_IMPORT_MAX_BYTES: usize = 2 * 1024 * 1024 * 1024;
 pub const MAX_COMMIT_PAGE_ITEMS: usize = 1_000;
 /// Maximum number of changes returned by one resumable diff page.
 pub const MAX_DIFF_PAGE_ITEMS: usize = 1_000;
@@ -421,6 +429,51 @@ pub struct ImportAuditRecord {
     pub completed_at_millis: u64,
 }
 
+/// Explicit resource envelope for a one-version bulk snapshot import.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BulkImportOptions {
+    pub max_items: usize,
+    pub max_logical_bytes: usize,
+    pub blob_upload_parallelism: usize,
+}
+
+impl Default for BulkImportOptions {
+    fn default() -> Self {
+        Self {
+            max_items: DEFAULT_BULK_IMPORT_MAX_ITEMS,
+            max_logical_bytes: DEFAULT_BULK_IMPORT_MAX_BYTES,
+            blob_upload_parallelism: DEFAULT_IMMUTABLE_UPLOAD_PARALLELISM,
+        }
+    }
+}
+
+impl BulkImportOptions {
+    fn validate(self) -> Result<Self> {
+        if self.max_items == 0 || self.max_logical_bytes == 0 {
+            return Err(Error::Validation(
+                "bulk import limits must be nonzero".into(),
+            ));
+        }
+        if !(1..=MAX_IMMUTABLE_UPLOAD_PARALLELISM).contains(&self.blob_upload_parallelism) {
+            return Err(Error::Validation(format!(
+                "bulk import blob upload parallelism must be 1..={MAX_IMMUTABLE_UPLOAD_PARALLELISM}"
+            )));
+        }
+        Ok(self)
+    }
+}
+
+/// Outcome of creating a table from one sorted item stream and publishing one
+/// initial version and one audit commit.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BulkImportResult {
+    pub description: TableDescription,
+    pub version: MapVersionId,
+    pub commit_id: CommitId,
+    pub item_count: usize,
+    pub logical_bytes: usize,
+}
+
 /// Content identity for one exact online secondary-index reconfiguration.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct IndexReconfigurationPlanId(pub [u8; 32]);
@@ -667,6 +720,40 @@ pub enum TransactWriteAction {
         condition: Condition,
         return_failure_old: bool,
     },
+}
+
+/// Resource envelope for an explicit non-AWS large write session.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LargeWriteOptions {
+    pub max_items: usize,
+    pub max_logical_bytes: usize,
+    pub blob_upload_parallelism: usize,
+}
+
+impl Default for LargeWriteOptions {
+    fn default() -> Self {
+        Self {
+            max_items: DEFAULT_LARGE_WRITE_MAX_ITEMS,
+            max_logical_bytes: DEFAULT_LARGE_WRITE_MAX_BYTES,
+            blob_upload_parallelism: DEFAULT_IMMUTABLE_UPLOAD_PARALLELISM,
+        }
+    }
+}
+
+impl LargeWriteOptions {
+    fn validate(self) -> Result<Self> {
+        if self.max_items == 0 || self.max_logical_bytes == 0 {
+            return Err(Error::Validation(
+                "large write limits must be nonzero".into(),
+            ));
+        }
+        if !(1..=MAX_IMMUTABLE_UPLOAD_PARALLELISM).contains(&self.blob_upload_parallelism) {
+            return Err(Error::Validation(format!(
+                "large write blob upload parallelism must be 1..={MAX_IMMUTABLE_UPLOAD_PARALLELISM}"
+            )));
+        }
+        Ok(self)
+    }
 }
 
 impl TransactWriteAction {
@@ -2544,9 +2631,31 @@ where
         committed_at_millis: u64,
     ) -> Result<()> {
         let encoded_commit = encode_commit_result(result)?;
-        let commit_catalog = tx
-            .load_named_root(COMMIT_CATALOG_ROOT_NAME)
-            .await?
+        // Commit metadata is a fixed cost on every logical write. Pin the
+        // global catalog and every participating table log in one ordered
+        // provider read instead of issuing one GetItem per root.
+        let log_names = result
+            .transitions
+            .iter()
+            .map(|transition| {
+                descriptions
+                    .get(&transition.table_name)
+                    .map(|description| Self::table_commit_log_root_name(&description.id))
+                    .ok_or_else(|| {
+                        Error::CorruptData(format!(
+                            "commit transition references unvalidated table {:?}",
+                            transition.table_name
+                        ))
+                    })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let mut root_names = Vec::with_capacity(log_names.len() + 1);
+        root_names.push(COMMIT_CATALOG_ROOT_NAME);
+        root_names.extend(log_names.iter().map(Vec::as_slice));
+        let mut roots = tx.load_named_roots_ordered(&root_names).await?.into_iter();
+        let commit_catalog = roots
+            .next()
+            .flatten()
             .unwrap_or_else(|| tx.create());
         if tx
             .get(&commit_catalog, &result.commit_id.0)
@@ -2570,7 +2679,7 @@ where
         tx.publish_named_root_at_millis(COMMIT_CATALOG_ROOT_NAME, &next, committed_at_millis)
             .await?;
         let mut seen_tables = BTreeSet::new();
-        for transition in &result.transitions {
+        for (transition, loaded_log) in result.transitions.iter().zip(roots) {
             let description = descriptions.get(&transition.table_name).ok_or_else(|| {
                 Error::CorruptData(format!(
                     "commit transition references unvalidated table {:?}",
@@ -2583,10 +2692,7 @@ where
                 ));
             }
             let log_name = Self::table_commit_log_root_name(&description.id);
-            let log = tx
-                .load_named_root(&log_name)
-                .await?
-                .unwrap_or_else(|| tx.create());
+            let log = loaded_log.unwrap_or_else(|| tx.create());
             let sequence = match tx.get(&log, COMMIT_SEQUENCE_KEY).await? {
                 Some(bytes) => decode_commit_sequence(&bytes)?
                     .checked_add(1)
@@ -3134,6 +3240,216 @@ where
             .await?
             .map(|bytes| decode_import_audit_record(&bytes))
             .transpose()
+    }
+
+    /// Create a new table from primary-key-sorted items while publishing only
+    /// one logical version and one commit. Immutable nodes and large blobs are
+    /// uploaded during the build and remain unreachable until the final root
+    /// transaction succeeds.
+    pub async fn bulk_import_sorted<I>(
+        &self,
+        name: impl Into<String>,
+        partition_key: crate::KeyAttribute,
+        sort_key: Option<crate::KeyAttribute>,
+        items: I,
+        options: BulkImportOptions,
+    ) -> Result<BulkImportResult>
+    where
+        I: IntoIterator<Item = Result<Item>>,
+    {
+        let options = options.validate()?;
+        if self.publication_mode != StoragePublicationMode::PrepublishImmutableNodes {
+            return Err(Error::Validation(
+                "bulk import requires PrepublishImmutableNodes storage publication mode".into(),
+            ));
+        }
+        let name = name.into();
+        if self
+            .engine
+            .versioned_map(CATALOG_MAP_ID)
+            .get(name.as_bytes())
+            .await?
+            .is_some()
+        {
+            return Err(Error::TableAlreadyExists(name));
+        }
+        let description = TableDescription {
+            name,
+            id: self.ids.generate()?,
+            attribute_definitions: table_key_definitions(&partition_key, sort_key.as_ref()),
+            partition_key,
+            sort_key,
+            secondary_indexes: Vec::new(),
+            status: TableStatus::Active,
+            created_at_millis: self.clock.now_millis(),
+        };
+        description.validate()?;
+
+        let mut base = AsyncSortedBatchBuilder::new(
+            self.engine.store().clone(),
+            self.engine.config().clone(),
+        );
+        let mut index_source = AsyncSortedBatchBuilder::new(
+            self.engine.store().clone(),
+            self.engine.config().clone(),
+        );
+        let mut previous_key: Option<Vec<u8>> = None;
+        let mut item_count = 0usize;
+        let mut logical_bytes = 0usize;
+        let mut introduced_blobs = BTreeMap::<prolly::Cid, BlobRef>::new();
+        let bulk_description = &description;
+        let bulk_blobs = &self.blobs;
+        let mut prepared_items = stream::iter(items.into_iter())
+            .map(move |item| async move {
+                let item = item?;
+                let item_bytes = item_size(&item)?;
+                let key = encode_primary_key(
+                    bulk_description,
+                    &key_from_item(bulk_description, &item)?,
+                )?;
+                let stored = bulk_blobs.prepare(encode_item(&item)?).await?;
+                let blob = match ValueRef::from_stored_bytes(&stored)? {
+                    ValueRef::Blob(reference) => Some(reference),
+                    ValueRef::Inline(_) => None,
+                };
+                let indexed =
+                    prepare_index_source_record(bulk_description, &item, stored.clone(), bulk_blobs)
+                        .await?;
+                Ok::<_, Error>((item_bytes, key, stored, indexed, blob))
+            })
+            // Preserve sorted source order while overlapping independent
+            // content-addressed blob uploads.
+            .buffered(options.blob_upload_parallelism);
+        while let Some((item_bytes, key, stored, indexed, blob)) =
+            prepared_items.try_next().await?
+        {
+            item_count = item_count
+                .checked_add(1)
+                .ok_or_else(|| Error::Validation("bulk import item count overflow".into()))?;
+            if item_count > options.max_items {
+                return Err(Error::Validation(format!(
+                    "bulk import exceeds {} items",
+                    options.max_items
+                )));
+            }
+            logical_bytes = logical_bytes
+                .checked_add(item_bytes)
+                .ok_or_else(|| Error::Validation("bulk import byte count overflow".into()))?;
+            if logical_bytes > options.max_logical_bytes {
+                return Err(Error::Validation(format!(
+                    "bulk import exceeds {} logical bytes",
+                    options.max_logical_bytes
+                )));
+            }
+            if previous_key.as_ref().is_some_and(|previous| key <= *previous) {
+                return Err(Error::Validation(
+                    "bulk import items must have strictly increasing primary keys".into(),
+                ));
+            }
+            if let Some(reference) = blob {
+                introduced_blobs.insert(reference.cid.clone(), reference);
+            }
+            base.add(key.clone(), stored).await?;
+            index_source.add(key.clone(), indexed).await?;
+            previous_key = Some(key);
+        }
+        drop(prepared_items);
+        base.add(
+            TABLE_SCHEMA_RECORD_KEY.to_vec(),
+            encode_table_schema_record(&description)?,
+        )
+        .await?;
+        let base = base.build().await?;
+        let index_source = index_source.build().await?;
+        let version = MapVersionId::for_tree(&base)?;
+        let budget = prolly::MaintenanceBudget::default();
+        let prepared_indexes = self
+            .engine
+            .prepare_indexed_map_from_source_with_policy(
+                Self::table_indexed_source_id(&description.id),
+                index_registry(&description)?,
+                index_source,
+                &budget,
+                table_index_policy(),
+            )
+            .await?;
+
+        let committed_at_millis = self.clock.now_millis();
+        let commit_id = CommitId(self.ids.generate()?.0);
+        let tx = self.engine.begin_transaction()?;
+        let maps = tx.versioned_maps_at_millis(committed_at_millis);
+        self.prefetch_transaction_global_roots(&tx).await?;
+        self.ensure_writes_unfenced(&tx, &maps).await?;
+        if maps
+            .get(CATALOG_MAP_ID, description.name.as_bytes())
+            .await?
+            .is_some()
+        {
+            tx.rollback();
+            return Err(Error::TableAlreadyExists(description.name));
+        }
+        if !matches!(
+            tx.compare_and_swap_named_root_at_millis(
+                prepared_indexes.root_name(),
+                prepared_indexes.expected_state_tree(),
+                Some(prepared_indexes.candidate_state_tree()),
+                committed_at_millis,
+            )
+            .await?,
+            NamedRootUpdate::Applied
+        ) {
+            tx.rollback();
+            return Err(Error::ConflictExhausted);
+        }
+        let table_map = self.engine.versioned_map(Self::table_map_id(&description.id));
+        tx.publish_named_root_at_millis(
+            &table_map.version_root_name(&version),
+            &base,
+            committed_at_millis,
+        )
+        .await?;
+        tx.publish_named_root_at_millis(table_map.head_name(), &base, committed_at_millis)
+            .await?;
+        self.stage_table_blob_references(
+            &tx,
+            &description.id,
+            introduced_blobs.values(),
+            committed_at_millis,
+        )
+        .await?;
+        self.stage_table_snapshot_manifest(
+            &tx,
+            &description,
+            &version,
+            prepared_indexes.manifest(),
+            committed_at_millis,
+        )
+        .await?;
+        let encoded = encode_description(&description)?;
+        maps.put(CATALOG_MAP_ID, description.name.as_bytes(), encoded.clone())
+            .await?;
+        maps.put(TABLE_DESCRIPTOR_MAP_ID, description.id.0.to_vec(), encoded)
+            .await?;
+        let commit = self
+            .stage_single_table_commit(
+                &tx,
+                &description,
+                commit_id.clone(),
+                None,
+                Some(version.clone()),
+                committed_at_millis,
+            )
+            .await?;
+        match tx.commit().await? {
+            TransactionUpdate::Applied { .. } => Ok(BulkImportResult {
+                description,
+                version,
+                commit_id: commit.commit_id,
+                item_count,
+                logical_bytes,
+            }),
+            TransactionUpdate::Conflict(_) => Err(Error::ConflictExhausted),
+        }
     }
 
     /// Create one active table and its empty initial version atomically.
@@ -4264,9 +4580,59 @@ where
         client_request_token: Option<&str>,
         expected_heads: &BTreeMap<String, MapVersionId>,
     ) -> Result<TransactWriteResult> {
-        if actions.is_empty() || actions.len() > MAX_TRANSACTION_ITEMS {
+        self.transact_write_with_limits(
+            actions,
+            client_request_token,
+            expected_heads,
+            MAX_TRANSACTION_ITEMS,
+            MAX_TRANSACTION_BYTES,
+            DEFAULT_IMMUTABLE_UPLOAD_PARALLELISM,
+            "TransactWriteItems",
+        )
+        .await
+    }
+
+    /// Apply a caller-bounded set of actions as one version and one commit.
+    /// This extension requires immutable-node prepublication and is not subject
+    /// to AWS `TransactWriteItems`' 100-item/4-MiB logical envelope.
+    pub async fn write_large(
+        &self,
+        actions: Vec<TransactWriteAction>,
+        client_request_token: Option<&str>,
+        expected_heads: &BTreeMap<String, MapVersionId>,
+        options: LargeWriteOptions,
+    ) -> Result<TransactWriteResult> {
+        let options = options.validate()?;
+        if self.publication_mode != StoragePublicationMode::PrepublishImmutableNodes {
+            return Err(Error::Validation(
+                "large writes require PrepublishImmutableNodes storage publication mode".into(),
+            ));
+        }
+        self.transact_write_with_limits(
+            actions,
+            client_request_token,
+            expected_heads,
+            options.max_items,
+            options.max_logical_bytes,
+            options.blob_upload_parallelism,
+            "large write",
+        )
+        .await
+    }
+
+    async fn transact_write_with_limits(
+        &self,
+        actions: Vec<TransactWriteAction>,
+        client_request_token: Option<&str>,
+        expected_heads: &BTreeMap<String, MapVersionId>,
+        max_items: usize,
+        max_logical_bytes: usize,
+        blob_upload_parallelism: usize,
+        operation: &str,
+    ) -> Result<TransactWriteResult> {
+        if actions.is_empty() || actions.len() > max_items {
             return Err(Error::Validation(format!(
-                "TransactWriteItems requires 1..={MAX_TRANSACTION_ITEMS} actions"
+                "{operation} requires 1..={max_items} actions"
             )));
         }
         validate_client_request_token(client_request_token)?;
@@ -4405,9 +4771,18 @@ where
                     )));
                 }
                 let map_id = Self::table_map_id(&description.id);
-                let old_item = match maps.get(&map_id, &encoded_key).await? {
-                    Some(bytes) => Some(decode_item(&self.blobs.resolve(&bytes).await?)?),
-                    None => None,
+                // Unconditional Put/Delete actions do not consume the old
+                // image. Avoid one tree/blob read per action; batch mutation
+                // and index maintenance remain authoritative for replacement
+                // and deletion semantics.
+                let needs_old_item = condition.is_some()
+                    || matches!(action, TransactWriteAction::Update { .. });
+                let old_item = match needs_old_item {
+                    true => match maps.get(&map_id, &encoded_key).await? {
+                        Some(bytes) => Some(decode_item(&self.blobs.resolve(&bytes).await?)?),
+                        None => None,
+                    },
+                    false => None,
                 };
                 if let Some(condition) = condition {
                     if !condition.evaluate(old_item.as_ref())? {
@@ -4450,9 +4825,9 @@ where
                 transaction_bytes = transaction_bytes
                     .checked_add(logical_bytes)
                     .ok_or_else(|| Error::Validation("transaction item size overflow".into()))?;
-                if transaction_bytes > MAX_TRANSACTION_BYTES {
+                if transaction_bytes > max_logical_bytes {
                     return Err(Error::Validation(format!(
-                        "TransactWriteItems aggregate item size exceeds {MAX_TRANSACTION_BYTES} bytes"
+                        "{operation} aggregate item size exceeds {max_logical_bytes} bytes"
                     )));
                 }
                 if let Some(mutation) = mutation {
@@ -4495,10 +4870,9 @@ where
                 let description = descriptions
                     .get(&table)
                     .expect("validated table description");
-                let mut prepared = Vec::with_capacity(mutations.len());
-                let mut indexed_mutations = Vec::with_capacity(mutations.len());
-                for mutation in mutations {
-                    match mutation {
+                let prepared_pairs = stream::iter(mutations)
+                    .map(|mutation| async move {
+                        Ok::<_, Error>(match mutation {
                         PendingMutation::Upsert { key, item } => {
                             let stored_item = self.blobs.prepare(encode_item(&item)?).await?;
                             let index_source = prepare_index_source_record(
@@ -4508,21 +4882,28 @@ where
                                 &self.blobs,
                             )
                             .await?;
-                            prepared.push(Mutation::Upsert {
-                                key: key.clone(),
-                                val: stored_item,
-                            });
-                            indexed_mutations.push(Mutation::Upsert {
-                                key,
-                                val: index_source,
-                            });
+                            (
+                                Mutation::Upsert {
+                                    key: key.clone(),
+                                    val: stored_item,
+                                },
+                                Mutation::Upsert {
+                                    key,
+                                    val: index_source,
+                                },
+                            )
                         }
-                        PendingMutation::Delete { key } => {
-                            prepared.push(Mutation::Delete { key: key.clone() });
-                            indexed_mutations.push(Mutation::Delete { key });
-                        }
-                    }
-                }
+                        PendingMutation::Delete { key } => (
+                            Mutation::Delete { key: key.clone() },
+                            Mutation::Delete { key },
+                        ),
+                    })
+                    })
+                    .buffer_unordered(blob_upload_parallelism)
+                    .try_collect::<Vec<_>>()
+                    .await?;
+                let (prepared, indexed_mutations): (Vec<_>, Vec<_>) =
+                    prepared_pairs.into_iter().unzip();
                 let before = before_versions[&table].clone();
                 let Some(after) = self
                     .stage_indexed_table_mutations(

--- a/dynamodb/core/src/lib.rs
+++ b/dynamodb/core/src/lib.rs
@@ -11,10 +11,11 @@ mod model;
 
 pub use blob::{BlobFuture, BlobStorage, InlineBlobStorage};
 pub use database::{
-    BatchGetResult, BatchGetTableRequest, BatchGetTableResult, BatchWriteAction,
+    BatchGetResult, BatchGetTableRequest, BatchGetTableResult, BatchWriteAction, BulkImportOptions,
+    BulkImportResult,
     BatchWriteExecutionError, BatchWriteResult, BatchWriteTransition, Clock, CommitId, Database,
     GcExecutionRecord, GcExecutionResult, GcExecutionState, IdGenerator, ImportAuditRecord,
-    ImportPlan, ImportPlanId, ImportResult, IndexQueryRequest, IndexReadPage,
+    ImportPlan, ImportPlanId, ImportResult, IndexQueryRequest, IndexReadPage, LargeWriteOptions,
     IndexReconfigurationAuditRecord, IndexReconfigurationPlan, IndexReconfigurationPlanId,
     IndexReconfigurationResult, ItemRead, ItemUpdate, ItemWrite, MaintenanceContext,
     MaintenanceLease, MaintenanceLeaseId, MaintenanceLeaseRelease, ReadPage, RestoreResult,
@@ -28,7 +29,10 @@ pub use database::{
     MAX_BATCH_WRITE_ITEMS, MAX_COLLECTED_DIFF_ITEMS, MAX_COLLECTED_VERSIONS, MAX_COMMIT_PAGE_ITEMS,
     MAX_DIFF_PAGE_ITEMS, MAX_GC_PLAN_DELETES, MAX_LOGICAL_RETRY_LIMIT,
     MAX_MAINTENANCE_LEASE_MILLIS, MAX_RETENTION_PROTECTED_VERSIONS, MAX_RETENTION_REMOVALS,
-    MAX_TRANSACTION_BYTES, MAX_TRANSACTION_ITEMS, MAX_VERSION_PAGE_ITEMS, MAX_WORKER_LEASE_MILLIS,
+    DEFAULT_BULK_IMPORT_MAX_BYTES, DEFAULT_BULK_IMPORT_MAX_ITEMS,
+    DEFAULT_IMMUTABLE_UPLOAD_PARALLELISM, DEFAULT_LARGE_WRITE_MAX_BYTES,
+    DEFAULT_LARGE_WRITE_MAX_ITEMS, MAX_IMMUTABLE_UPLOAD_PARALLELISM, MAX_TRANSACTION_BYTES,
+    MAX_TRANSACTION_ITEMS, MAX_VERSION_PAGE_ITEMS, MAX_WORKER_LEASE_MILLIS,
     MIN_MAINTENANCE_LEASE_MILLIS, MIN_WORKER_LEASE_MILLIS, TTL_MAX_PAST_SECONDS,
 };
 pub use error::{Error, Result};

--- a/dynamodb/core/tests/core_contract.rs
+++ b/dynamodb/core/tests/core_contract.rs
@@ -14,12 +14,131 @@ use prolly::{
 use prolly_dynamodb_core::{
     encode_item, encode_primary_key, item_size, parse_key_condition, parse_projection,
     parse_update, AttributeValue, BatchGetTableRequest, BatchWriteAction, BatchWriteExecutionError,
-    BlobFuture, BlobStorage, Clock, Condition, Database, DatabaseFormatRecord, DynamoNumber,
-    IdGenerator, IndexQueryRequest, Item, KeyAttribute, KeyCondition, KeyKind, LargeValueConfig,
-    MaintenanceContext, Result, RetentionPolicy, SecondaryIndexDefinition, SecondaryIndexKind,
-    SecondaryIndexProjection, StoragePublicationMode, TableArchive, TableArchiveLimits, TableId,
-    TransactGetRequest, TransactWriteAction, TransactionCancellationCode,
+    BlobFuture, BlobStorage, BulkImportOptions, Clock, Condition, Database, DatabaseFormatRecord,
+    DynamoNumber, IdGenerator, IndexQueryRequest, Item, KeyAttribute, KeyCondition, KeyKind,
+    LargeValueConfig, LargeWriteOptions, MaintenanceContext, Result, RetentionPolicy,
+    SecondaryIndexDefinition, SecondaryIndexKind, SecondaryIndexProjection,
+    StoragePublicationMode, TableArchive, TableArchiveLimits, TableId, TransactGetRequest,
+    TransactWriteAction, TransactionCancellationCode,
 };
+
+#[test]
+fn bulk_import_sorted_publishes_one_version_and_one_commit() {
+    block_on(async {
+        let database = Database::open_with_blob_storage_and_mode_and_sources(
+            SyncStoreAsAsync::new(Arc::new(MemStore::new())),
+            Config::default(),
+            Arc::new(RecordingBlobs::default()),
+            LargeValueConfig::default(),
+            StoragePublicationMode::PrepublishImmutableNodes,
+            Arc::new(WideSequenceIds::default()),
+            Arc::new(FixedClock),
+        )
+        .await
+        .unwrap();
+        let key = KeyAttribute {
+            name: "id".into(),
+            kind: KeyKind::String,
+        };
+        let items = (0..1_001)
+            .map(|index| {
+                Item::from([
+                    ("id".into(), AttributeValue::S(format!("{index:08}"))),
+                    ("value".into(), AttributeValue::S("payload".into())),
+                ])
+            })
+            .collect::<Vec<_>>();
+        let result = database
+            .bulk_import_sorted(
+                "Imported",
+                key,
+                None,
+                items.into_iter().map(Ok),
+                BulkImportOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.item_count, 1_001);
+        assert_eq!(database.versions("Imported").await.unwrap().len(), 1);
+        assert_eq!(
+            database
+                .commits("Imported", None, 10)
+                .await
+                .unwrap()
+                .commits
+                .len(),
+            1
+        );
+        let found = database
+            .get_item(
+                "Imported",
+                &Item::from([("id".into(), AttributeValue::S("00001000".into()))]),
+            )
+            .await
+            .unwrap();
+        assert!(found.is_some());
+    });
+}
+
+#[test]
+fn explicit_large_write_exceeds_aws_action_limit_in_one_commit() {
+    block_on(async {
+        let database = Database::open_with_blob_storage_and_mode_and_sources(
+            SyncStoreAsAsync::new(Arc::new(MemStore::new())),
+            Config::default(),
+            Arc::new(RecordingBlobs::default()),
+            LargeValueConfig::default(),
+            StoragePublicationMode::PrepublishImmutableNodes,
+            Arc::new(WideSequenceIds::default()),
+            Arc::new(FixedClock),
+        )
+        .await
+        .unwrap();
+        database
+            .create_table(
+                "Large",
+                KeyAttribute {
+                    name: "id".into(),
+                    kind: KeyKind::String,
+                },
+                None,
+            )
+            .await
+            .unwrap();
+        let actions = (0..101)
+            .map(|index| TransactWriteAction::Put {
+                table_name: "Large".into(),
+                item: Item::from([(
+                    "id".into(),
+                    AttributeValue::S(format!("{index:08}")),
+                )]),
+                condition: None,
+                return_failure_old: false,
+            })
+            .collect();
+        database
+            .write_large(
+                actions,
+                None,
+                &BTreeMap::new(),
+                LargeWriteOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(database.versions("Large").await.unwrap().len(), 2);
+        assert_eq!(
+            database
+                .commits("Large", None, 10)
+                .await
+                .unwrap()
+                .commits
+                .len(),
+            2
+        );
+    });
+}
 
 #[test]
 fn logical_retry_tuning_is_bounded_and_format_neutral() {

--- a/plans/019-versioned-dynamodb-client-package.md
+++ b/plans/019-versioned-dynamodb-client-package.md
@@ -2281,6 +2281,54 @@ item tables; cold/warm point reads; uniform and hot-table writers; small and
 1-MB queries; 1/10/100-item logical transactions where effective limits allow;
 and history depths from 10 to 100K transitions.
 
+### 18.1 Bulk ingestion and large commits
+
+High-cardinality migration must not be implemented as one compatible
+`PutItem` or `BatchWriteItem` call per source record. Two explicit extension
+paths preserve the compatible API while reducing version and commit count:
+
+```rust
+let imported = client
+    .bulk_import_sorted(
+        "Events",
+        KeyAttribute { name: "id".into(), kind: KeyKind::String },
+        None,
+        primary_key_sorted_items,
+        BulkImportOptions::default(),
+    )
+    .await?;
+assert_eq!(imported.item_count, 1_000_000);
+
+let mut writes = client
+    .table("Events")
+    .write_session()
+    .options(LargeWriteOptions::default())
+    .if_head(imported.version);
+writes.put(next_item)?;
+writes.delete(expired_key)?;
+let commit = writes.commit().await?;
+```
+
+`bulk_import_sorted` creates a fresh table. It consumes strictly increasing
+canonical primary keys through the memory-bounded sorted tree builder,
+prepublishes immutable nodes and blobs, and atomically exposes the catalog,
+table head, version root, index snapshot, blob registry, and one commit. Thus a
+one-million-record import creates one table version and one commit, not one
+million versions.
+
+`WriteSession` is an explicit buffered extension for an existing table. One
+successful `commit()` produces one version and one commit for all distinct
+buffered item targets. Its caller-selected `LargeWriteOptions` bounds item
+count and logical bytes. It requires `PrepublishImmutableNodes`; compatible
+`TransactWriteItems` remains limited to 100 items and 4 MiB.
+
+The optimized commit path loads the global commit catalog and all participating
+table logs with one ordered root batch. Immutable node publication is divided
+into DynamoDB's 25-request batches and bounded by the backend's
+`batch_write_parallelism`; large-value preparation overlaps up to eight
+independent content-addressed blob uploads. A final root transaction remains
+the only visibility point.
+
 ## 19. Risks and mitigations
 
 | Risk | Consequence | Mitigation |


### PR DESCRIPTION
## Summary

- add memory-bounded sorted bulk import that creates one table version and one commit
- add explicit Rust `WriteSession` for caller-bounded large atomic writes
- batch commit catalog/log root reads and skip unused old-item reads
- overlap immutable blob uploads while retaining bounded DynamoDB node batch parallelism
- add `bulk` and `large` DynamoDB Local benchmark workloads with per-API SDK metrics

## Semantics

Compatible `PutItem`, `BatchWriteItem`, and `TransactWriteItems` behavior is unchanged. The new paths are explicit client extensions and require `PrepublishImmutableNodes`.

## Verification

- 50/50 core contract tests
- complete client test suite
- client and benchmark clippy with `-D warnings`
- benchmark unit tests
- frozen public API check
- packaged-crate and downstream consumer verification

The focused core tests verify 1,001 imported records produce exactly one version/commit and 101 session actions produce exactly one additional version/commit. The benchmark can now execute the full 1M-record DynamoDB Local measurement; that long-running result is intentionally not claimed in this PR.