### PR TITLE
Reduce versioned S3 request amplification

### DIFF
--- a/.github/workflows/versioned-s3-client-required.yml
+++ b/.github/workflows/versioned-s3-client-required.yml
@@ -51,8 +51,11 @@ jobs:
           -- --skip seeded_histories_are_identical_across_stores_and_restart
       - name: Independent canonical-format verifier
         run: python3 extensions/s3/fixtures/verify_canonical_v1.py
-      - name: Soak evidence verifier contracts
-        run: python3 -m unittest s3.scripts.tests.test_verify_soak_evidence
+      - name: Qualification evidence verifier contracts
+        run: |
+          python3 -m unittest discover -s extensions/s3/scripts/tests -p 'test_*.py'
+          python3 extensions/s3/scripts/verify_production_limits.py \
+            --profile aws-release --validate-limits
 
   msrv-and-downstream:
     runs-on: ubuntu-24.04

--- a/extensions/s3/COMPLETION-AUDIT.md
+++ b/extensions/s3/COMPLETION-AUDIT.md
@@ -69,7 +69,7 @@ final run.
 | SlateDB loss affects performance only | **Proven** | Complete live cache deletion/rebuild with unchanged canonical snapshot |
 | Clone, fsck, retention, GC, sweep, and recovery are bounded and rehearsed | **Proven** | Cross-repository, maintenance, fault, IAM, and backup/restore matrices |
 | GC protects active leases and exact-deletes native physical versions | **Proven** | Lease-fencing tests and live exact-version deletion/sweep evidence |
-| Resource use and provider amplification are measured | **Proven** | Published cost matrices, contention tiers, RSS probe, and qualification baselines |
+| Resource use and provider amplification are measured and regression-bounded | **Proven locally** | Published cost matrices, checked-in request budgets, fail-closed 1/8/32 contention tiers, RSS probe, and qualification baselines; AWS release evidence remains external |
 | Open starts no hidden worker | **Proven** | API/lifecycle implementation audit and read-only namespace snapshot |
 | Clean downstream packages compile at declared toolchains/dependencies | **Proven** | Rust 1.89 core, Rust 1.94.1 client, newest-line check, offline exact-pair package rehearsal |
 | Upgrade and rollback are negotiated and tested | **Proven** | New→legacy→new packaged rolling rehearsal and fail-closed future-format fixtures |

--- a/extensions/s3/OPERATIONS.md
+++ b/extensions/s3/OPERATIONS.md
@@ -75,7 +75,11 @@ Run these against a reopened client:
    `fsck()` explicitly rather than on client open.
 4. Snapshot `s3_operation_metrics()` around representative operations. These
    count object-plane SDK calls and body bytes, not Smithy-internal retries.
-5. Alert on `ProviderNotQualified`, `Corrupt*`, `MissingClosure`, sustained
+5. Compare operation snapshots and wire-attempt metrics with
+   `qualification/production-limits-v1.json`. Alert before sustained traffic
+   reaches a request, retry, or latency release ceiling; do not cancel an
+   in-flight mutation merely because a budget is crossed.
+6. Alert on `ProviderNotQualified`, `Corrupt*`, `MissingClosure`, sustained
    `RefConflict`, `OutcomeUnknown`, or a `Running` GC fence without an owner.
 
 ## Ambiguous mutation outcome
