### PR TITLE
Add RustFS AWS CLI verification helper

### DIFF
--- a/s3/COMPLETION-AUDIT.md
+++ b/s3/COMPLETION-AUDIT.md
@@ -36,7 +36,13 @@ Status meanings:
 | Bounded streaming and retry without rereading caller bodies | **Proven** | Deterministic failure tests, 10,000-operation corpus, and 160 MiB RSS probe |
 | Retention, fsck, exact-version GC, and recoverability | **Proven** | Fault-injection tests, maintenance matrix, lease fencing, IAM drill, and physical backup/restore rehearsal |
 | Operational and release instructions | **Proven** | `README.md`, `OPERATIONS.md`, required CI workflow, dependency-security gate, and signed package rehearsal |
-| Corrected final-source 24-hour RustFS stability run | **Running** | `soak-evidence/local-20260809-24h-cleanup-v2-screen-final/soak.log`; completion requires the terminal manifest, checksums, independent verifier, 86,400 elapsed seconds, zero failed/missing workflow or cleanup records, zero restarts, and all resource bounds |
+| Corrected final-source 24-hour RustFS stability run | **Incomplete** | `soak-evidence/local-20260809-24h-cleanup-v2-screen-final/soak.log` ended at iteration 37 after the local Docker daemon stopped and the provider endpoint became unreachable. A new uninterrupted run is required. |
+
+The screen-supervised
+`local-20260809-24h-cleanup-v2-screen-final` run completed 36 valid iterations,
+then failed during iteration 37 when the local Docker daemon stopped and
+`127.0.0.1:9000` refused connections. Its evidence remains preserved as an
+incomplete diagnostic run and contributes no elapsed time to the release gate.
 
 The earlier terminal-owned
 `local-20260809-24h-cleanup-v2-final` evidence ended after 5,343 valid seconds

--- a/s3/README.md
+++ b/s3/README.md
@@ -75,6 +75,20 @@ can live in the same physical bucket under disjoint prefixes. The credentials
 in `.env.example` are local-only and must not be reused on a reachable
 deployment.
 
+Verify the live endpoint, credentials, bucket access, byte round trip, and
+exact-version cleanup using only the AWS CLI's `s3api` commands:
+
+```bash
+bash s3/scripts/verify_rustfs_aws_cli.sh
+```
+
+The verifier defaults to `prolly-versioned-s3-demo`. Override
+`PROLLY_RUSTFS_ENDPOINT`, `PROLLY_RUSTFS_ACCESS_KEY`,
+`PROLLY_RUSTFS_SECRET_KEY`, `PROLLY_RUSTFS_REGION`, or
+`PROLLY_RUSTFS_BUCKET` as needed. Its unique probe key is outside the Prolly
+repository namespace. It removes the exact probe version after a successful
+check and makes a best-effort cleanup attempt if verification fails.
+
 Stop the server without deleting data:
 
 ```bash

--- a/s3/scripts/verify_rustfs_aws_cli.sh
+++ b/s3/scripts/verify_rustfs_aws_cli.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+endpoint="${PROLLY_RUSTFS_ENDPOINT:-http://127.0.0.1:9000}"
+access_key="${PROLLY_RUSTFS_ACCESS_KEY:-prollyadmin}"
+secret_key="${PROLLY_RUSTFS_SECRET_KEY:-prolly-local-secret-change-me}"
+region="${PROLLY_RUSTFS_REGION:-us-east-1}"
+bucket="${PROLLY_RUSTFS_BUCKET:-prolly-versioned-s3-demo}"
+
+for command_name in aws curl cmp mktemp; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "required command is unavailable: $command_name" >&2
+    exit 1
+  fi
+done
+
+aws_s3api() {
+  AWS_ACCESS_KEY_ID="$access_key" \
+    AWS_SECRET_ACCESS_KEY="$secret_key" \
+    AWS_DEFAULT_REGION="$region" \
+    aws --no-cli-pager --region "$region" --endpoint-url "$endpoint" s3api "$@"
+}
+
+temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/prolly-rustfs-aws-cli.XXXXXX")"
+payload_file="$temporary_directory/payload.txt"
+download_file="$temporary_directory/download.txt"
+probe_key="manual-verification/aws-cli-$(date -u +%Y%m%dT%H%M%SZ)-$$.txt"
+probe_version_id=""
+probe_written=0
+
+delete_probe() {
+  if [[ "$probe_written" -ne 1 ]]; then
+    return
+  fi
+
+  if [[ -n "$probe_version_id" && "$probe_version_id" != "None" && "$probe_version_id" != "null" ]]; then
+    aws_s3api delete-object \
+      --bucket "$bucket" \
+      --key "$probe_key" \
+      --version-id "$probe_version_id" >/dev/null
+  else
+    aws_s3api delete-object --bucket "$bucket" --key "$probe_key" >/dev/null
+  fi
+  probe_written=0
+}
+
+cleanup() {
+  set +e
+  delete_probe
+  rm -f -- "$payload_file" "$download_file"
+  rmdir "$temporary_directory" 2>/dev/null
+}
+trap cleanup EXIT
+
+echo "Checking RustFS health at ${endpoint%/}/health"
+curl --fail --silent --show-error "${endpoint%/}/health"
+echo
+
+echo "Authenticating as $access_key and listing buckets"
+aws_s3api list-buckets --query 'Buckets[].Name' --output table
+
+echo "Checking bucket $bucket"
+aws_s3api head-bucket --bucket "$bucket"
+
+echo "Native bucket versioning configuration"
+if ! aws_s3api get-bucket-versioning --bucket "$bucket" --output json; then
+  echo "The provider did not expose GetBucketVersioning for $bucket" >&2
+fi
+
+printf 'prolly RustFS AWS CLI verification\n' >"$payload_file"
+
+echo "Writing probe s3://$bucket/$probe_key"
+probe_version_id="$(
+  aws_s3api put-object \
+    --bucket "$bucket" \
+    --key "$probe_key" \
+    --body "$payload_file" \
+    --content-type text/plain \
+    --query VersionId \
+    --output text
+)"
+probe_written=1
+
+echo "Reading probe metadata"
+aws_s3api head-object \
+  --bucket "$bucket" \
+  --key "$probe_key" \
+  --query '{ContentLength:ContentLength,ContentType:ContentType,ETag:ETag,VersionId:VersionId}' \
+  --output json
+
+echo "Downloading and comparing probe bytes"
+aws_s3api get-object --bucket "$bucket" --key "$probe_key" "$download_file" >/dev/null
+if ! cmp -s "$payload_file" "$download_file"; then
+  echo "downloaded probe does not match the uploaded bytes" >&2
+  exit 1
+fi
+
+echo "Deleting the exact probe version when the provider returned one"
+delete_probe
+
+if aws_s3api head-object --bucket "$bucket" --key "$probe_key" >/dev/null 2>&1; then
+  echo "probe is still visible after deletion" >&2
+  exit 1
+fi
+
+echo "RUSTFS_AWS_CLI_VERIFICATION_COMPLETE bucket=$bucket endpoint=$endpoint"


### PR DESCRIPTION
## Summary

- add a Bash verifier that exercises the versioned S3 endpoint with AWS CLI `s3api` operations
- document the manual RustFS credential and verification workflow
- update the completion audit with the new verification surface

## Why

PR #74 merged before this follow-up commit was pushed. This PR carries only the previously unmerged AWS CLI verification work on top of current `main`.

## Validation

- `bash -n s3/scripts/verify_rustfs_aws_cli.sh`
- `git diff --check origin/main...HEAD`