@@ -288,6 +292,28 @@ PROLLY_S3_SOAK_RUN_ID=release-YYYYMMDD \
 PROLLY_S3_SOAK_EVIDENCE_DIR=/Volumes/Workspace/prolly-build/versioned-s3/soak-evidence/release-YYYYMMDD \
   bash extensions/s3/scripts/run_rustfs_soak.sh
 ```
+
+The RustFS cost and contention runners enforce
+`qualification/production-limits-v1.json` automatically. Do not preserve only
+the Cargo result: preserve the `PRODUCTION_COST_LIMITS_VERIFIED` and
+`PRODUCTION_CONTENTION_LIMITS_VERIFIED` records too.
+
+For AWS promotion, provide all five evidence inputs and run the fail-closed
+aggregate verifier:
+
+```bash
+PROLLY_S3_AWS_COST_LOG=/evidence/cost.log \
+PROLLY_S3_AWS_CONTENTION_LOG=/evidence/contention.log \
+PROLLY_S3_AWS_LOAD_LOG=/evidence/load.log \
+PROLLY_S3_AWS_SCALE_LOG=/evidence/scale.log \
+PROLLY_S3_AWS_REQUEST_PRICES=/evidence/request-prices.json \
+  bash extensions/s3/scripts/verify_aws_release_limits.sh
+```
+
+The request-price JSON must contain exactly the numeric keys `get`, `head`,
+`put`, `list`, `list_versions`, and `delete`, expressed in USD per 1,000
+requests for the qualification region. Archive its source and effective date
+with the signed release evidence.
 
 Also attach real-AWS qualification, wire-level retry/request telemetry,
 release-topology cost and SlateDB HTTP-correlation measurements, IAM simulator

--- a/extensions/s3/QUALIFICATION.md
+++ b/extensions/s3/QUALIFICATION.md
@@ -110,7 +110,7 @@ It is not a production attestation.
   classes, and attempts without a response. A deterministic local server
   returned 503 then 200; the fixture observed exactly one execution, two wire
   transmissions, one retry, one server-error response, and one success. The
-  refreshed ordinary RustFS probe observed 1,134 executions/transmissions for
+  refreshed ordinary RustFS probe observed 554 executions/transmissions for
   writes and 100 for reads, with zero SDK retry transmissions.
 - S3-shaped cost matrix: 17 measured object rows covered put/head/current and
   historical get/object and version listing/copy/single and atomic
@@ -119,7 +119,7 @@ It is not a production attestation.
   call mix, actual transmissions/retries, transferred body bytes, and exact
   physical-version storage growth through a separate uninstrumented accounting
   client; all rows completed with zero SDK retries and final fsck passed.
-- Repository maintenance cost matrix: 24 additional rows ran in an isolated
+- Repository maintenance cost matrix: 23 additional rows ran in an isolated
   physically versioned bucket and covered head/log, branch/tag/retention-pin
   administration, reflog/native-ref history, diff/merge planning/merge,
   restore/reset, commit and repository fsck, plus a GC reclaim plan and actual
@@ -127,9 +127,9 @@ It is not a production attestation.
   reported issued calls, actual transmissions, transferred bytes, latency, and
   physical-version storage growth; all rows completed with zero SDK retries.
 - Cross-repository cost matrix: four rows covered qualified clone, ordinary
-  fetch, resumable fetch, and push. Clone exposed 71 object-plane calls plus
+  fetch, resumable fetch, and push. Clone exposed 70 object-plane calls plus
   three explicitly classified provider control-plane qualification requests;
-  fetch/resumable-fetch/push issued 84/111/130 object-plane calls in the
+  fetch/resumable-fetch/push issued 84/109/122 object-plane calls in the
   measured fixture. Both source and destination metrics were aggregated and
   every row completed with zero SDK retries and final fsck on both sides.
 - Advisory rebuild cost matrix: one row rebuilt nine branch heads while
@@ -211,18 +211,18 @@ These are host-specific observations, not service-level objectives.
 | Workload | Observation |
 | --- | --- |
 | Deterministic engine corpus | Final audited source on Rust 1.89.0: 10,000 paired logical mutations in 1,102.53 s; 9.07 paired mutations/s; retained dual-store history used roughly 2.5 GiB RSS near completion |
-| RustFS ordinary sequential | Refreshed instrumented run, 20 × 64 KiB: 10.061 s writes (1.988 puts/s), 0.188 s reads (106.469 gets/s). Writes issued 1,134 object-plane SDK calls (56.70/op), uploaded 1.182× logical bytes, and downloaded 1.175×; reads issued 100 calls (5/op) and downloaded 1.016×. The Smithy interceptor observed the same 1,134/100 wire transmissions and zero SDK retries. |
-| RustFS S3-shaped cost matrix | Serialized runner observations: 64 KiB put: 51 calls and roughly +69.6 KiB of physical-version bytes; head/list/list-versions: 2 calls each, no storage growth; current/historical 64 KiB get: 5 calls and about 1.016× download each; zero-copy copy: 44 calls; delete: 39 calls; two-key delete: 47 calls; multipart create/upload/list-parts/list-uploads 2/10/2/4 calls; complete varied from 61–71 calls as generated catalog/tree identifiers crossed chunk boundaries; abort: 4 calls; part-copy: 13 calls; two-object 128 KiB atomic commit varied from 74–84 calls and approximately 1.125–1.128× upload. Zero SDK retries throughout. |
-| RustFS repository maintenance matrix | Serialized 24-row physically versioned run: head/log/list-branches 1/4/3 calls; branch create/delete 11/4; tag create/list/delete 11/2/4; retention-pin create/list/delete 11/2/3; diff/merge-bases/plan-merge 2/8/13; merge/restore/reset 63/58/18; reflog/native-ref versions 7/7; commit/repository fsck 21/28. A known 1 KiB unreachable content closure produced a 16-call GC plan and a 29-call exact-version sweep (three deletes, −969 physical bytes), followed by successful fsck. Zero SDK retries throughout. |
-| RustFS cross-repository matrix | Qualified clone: 71 object-plane calls plus three provider control-plane calls, 1.053× upload and 1.042× download relative to 13,433 immutable bytes; ordinary fetch/resumable fetch/push: 84/111/130 calls and +6,982/+7,888/+898 physical bytes. Zero SDK retries; source and destination fsck passed. |
+| RustFS ordinary sequential | Refreshed instrumented run after publication batching and CAS readback removal, 20 × 64 KiB: 2.125 s writes (9.413 puts/s), 0.241 s reads (82.847 gets/s). Writes issued 554 object-plane SDK calls (27.70/op), uploaded 1.151× logical bytes, and downloaded 1.141×; reads issued 100 calls (5/op) and downloaded 1.016×. The Smithy interceptor observed the same 554/100 wire transmissions and zero SDK retries. |
+| RustFS S3-shaped cost matrix | Serialized runner observations after publication batching and CAS readback removal: 64 KiB put: 22 calls and +67.9 KiB of physical-version bytes; head/list/list-versions: 2 calls each, no storage growth; current/historical 64 KiB get: 5 calls and about 1.016× download each; zero-copy copy: 24 calls; delete: 19 calls; two-key delete: 21 calls; multipart create/upload/list-parts/list-uploads 1/9/2/4 calls; complete: 33 calls; abort: 3 calls; part-copy: 9 calls; two-object 128 KiB atomic commit: 43 calls and approximately 1.112× upload. Zero SDK retries throughout. |
+| RustFS repository maintenance matrix | Serialized physically versioned run after the same optimization: head/log/list-branches 1/4/3 calls; branch create/delete 7/3; tag create/list/delete 7/2/3; retention-pin create/list/delete 7/2/2; diff/merge-bases/plan-merge 2/8/13; merge/restore/reset 40/29/10; reflog/native-ref versions 7/7; commit/repository fsck 21/28. A known 1 KiB unreachable content closure produced a 16-call GC plan and a 27-call exact-version sweep (three deletes, −969 physical bytes), followed by successful fsck. Zero SDK retries throughout. |
+| RustFS cross-repository matrix | Qualified clone: 70 object-plane calls plus three provider control-plane calls, 1.054× upload and 1.023× download relative to 13,462 immutable bytes; ordinary fetch/resumable fetch/push: 84/109/122 calls and +6,974/+8,053/+1,505 physical bytes. Zero SDK retries; source and destination fsck passed. |
 | RustFS SlateDB advisory rebuild | Nine canonical branch heads plus one corrupt cache entry: 10 canonical SDK calls/transmissions, zero retries, and 1.277–1.299 s elapsed. Across the serialized and race-hardened reruns, the separately counted SlateDB stack issued 19 `object_store` API calls (13 puts, four gets, two lists), uploaded 5,545–5,625 bytes, returned 164 bytes, and added the same 5,545–5,625 physical-version bytes across authority and cache prefixes. A body-blind dedicated proxy correlated the full lifecycle one-to-one: 125 API calls and 125 HTTP attempts (91 GET, nine HEAD, 25 PUT), 125 unique RustFS request IDs, 84 successes, and 41 expected discovery misses with no unexpected response class. |
 | RustFS accepted-CAS active-outage matrix | Eight serial workflows covered ordinary put, two-parent merge, multipart completion, atomic workspace publication, atomic multi-delete, restore, administrative reset, and branch tombstone. Every accepted ref-CAS response was discarded before a RustFS restart, followed by four consecutive authenticated readiness probes. The 41 s run issued 375 first-attempt SDK calls with zero wire retries; eight restarts used 30.232 s and provider data grew 1,296 KiB. Operation-bearing workflows reconciled one bucket commit with coordination-only replay growth; ref-only reset/delete replay created zero physical versions or commits. Exact operation/ref/tombstone state, payloads, delete markers, merge parents, reflogs, and fsck passed. |
 | RustFS IAM/credential rotation | Generated prefix-only runtime policy; five denied cross-prefix/delete/versioning probes; old/new overlap publication; old-key disable mapped to non-retryable `PermissionDenied`; three payload rereads, four-commit history, enabled bucket versioning, fsck, and removal of two users plus one policy. Completed in 23 s with +328 KiB provider data. RustFS beta.10 aliases native-version list/read to ordinary list/get grants, so the local runtime role is recovery-read capable. |
 | RustFS physical backup/restore | Stable 112-version source inventory archived as 111 hashed bodies plus one delete-marker record and a canonical hashed manifest (21,769 body bytes). Replay reconstructed 112 versions in a fresh versioned bucket; independent qualification preserved repository identity, main/feature/tag and logical historical reads, three native ref revisions, post-restore publication, and fsck. Three generated buckets were exact-version cleaned. Completed in 16 s with +2,940 KiB provider-directory growth. |
 | RustFS signed packaged rolling rehearsal | Cargo produced the exact `prolly-s3-core` and `prolly-s3-client` archives; an offline extracted-pair check prevented registry sibling substitution before current and field-absent legacy binaries were built from those archives. The mandatory dependency gate excluded legacy TLS and unused Foyer/Bincode/Paste paths and allowed only the documented unmaintained canonical-codec advisory. New→legacy→new publication, dual fsck, six exact `UnsupportedRepositoryFormat` rejections, and unchanged physical snapshots passed. The final-source signed twelve-artifact set includes the dependency policy/result and reverified with manifest SHA-256 `259fb064b4615e79ec433ab9d4feb47f55e384f1fa6c611753f74f18ac18a39b`. Local signer/source state was explicitly ephemeral/dirty. |
-| RustFS hot branch, 1 writer | p50/p95/p99/max 265.583 ms; 51 issued object-plane calls/write |
-| RustFS hot branch, 8 writers | p50 2,447.503 ms; p95/p99/max 3,901.975 ms; 170 issued calls/write |
-| RustFS hot branch, 32 writers | p50 30,452.888 ms; p95 37,216.516 ms; p99/max 37,351.528 ms; 579.5 issued calls/write |
+| RustFS hot branch, 1 writer | p50/p95/p99/max 103.711 ms; 22 issued object-plane calls/write |
+| RustFS hot branch, 8 writers | p50 814.523 ms; p95/p99/max 1,278.292 ms; 81.5 issued calls/write |
+| RustFS hot branch, 32 writers | p50 9,158.176 ms; p95 13,664.870 ms; p99/max 13,916.339 ms; 301.312 issued calls/write |
 | RustFS streamed multipart | Final-source 160 MiB upload + streamed read in 29.57 s; 107,921,408-byte maximum RSS; prior 8,830,976-byte no-op baseline retained as measurement context |
 
 The single-node RustFS development profile is supported through 32 concurrent
@@ -230,6 +230,61 @@ hot-branch writers. A 128-writer pressure attempt encountered provider 503s and
 did not converge within 3.5 minutes even with idempotent reconciliation, so 128
 is not a qualified tier for this profile. The checked-in probe now has a hard
 per-tier deadline and higher tiers are opt-in.
+
+## Enforced qualification limits
+
+`qualification/production-limits-v1.json` is the machine-readable release
+contract. The RustFS cost and contention runners feed their structured output
+to `scripts/verify_production_limits.py`; a successful Cargo exit without the
+required evidence rows is a failure. Every cost-matrix operation has an
+explicit SDK-call ceiling, and an unexpected or missing operation also fails.
+
+The highest-risk request ceilings are:
+
+| Logical operation | Maximum SDK calls | Maximum modeled request cost per 1,000 logical operations |
+| --- | ---: | ---: |
+| 64 KiB put | 55 | $0.25 |
+| Current or historical get | 6 | $0.005 |
+| Two-object atomic commit | 90 | $0.30 |
+| Multipart completion | 80 | $0.25 |
+| Merge | 70 | $0.25 |
+| Restore | 65 | $0.25 |
+| Push | 150 | $0.40 |
+
+Request cost is calculated from the observed GET, HEAD, PUT, LIST,
+ListVersions, and DELETE counts and a release-supplied JSON file containing the
+current per-1,000 request prices for the qualification region. Prices are not
+hard-coded because provider and regional prices change. The AWS verifier
+rejects missing prices.
+
+The RustFS regression tiers cap p95/calls per write at 750 ms/70 for one
+writer, 6 seconds/220 for eight writers, and 50 seconds/650 for 32 writers,
+with zero transport retries. The AWS release tiers are 2 seconds/70,
+20 seconds/220, and 60 seconds/650, with at most a 1% wire-retry rate. The
+contention probe uses the public logical retry maximum of 16 plus its existing
+bounded, operation-ID-preserving reconciliation loop; the configured retry
+limit is included in the evidence and must match the contract.
+
+AWS promotion additionally requires aggregate `LOAD_QUALIFICATION` evidence
+for put, current and historical get, atomic commit, multipart completion,
+merge, restore, and push. Each record includes sample count, p95 latency,
+terminal error rate, throttle rate, and modeled request cost. The scale record
+must prove at least 1 million live keys, 10 million retained versions,
+10,000 metadata files/second bulk loading, cold-read p95 at or below 200 ms,
+writable reopen within 30 seconds, and memory below 4 GiB. These are release
+gates, not claims established by the local RustFS profile.
+
+After producing dated AWS evidence and a regional price file, verify the whole
+profile with:
+
+```bash
+PROLLY_S3_AWS_COST_LOG=/evidence/cost.log \
+PROLLY_S3_AWS_CONTENTION_LOG=/evidence/contention.log \
+PROLLY_S3_AWS_LOAD_LOG=/evidence/load.log \
+PROLLY_S3_AWS_SCALE_LOG=/evidence/scale.log \
+PROLLY_S3_AWS_REQUEST_PRICES=/evidence/request-prices.json \
+  bash extensions/s3/scripts/verify_aws_release_limits.sh
+```
 
 ## Gates intentionally still open
 

--- a/extensions/s3/README.md
+++ b/extensions/s3/README.md
@@ -259,13 +259,13 @@ The v1 contract favors correctness and recoverability over raw single-object thr
 | Logical deletion | Selected logical-version deletion is not supported |
 | Write cost | One logical write creates immutable metadata and publishes a ref; it is not one physical `PutObject` |
 | Hot-branch concurrency | Writers contend on one branch ref; use branches or batch related work when possible |
-| Keyspace scale | Trees and APIs are paged, but a million-object production workload has not been qualified |
+| Keyspace scale | AWS release evidence must prove at least 1 million live keys and 10 million retained logical versions; ordinary tests do not satisfy this gate |
 | Background work | `open()` starts no workers; multipart expiry, integrity checks, index rebuild, and garbage collection are explicit |
 | Garbage collection | Requires a persisted dry run and a separately approved, fenced sweep |
 | Native bucket versioning | Optional for correctness; recommended for native ref-recovery history |
 | Production status | Local RustFS evidence exists; AWS, release-topology soak, IAM, cost, and recovery gates remain open |
 
-The measured local cost explains why small sequential writes are slower than raw S3. A 64 KiB put used 51 object-plane calls in the RustFS cost matrix. A separate 20-write sequential run averaged 1.988 writes per second with zero SDK retries. These numbers describe one local single-node setup, not a service-level objective. See [measured development baselines](QUALIFICATION.md#measured-development-baselines) for the complete call, byte, contention, and memory data.
+The measured local cost explains why small sequential writes are still slower than raw S3. Publication-protection batching and removal of successful-CAS readbacks reduced a 64 KiB put from 51 to 22 object-plane calls in the RustFS cost matrix. A separate 20-write sequential run averaged 9.413 writes per second and 27.70 calls per write as the state trees grew, with zero SDK retries. These numbers describe one local single-node setup, not a service-level objective. The checked-in [production limits](qualification/production-limits-v1.json) turn request amplification, hot-branch latency, AWS request cost, and the one-million-key tier into fail-closed release gates. See [measured development baselines](QUALIFICATION.md#measured-development-baselines) for the observations and [enforced qualification limits](QUALIFICATION.md#enforced-qualification-limits) for the ceilings.
 
 ## Operate it safely
 

--- a/extensions/s3/SLATEDB-NODE-STORE-DESIGN.md
+++ b/extensions/s3/SLATEDB-NODE-STORE-DESIGN.md
@@ -51,8 +51,9 @@ The current S3 store maps each 32-byte node CID to one immutable object:
 
 A one-key versioned write updates the objects, versions, and operations trees,
 and a non-empty payload also builds a content chunk-index tree. At scale, a
-point mutation rewrites a root-to-leaf path in each affected tree. The current
-64 KiB qualification result is 51 object-plane calls for one ordinary write.
+point mutation rewrites a root-to-leaf path in each affected tree. Publication
+batching and CAS readback removal reduced the current 64 KiB qualification
+result from 51 to 22 object-plane calls for one ordinary write.
 
 SlateDB can pack many immutable Prolly nodes into WAL and compacted SST files:
 
@@ -750,9 +751,10 @@ production data until Phase 8 completes.
 
 #### Context
 
-The existing 51-call write result measures the whole S3-shaped operation, not
-only Prolly-node traffic. Without a node-specific baseline, adoption could add
-compaction complexity while failing to improve the dominant cost.
+The former 51-call and current 22-call write results measure the whole
+S3-shaped operation, not only Prolly-node traffic. Without a node-specific
+baseline, adoption could add compaction complexity while failing to improve
+the dominant cost.
 
 #### Work
 

--- a/extensions/s3/client/src/aws_object.rs
+++ b/extensions/s3/client/src/aws_object.rs
@@ -271,9 +271,11 @@ impl ObjectPlane for AwsS3ObjectPlane {
 
     async fn compare_exchange(&self, request: CompareExchange) -> Result<CompareExchangeOutcome> {
         self.metrics.put_object.fetch_add(1, Ordering::Relaxed);
+        let len = request.bytes.len() as u64;
+        let sha256: [u8; 32] = Sha256::digest(&request.bytes).into();
         self.metrics
             .uploaded_body_bytes
-            .fetch_add(request.bytes.len() as u64, Ordering::Relaxed);
+            .fetch_add(len, Ordering::Relaxed);
         let mut operation = self
             .client
             .put_object()
@@ -287,20 +289,22 @@ impl ObjectPlane for AwsS3ObjectPlane {
         };
         match operation.send().await {
             Ok(output) => {
-                let current = self.get_current(&request.path).await?.ok_or_else(|| {
+                let etag = output.e_tag().ok_or_else(|| {
                     Error::new(
                         ErrorCode::OutcomeUnknown,
-                        "CAS was accepted but the new value is not readable",
+                        "CAS was accepted but the provider omitted its ETag",
                     )
                 })?;
-                let mut metadata = current.metadata;
-                if let Some(etag) = output.e_tag() {
-                    metadata.token.etag = etag.to_string();
-                }
-                if output.version_id().is_some() {
-                    metadata.token.version_id = output.version_id().map(ToString::to_string);
-                }
-                Ok(CompareExchangeOutcome::Applied(metadata))
+                Ok(CompareExchangeOutcome::Applied(StoredMetadata {
+                    token: StorageToken {
+                        etag: etag.to_string(),
+                        version_id: output.version_id().map(ToString::to_string),
+                    },
+                    len,
+                    sha256,
+                    last_modified_millis: 0,
+                    delete_marker: false,
+                }))
             }
             Err(error) if is_precondition_failed(&error) => Ok(CompareExchangeOutcome::Conflict(
                 self.get_current(&request.path).await?,

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -30,7 +30,7 @@ use prolly_s3_client::{
         GetRequest, ImmutablePut, ImmutablePutOutcome, ListRequest, MergePolicy, MultipartStateV1,
         MultipartUploadV1, ObjectHeaders, ObjectPath, ObjectPlane, ObjectVersionKindV1,
         OperationId, PhysicalListPage, PhysicalVersion, PhysicalVersioning, Repository,
-        RepositoryOptions, RetryAdvice, StoredMetadata, StoredObject,
+        RepositoryOptions, RetryAdvice, StoredMetadata, StoredObject, MAX_LOGICAL_RETRY_LIMIT,
     },
     AwsS3ObjectPlane, Client, HmacAttestationSigner, HmacTokenSigner, ProviderIdentity,
     S3OperationMetrics, S3WireAttemptInterceptor, S3WireAttemptMetrics, WriteOptions,
@@ -2485,19 +2485,20 @@ async fn rustfs_contention_latency_probe() {
         .parse()
         .expect("PROLLY_S3_CONTENTION_DEADLINE_SECONDS must be an integer");
     assert!(deadline_seconds > 0);
-    let (aws, bucket) = rustfs_client().await;
+    let (aws, bucket, wire_metrics) = rustfs_client_with_wire_metrics().await;
     let client = Client::builder()
         .aws_client(aws)
         .bucket(&bucket)
         .repository_prefix(unique_prefix("contention-latency"))
         .writer(format!("contention-{writers}"))
-        .logical_retry_limit(u8::MAX)
+        .logical_retry_limit(MAX_LOGICAL_RETRY_LIMIT)
         .provider_identity(rustfs_provider_identity())
         .attestation_signer(test_attestation_signer())
         .initialize()
         .await
         .unwrap();
     client.reset_s3_operation_metrics();
+    wire_metrics.reset();
     let barrier = Arc::new(Barrier::new(writers));
     let tasks = (0..writers)
         .map(|writer| {
@@ -2571,15 +2572,19 @@ async fn rustfs_contention_latency_probe() {
         latencies[index.min(latencies.len() - 1)]
     };
     let metrics = client.reset_s3_operation_metrics();
+    let wire = wire_metrics.reset();
+    assert_eq!(wire.executions, metrics.total_calls());
     client.fsck().await.unwrap();
     eprintln!(
-        "CONTENTION_PROBE writers={writers} p50_ms={:.3} p95_ms={:.3} p99_ms={:.3} max_ms={:.3} sdk_calls={} calls_per_write={:.3} get={} head={} put={} list={} list_versions={} delete={} uploaded_bytes={} downloaded_bytes={}",
+        "CONTENTION_PROBE writers={writers} logical_retry_limit={MAX_LOGICAL_RETRY_LIMIT} p50_ms={:.3} p95_ms={:.3} p99_ms={:.3} max_ms={:.3} sdk_calls={} calls_per_write={:.3} wire_transmissions={} wire_retries={} get={} head={} put={} list={} list_versions={} delete={} uploaded_bytes={} downloaded_bytes={}",
         percentile(50, 100),
         percentile(95, 100),
         percentile(99, 100),
         latencies[latencies.len() - 1],
         metrics.total_calls(),
         metrics.total_calls() as f64 / writers as f64,
+        wire.transmissions,
+        wire.retry_transmissions(),
         metrics.get_object,
         metrics.head_object,
         metrics.put_object,
@@ -6117,6 +6122,7 @@ async fn rustfs_conditional_object_plane_conformance() {
     ));
 
     let ref_path = ObjectPath::new(format!("{prefix}/ref")).unwrap();
+    plane.reset_metrics();
     let created = match plane
         .compare_exchange(CompareExchange {
             path: ref_path.clone(),
@@ -6129,6 +6135,9 @@ async fn rustfs_conditional_object_plane_conformance() {
         CompareExchangeOutcome::Applied(metadata) => metadata,
         other => panic!("unexpected create result: {other:?}"),
     };
+    let create_metrics = plane.reset_metrics();
+    assert_eq!(create_metrics.put_object, 1);
+    assert_eq!(create_metrics.get_object, 0);
 
     let tasks = (0..32)
         .map(|writer| {
@@ -6156,6 +6165,9 @@ async fn rustfs_conditional_object_plane_conformance() {
     }
     assert_eq!(applied, 1);
     assert_eq!(conflicts, 31);
+    let update_metrics = plane.reset_metrics();
+    assert_eq!(update_metrics.put_object, 32);
+    assert_eq!(update_metrics.get_object, 31);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/extensions/s3/core/src/protection.rs
+++ b/extensions/s3/core/src/protection.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 
 use tokio::sync::Mutex;
 
@@ -11,12 +11,21 @@ use crate::{
 
 #[async_trait::async_trait]
 pub trait ProtectionSink: Send + Sync {
+    /// Adds a physical path to the current bounded protection segment.
+    ///
+    /// The publication coordinator, which owns the concrete lease, is
+    /// responsible for durably flushing the segment before moving a ref.
     async fn protect(&self, path: ObjectPath) -> Result<()>;
 }
+
+const MAX_PROTECTION_SEGMENT_PATHS: usize = 1_024;
+const PROTECTION_FLUSH_INTERVAL_DIVISOR: u64 = 4;
 
 struct LeaseRuntime {
     value: PublicationLeaseV1,
     token: StorageToken,
+    pending_paths: BTreeSet<ObjectPath>,
+    pending_since_millis: Option<u64>,
 }
 
 pub struct PublicationLease<P: ObjectPlane> {
@@ -124,7 +133,12 @@ impl<P: ObjectPlane> PublicationLease<P> {
             prefix,
             ttl_millis,
             clock,
-            runtime: Arc::new(Mutex::new(LeaseRuntime { value, token })),
+            runtime: Arc::new(Mutex::new(LeaseRuntime {
+                value,
+                token,
+                pending_paths: BTreeSet::new(),
+                pending_since_millis: None,
+            })),
         })
     }
 
@@ -160,6 +174,7 @@ impl<P: ObjectPlane> PublicationLease<P> {
     }
 
     pub async fn complete(&self, commit: CommitId) -> Result<()> {
+        self.flush_protection().await?;
         self.update(|value, _| {
             match value.state {
                 PublicationLeaseStateV1::Completed { commit: existing } if existing == commit => {
@@ -195,6 +210,88 @@ impl<P: ObjectPlane> PublicationLease<P> {
 
     pub async fn snapshot(&self) -> PublicationLeaseV1 {
         self.runtime.lock().await.value.clone()
+    }
+
+    /// Durably links every buffered physical path into the publication lease.
+    ///
+    /// Repository publication must call this before moving a branch ref. The
+    /// regular write path also flushes automatically when a segment reaches
+    /// 1,024 paths or a subsequent path observes that the derived flush
+    /// interval elapsed.
+    pub async fn flush_protection(&self) -> Result<()> {
+        let mut runtime = self.runtime.lock().await;
+        if runtime.pending_paths.is_empty() {
+            return Ok(());
+        }
+        let now = self.clock.now_millis()?;
+        self.ensure_runtime_active(&runtime, now)?;
+        self.flush_locked(&mut runtime, now).await
+    }
+
+    fn ensure_runtime_active(&self, runtime: &LeaseRuntime, now: u64) -> Result<()> {
+        match runtime.value.state {
+            PublicationLeaseStateV1::Completed { .. } => Ok(()),
+            PublicationLeaseStateV1::Active if runtime.value.expires_at_millis > now => Ok(()),
+            PublicationLeaseStateV1::Active | PublicationLeaseStateV1::Abandoned => {
+                Err(Error::new(
+                    ErrorCode::OperationCanceled,
+                    "publication lease is not active while protecting an object",
+                ))
+            }
+        }
+    }
+
+    async fn flush_locked(&self, runtime: &mut LeaseRuntime, now: u64) -> Result<()> {
+        if runtime.pending_paths.is_empty() {
+            return Ok(());
+        }
+        let operation = runtime.value.operation;
+        let segment = ProtectionSegmentV1 {
+            operation,
+            previous: runtime.value.protection_head,
+            paths: runtime.pending_paths.iter().cloned().collect(),
+            created_at_millis: runtime.pending_since_millis.unwrap_or(now),
+        };
+        let id = segment.id()?;
+        let bytes = encode_canonical(&segment)?;
+        self.plane
+            .put_immutable(ImmutablePut {
+                path: segment_path(&self.prefix, id)?,
+                expected_sha256: crate::codec::sha256(&bytes),
+                bytes,
+            })
+            .await?;
+        let mut next = runtime.value.clone();
+        next.protection_head = Some(id);
+        next.expires_at_millis = now
+            .checked_add(self.ttl_millis)
+            .ok_or_else(|| invariant("publication lease expiry overflow"))?;
+        next.generation = next
+            .generation
+            .checked_add(1)
+            .ok_or_else(|| invariant("publication lease generation overflow"))?;
+        next.updated_at_millis = now;
+        match self
+            .plane
+            .compare_exchange(CompareExchange {
+                path: lease_path(&self.prefix, operation)?,
+                expected: Some(runtime.token.clone()),
+                bytes: encode_canonical(&next)?,
+            })
+            .await?
+        {
+            CompareExchangeOutcome::Applied(metadata) => {
+                runtime.value = next;
+                runtime.token = metadata.token;
+                runtime.pending_paths.clear();
+                runtime.pending_since_millis = None;
+                Ok(())
+            }
+            CompareExchangeOutcome::Conflict(_) => Err(Error::new(
+                ErrorCode::RefConflict,
+                "publication lease changed concurrently",
+            )),
+        }
     }
 
     async fn update(
@@ -237,66 +334,30 @@ impl<P: ObjectPlane> ProtectionSink for PublicationLease<P> {
     async fn protect(&self, path: ObjectPath) -> Result<()> {
         let mut runtime = self.runtime.lock().await;
         let now = self.clock.now_millis()?;
-        match runtime.value.state {
-            // An idempotent replay may restage identical immutable objects
-            // before its operation-tree record proves the prior result. The
-            // committed proposal is already a retained root, so no new lease
-            // links are necessary.
-            PublicationLeaseStateV1::Completed { .. } => return Ok(()),
-            PublicationLeaseStateV1::Active if runtime.value.expires_at_millis > now => {}
-            PublicationLeaseStateV1::Active | PublicationLeaseStateV1::Abandoned => {
-                return Err(Error::new(
-                    ErrorCode::OperationCanceled,
-                    "publication lease is not active while protecting an object",
-                ));
-            }
+        // An idempotent replay may restage identical immutable objects before
+        // its operation-tree record proves the prior result. The committed
+        // proposal is already a retained root, so no new lease links are
+        // necessary.
+        if matches!(
+            runtime.value.state,
+            PublicationLeaseStateV1::Completed { .. }
+        ) {
+            return Ok(());
         }
-        let operation = runtime.value.operation;
-        let previous = runtime.value.protection_head;
-        let segment = ProtectionSegmentV1 {
-            operation,
-            previous,
-            paths: vec![path],
-            created_at_millis: now,
-        };
-        let id = segment.id()?;
-        let bytes = encode_canonical(&segment)?;
-        self.plane
-            .put_immutable(ImmutablePut {
-                path: segment_path(&self.prefix, id)?,
-                expected_sha256: crate::codec::sha256(&bytes),
-                bytes,
-            })
-            .await?;
-        let mut next = runtime.value.clone();
-        next.protection_head = Some(id);
-        next.expires_at_millis = now
-            .checked_add(self.ttl_millis)
-            .ok_or_else(|| invariant("publication lease expiry overflow"))?;
-        next.generation = next
-            .generation
-            .checked_add(1)
-            .ok_or_else(|| invariant("publication lease generation overflow"))?;
-        next.updated_at_millis = now;
-        match self
-            .plane
-            .compare_exchange(CompareExchange {
-                path: lease_path(&self.prefix, operation)?,
-                expected: Some(runtime.token.clone()),
-                bytes: encode_canonical(&next)?,
-            })
-            .await?
-        {
-            CompareExchangeOutcome::Applied(metadata) => {
-                runtime.value = next;
-                runtime.token = metadata.token;
-                Ok(())
-            }
-            CompareExchangeOutcome::Conflict(_) => Err(Error::new(
-                ErrorCode::RefConflict,
-                "publication lease changed concurrently",
-            )),
+        self.ensure_runtime_active(&runtime, now)?;
+        if runtime.pending_paths.is_empty() {
+            runtime.pending_since_millis = Some(now);
         }
+        runtime.pending_paths.insert(path);
+        let flush_interval = self.ttl_millis / PROTECTION_FLUSH_INTERVAL_DIVISOR;
+        let flush_due = runtime.pending_paths.len() >= MAX_PROTECTION_SEGMENT_PATHS
+            || runtime
+                .pending_since_millis
+                .is_some_and(|started| now.saturating_sub(started) >= flush_interval);
+        if flush_due {
+            self.flush_locked(&mut runtime, now).await?;
+        }
+        Ok(())
     }
 }
 

--- a/extensions/s3/core/src/repository.rs
+++ b/extensions/s3/core/src/repository.rs
@@ -6332,6 +6332,7 @@ impl<P: ObjectPlane> Repository<P> {
     }
 
     async fn ensure_publication_allowed(&self, lease: &PublicationLease<P>) -> Result<()> {
+        lease.flush_protection().await?;
         self.ensure_gc_idle().await?;
         lease.ensure_active().await
     }

--- a/extensions/s3/core/tests/repository_contract.rs
+++ b/extensions/s3/core/tests/repository_contract.rs
@@ -469,6 +469,7 @@ async fn fenced_gc_retains_active_publications_and_deletes_exact_orphans() {
     .await
     .unwrap();
     lease.protect(protected.clone()).await.unwrap();
+    lease.flush_protection().await.unwrap();
 
     let dry_run = repository.plan_gc(2 * 60 * 60 * 1_000, 100).await.unwrap();
     assert!(dry_run
@@ -531,6 +532,53 @@ async fn fenced_gc_retains_active_publications_and_deletes_exact_orphans() {
         repository.sweep_gc(stale.plan.id).await.unwrap_err().code,
         ErrorCode::PreconditionFailed
     );
+}
+
+#[tokio::test]
+async fn publication_protection_batches_and_seals_bounded_segments() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let operation = OperationId::new();
+    let lease = PublicationLease::create_or_resume(
+        plane.clone(),
+        "repo-protection-batch",
+        operation,
+        "batch-test",
+        60 * 60 * 1_000,
+    )
+    .await
+    .unwrap();
+
+    for ordinal in 0..1_024 {
+        lease
+            .protect(ObjectPath::new(format!("repo-protection-batch/data/{ordinal:04}")).unwrap())
+            .await
+            .unwrap();
+    }
+    let first_head = lease
+        .snapshot()
+        .await
+        .protection_head
+        .expect("a full segment is sealed automatically");
+    let first = load_protection_segment(plane.as_ref(), "repo-protection-batch", first_head)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.paths.len(), 1_024);
+    assert_eq!(first.previous, None);
+
+    let final_path = ObjectPath::new("repo-protection-batch/data/final").unwrap();
+    lease.protect(final_path.clone()).await.unwrap();
+    assert_eq!(lease.snapshot().await.protection_head, Some(first_head));
+    lease.flush_protection().await.unwrap();
+
+    let second_head = lease.snapshot().await.protection_head.unwrap();
+    assert_ne!(second_head, first_head);
+    let second = load_protection_segment(plane.as_ref(), "repo-protection-batch", second_head)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(second.paths, vec![final_path]);
+    assert_eq!(second.previous, Some(first_head));
 }
 
 #[tokio::test]
@@ -1480,6 +1528,7 @@ async fn put_get_delete_and_version_history_are_bucket_atomic() {
     ));
     let mut segment_id = lease.protection_head;
     let mut protected = 0;
+    let mut protection_segments = 0;
     while let Some(id) = segment_id {
         let segment = load_protection_segment(plane.as_ref(), "repo-history", id)
             .await
@@ -1489,8 +1538,10 @@ async fn put_get_delete_and_version_history_are_bucket_atomic() {
         assert!(!segment.paths.is_empty());
         assert!(segment.paths.len() <= 1_024);
         protected += segment.paths.len();
+        protection_segments += 1;
         segment_id = segment.previous;
     }
+    assert_eq!(protection_segments, 1, "ordinary put protection is batched");
     assert!(
         protected >= 4,
         "content, nodes, delta, commit, and reflog are protected"

--- a/extensions/s3/qualification/production-limits-v1.json
+++ b/extensions/s3/qualification/production-limits-v1.json
@@ -1,0 +1,128 @@
+{
+  "schema": "prolly-s3-production-limits/v1",
+  "description": "Initial fail-closed request, contention, AWS load, and scale gates. Request limits are per logical operation and exclude provider retries.",
+  "request_budgets": {
+    "abort_multipart_upload": { "max_sdk_calls": 5 },
+    "admin_create_branch": { "max_sdk_calls": 10 },
+    "admin_create_retention_pin": { "max_sdk_calls": 10 },
+    "admin_create_tag": { "max_sdk_calls": 10 },
+    "admin_delete_branch": { "max_sdk_calls": 5 },
+    "admin_delete_retention_pin": { "max_sdk_calls": 4 },
+    "admin_delete_tag": { "max_sdk_calls": 5 },
+    "admin_head_commit": { "max_sdk_calls": 2 },
+    "admin_list_branches": { "max_sdk_calls": 4 },
+    "admin_list_native_ref_versions": { "max_sdk_calls": 9 },
+    "admin_list_reflog": { "max_sdk_calls": 9 },
+    "admin_list_retention_pins": { "max_sdk_calls": 3 },
+    "admin_list_tags": { "max_sdk_calls": 3 },
+    "admin_log": { "max_sdk_calls": 5 },
+    "admin_reset_branch": { "max_sdk_calls": 15 },
+    "atomic_commit_session_2_puts": {
+      "max_sdk_calls": 55,
+      "max_request_cost_usd_per_1000_logical_operations": 0.30
+    },
+    "complete_multipart_upload": {
+      "max_sdk_calls": 45,
+      "max_request_cost_usd_per_1000_logical_operations": 0.25
+    },
+    "copy_object": { "max_sdk_calls": 35 },
+    "create_multipart_upload": { "max_sdk_calls": 2 },
+    "delete_object": { "max_sdk_calls": 30 },
+    "delete_objects": { "max_sdk_calls": 35 },
+    "get_object": {
+      "max_sdk_calls": 6,
+      "max_request_cost_usd_per_1000_logical_operations": 0.005
+    },
+    "get_object_version": {
+      "max_sdk_calls": 6,
+      "max_request_cost_usd_per_1000_logical_operations": 0.005
+    },
+    "head_object": { "max_sdk_calls": 3 },
+    "list_multipart_uploads": { "max_sdk_calls": 5 },
+    "list_object_versions": { "max_sdk_calls": 3 },
+    "list_objects_v2": { "max_sdk_calls": 3 },
+    "list_parts": { "max_sdk_calls": 3 },
+    "maintenance_clone_to_qualified_target": { "max_sdk_calls": 80 },
+    "maintenance_diff": { "max_sdk_calls": 3 },
+    "maintenance_fetch_missing_closure": { "max_sdk_calls": 100 },
+    "maintenance_fetch_resumable": { "max_sdk_calls": 130 },
+    "maintenance_fsck_commit": { "max_sdk_calls": 25 },
+    "maintenance_fsck_repository": { "max_sdk_calls": 35 },
+    "maintenance_gc_reclaim_plan": { "max_sdk_calls": 20 },
+    "maintenance_gc_sweep": { "max_sdk_calls": 35 },
+    "maintenance_merge": {
+      "max_sdk_calls": 50,
+      "max_request_cost_usd_per_1000_logical_operations": 0.25
+    },
+    "maintenance_merge_bases": { "max_sdk_calls": 10 },
+    "maintenance_plan_merge": { "max_sdk_calls": 15 },
+    "maintenance_push": {
+      "max_sdk_calls": 150,
+      "max_request_cost_usd_per_1000_logical_operations": 0.40
+    },
+    "maintenance_rebuild_slatedb_advisory_index": { "max_sdk_calls": 15 },
+    "maintenance_restore": {
+      "max_sdk_calls": 40,
+      "max_request_cost_usd_per_1000_logical_operations": 0.25
+    },
+    "put_object": {
+      "max_sdk_calls": 30,
+      "max_request_cost_usd_per_1000_logical_operations": 0.25
+    },
+    "upload_part": { "max_sdk_calls": 12 },
+    "upload_part_copy": { "max_sdk_calls": 12 }
+  },
+  "profiles": {
+    "rustfs-development": {
+      "cost": {
+        "max_wire_retries_per_operation": 0,
+        "require_request_prices": false
+      },
+      "contention": {
+        "logical_retry_limit": 16,
+        "tiers": {
+          "1": { "max_p95_ms": 500, "max_calls_per_write": 30, "max_wire_retry_rate": 0.0 },
+          "8": { "max_p95_ms": 3000, "max_calls_per_write": 110, "max_wire_retry_rate": 0.0 },
+          "32": { "max_p95_ms": 30000, "max_calls_per_write": 350, "max_wire_retry_rate": 0.0 }
+        }
+      }
+    },
+    "aws-release": {
+      "cost": {
+        "max_wire_retries_per_operation": 2,
+        "max_wire_retry_rate": 0.01,
+        "require_request_prices": true
+      },
+      "contention": {
+        "logical_retry_limit": 16,
+        "tiers": {
+          "1": { "max_p95_ms": 2000, "max_calls_per_write": 70, "max_wire_retry_rate": 0.01 },
+          "8": { "max_p95_ms": 20000, "max_calls_per_write": 220, "max_wire_retry_rate": 0.01 },
+          "32": { "max_p95_ms": 60000, "max_calls_per_write": 650, "max_wire_retry_rate": 0.01 }
+        }
+      },
+      "load": {
+        "provider": "aws",
+        "operations": {
+          "put_object": { "min_samples": 1000, "max_p95_ms": 2000, "max_error_rate": 0.0, "max_throttle_rate": 0.01 },
+          "get_object": { "min_samples": 1000, "max_p95_ms": 500, "max_error_rate": 0.0, "max_throttle_rate": 0.01 },
+          "get_object_version": { "min_samples": 1000, "max_p95_ms": 500, "max_error_rate": 0.0, "max_throttle_rate": 0.01 },
+          "atomic_commit_session_2_puts": { "min_samples": 250, "max_p95_ms": 4000, "max_error_rate": 0.0, "max_throttle_rate": 0.01 },
+          "complete_multipart_upload": { "min_samples": 250, "max_p95_ms": 4000, "max_error_rate": 0.0, "max_throttle_rate": 0.01 },
+          "maintenance_merge": { "min_samples": 100, "max_p95_ms": 5000, "max_error_rate": 0.0, "max_throttle_rate": 0.01 },
+          "maintenance_restore": { "min_samples": 100, "max_p95_ms": 5000, "max_error_rate": 0.0, "max_throttle_rate": 0.01 },
+          "maintenance_push": { "min_samples": 100, "max_p95_ms": 10000, "max_error_rate": 0.0, "max_throttle_rate": 0.01 }
+        }
+      },
+      "scale": {
+        "provider": "aws",
+        "min_live_keys": 1000000,
+        "min_retained_versions": 10000000,
+        "max_cold_read_p95_ms": 200,
+        "min_bulk_files_per_second": 10000,
+        "max_writable_reopen_seconds": 30,
+        "max_memory_bytes": 4294967296
+      }
+    }
+  }
+}

--- a/extensions/s3/scripts/run_rustfs_contention_matrix.sh
+++ b/extensions/s3/scripts/run_rustfs_contention_matrix.sh
@@ -3,9 +3,19 @@ set -euo pipefail
 
 matrix_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # This single-node RustFS development profile is qualified through 32 hot-branch
-# writers. Set an explicit matrix containing 128 to probe, not imply, that tier.
+# writers. Tiers without a checked-in budget fail closed instead of silently
+# becoming qualification evidence.
 writer_matrix="${PROLLY_S3_CONTENTION_MATRIX:-1 8 32}"
 cargo_toolchain="${PROLLY_S3_CARGO_TOOLCHAIN:-+1.94.1}"
+limits="${PROLLY_S3_PRODUCTION_LIMITS:-$matrix_root/qualification/production-limits-v1.json}"
+scratch="$(mktemp -d)"
+test_log="$scratch/contention-matrix.log"
+
+cleanup() {
+  rm -f -- "$test_log"
+  rmdir "$scratch" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
 
 if [[ "${PROLLY_S3_RUSTFS:-}" != "1" ]]; then
   echo "set PROLLY_S3_RUSTFS=1 and the RustFS endpoint credentials" >&2
@@ -14,15 +24,34 @@ fi
 
 export PROLLY_S3_CONTENTION=1
 export RUSTC_WRAPPER=""
-for writers in $writer_matrix; do
+read -r -a writer_tiers <<<"$writer_matrix"
+if [[ "${#writer_tiers[@]}" == "0" ]]; then
+  echo "PROLLY_S3_CONTENTION_MATRIX must contain at least one writer count" >&2
+  exit 2
+fi
+expected_writers="$(IFS=,; echo "${writer_tiers[*]}")"
+for writers in "${writer_tiers[@]}"; do
   if [[ ! "$writers" =~ ^[1-9][0-9]*$ ]] || (( writers > 128 )); then
     echo "invalid writer count in PROLLY_S3_CONTENTION_MATRIX: $writers" >&2
     exit 2
   fi
+  set +e
   PROLLY_S3_CONTENTION_WRITERS="$writers" cargo "$cargo_toolchain" test \
     --manifest-path "$matrix_root/Cargo.toml" \
     -p prolly-s3-client --all-features --test rustfs_repository \
-    rustfs_contention_latency_probe -- --nocapture
+    rustfs_contention_latency_probe -- --nocapture \
+    2>&1 | tee -a "$test_log"
+  test_status="${PIPESTATUS[0]}"
+  set -e
+  if [[ "$test_status" != "0" ]]; then
+    exit "$test_status"
+  fi
 done
+
+python3 "$matrix_root/scripts/verify_production_limits.py" \
+  --limits "$limits" \
+  --profile rustfs-development \
+  --contention-log "$test_log" \
+  --expected-writers "$expected_writers"
 
 echo "RUSTFS_CONTENTION_MATRIX_COMPLETE writers=$writer_matrix"

--- a/extensions/s3/scripts/run_rustfs_cost_matrix.sh
+++ b/extensions/s3/scripts/run_rustfs_cost_matrix.sh
@@ -3,6 +3,15 @@ set -euo pipefail
 
 matrix_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cargo_toolchain="${PROLLY_S3_CARGO_TOOLCHAIN:-+1.94.1}"
+limits="${PROLLY_S3_PRODUCTION_LIMITS:-$matrix_root/qualification/production-limits-v1.json}"
+scratch="$(mktemp -d)"
+test_log="$scratch/cost-matrix.log"
+
+cleanup() {
+  rm -f -- "$test_log"
+  rmdir "$scratch" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
 
 if [[ "${PROLLY_S3_RUSTFS:-}" != "1" ]]; then
   echo "set PROLLY_S3_RUSTFS=1 and the RustFS endpoint credentials" >&2
@@ -11,9 +20,21 @@ fi
 
 export PROLLY_S3_COST_MATRIX=1
 export RUSTC_WRAPPER=""
+set +e
 cargo "$cargo_toolchain" test \
   --manifest-path "$matrix_root/Cargo.toml" \
   -p prolly-s3-client --all-features --test rustfs_repository \
-  rustfs_s3_shaped_operation_cost_matrix -- --nocapture --test-threads=1
+  rustfs_s3_shaped_operation_cost_matrix -- --nocapture --test-threads=1 \
+  2>&1 | tee "$test_log"
+test_status="${PIPESTATUS[0]}"
+set -e
+if [[ "$test_status" != "0" ]]; then
+  exit "$test_status"
+fi
 
-echo "RUSTFS_COST_MATRIX_COMPLETE object_rows=17 maintenance_rows=24 cross_repository_rows=4 advisory_rows=1 total_rows=46"
+python3 "$matrix_root/scripts/verify_production_limits.py" \
+  --limits "$limits" \
+  --profile rustfs-development \
+  --cost-log "$test_log"
+
+echo "RUSTFS_COST_MATRIX_COMPLETE object_rows=17 maintenance_rows=23 cross_repository_rows=4 advisory_rows=1 total_rows=45"

--- a/extensions/s3/scripts/tests/test_verify_production_limits.py
+++ b/extensions/s3/scripts/tests/test_verify_production_limits.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+import verify_production_limits as verifier  # noqa: E402
+
+
+class ProductionLimitsVerifierTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.limits = {
+            "schema": verifier.SCHEMA,
+            "request_budgets": {
+                "put_object": {
+                    "max_sdk_calls": 3,
+                    "max_request_cost_usd_per_1000_logical_operations": 0.02,
+                }
+            },
+            "profiles": {
+                "test": {
+                    "cost": {
+                        "max_wire_retries_per_operation": 0,
+                        "require_request_prices": False,
+                    },
+                    "contention": {
+                        "logical_retry_limit": 16,
+                        "tiers": {
+                            "1": {
+                                "max_p95_ms": 100,
+                                "max_calls_per_write": 4,
+                                "max_wire_retry_rate": 0.0,
+                            }
+                        },
+                    },
+                    "load": {
+                        "provider": "aws",
+                        "operations": {
+                            "put_object": {
+                                "min_samples": 10,
+                                "max_p95_ms": 200,
+                                "max_error_rate": 0.0,
+                                "max_throttle_rate": 0.01,
+                            }
+                        },
+                    },
+                    "scale": {
+                        "provider": "aws",
+                        "min_live_keys": 100,
+                        "min_retained_versions": 1000,
+                        "max_cold_read_p95_ms": 200,
+                        "min_bulk_files_per_second": 10,
+                        "max_writable_reopen_seconds": 30,
+                        "max_memory_bytes": 1024,
+                    },
+                }
+            },
+        }
+        self.temporary_paths: list[pathlib.Path] = []
+
+    def tearDown(self) -> None:
+        for path in self.temporary_paths:
+            path.unlink(missing_ok=True)
+
+    def evidence(self, text: str) -> pathlib.Path:
+        handle = tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False)
+        with handle:
+            handle.write(text)
+        path = pathlib.Path(handle.name)
+        self.temporary_paths.append(path)
+        return path
+
+    def test_checked_in_limits_are_valid(self) -> None:
+        limits_path = SCRIPTS.parent / "qualification" / "production-limits-v1.json"
+        limits = verifier.load_limits(limits_path)
+        self.assertEqual(limits["schema"], verifier.SCHEMA)
+        self.assertIn("aws-release", limits["profiles"])
+        self.assertEqual(len(limits["request_budgets"]), 45)
+
+    def test_cost_budget_passes_and_rejects_call_regression(self) -> None:
+        passing = self.evidence(
+            "OPERATION_COST operation=put_object sdk_calls=3 wire_transmissions=3 "
+            "wire_retries=0 get=1 head=0 put=2 list=0 list_versions=0 delete=0\n"
+        )
+        output = verifier.verify_cost(passing, self.limits, "test")
+        self.assertIn("operations=1", output)
+
+        failing = self.evidence(
+            "OPERATION_COST operation=put_object sdk_calls=4 wire_transmissions=4 "
+            "wire_retries=0 get=1 head=0 put=3 list=0 list_versions=0 delete=0\n"
+        )
+        with self.assertRaisesRegex(verifier.LimitsError, "sdk_calls=4 exceeds 3"):
+            verifier.verify_cost(failing, self.limits, "test")
+
+    def test_cost_budget_rejects_missing_operation(self) -> None:
+        empty = self.evidence("test result: ok\n")
+        with self.assertRaisesRegex(verifier.LimitsError, "cost operation mismatch"):
+            verifier.verify_cost(empty, self.limits, "test")
+
+    def test_request_price_model_is_region_input_and_budgeted(self) -> None:
+        evidence = self.evidence(
+            "OPERATION_COST operation=put_object sdk_calls=3 wire_transmissions=3 "
+            "wire_retries=0 get=1 head=0 put=2 list=0 list_versions=0 delete=0\n"
+        )
+        prices = self.evidence(
+            json.dumps(
+                {
+                    "get": 0.001,
+                    "head": 0.001,
+                    "put": 0.005,
+                    "list": 0.005,
+                    "list_versions": 0.005,
+                    "delete": 0.0,
+                }
+            )
+        )
+        output = verifier.verify_cost(evidence, self.limits, "test", prices)
+        self.assertIn("request_prices=provided", output)
+
+        expensive = self.evidence(
+            json.dumps(
+                {
+                    "get": 0.01,
+                    "head": 0.01,
+                    "put": 0.01,
+                    "list": 0.01,
+                    "list_versions": 0.01,
+                    "delete": 0.0,
+                }
+            )
+        )
+        with self.assertRaisesRegex(verifier.LimitsError, "modeled request cost"):
+            verifier.verify_cost(evidence, self.limits, "test", expensive)
+
+    def test_contention_budget_checks_retry_contract_latency_and_calls(self) -> None:
+        passing = self.evidence(
+            "CONTENTION_PROBE writers=1 logical_retry_limit=16 p95_ms=99 "
+            "calls_per_write=4 wire_transmissions=4 wire_retries=0\n"
+        )
+        output = verifier.verify_contention(passing, self.limits, "test", {"1"})
+        self.assertIn("writers=1", output)
+
+        wrong_retry_limit = self.evidence(
+            "CONTENTION_PROBE writers=1 logical_retry_limit=255 p95_ms=99 "
+            "calls_per_write=4 wire_transmissions=4 wire_retries=0\n"
+        )
+        with self.assertRaisesRegex(verifier.LimitsError, "logical_retry_limit=255"):
+            verifier.verify_contention(wrong_retry_limit, self.limits, "test", {"1"})
+
+    def test_aws_load_and_scale_are_fail_closed(self) -> None:
+        load = self.evidence(
+            "LOAD_QUALIFICATION provider=aws operation=put_object samples=10 p95_ms=200 "
+            "error_rate=0 throttle_rate=0.01 request_cost_usd_per_1000=0.02\n"
+        )
+        self.assertIn("operations=1", verifier.verify_load(load, self.limits, "test"))
+
+        scale = self.evidence(
+            "SCALE_QUALIFICATION provider=aws live_keys=100 retained_versions=1000 "
+            "cold_read_p95_ms=200 bulk_files_per_second=10 writable_reopen_seconds=30 "
+            "memory_bytes=1024\n"
+        )
+        self.assertIn("live_keys=100", verifier.verify_scale(scale, self.limits, "test"))
+
+        too_small = self.evidence(
+            "SCALE_QUALIFICATION provider=aws live_keys=99 retained_versions=1000 "
+            "cold_read_p95_ms=200 bulk_files_per_second=10 writable_reopen_seconds=30 "
+            "memory_bytes=1024\n"
+        )
+        with self.assertRaisesRegex(verifier.LimitsError, "live_keys is below"):
+            verifier.verify_scale(too_small, self.limits, "test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/extensions/s3/scripts/verify_aws_release_limits.sh
+++ b/extensions/s3/scripts/verify_aws_release_limits.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+qualification_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+limits="${PROLLY_S3_PRODUCTION_LIMITS:-$qualification_root/qualification/production-limits-v1.json}"
+
+required_variables=(
+  PROLLY_S3_AWS_COST_LOG
+  PROLLY_S3_AWS_CONTENTION_LOG
+  PROLLY_S3_AWS_LOAD_LOG
+  PROLLY_S3_AWS_SCALE_LOG
+  PROLLY_S3_AWS_REQUEST_PRICES
+)
+
+for variable in "${required_variables[@]}"; do
+  value="${!variable:-}"
+  if [[ -z "$value" || ! -f "$value" ]]; then
+    echo "$variable must name a regular release-evidence file" >&2
+    exit 2
+  fi
+done
+
+python3 "$qualification_root/scripts/verify_production_limits.py" \
+  --limits "$limits" \
+  --profile aws-release \
+  --cost-log "$PROLLY_S3_AWS_COST_LOG" \
+  --contention-log "$PROLLY_S3_AWS_CONTENTION_LOG" \
+  --expected-writers 1,8,32 \
+  --load-log "$PROLLY_S3_AWS_LOAD_LOG" \
+  --scale-log "$PROLLY_S3_AWS_SCALE_LOG" \
+  --request-prices "$PROLLY_S3_AWS_REQUEST_PRICES"
+
+echo "AWS_RELEASE_LIMITS_COMPLETE profile=aws-release limits=$limits"

--- a/extensions/s3/scripts/verify_production_limits.py
+++ b/extensions/s3/scripts/verify_production_limits.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Fail closed when cost, contention, AWS load, or scale evidence exceeds v1 limits."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import shlex
+from typing import Any
+
+
+SCHEMA = "prolly-s3-production-limits/v1"
+PRICE_FIELDS = {"get", "head", "put", "list", "list_versions", "delete"}
+
+
+class LimitsError(ValueError):
+    pass
+
+
+def load_limits(path: pathlib.Path) -> dict[str, Any]:
+    try:
+        limits = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise LimitsError(f"cannot load limits from {path}: {error}") from error
+    if limits.get("schema") != SCHEMA:
+        raise LimitsError(f"limits schema must be {SCHEMA!r}")
+    budgets = limits.get("request_budgets")
+    profiles = limits.get("profiles")
+    if not isinstance(budgets, dict) or not budgets:
+        raise LimitsError("request_budgets must be a non-empty object")
+    if not isinstance(profiles, dict) or not profiles:
+        raise LimitsError("profiles must be a non-empty object")
+    for operation, budget in budgets.items():
+        if not isinstance(operation, str) or not operation:
+            raise LimitsError("request budget operation names must be non-empty strings")
+        if not isinstance(budget, dict):
+            raise LimitsError(f"request budget for {operation} must be an object")
+        positive_number(budget, "max_sdk_calls", f"request budget {operation}")
+        if "max_request_cost_usd_per_1000_logical_operations" in budget:
+            positive_number(
+                budget,
+                "max_request_cost_usd_per_1000_logical_operations",
+                f"request budget {operation}",
+            )
+    for name, profile in profiles.items():
+        if not isinstance(profile, dict):
+            raise LimitsError(f"profile {name} must be an object")
+        contention = profile.get("contention")
+        if contention is not None:
+            positive_number(contention, "logical_retry_limit", f"profile {name} contention")
+            tiers = contention.get("tiers")
+            if not isinstance(tiers, dict) or not tiers:
+                raise LimitsError(f"profile {name} contention tiers must be non-empty")
+            for writers, tier in tiers.items():
+                if not writers.isdigit() or int(writers) < 1:
+                    raise LimitsError(f"profile {name} has invalid writer tier {writers!r}")
+                for field in ("max_p95_ms", "max_calls_per_write"):
+                    positive_number(tier, field, f"profile {name} contention tier {writers}")
+                rate(tier, "max_wire_retry_rate", f"profile {name} contention tier {writers}")
+    return limits
+
+
+def positive_number(record: dict[str, Any], field: str, context: str) -> float:
+    value = record.get(field)
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+        raise LimitsError(f"{context} field {field} must be positive")
+    return float(value)
+
+
+def rate(record: dict[str, Any], field: str, context: str) -> float:
+    value = record.get(field)
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or not 0 <= value <= 1:
+        raise LimitsError(f"{context} field {field} must be between 0 and 1")
+    return float(value)
+
+
+def records(path: pathlib.Path, kind: str) -> list[dict[str, str]]:
+    if not path.is_file() or path.is_symlink():
+        raise LimitsError(f"evidence is not a regular file: {path}")
+    prefix = f"{kind} "
+    found: list[dict[str, str]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        offset = line.find(prefix)
+        if offset < 0:
+            continue
+        parsed: dict[str, str] = {}
+        for item in shlex.split(line[offset + len(prefix) :]):
+            key, separator, value = item.partition("=")
+            if not separator or not key or not value:
+                raise LimitsError(f"malformed {kind} field: {item!r}")
+            if key in parsed:
+                raise LimitsError(f"duplicate {kind} field: {key}")
+            parsed[key] = value
+        found.append(parsed)
+    return found
+
+
+def integer(record: dict[str, str], field: str, context: str) -> int:
+    try:
+        value = int(record[field])
+    except KeyError as error:
+        raise LimitsError(f"{context} is missing {field}") from error
+    except ValueError as error:
+        raise LimitsError(f"{context} field {field} is not an integer") from error
+    if value < 0:
+        raise LimitsError(f"{context} field {field} must be nonnegative")
+    return value
+
+
+def number(record: dict[str, str], field: str, context: str) -> float:
+    try:
+        value = float(record[field])
+    except KeyError as error:
+        raise LimitsError(f"{context} is missing {field}") from error
+    except ValueError as error:
+        raise LimitsError(f"{context} field {field} is not numeric") from error
+    if value < 0:
+        raise LimitsError(f"{context} field {field} must be nonnegative")
+    return value
+
+
+def unique_by(items: list[dict[str, str]], field: str, kind: str) -> dict[str, dict[str, str]]:
+    indexed: dict[str, dict[str, str]] = {}
+    for item in items:
+        value = item.get(field)
+        if not value:
+            raise LimitsError(f"{kind} record has no {field}")
+        if value in indexed:
+            raise LimitsError(f"duplicate {kind} record for {field}={value}")
+        indexed[value] = item
+    return indexed
+
+
+def load_prices(path: pathlib.Path) -> dict[str, float]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise LimitsError(f"cannot load request prices from {path}: {error}") from error
+    if set(raw) != PRICE_FIELDS:
+        raise LimitsError(
+            f"request prices must contain exactly {sorted(PRICE_FIELDS)}, found {sorted(raw)}"
+        )
+    prices: dict[str, float] = {}
+    for field, value in raw.items():
+        if not isinstance(value, (int, float)) or isinstance(value, bool) or value < 0:
+            raise LimitsError(f"request price {field} must be nonnegative")
+        prices[field] = float(value)
+    return prices
+
+
+def verify_cost(
+    path: pathlib.Path,
+    limits: dict[str, Any],
+    profile_name: str,
+    price_path: pathlib.Path | None = None,
+) -> str:
+    profile = limits["profiles"][profile_name]
+    cost_limits = profile.get("cost", {})
+    price_required = cost_limits.get("require_request_prices") is True
+    if price_required and price_path is None:
+        raise LimitsError(f"profile {profile_name} requires --request-prices")
+    prices = load_prices(price_path) if price_path is not None else None
+    observed = unique_by(records(path, "OPERATION_COST"), "operation", "OPERATION_COST")
+    budgets = limits["request_budgets"]
+    if set(observed) != set(budgets):
+        missing = sorted(set(budgets) - set(observed))
+        unexpected = sorted(set(observed) - set(budgets))
+        raise LimitsError(f"cost operation mismatch: missing={missing} unexpected={unexpected}")
+    total_transmissions = 0
+    total_retries = 0
+    max_retries = cost_limits.get("max_wire_retries_per_operation")
+    for operation, budget in budgets.items():
+        record = observed[operation]
+        context = f"operation {operation}"
+        calls = integer(record, "sdk_calls", context)
+        if calls > budget["max_sdk_calls"]:
+            raise LimitsError(
+                f"{context} sdk_calls={calls} exceeds {budget['max_sdk_calls']}"
+            )
+        transmissions = integer(record, "wire_transmissions", context)
+        retries = integer(record, "wire_retries", context)
+        total_transmissions += transmissions
+        total_retries += retries
+        if max_retries is not None and retries > max_retries:
+            raise LimitsError(f"{context} wire_retries={retries} exceeds {max_retries}")
+        if prices is not None and "max_request_cost_usd_per_1000_logical_operations" in budget:
+            modeled = sum(integer(record, field, context) * prices[field] for field in PRICE_FIELDS)
+            maximum = budget["max_request_cost_usd_per_1000_logical_operations"]
+            if modeled > maximum:
+                raise LimitsError(
+                    f"{context} modeled request cost ${modeled:.6f}/1000 exceeds ${maximum:.6f}"
+                )
+    maximum_rate = cost_limits.get("max_wire_retry_rate")
+    retry_rate = total_retries / total_transmissions if total_transmissions else 0.0
+    if maximum_rate is not None and retry_rate > maximum_rate:
+        raise LimitsError(
+            f"cost matrix wire retry rate {retry_rate:.6f} exceeds {maximum_rate:.6f}"
+        )
+    return (
+        f"PRODUCTION_COST_LIMITS_VERIFIED profile={profile_name} operations={len(observed)} "
+        f"wire_transmissions={total_transmissions} wire_retries={total_retries} "
+        f"request_prices={'provided' if prices is not None else 'not-required'}"
+    )
+
+
+def verify_contention(
+    path: pathlib.Path,
+    limits: dict[str, Any],
+    profile_name: str,
+    expected_writers: set[str] | None = None,
+) -> str:
+    contention = limits["profiles"][profile_name].get("contention")
+    if not isinstance(contention, dict):
+        raise LimitsError(f"profile {profile_name} has no contention limits")
+    tiers = contention["tiers"]
+    expected = expected_writers if expected_writers is not None else set(tiers)
+    unknown = expected - set(tiers)
+    if unknown:
+        raise LimitsError(f"profile {profile_name} has no budget for writer tiers {sorted(unknown)}")
+    observed = unique_by(records(path, "CONTENTION_PROBE"), "writers", "CONTENTION_PROBE")
+    if set(observed) != expected:
+        raise LimitsError(
+            f"contention tier mismatch: expected={sorted(expected)} observed={sorted(observed)}"
+        )
+    for writers in expected:
+        record = observed[writers]
+        tier = tiers[writers]
+        context = f"contention tier {writers}"
+        logical_retry_limit = integer(record, "logical_retry_limit", context)
+        if logical_retry_limit != contention["logical_retry_limit"]:
+            raise LimitsError(
+                f"{context} logical_retry_limit={logical_retry_limit} expected={contention['logical_retry_limit']}"
+            )
+        p95 = number(record, "p95_ms", context)
+        if p95 > tier["max_p95_ms"]:
+            raise LimitsError(f"{context} p95_ms={p95:.3f} exceeds {tier['max_p95_ms']}")
+        calls = number(record, "calls_per_write", context)
+        if calls > tier["max_calls_per_write"]:
+            raise LimitsError(
+                f"{context} calls_per_write={calls:.3f} exceeds {tier['max_calls_per_write']}"
+            )
+        transmissions = integer(record, "wire_transmissions", context)
+        retries = integer(record, "wire_retries", context)
+        retry_rate = retries / transmissions if transmissions else 0.0
+        if retry_rate > tier["max_wire_retry_rate"]:
+            raise LimitsError(
+                f"{context} wire retry rate {retry_rate:.6f} exceeds {tier['max_wire_retry_rate']:.6f}"
+            )
+    return (
+        f"PRODUCTION_CONTENTION_LIMITS_VERIFIED profile={profile_name} "
+        f"writers={','.join(sorted(expected, key=int))}"
+    )
+
+
+def verify_load(path: pathlib.Path, limits: dict[str, Any], profile_name: str) -> str:
+    load = limits["profiles"][profile_name].get("load")
+    if not isinstance(load, dict):
+        raise LimitsError(f"profile {profile_name} has no load limits")
+    observed = unique_by(records(path, "LOAD_QUALIFICATION"), "operation", "LOAD_QUALIFICATION")
+    operations = load["operations"]
+    if set(observed) != set(operations):
+        raise LimitsError(
+            f"load operation mismatch: expected={sorted(operations)} observed={sorted(observed)}"
+        )
+    for operation, budget in operations.items():
+        record = observed[operation]
+        context = f"load operation {operation}"
+        if record.get("provider") != load["provider"]:
+            raise LimitsError(f"{context} provider must be {load['provider']}")
+        if integer(record, "samples", context) < budget["min_samples"]:
+            raise LimitsError(f"{context} has too few samples")
+        for field, maximum in (
+            ("p95_ms", budget["max_p95_ms"]),
+            ("error_rate", budget["max_error_rate"]),
+            ("throttle_rate", budget["max_throttle_rate"]),
+        ):
+            observed_value = number(record, field, context)
+            if observed_value > maximum:
+                raise LimitsError(f"{context} {field}={observed_value} exceeds {maximum}")
+        request_budget = limits["request_budgets"].get(operation, {})
+        maximum_cost = request_budget.get("max_request_cost_usd_per_1000_logical_operations")
+        if maximum_cost is not None:
+            cost = number(record, "request_cost_usd_per_1000", context)
+            if cost > maximum_cost:
+                raise LimitsError(f"{context} request cost ${cost:.6f} exceeds ${maximum_cost:.6f}")
+    return f"PRODUCTION_LOAD_LIMITS_VERIFIED profile={profile_name} operations={len(observed)}"
+
+
+def verify_scale(path: pathlib.Path, limits: dict[str, Any], profile_name: str) -> str:
+    scale = limits["profiles"][profile_name].get("scale")
+    if not isinstance(scale, dict):
+        raise LimitsError(f"profile {profile_name} has no scale limits")
+    found = records(path, "SCALE_QUALIFICATION")
+    if len(found) != 1:
+        raise LimitsError(f"expected one SCALE_QUALIFICATION record, found {len(found)}")
+    record = found[0]
+    if record.get("provider") != scale["provider"]:
+        raise LimitsError(f"scale provider must be {scale['provider']}")
+    minimums = {
+        "live_keys": scale["min_live_keys"],
+        "retained_versions": scale["min_retained_versions"],
+        "bulk_files_per_second": scale["min_bulk_files_per_second"],
+    }
+    maximums = {
+        "cold_read_p95_ms": scale["max_cold_read_p95_ms"],
+        "writable_reopen_seconds": scale["max_writable_reopen_seconds"],
+        "memory_bytes": scale["max_memory_bytes"],
+    }
+    for field, minimum in minimums.items():
+        if number(record, field, "scale qualification") < minimum:
+            raise LimitsError(f"scale qualification {field} is below {minimum}")
+    for field, maximum in maximums.items():
+        if number(record, field, "scale qualification") > maximum:
+            raise LimitsError(f"scale qualification {field} exceeds {maximum}")
+    return (
+        f"PRODUCTION_SCALE_LIMITS_VERIFIED profile={profile_name} "
+        f"live_keys={record['live_keys']} retained_versions={record['retained_versions']}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--limits",
+        default=str(pathlib.Path(__file__).resolve().parent.parent / "qualification" / "production-limits-v1.json"),
+    )
+    parser.add_argument("--profile", default="rustfs-development")
+    parser.add_argument("--cost-log")
+    parser.add_argument("--contention-log")
+    parser.add_argument("--load-log")
+    parser.add_argument("--scale-log")
+    parser.add_argument("--request-prices")
+    parser.add_argument("--expected-writers")
+    parser.add_argument("--validate-limits", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        limits = load_limits(pathlib.Path(args.limits))
+        if args.profile not in limits["profiles"]:
+            raise LimitsError(f"unknown profile {args.profile!r}")
+        outputs: list[str] = []
+        if args.cost_log:
+            outputs.append(
+                verify_cost(
+                    pathlib.Path(args.cost_log),
+                    limits,
+                    args.profile,
+                    pathlib.Path(args.request_prices) if args.request_prices else None,
+                )
+            )
+        if args.contention_log:
+            expected = set(args.expected_writers.split(",")) if args.expected_writers else None
+            outputs.append(
+                verify_contention(
+                    pathlib.Path(args.contention_log), limits, args.profile, expected
+                )
+            )
+        if args.load_log:
+            outputs.append(verify_load(pathlib.Path(args.load_log), limits, args.profile))
+        if args.scale_log:
+            outputs.append(verify_scale(pathlib.Path(args.scale_log), limits, args.profile))
+        if not outputs and not args.validate_limits:
+            raise LimitsError("provide evidence logs or --validate-limits")
+        if args.validate_limits:
+            outputs.insert(0, f"PRODUCTION_LIMITS_VALID schema={SCHEMA} profile={args.profile}")
+        for output in outputs:
+            print(output)
+    except LimitsError as error:
+        raise SystemExit(f"invalid production qualification evidence: {error}") from error
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

- Batch up to 1,024 publication-protection paths and durably flush the segment before branch ref publication.
- Construct successful conditional-write metadata from the S3 `PutObject` response instead of issuing a GET readback.
- Add bounded-segment, crash/fault, and live conditional-write regression coverage.
- Add fail-closed request, contention, AWS load/cost, and million-key production qualification limits.
- Refresh RustFS cost, contention, operations, and SlateDB design documentation.

## Why

A single 64 KiB logical write issued 51 S3 calls. The main source was a shallow publication-protection path that wrote one segment and moved/read the lease for every immutable object. Successful CAS operations also re-read state that the accepted `PutObject` response already identified.

## Impact

The versioned RustFS matrix now measures:

- 64 KiB put: 51 → 22 calls
- Two-object atomic commit: 74–84 → 43 calls
- Multipart completion: 61–71 → 33 calls
- Merge/restore: 63/58 → 40/29 calls
- 1/8/32 hot-branch writers: 22/81.5/301.312 calls per write in the final verifier run

The 20-write sequential probe improved from 1.988 to 9.413 writes/s on the local RustFS setup. AWS latency, request-price, throttling, and million-key evidence remain explicit release gates.

## Validation

- `cargo check -p prolly-s3-core --tests`
- All 33 `prolly-s3-core` repository contract tests, including prewrite fault matrices
- Live RustFS conditional object-plane conformance
- All 45 live versioned RustFS operation-cost rows
- Live 1/8/32-writer contention probes
- Production limits verifier: all 45 cost budgets and all contention tiers passed
- 6 production-verifier unit tests
- Rust formatting, JSON validation, shell syntax, and diff checks
