### PR TITLE
Implement native-versioned S3 repository profile

### DIFF
--- a/extensions/s3/Cargo.lock
+++ b/extensions/s3/Cargo.lock
@@ -2228,6 +2228,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "http-body 1.1.0",
+ "md-5 0.10.6",
  "percent-encoding",
  "prolly-s3-core",
  "serde",

--- a/extensions/s3/Cargo.lock
+++ b/extensions/s3/Cargo.lock
@@ -2257,6 +2257,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "sha2 0.10.9",
+ "tempfile",
  "thiserror 2.0.20",
  "tokio",
  "uuid",

--- a/extensions/s3/NATIVE-VERSIONED-S3-DESIGN.md
+++ b/extensions/s3/NATIVE-VERSIONED-S3-DESIGN.md
@@ -1,0 +1,813 @@
+# Native-versioned S3 client architecture
+
+> Status: accepted architecture; experimental implementation
+>
+> Decision owner: Prolly S3 maintainers
+>
+> Scope: a new repository profile in which Prolly is the authoritative,
+> exclusive writer and each logical object version is one native S3 object
+> version at the original key.
+
+This document defines how Prolly supplies logical history for whole objects in
+a versioned Amazon S3 bucket. It specifies the authority model, persisted
+identities, write and recovery protocols, request budgets, operational limits,
+and the evidence required before production use.
+
+This design replaces repository-level content chunks for the new profile. It
+does not change the persisted layout of existing repositories.
+
+![Native-versioned S3 architecture](diagram/native-versioned-s3-architecture.svg)
+
+Related material:
+
+- [Versioned S3 workspace overview](README.md)
+- [Existing SlateDB node-store proposal](SLATEDB-NODE-STORE-DESIGN.md)
+- [Operations runbook](OPERATIONS.md)
+- [Qualification record](QUALIFICATION.md)
+
+## Current delivery status
+
+The experimental implementation exercises the core architecture, but the
+profile is not production-qualified. The repository currently supports:
+
+- persisted profile negotiation and exact native `VersionId` bindings;
+- whole-object put, copy, delete, current reads, and historical reads;
+- one packed Prolly-node publication per bucket commit;
+- four-call warm writes at 1, 8, and 32 queued callers;
+- five-call two-object commit sessions and three-call merge or restore;
+- writer fencing, explicit takeover, idempotent replay, lost-put response
+  reconciliation, checkpoints, exact-version garbage collection, and fsck.
+
+The implementation fails closed for native multipart and cross-bucket clone,
+fetch, push, or repair. Those paths need the protocols in this design to
+capture or rebind destination `VersionId` values. The current generic put
+adapter also collects the request body before calling the object plane; it
+must use streaming checksums or bounded disk spooling before production use.
+The four-call whole-object path now passes against the pinned RustFS image with
+four SDK executions and four wire transmissions. Broader RustFS failure drills
+and the Amazon Web Services (AWS) scale gates remain release requirements, not
+inferred guarantees.
+
+## Decision
+
+Add a persisted repository profile named `native-versioned-v1` with these
+properties:
+
+- The physical bucket has native versioning enabled.
+- A live object is stored once, as a whole object at its original S3 key.
+- The object version records the exact provider-issued S3 `VersionId`.
+- Prolly trees remain the authority for current state, version history,
+  branches, commit sessions, merge, and restore.
+- Exactly one fenced writer service owns the repository. Concurrent callers
+  queue inside that service; independent writer processes are unsupported.
+- Readers always resolve a logical object version through Prolly and issue
+  `GetObject(key, version_id)`. A raw unversioned `GetObject(key)` is
+  diagnostic only.
+- New Prolly nodes created by one bucket commit are packed into one immutable
+  S3 object.
+- One small immutable bucket-commit object and one conditional branch-ref
+  update complete publication.
+
+The steady-state foreground budget for a conflict-free 64 KiB put is four S3
+calls:
+
+1. `PutObject` at the original key;
+2. put one immutable Prolly node pack;
+3. put one immutable bucket commit;
+4. compare-and-exchange the branch ref.
+
+This four-call claim applies to a warm, long-lived writer. Provider retries,
+writer-lease renewal, cold reopen, checkpoint creation, GC, and multipart part
+uploads are measured separately and are never hidden inside that number.
+
+## Why this profile
+
+The current profile stores a small object as a content chunk, a content-index
+tree, and a content manifest before updating three logical-bucket trees and
+publishing the commit. That gives the repository its own content-addressed
+data plane, but it duplicates capabilities already supplied by a versioned S3
+bucket and amplifies requests for ordinary files.
+
+The new profile keeps the part Prolly is good at: an ordered, immutable history
+of logical metadata. Native S3 keeps the bytes and supplies physical versions.
+The two identities remain distinct:
+
+- `ObjectVersionId` is a logical repository identity.
+- S3 `VersionId` identifies the physical bytes or physical delete marker.
+- `StorageToken` protects a mutable repository record such as a branch ref.
+
+## Goals
+
+- At most four foreground S3 calls for a warm, conflict-free single-object
+  put, copy, or delete.
+- One payload copy at the original key; no repository content chunks,
+  content-index tree, or content manifest.
+- Exact current and historical reads even when the physical bucket's current
+  version belongs to another branch.
+- Preserve logical branches, atomic commit sessions, merge, restore,
+  idempotency, conditional writes, and delete-marker behavior.
+- Make every visible bucket commit recoverable by a new process using only
+  durable bucket state.
+- Reclaim unpublished native versions and node packs without risking retained
+  history.
+- Qualify AWS latency, request cost, throttling, hot-branch behavior, cold
+  recovery, one million live keys, and ten million retained versions.
+
+## Non-goals
+
+- Supporting unmanaged writers to the same object-key namespace.
+- Treating raw, unversioned S3 reads or listings as canonical.
+- Supporting several independent writer processes.
+- Repository-level chunking, deduplication, or partial-file mutation.
+- Preserving provider `VersionId` values when cloning to another bucket.
+- Transparently converting an existing repository in place.
+- Claiming that a large multipart upload takes fewer than its native S3
+  create, part, and completion calls.
+- Supporting S3 directory buckets, which do not provide the required native
+  version history.
+
+## Authority and invariants
+
+The implementation must fail closed when any invariant is false.
+
+1. **Prolly is authoritative.** A native S3 version is visible only after a
+   reachable bucket commit names it.
+2. **Native versioning is mandatory.** Repository create and writable open
+   require `Enabled`, not `Unversioned` or `Suspended`.
+3. **Every physical mutation returns an identity.** A successful put, copy,
+   multipart completion, or delete must yield a non-empty S3 `VersionId`.
+4. **Canonical reads are exact.** Live reads use `GetObject` with the recorded
+   `VersionId`; GC deletes with `DeleteObject(key, version_id)`.
+5. **One fenced writer publishes.** A bucket commit and its branch ref carry
+   the current writer-fence generation. Credential isolation and exclusive
+   process ownership prevent overlapping writers; branch CAS rejects a stale
+   base state.
+6. **Publication is ordered.** Payload version, node pack, and bucket commit
+   are durable before the branch ref changes.
+7. **The branch ref is the visibility point.** Objects written before a failed
+   ref update are unreachable orphans, not partially committed state.
+8. **Lifecycle never removes retained closure.** Noncurrent-version expiry and
+   current-version expiry are forbidden for managed keys. Prolly GC is the
+   retention authority.
+9. **Repository metadata is isolated.** The prefix
+   `.prolly/native-versioned/v1/` is reserved and rejected as a user key.
+10. **Caches do not affect results.** Node-locator indexes and local caches are
+    advisory indexes and must be rebuildable from retained bucket commits and
+    node-pack tables of contents.
+
+## Persisted profile and compatibility
+
+Repository initialization records the profile in a create-once format marker:
+
+```rust,ignore
+pub enum RepositoryStorageProfile {
+    DistributedContentAddressedV1,
+    NativeVersionedV1,
+}
+```
+
+The marker also records minimum reader and writer capabilities. A client must
+decode and validate it before reading any profile-specific object-version
+record. Older clients and clients built without native-version support reject
+the repository before performing writes.
+
+Existing `RepositoryFormatV1` repositories retain their current layout and
+semantics. `native-versioned-v1` is created under a fresh repository prefix;
+there is no mixed-content mode and no in-place marker rewrite.
+
+## Logical and physical data model
+
+The logical body is hashed independently from the provider binding. This
+allows a clone to preserve logical object identities when the destination S3
+bucket assigns different native `VersionId` values.
+
+```rust,ignore
+pub struct ObjectVersionV2 {
+    pub id: ObjectVersionId,
+    pub body: LogicalObjectVersionBodyV2,
+    pub binding: NativeObjectBindingV1,
+}
+
+pub struct LogicalObjectVersionBodyV2 {
+    pub order: ObjectVersionOrder,
+    pub created_at_millis: u64,
+    pub kind: LogicalObjectVersionKindV2,
+}
+
+pub enum LogicalObjectVersionKindV2 {
+    Live {
+        size: u64,
+        logical_etag: String,
+        headers: ObjectHeaders,
+        checksums: Checksums,
+        user_metadata: BTreeMap<String, String>,
+        tags: BTreeMap<String, String>,
+    },
+    DeleteMarker,
+}
+
+pub enum NativeObjectBindingV1 {
+    Live {
+        version_id: String,
+        provider_etag: String,
+        checksum_sha256: [u8; 32],
+    },
+    DeleteMarker {
+        version_id: String,
+    },
+}
+```
+
+`ObjectVersionId` is derived from repository ID, logical key, operation ID,
+and canonical logical body. The native binding is authenticated by the bucket
+commit but excluded from that logical ID derivation. The Prolly versions tree
+stores the complete `ObjectVersionV2`, including the binding.
+
+The live binding deliberately does not store another physical key. In this
+profile the physical key is the logical UTF-8 key, byte for byte. This removes
+aliasing and prevents a record from redirecting a read outside the managed
+namespace.
+
+The response ETag remains the logical S3-shaped ETag. The provider ETag is
+diagnostic and must not be interpreted as MD5, especially for multipart or
+encrypted objects.
+
+## Physical layout
+
+User data stays outside the repository prefix:
+
+```text
+photos/2026/launch.jpg                         # native S3 versions of the file
+reports/q3.parquet                             # native S3 versions of the file
+
+.prolly/native-versioned/v1/
+├── format.cbor                                # create-once profile marker
+├── writers/lease.cbor                         # mutable fenced writer lease
+├── refs/heads/<encoded-branch>.cbor            # mutable branch ref
+├── refs/tags/<encoded-tag>.cbor                # mutable tag ref
+├── commits/sha256/aa/bb/<commit-id>.cbor       # immutable bucket commits
+├── node-packs/sha256/aa/bb/<pack-id>.pack      # immutable Prolly nodes
+├── node-index/checkpoints/<generation>.cbor    # advisory index checkpoint
+├── pins/<encoded-name>.cbor                    # retention pins
+├── gc/...                                      # resumable mark/sweep state
+└── maintenance/...                             # fsck and migration state
+```
+
+The same-bucket layout intentionally reserves one key prefix. Deployments that
+must expose every possible S3 key, including the reserved prefix, need a future
+separate control-bucket profile.
+
+## Packed Prolly node store
+
+One logical mutation may create nodes in the objects, versions, and operations
+trees. The repository buffers those immutable nodes in a commit-scoped batch,
+deduplicates them by CID, and writes one pack.
+
+```rust,ignore
+pub struct NodePackV1 {
+    pub format_digest: TreeFormatDigest,
+    pub entries: Vec<NodePackEntryV1>, // sorted by CID
+    pub attachments: Vec<NodePackAttachmentV1>,
+    pub payload: Vec<u8>,              // concatenated canonical node bytes
+}
+
+pub struct NodePackEntryV1 {
+    pub cid: Cid,
+    pub offset: u64,
+    pub len: u32,
+    pub sha256: [u8; 32],
+}
+
+pub struct NodePackRefV1 {
+    pub id: NodePackId,
+    pub object_len: u64,
+    pub node_count: u32,
+}
+
+pub struct NodePackAttachmentV1 {
+    pub kind: NodePackAttachmentKindV1,
+    pub digest: [u8; 32],
+    pub offset: u64,
+    pub len: u32,
+}
+
+pub enum NodePackAttachmentKindV1 {
+    BucketDelta,
+}
+```
+
+The pack ID hashes the complete canonical pack. Reads use ranged GETs after
+locating the CID in its table of contents. Every returned node is verified
+against its CID.
+
+Each bucket commit records the pack containing nodes introduced by that
+commit. The union of reachable commit records is therefore a canonical way to
+rebuild `CID -> (pack, offset, length)`. A periodically written node-index
+checkpoint accelerates open and lookup, but it is an advisory index: deleting
+it can hurt latency, never correctness.
+
+The write path must expose a commit-scoped `NodePublicationBatch`; allowing the
+three state trees to flush independently would break the one-pack call budget.
+
+### Checkpoint and reopen policy
+
+- Create a checkpoint after a configurable commit or byte threshold.
+- Publish checkpoints in the background and account for their S3 calls in a
+  separate metric.
+- On writable open, load the newest valid checkpoint and replay the bounded
+  bucket-commit tail.
+- If all checkpoints are missing or corrupt, rebuild from reachable commits
+  and pack tables of contents.
+- Do not admit writes until the writer can locate the complete base-state
+  closure.
+- The AWS release gate requires writable reopen in at most 30 seconds at the
+  qualified scale with the newest checkpoint present. Full rebuild is a
+  separately measured repair operation.
+
+## Bucket commit and branch ref
+
+The v2 bucket commit embeds data that currently requires separate delta and
+normal-path reflog objects:
+
+```rust,ignore
+pub struct BucketCommitV2 {
+    pub state: BucketStateV1,
+    pub parents: Vec<CommitId>,
+    pub generation: CommitGeneration,
+    pub changes: BucketChangeSummaryV2,
+    pub node_pack: Option<NodePackRefV1>,
+    pub writer_fence_generation: u64,
+    pub author: String,
+    pub message: Option<String>,
+    pub created_at_millis: u64,
+    pub metadata: BTreeMap<String, Vec<u8>>,
+}
+
+pub enum BucketChangeSummaryV2 {
+    Inline(BucketDeltaV1),
+    Packed {
+        digest: [u8; 32],
+        len: u32,
+    },
+}
+
+pub struct RefValueV2 {
+    pub target: CommitId,
+    pub previous_target: Option<CommitId>,
+    pub generation: RefGeneration,
+    pub operation: OperationId,
+    pub writer_id: String,
+    pub writer_fence_generation: u64,
+    pub updated_at_millis: u64,
+    pub tombstone: bool,
+}
+```
+
+Normal history comes from commit parents and embedded changes. Administrative
+ref moves that do not create a bucket commit may use a separate immutable
+audit record; their extra call is not charged to ordinary writes.
+
+Large commit-session deltas are encoded inside the node pack and referenced by
+the bucket commit rather than emitted as another S3 object. The commit object
+has a strict maximum size.
+
+## Exclusive writer and fencing
+
+The writer service acquires `.prolly/native-versioned/v1/writers/lease.cbor`
+with compare-and-exchange. The record contains repository ID, writer ID,
+monotonic generation, random fencing token, expiry, and last-renewed time.
+
+Rules:
+
+- Acquisition, renewal, and handoff are conditional writes.
+- A takeover increments the generation.
+- Every bucket commit and branch ref carries that generation.
+- Publication verifies the locally cached monotonic lease deadline immediately
+  before branch-ref CAS; lease renewal runs independently of the operation.
+- Losing renewal stops admission of new mutations and fails closed before the
+  ref update.
+- A branch-ref conflict in this profile is a fencing or invariant failure. The
+  writer does not enter the distributed logical retry loop.
+- Multiple application callers may be concurrent, but one in-process commit
+  sequencer orders branch publications. Work may be prepared concurrently.
+- Automatic takeover based only on lease expiry is forbidden. A coordinator or
+  operator must first prove the old process has stopped or lost its write
+  credentials. The new writer then CAS-updates each branch ref to the same
+  target with the new fence generation before admitting mutations.
+
+Lease renewal is amortized service traffic. Its calls and failures are exposed
+separately from logical-operation call counts.
+
+S3 cannot atomically make a branch-ref update conditional on a separate writer
+lease object. The lease is therefore cooperative coordination, not a hard
+cross-object fence. The hard boundary is that only the exclusive writer
+service holds the write role. Deployments that cannot guarantee credential
+isolation and non-overlapping handoff do not qualify for this profile.
+
+IAM and bucket policy provide the outer fence. Only the writer role can put or
+delete managed object keys and repository metadata. Reader roles receive exact
+version reads and the minimum metadata reads needed by the client. No other
+principal may mutate managed keys.
+
+## Protocols
+
+### Put object
+
+1. Admit the operation through the fenced writer and serialize its branch
+   publication slot.
+2. Load the cached branch ref and evaluate logical preconditions against that
+   exact base bucket commit.
+3. Below the qualified single-put threshold, stream the whole body to
+   `PutObject(logical_key)`. Add the repository ID, operation ID,
+   writer-fence generation, and logical checksum as reserved object metadata.
+   Require a non-empty returned `VersionId`. Use native multipart above that
+   threshold.
+4. Build the logical object version with the returned native binding and update
+   the objects, versions, and operations Prolly trees in one node batch.
+5. Put the immutable node pack.
+6. Put the immutable bucket commit.
+7. Revalidate the writer lease and compare-and-exchange the branch ref.
+8. Return the logical object version and bucket commit IDs.
+
+The input stream is not buffered merely to implement repository chunking.
+Checksums are computed while streaming; SDK/provider checksum trailers are
+used where available. If a caller requests validation that cannot be computed
+in one pass, the API requires a replayable body or rejects that combination
+before upload.
+
+### Get object
+
+1. Pin a bucket commit from the requested branch or explicit snapshot.
+2. Resolve the logical key and optional `ObjectVersionId` through the Prolly
+   trees.
+3. For a live record, call `GetObject(key, version_id)` with the exact native
+   binding. Preserve range and conditional-read behavior.
+4. For a current delete marker, return `NoSuchKey`; for an explicitly selected
+   logical delete marker, return delete-marker metadata.
+
+A warm read requires one S3 data call. A cold read may additionally load a
+branch ref, bucket commit, checkpoint, and one or more node-pack ranges. Those
+metadata calls are reported as cold-read amplification.
+
+### Delete object
+
+Call `DeleteObject(key)` so the versioned bucket creates a native delete
+marker. Require its returned `VersionId`, create the logical delete marker,
+then publish node pack, bucket commit, and branch ref. A warm delete therefore
+uses four calls.
+
+### Copy object
+
+Use native `CopyObject` with the exact source `VersionId` to create a
+destination version at the destination key, capture its new `VersionId`, and
+publish the logical mutation. A metadata-only logical copy optimization is not
+used because the original-key bucket must contain an independent destination
+object.
+
+### Multipart upload
+
+Multipart remains native S3 multipart:
+
+- create and upload parts directly against the original key;
+- do not put parts or a chunk index in Prolly;
+- on successful native completion, require the completed object's
+  `VersionId`;
+- then publish one node pack, one bucket commit, and one branch-ref CAS;
+- aborting multipart creates no logical object version.
+
+For `N` parts, a complete upload requires at least `N + 5` foreground calls:
+create, `N` uploads, complete, node pack, bucket commit, and branch ref.
+Only the post-upload completion phase has a four-call target.
+
+### Atomic commit session
+
+Upload each staged object as one native version, then apply every mutation to
+one Prolly state and publish one node pack, one bucket commit, and one branch
+ref. A two-object put session therefore targets five calls, not eight. If
+publication fails, neither uploaded version is logically visible.
+
+### Merge and restore
+
+Merge and restore normally select bindings that already exist. They write no
+payload and target three calls: node pack, bucket commit, and branch ref. If a
+policy requires copying bytes to a new original-key version, each copy is an
+additional explicit data call.
+
+### Clone, fetch, push, and repair
+
+Cross-bucket transfer operates on logical history, not physical repository
+paths. Copying commit objects and node packs byte for byte is invalid because
+their native bindings name source-bucket `VersionId` values.
+
+A transfer follows this protocol:
+
+1. Pin every selected source ref and compute its retained commit closure.
+2. Traverse commits in parent-before-child order and assign each source
+   commit a destination commit ID.
+3. For each previously unseen live logical object version, read the exact
+   source `(key, VersionId)`, stream it to the destination's original key,
+   verify its logical checksum, and capture the destination `VersionId`.
+4. Recreate retained delete markers in the same per-key logical order and
+   capture their destination `VersionId` values.
+5. Rebuild each logical version with its destination binding. Preserve its
+   `ObjectVersionId` because binding data is excluded from logical identity.
+6. Rebuild Prolly state, node packs, and bucket commits with mapped parent IDs.
+   Commit IDs change because each commit authenticates destination bindings.
+7. Verify the complete destination closure before updating destination refs.
+8. Move each destination ref through its local writer fence and branch CAS.
+
+The transfer journal stores source IDs, destination IDs, checksums, and exact
+bindings so retries don't create duplicate destination versions. A repair uses
+the same protocol for missing destination bindings. It never copies a source
+commit whose binding still points at the source bucket.
+
+## Idempotency and outcome reconciliation
+
+The operation ID remains the durable idempotency handle.
+
+- The operation record is written into the operations Prolly tree in the same
+  node pack as the mutation.
+- A lost branch-ref response is reconciled by reading the branch ref and its
+  selected bucket commit, then checking the operation record.
+- A retried request with the same operation ID and input digest returns the
+  prior logical result without uploading again.
+- Reuse with a different input digest fails with `IdempotencyConflict`.
+
+A payload request whose response is lost is more difficult because the caller
+may not know its `VersionId`. Each native object upload carries the operation
+ID and checksum in user metadata. Reconciliation performs a bounded
+`ListObjectVersions` for that exact key and verifies candidate metadata and
+checksum before continuing. More than one matching candidate is a fail-closed
+repair case; the client never guesses.
+
+## Failure behavior
+
+| Failure point | Visible state | Recovery |
+| --- | --- | --- |
+| Before native payload succeeds | Old branch state | Retry normally. |
+| Payload succeeds, response lost | Old branch state; possible orphan version | Reconcile exact key by operation metadata and checksum. |
+| After payload, before node pack | Old branch state; orphan native version | GC after grace period. |
+| After node pack, before bucket commit | Old branch state; orphan version and pack | GC after grace period. |
+| After bucket commit, before ref CAS | Old branch state; unreachable proposed closure | GC after grace period. |
+| Branch-ref CAS conflicts | Old branch state for this operation | Fence writer, stop publication, require operator/reopen. |
+| Ref CAS succeeds, response lost | New state is visible | Reconcile operation from selected commit and return success. |
+| Writer lease expires before CAS | Old branch state | Do not publish; revoke/stop the old writer before a credential-isolated handoff. |
+| Retained native version is missing | Repository closure is incomplete | Fail read/fsck; restore from qualified backup. |
+| External unindexed version appears | No logical effect | Alert and quarantine; never auto-adopt. |
+
+## Garbage collection and retention
+
+GC traces every branch ref, tag, retention pin, in-progress protected
+operation, and policy-retained bucket commit. It marks:
+
+- bucket commits and their node packs;
+- every exact `(logical key, native VersionId)` reachable from retained logical
+  object versions;
+- native delete-marker versions when retained;
+- required format, ref, pin, and maintenance records.
+
+Sweep rules:
+
+- Apply a grace period greater than the maximum writer-lease duration and
+  maximum operation-reconciliation window.
+- Delete native payloads and delete markers only with exact `VersionId`.
+- Never use key-only deletion during GC.
+- Treat Object Lock or legal-hold rejection as retained and report it.
+- Recompute reachability from canonical roots after a crash; checkpoints may
+  resume enumeration but never replace the mark proof.
+- Reclaim an unpublished native version only after proving it is absent from
+  all retained object-version bindings.
+
+Bucket lifecycle may transition retained noncurrent versions to a storage
+class the client supports, but it may not expire them. Abort-incomplete-
+multipart rules are allowed because uncompleted parts are not repository
+history.
+
+## Security and operational requirements
+
+- Enable native versioning before repository creation and continuously verify
+  it remains enabled.
+- Deny direct `PutObject`, `DeleteObject`, multipart completion, and metadata-
+  prefix mutation except from the fenced writer role.
+- Keep the writer role inside the exclusive service. If application code can
+  access the same raw AWS credentials, bucket policy cannot distinguish a
+  wrapper call from a bypass call and authority is only a coding convention.
+- Permit readers to use `GetObjectVersion`; grant version listing only to
+  components that need history, reconciliation, fsck, or GC.
+- Include the necessary SSE-KMS permissions for both original objects and
+  repository metadata.
+- Deny or continuously audit lifecycle rules that expire managed current or
+  noncurrent versions.
+- Emit writer generation, branch generation, operation ID, logical version ID,
+  native `VersionId`, and bucket commit ID in structured traces.
+- Alarm on missing `VersionId`, branch-ref conflict, unindexed native version,
+  versioning suspension, lifecycle drift, checkpoint lag, GC backlog, and
+  closure corruption.
+- Back up both native object versions and repository metadata. A metadata-only
+  backup cannot restore exact reads.
+
+## Request budgets
+
+Foreground budgets exclude provider retries and are enforced independently
+from cold-open and background-maintenance budgets.
+
+| Logical operation | Warm foreground S3 calls | Notes |
+| --- | ---: | --- |
+| 64 KiB put | 4 | Payload + pack + commit + branch CAS. |
+| Delete | 4 | Native delete marker + three metadata calls. |
+| Copy | 4 | Native copy + three metadata calls. |
+| Two-object commit session | 5 | Two payloads + one shared publication. |
+| Warm current/historical get | 1 | Exact native-version GET. |
+| Merge or restore | 3 | Reuses existing native bindings. |
+| Multipart, `N` parts | `N + 5` | Native create/parts/complete + publication. |
+| Push, `N` copied object versions | `N + 3` | Native copies + shared publication. |
+
+The implementation records SDK calls by category: payload, node pack, commit,
+ref, cold metadata, provider retry, reconciliation, writer lease, checkpoint,
+GC, and repair. A release result must never report only the foreground number.
+
+## Production qualification
+
+RustFS is the deterministic development and crash-test provider. AWS is the
+release authority for latency, cost, throttling, versioning semantics, and
+scale.
+
+### Correctness gates
+
+- Native versioning enabled, suspended, and accidentally disabled cases.
+- Exact current and historical reads across put, copy, delete, restore, merge,
+  and multiple branches.
+- Native multipart completion and abort.
+- Crash injection after every protocol step in the failure table.
+- Lost responses for payload upload and branch-ref CAS.
+- Writer-lease expiry, takeover, and stale-writer branch publication.
+- Credential-isolated handoff and rejection of automatic overlapping takeover.
+- GC with unpublished versions, node packs, retained history, pins, Object
+  Lock, and lifecycle drift.
+- Checkpoint deletion/corruption followed by deterministic index rebuild.
+- Fsck detects every missing or corrupt native version, bucket commit, pack,
+  and node.
+
+### Request and load gates
+
+- Warm 64 KiB put: maximum four foreground calls at 1, 8, and 32 concurrent
+  application callers.
+- Concurrency uses one writer queue; logical branch-CAS retries must remain
+  zero. Report queue time separately from service time.
+- At least 1,000 AWS samples each for put, current get, and historical get.
+- At least 250 AWS samples each for two-object commit and multipart completion.
+- Measure p50, p95, p99, error rate, provider retry rate, throttle rate, bytes,
+  and request cost at expected key counts and traffic levels.
+- Run hot-branch tests with sustained caller concurrency and realistic writer
+  lease renewal.
+- No hidden checkpoint or GC call may be charged to an unreported category.
+
+### Scale and recovery gates
+
+- At least one million live logical keys.
+- At least ten million retained logical object versions.
+- Writable reopen within 30 seconds using the newest valid checkpoint.
+- Bounded-memory index rebuild after local-cache loss.
+- Cold point-read latency reported with all branch, commit, checkpoint, pack,
+  and payload calls.
+- GC mark and sweep complete within an operator-defined window without
+  unbounded memory or list calls.
+- Clone/restore proves every logical checksum after destination `VersionId`
+  rebinding.
+
+Million-object production readiness is not claimed until these AWS gates pass.
+
+## Migration and bootstrap
+
+Migration creates a new `native-versioned-v1` repository. It never rewrites an
+existing format marker.
+
+### From the content-addressed profile
+
+1. Stop old writers and pin the cutover bucket commit.
+2. Create a fresh native-versioned repository and acquire its writer fence.
+3. Materialize each retained logical live version as one native S3 object
+   version at the original key, preserving logical checksum and metadata.
+4. Recreate delete markers and bucket commits in deterministic order.
+5. Preserve logical object-version IDs where the logical body is unchanged;
+   record newly assigned native `VersionId` bindings.
+6. Verify logical listings, exact reads, checksums, branch refs, and retained
+   history on both sides.
+7. Switch all readers and the exclusive writer together.
+
+### From an existing ordinary versioned bucket
+
+Bootstrap requires an exclusive maintenance window. Inventory every key and
+native version, reject the reserved metadata prefix, and build Prolly history
+from exact version records. S3 does not provide a reliable total order across
+different keys, so bootstrap must either:
+
+- import one current-state bucket commit plus per-key historical versions; or
+- use an external authoritative event log to reconstruct cross-key commits.
+
+The importer must not invent atomic relationships from `LastModified` ties.
+
+Native `VersionId` values cannot be preserved when the target is a different
+physical bucket. Clone copies bytes, verifies logical checksums, records the
+new bindings, and necessarily creates new bucket commit IDs.
+
+## API impact
+
+The AWS-shaped client surface remains recognizable. Configuration adds:
+
+- explicit `native-versioned-v1` selection at create time;
+- writer identity and lease settings for writable clients;
+- read-only mode for readers;
+- reserved-prefix validation;
+- separate metrics for warm foreground, cold metadata, provider retry, and
+  background traffic.
+
+### Relationship to the SlateDB proposal
+
+This profile is an alternative to the SlateDB proposal's original payload
+layout, not an implicit upgrade to it. The earlier proposal retains repository
+content chunks and changes how Prolly nodes are stored. `native-versioned-v1`
+removes repository content chunks and introduces its own commit-scoped node
+pack. SlateDB may later accelerate the advisory CID locator, but it must remain
+rebuildable and must not become another foreground publication call.
+
+Raw provider access is intentionally outside the correctness contract. The
+client documentation must describe direct reads as diagnostics and direct
+writes as repository corruption risk.
+
+An uploaded native version becomes the physical bucket's raw current version
+before its branch ref is published. Consequently, raw readers can observe an
+uncommitted or branch-inappropriate version. Atomic visibility and history are
+guaranteed only through the wrapper's exact-version reads.
+
+## Implementation plan
+
+Each phase must land with codec fixtures, upgrade rejection tests, and request
+accounting before the next phase depends on it.
+
+1. **Persist the profile.** Add the format descriptor, capability negotiation,
+   create/open validation, and reserved-key guard.
+2. **Add the v2 object model.** Separate logical object identity from native
+   binding and add canonical codec fixtures.
+3. **Add the native data plane.** Implement exact-version put, get, delete,
+   copy, multipart completion, checksums, and lost-response reconciliation.
+4. **Add commit-scoped node packing.** Buffer publications across all state
+   trees, implement pack range reads, and verify CIDs.
+5. **Add advisory checkpoints.** Implement bounded reopen, deterministic
+   rebuild, corruption fallback, and checkpoint metrics.
+6. **Collapse publication.** Embed changes in `BucketCommitV2`, remove ordinary
+   per-write lease/delta/reflog objects, and publish with one ref CAS.
+7. **Fence the exclusive writer.** Add acquisition, renewal, takeover, queueing,
+   fail-closed conflicts, and IAM examples.
+8. **Complete repository features.** Adapt commit sessions, branches, merge,
+   restore, clone, push, and operation lookup to native bindings.
+9. **Add GC, fsck, and repair.** Trace exact native versions and packs, test
+   every crash boundary, and produce operator reports.
+10. **Add migration and qualification.** Build import/export tools, RustFS
+    verification, AWS load/cost/throttle gates, and million-key recovery tests.
+
+## Rejected alternatives
+
+### Keep repository chunks for small files
+
+This preserves deduplication but retains the content-index and manifest writes
+that dominate ordinary-file amplification. It does not match the thin-wrapper
+goal.
+
+### Store only the native key, not `VersionId`
+
+This makes reads depend on the physical bucket's current version. Branches,
+history, crash isolation, and concurrent prepared work become incorrect.
+
+### Let applications write S3 directly and index afterward
+
+There is a window in which raw state and Prolly state disagree, and the indexer
+cannot reliably recover multi-object atomic intent or lost delete events.
+Exclusive authoritative writes are required.
+
+### Put every Prolly node in a separate S3 object
+
+This stores one object per node, but a single logical mutation rewrites several
+root-to-leaf paths and cannot meet the four-call target.
+
+### Treat the node-locator checkpoint as authority
+
+A missing or stale checkpoint would make a retained bucket commit unreadable.
+The authoritative locator chain therefore comes from bucket commits and their
+immutable node-pack references.
+
+## Open implementation questions
+
+These do not change the architectural decision but must be resolved before the
+format is marked stable:
+
+- Exact maximum node-pack and bucket-commit sizes.
+- Checkpoint thresholds that satisfy the 30-second reopen gate at qualified
+  scale.
+- Whether checksum trailers cover every supported replayable and streaming
+  body shape without local spooling.
+- The bounded search window and operator workflow for ambiguous lost-payload
+  reconciliation.
+- Whether deployments needing the reserved key prefix require a separate
+  control-bucket profile in the first release.
+- The initial storage-class matrix for historical exact-version reads.

--- a/extensions/s3/NATIVE-VERSIONED-S3-DESIGN.md
+++ b/extensions/s3/NATIVE-VERSIONED-S3-DESIGN.md
@@ -27,8 +27,8 @@ Related material:
 
 ## Current delivery status
 
-The experimental implementation exercises the core architecture, but the
-profile is not production-qualified. The repository currently supports:
+The implementation exercises the core architecture, but the profile is not
+production-qualified. The repository currently supports:
 
 - persisted profile negotiation and exact native `VersionId` bindings;
 - whole-object put, copy, delete, current reads, and historical reads;
@@ -36,17 +36,30 @@ profile is not production-qualified. The repository currently supports:
 - four-call warm writes at 1, 8, and 32 queued callers;
 - five-call two-object commit sessions and three-call merge or restore;
 - writer fencing, explicit takeover, idempotent replay, lost-put response
-  reconciliation, checkpoints, exact-version garbage collection, and fsck.
+  reconciliation, lost-copy and lost-delete reconciliation, checkpoints,
+  exact-version garbage collection, and fsck;
+- native multipart create, streamed part upload, part copy, listing,
+  restart-safe completion, and abort at the `N + 5` request budget;
+- bounded disk spooling for generic whole-object uploads, multipart parts, and
+  cross-bucket object transfer;
+- logical clone, fetch, push, and repair with destination-issued `VersionId`
+  rebinding and destination-local commit IDs;
+- independent lease renewal for writable AWS-shaped clients, with fail-closed
+  admission after an ambiguous or conflicting renewal.
 
-The implementation fails closed for native multipart and cross-bucket clone,
-fetch, push, or repair. Those paths need the protocols in this design to
-capture or rebind destination `VersionId` values. The current generic put
-adapter also collects the request body before calling the object plane; it
-must use streaming checksums or bounded disk spooling before production use.
-The four-call whole-object path now passes against the pinned RustFS image with
-four SDK executions and four wire transmissions. Broader RustFS failure drills
-and the Amazon Web Services (AWS) scale gates remain release requirements, not
-inferred guarantees.
+The four-call whole-object path, `N + 5` multipart path, and logical
+clone/incremental-push path pass against the pinned RustFS image. RustFS
+beta.10 does not return per-part SHA-256 values from `ListParts`, rejects the
+AWS full-object checksum mode at multipart creation, and can briefly omit a
+new upload from `ListMultipartUploads`; the client therefore persists the
+original signed upload handle, accepts caller-carried completion checksums and
+part sizes after restart, and treats provider listings as discovery rather
+than completion authority.
+
+Automatic checkpoint scheduling, the migration/bootstrap command surface,
+the bounded resumable-transfer batch API, broader crash drills, and the AWS
+scale gates remain release work. None of the local evidence qualifies the
+profile for production or million-object scale.
 
 ## Decision
 
@@ -516,10 +529,20 @@ A transfer follows this protocol:
 7. Verify the complete destination closure before updating destination refs.
 8. Move each destination ref through its local writer fence and branch CAS.
 
-The transfer journal stores source IDs, destination IDs, checksums, and exact
-bindings so retries don't create duplicate destination versions. A repair uses
-the same protocol for missing destination bindings. It never copies a source
-commit whose binding still points at the source bucket.
+Each completed destination commit is also an immutable transfer checkpoint.
+The transfer implementation derives a binding-independent logical commit
+fingerprint, scans both referenced and unreferenced destination commits, and
+uses matching fingerprints as the durable source-to-destination commit map.
+Payload requests carry the source operation ID and checksum, so a response-lost
+payload can be reconciled at its exact key. This self-journaling layout avoids
+adding a mutable journal write to every copied version or commit. A future
+bounded batch API may add a small mutable cursor for discovery progress, but
+that cursor is advisory and does not replace immutable commit checkpoints.
+
+A repair uses the same replay protocol. If fsck finds a missing destination
+binding, repair deliberately forces fresh bindings, rebuilds the selected
+history, verifies it, and moves the destination branch through local CAS. It
+never publishes a commit whose binding still points at the source bucket.
 
 ## Idempotency and outcome reconciliation
 
@@ -620,7 +643,7 @@ from cold-open and background-maintenance budgets.
 | Warm current/historical get | 1 | Exact native-version GET. |
 | Merge or restore | 3 | Reuses existing native bindings. |
 | Multipart, `N` parts | `N + 5` | Native create/parts/complete + publication. |
-| Push, `N` copied object versions | `N + 3` | Native copies + shared publication. |
+| Push, `N` copied object versions in one commit | `N + 3` destination writes | `N` destination payload writes + pack + commit + ref. Source exact GETs and history discovery are reported separately; end-to-end transfer is at least `2N + 3`. |
 
 The implementation records SDK calls by category: payload, node pack, commit,
 ref, cold metadata, provider retry, reconciliation, writer lease, checkpoint,

--- a/extensions/s3/QUALIFICATION.md
+++ b/extensions/s3/QUALIFICATION.md
@@ -21,17 +21,42 @@ no retry. The probe then replaced the same key and read the first logical
 version through its exact RustFS `VersionId`, proving that the measured path
 retained historical bytes without repository content chunks.
 
-The deterministic memory-plane suite separately passed 16 native-profile
-cases. It covers exact current and historical access, copy, delete markers,
-four-call writes at 1, 8, and 32 queued callers, a five-call two-object commit,
-three-call merge and restore, writer takeover fencing, idempotent replay,
-lost-put response reconciliation, checkpoints, exact-version garbage
-collection, and fail-closed native multipart and cross-bucket transfer.
+The deterministic memory-plane suite now covers exact current and historical
+access, copy, delete markers, four-call writes at 1, 8, and 32 queued callers,
+a five-call two-object commit, three-call merge and restore, writer takeover
+fencing, idempotent replay, lost put/copy/delete response reconciliation,
+checkpoints, exact-version garbage collection, native multipart, logical
+clone/fetch/push, and missing-binding repair.
+
+Native multipart passed both the deterministic object plane and live RustFS at
+exactly `N + 5` calls. The live two-part fixture issued create + two part
+uploads + completion + pack + commit + ref, for seven SDK executions and seven
+wire transmissions. A separate AWS-shaped client fixture completed after a
+client reopen using the durable upload handle, caller-carried part checksums,
+and explicit part sizes; list and abort also passed.
+
+The live native transfer fixture replayed two historical logical versions into
+a new repository prefix, proved that logical `ObjectVersionId` values stayed
+the same while RustFS `VersionId` bindings changed, reread current and
+historical bytes exactly, then transferred one incremental version and moved
+the destination ref. Source downloads and destination uploads use bounded disk
+spools rather than materializing an entire transfer body in memory.
+
+RustFS `1.0.0-beta.10` exposed three multipart compatibility constraints:
+
+- `CreateMultipartUpload` rejects the AWS full-object checksum type;
+- `ListParts` omits per-part SHA-256 values even when uploads supplied them;
+- `ListMultipartUploads` may briefly omit an upload immediately after create.
+
+The client does not infer correctness from those fields. Completion requires
+the original signed handle plus exact whole-object and per-part evidence, and
+provider listings remain discovery surfaces.
 
 This focused result supersedes the old 22-call distributed-profile baseline
-only for the new native profile. It does not qualify multipart, clone, push,
-streaming-body memory bounds, AWS latency or cost, outage recovery, or the
-million-key scale target.
+only for the new native profile. It locally qualifies the exercised multipart,
+transfer, and bounded-spooling paths against RustFS; it does not qualify AWS
+latency or cost, automatic checkpoint policy, transfer at million-version
+scale, outage recovery for every new boundary, or the million-key target.
 
 ## Local qualification — 2026-08-09
 

--- a/extensions/s3/QUALIFICATION.md
+++ b/extensions/s3/QUALIFICATION.md
@@ -4,6 +4,35 @@ This record distinguishes executable local evidence from production-release
 evidence that requires an AWS account, elapsed soak time, and operator drills.
 It is not a production attestation.
 
+## Native-versioned architecture probe — 2026-08-11
+
+The experimental `native-versioned-v1` profile passed a focused live probe
+against the pinned RustFS image and an enabled versioned bucket. After one
+warm-up publication, a 64 KiB whole-object put issued exactly four object-plane
+SDK calls:
+
+- one `PutObject` for the payload at its original logical key;
+- one `PutObject` for the commit-scoped Prolly node pack;
+- one `PutObject` for the immutable bucket commit;
+- one conditional `PutObject` for the branch ref.
+
+The Smithy interceptor observed four executions and four transmissions, with
+no retry. The probe then replaced the same key and read the first logical
+version through its exact RustFS `VersionId`, proving that the measured path
+retained historical bytes without repository content chunks.
+
+The deterministic memory-plane suite separately passed 16 native-profile
+cases. It covers exact current and historical access, copy, delete markers,
+four-call writes at 1, 8, and 32 queued callers, a five-call two-object commit,
+three-call merge and restore, writer takeover fencing, idempotent replay,
+lost-put response reconciliation, checkpoints, exact-version garbage
+collection, and fail-closed native multipart and cross-bucket transfer.
+
+This focused result supersedes the old 22-call distributed-profile baseline
+only for the new native profile. It does not qualify multipart, clone, push,
+streaming-body memory bounds, AWS latency or cost, outage recovery, or the
+million-key scale target.
+
 ## Local qualification — 2026-08-09
 
 - Host: Apple arm64 development workstation. The broad workspace/RustFS

--- a/extensions/s3/README.md
+++ b/extensions/s3/README.md
@@ -33,10 +33,13 @@ Use this client when your application needs repository semantics across objects.
 | Check supported S3 fields | [Compatibility contract](compatibility-v1.json) |
 | Deploy, recover, or run garbage collection | [Operations runbook](OPERATIONS.md) |
 | Review measured evidence | [Qualification record](QUALIFICATION.md) |
+| Review the experimental thin-wrapper architecture | [Native-versioned S3 design](NATIVE-VERSIONED-S3-DESIGN.md) |
 
 ## How the repository works
 
 The adapter runs inside your Rust process. It uses the `aws_sdk_s3::Client` you supply, so your application still controls credentials, endpoint selection, transport, and AWS SDK retries. It is not an HTTP proxy or a wire-compatible S3 endpoint.
+
+This section describes the default distributed content-addressed profile. The experimental [`native-versioned-v1` profile](NATIVE-VERSIONED-S3-DESIGN.md) instead stores each whole file once at its original key and records the exact provider `VersionId` in Prolly history.
 
 ![Versioned S3 architecture](diagram/versioned-s3-architecture.svg)
 
@@ -314,6 +317,7 @@ Each document has one job:
 | [Compatibility contract](compatibility-v1.json) | Machine-readable supported fields and fail-closed behavior |
 | [Operations runbook](OPERATIONS.md) | Deployment, recovery, integrity, GC, backup, and key rotation |
 | [Qualification record](QUALIFICATION.md) | Dated test evidence, performance measurements, and open release gates |
+| [Native-versioned S3 design](NATIVE-VERSIONED-S3-DESIGN.md) | Accepted experimental exclusive-writer profile using whole native S3 versions and packed Prolly nodes |
 | [Completion audit](COMPLETION-AUDIT.md) | Requirement-by-requirement evidence status |
 | [Technical design and phased plan](../plans/020-versioned-s3-client-adapter.md) | Design decisions, durable formats, algorithms, phase gates, and rollback boundaries |
 | [Canonical fixtures](fixtures/canonical-v1.json) | Language-neutral CBOR and identifier compatibility examples |

--- a/extensions/s3/client/Cargo.toml
+++ b/extensions/s3/client/Cargo.toml
@@ -23,6 +23,7 @@ base64 = "0.22"
 futures-util = "0.3"
 hmac = "0.12"
 http-body = "1"
+md-5 = "0.10"
 percent-encoding = "2.3"
 hex = "0.4"
 prolly-s3-core = { path = "../core", version = "0.1.0" }

--- a/extensions/s3/client/src/aws_object.rs
+++ b/extensions/s3/client/src/aws_object.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     ops::RangeInclusive,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -6,14 +7,18 @@ use std::{
     },
 };
 
-use aws_sdk_s3::{primitives::ByteStream, Client};
+use aws_sdk_s3::{primitives::ByteStream, types::MetadataDirective, Client};
 use aws_smithy_types::error::metadata::ProvideErrorMetadata;
+use aws_smithy_types::DateTime;
 use aws_types::request_id::RequestId;
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use md5::Md5;
 use prolly_s3_core::{
-    CompareExchange, CompareExchangeOutcome, DeleteOutcome, Error, ErrorCode, GetRequest,
-    ImmutablePut, ImmutablePutOutcome, ListRequest, ObjectPath, ObjectPlane, PhysicalListEntry,
-    PhysicalListPage, PhysicalVersion, Result, RetryAdvice, StorageToken, StoredMetadata,
-    StoredObject,
+    Checksums, CompareExchange, CompareExchangeOutcome, DeleteOutcome, Error, ErrorCode,
+    GetRequest, ImmutablePut, ImmutablePutOutcome, ListRequest, NativeCopy, NativeDelete,
+    NativeObjectBindingV1, NativeObjectWriteResult, NativePut, ObjectPath, ObjectPlane,
+    PhysicalListEntry, PhysicalListPage, PhysicalVersion, Result, RetryAdvice, StorageToken,
+    StoredMetadata, StoredObject,
 };
 use sha2::{Digest, Sha256};
 
@@ -25,6 +30,7 @@ pub struct S3OperationMetrics {
     pub get_object: u64,
     pub head_object: u64,
     pub put_object: u64,
+    pub copy_object: u64,
     pub list_objects_v2: u64,
     pub list_object_versions: u64,
     pub delete_object: u64,
@@ -37,6 +43,7 @@ impl S3OperationMetrics {
         self.get_object
             + self.head_object
             + self.put_object
+            + self.copy_object
             + self.list_objects_v2
             + self.list_object_versions
             + self.delete_object
@@ -48,6 +55,7 @@ struct AtomicS3OperationMetrics {
     get_object: AtomicU64,
     head_object: AtomicU64,
     put_object: AtomicU64,
+    copy_object: AtomicU64,
     list_objects_v2: AtomicU64,
     list_object_versions: AtomicU64,
     delete_object: AtomicU64,
@@ -61,6 +69,7 @@ impl AtomicS3OperationMetrics {
             get_object: self.get_object.load(Ordering::Relaxed),
             head_object: self.head_object.load(Ordering::Relaxed),
             put_object: self.put_object.load(Ordering::Relaxed),
+            copy_object: self.copy_object.load(Ordering::Relaxed),
             list_objects_v2: self.list_objects_v2.load(Ordering::Relaxed),
             list_object_versions: self.list_object_versions.load(Ordering::Relaxed),
             delete_object: self.delete_object.load(Ordering::Relaxed),
@@ -74,6 +83,7 @@ impl AtomicS3OperationMetrics {
             get_object: self.get_object.swap(0, Ordering::Relaxed),
             head_object: self.head_object.swap(0, Ordering::Relaxed),
             put_object: self.put_object.swap(0, Ordering::Relaxed),
+            copy_object: self.copy_object.swap(0, Ordering::Relaxed),
             list_objects_v2: self.list_objects_v2.swap(0, Ordering::Relaxed),
             list_object_versions: self.list_object_versions.swap(0, Ordering::Relaxed),
             delete_object: self.delete_object.swap(0, Ordering::Relaxed),
@@ -155,6 +165,12 @@ impl ObjectPlane for AwsS3ObjectPlane {
             .unwrap_or_default();
         let content_length = output.content_length();
         let delete_marker = output.delete_marker().unwrap_or(false);
+        let user_metadata = output
+            .metadata()
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
         let collected = output
             .body
             .collect()
@@ -174,6 +190,7 @@ impl ObjectPlane for AwsS3ObjectPlane {
                 sha256: digest,
                 last_modified_millis,
                 delete_marker,
+                user_metadata,
             },
             bytes,
         }))
@@ -215,6 +232,12 @@ impl ObjectPlane for AwsS3ObjectPlane {
                 .and_then(|seconds| seconds.checked_mul(1_000))
                 .unwrap_or_default(),
             delete_marker: output.delete_marker().unwrap_or(false),
+            user_metadata: output
+                .metadata()
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .collect(),
         }))
     }
 
@@ -243,6 +266,10 @@ impl ObjectPlane for AwsS3ObjectPlane {
                 sha256: request.expected_sha256,
                 last_modified_millis: 0,
                 delete_marker: false,
+                user_metadata: BTreeMap::from([(
+                    "prolly-sha256".to_string(),
+                    hex::encode(request.expected_sha256),
+                )]),
             })),
             Err(error) if is_precondition_failed(&error) => {
                 let existing = self.get_current(&request.path).await?.ok_or_else(|| {
@@ -304,6 +331,7 @@ impl ObjectPlane for AwsS3ObjectPlane {
                     sha256,
                     last_modified_millis: 0,
                     delete_marker: false,
+                    user_metadata: BTreeMap::new(),
                 }))
             }
             Err(error) if is_precondition_failed(&error) => Ok(CompareExchangeOutcome::Conflict(
@@ -351,6 +379,7 @@ impl ObjectPlane for AwsS3ObjectPlane {
                             .and_then(|seconds| seconds.checked_mul(1_000))
                             .unwrap_or_default(),
                         delete_marker: false,
+                        user_metadata: BTreeMap::new(),
                     },
                 })
             })
@@ -383,6 +412,143 @@ impl ObjectPlane for AwsS3ObjectPlane {
             Err(error) if is_precondition_failed(&error) => Ok(DeleteOutcome::TokenMismatch),
             Err(error) => Err(map_sdk_error("DeleteObject", error)),
         }
+    }
+
+    async fn put_native(&self, request: NativePut) -> Result<NativeObjectWriteResult> {
+        self.metrics.put_object.fetch_add(1, Ordering::Relaxed);
+        let size = request.bytes.len() as u64;
+        self.metrics
+            .uploaded_body_bytes
+            .fetch_add(size, Ordering::Relaxed);
+        let checksum_sha256: [u8; 32] = Sha256::digest(&request.bytes).into();
+        let checksum_md5: [u8; 16] = Md5::digest(&request.bytes).into();
+        let logical_etag = format!("\"{}\"", hex::encode(checksum_md5));
+        let metadata = native_metadata(
+            request.user_metadata,
+            request.repository.to_string(),
+            request.operation.to_string(),
+            request.writer_fence_generation,
+            checksum_sha256,
+        )?;
+        let mut operation = self
+            .client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(request.path.as_str())
+            .set_cache_control(request.headers.cache_control)
+            .set_content_disposition(request.headers.content_disposition)
+            .set_content_encoding(request.headers.content_encoding)
+            .set_content_language(request.headers.content_language)
+            .set_content_type(request.headers.content_type)
+            .set_expires(
+                request
+                    .headers
+                    .expires_at_millis
+                    .and_then(|millis| i64::try_from(millis / 1_000).ok())
+                    .map(DateTime::from_secs),
+            )
+            .set_metadata(Some(metadata))
+            .checksum_sha256(STANDARD.encode(checksum_sha256))
+            .body(ByteStream::from(request.bytes));
+        operation = operation.metadata("prolly-logical-etag", &logical_etag);
+        let output = operation
+            .send()
+            .await
+            .map_err(|error| map_sdk_error("PutObject native", error))?;
+        let version_id = required_version_id("PutObject", output.version_id())?;
+        let provider_etag = output.e_tag().unwrap_or_default().to_string();
+        Ok(NativeObjectWriteResult {
+            binding: NativeObjectBindingV1::Live {
+                version_id,
+                provider_etag,
+                checksum_sha256,
+            },
+            size,
+            logical_etag,
+            checksums: Checksums {
+                md5: Some(checksum_md5),
+                sha256: Some(checksum_sha256),
+                algorithm_values: Default::default(),
+            },
+        })
+    }
+
+    async fn copy_native(&self, request: NativeCopy) -> Result<NativeObjectWriteResult> {
+        self.metrics.copy_object.fetch_add(1, Ordering::Relaxed);
+        let metadata = native_metadata(
+            request.user_metadata,
+            request.repository.to_string(),
+            request.operation.to_string(),
+            request.writer_fence_generation,
+            request.checksum_sha256,
+        )?;
+        let copy_source = format!(
+            "{}/{}?versionId={}",
+            self.bucket,
+            request.source.as_str(),
+            request.source_version_id
+        );
+        let output = self
+            .client
+            .copy_object()
+            .bucket(&self.bucket)
+            .key(request.destination.as_str())
+            .copy_source(copy_source)
+            .metadata_directive(MetadataDirective::Replace)
+            .set_cache_control(request.headers.cache_control)
+            .set_content_disposition(request.headers.content_disposition)
+            .set_content_encoding(request.headers.content_encoding)
+            .set_content_language(request.headers.content_language)
+            .set_content_type(request.headers.content_type)
+            .set_expires(
+                request
+                    .headers
+                    .expires_at_millis
+                    .and_then(|millis| i64::try_from(millis / 1_000).ok())
+                    .map(DateTime::from_secs),
+            )
+            .set_metadata(Some(metadata))
+            .checksum_algorithm(aws_sdk_s3::types::ChecksumAlgorithm::Sha256)
+            .send()
+            .await
+            .map_err(|error| map_sdk_error("CopyObject native", error))?;
+        let version_id = required_version_id("CopyObject", output.version_id())?;
+        let provider_etag = output
+            .copy_object_result()
+            .and_then(|result| result.e_tag())
+            .unwrap_or_default()
+            .to_string();
+        Ok(NativeObjectWriteResult {
+            binding: NativeObjectBindingV1::Live {
+                version_id,
+                provider_etag,
+                checksum_sha256: request.checksum_sha256,
+            },
+            size: request.size,
+            logical_etag: request.logical_etag,
+            checksums: request.checksums,
+        })
+    }
+
+    async fn delete_native(&self, request: NativeDelete) -> Result<NativeObjectBindingV1> {
+        self.metrics.delete_object.fetch_add(1, Ordering::Relaxed);
+        let output = self
+            .client
+            .delete_object()
+            .bucket(&self.bucket)
+            .key(request.path.as_str())
+            .send()
+            .await
+            .map_err(|error| map_sdk_error("DeleteObject native", error))?;
+        if output.delete_marker() != Some(true) {
+            return Err(Error::new(
+                ErrorCode::ProviderNotQualified,
+                "DeleteObject did not create a native delete marker",
+            ));
+        }
+        Ok(NativeObjectBindingV1::DeleteMarker {
+            version_id: required_version_id("DeleteObject", output.version_id())?,
+        })
     }
 }
 
@@ -434,6 +600,7 @@ impl AwsS3ObjectPlane {
                         .and_then(|seconds| seconds.checked_mul(1_000))
                         .unwrap_or_default(),
                     delete_marker: false,
+                    user_metadata: BTreeMap::new(),
                 },
             });
         }
@@ -460,6 +627,7 @@ impl AwsS3ObjectPlane {
                         .and_then(|seconds| seconds.checked_mul(1_000))
                         .unwrap_or_default(),
                     delete_marker: true,
+                    user_metadata: BTreeMap::new(),
                 },
             });
         }
@@ -476,6 +644,47 @@ impl AwsS3ObjectPlane {
             continuation,
         })
     }
+}
+
+fn native_metadata(
+    user_metadata: std::collections::BTreeMap<String, String>,
+    repository: String,
+    operation: String,
+    writer_fence_generation: u64,
+    checksum_sha256: [u8; 32],
+) -> Result<std::collections::HashMap<String, String>> {
+    if user_metadata
+        .keys()
+        .any(|key| key.to_ascii_lowercase().starts_with("prolly-"))
+    {
+        return Err(Error::new(
+            ErrorCode::InvalidRequest,
+            "user metadata keys beginning with prolly- are reserved",
+        ));
+    }
+    let mut metadata = user_metadata
+        .into_iter()
+        .collect::<std::collections::HashMap<_, _>>();
+    metadata.insert("prolly-repository-id".to_string(), repository);
+    metadata.insert("prolly-operation-id".to_string(), operation);
+    metadata.insert(
+        "prolly-writer-fence".to_string(),
+        writer_fence_generation.to_string(),
+    );
+    metadata.insert("prolly-sha256".to_string(), hex::encode(checksum_sha256));
+    Ok(metadata)
+}
+
+fn required_version_id(operation: &str, version_id: Option<&str>) -> Result<String> {
+    version_id
+        .filter(|value| !value.is_empty() && *value != "null")
+        .map(ToString::to_string)
+        .ok_or_else(|| {
+            Error::new(
+                ErrorCode::ProviderNotQualified,
+                format!("{operation} succeeded without a native S3 VersionId"),
+            )
+        })
 }
 
 fn format_range(range: &RangeInclusive<u64>) -> String {

--- a/extensions/s3/client/src/aws_object.rs
+++ b/extensions/s3/client/src/aws_object.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::BTreeMap,
+    io::Write as _,
     ops::RangeInclusive,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -16,13 +17,14 @@ use md5::Md5;
 use prolly_s3_core::{
     Checksums, CompareExchange, CompareExchangeOutcome, DeleteOutcome, Error, ErrorCode,
     GetRequest, ImmutablePut, ImmutablePutOutcome, ListRequest, NativeCopy, NativeDelete,
-    NativeFilePut, NativeMultipartAbort, NativeMultipartComplete, NativeMultipartCreate,
-    NativeMultipartFilePart, NativeMultipartListParts, NativeMultipartListPartsPage,
-    NativeMultipartListUploads, NativeMultipartListUploadsPage, NativeMultipartPartResult,
-    NativeMultipartUploadEntry, NativeMultipartUploadPart, NativeMultipartUploadPartCopy,
-    NativeObjectBindingV1, NativeObjectWriteResult, NativePut, ObjectPath, ObjectPlane,
-    PhysicalListEntry, PhysicalListPage, PhysicalVersion, Result, RetryAdvice, StorageToken,
-    StoredMetadata, StoredObject,
+    NativeFileGet, NativeFileGetResult, NativeFilePut, NativeMultipartAbort,
+    NativeMultipartComplete, NativeMultipartCreate, NativeMultipartFilePart,
+    NativeMultipartListParts, NativeMultipartListPartsPage, NativeMultipartListUploads,
+    NativeMultipartListUploadsPage, NativeMultipartPartResult, NativeMultipartUploadEntry,
+    NativeMultipartUploadPart, NativeMultipartUploadPartCopy, NativeObjectBindingV1,
+    NativeObjectWriteResult, NativePut, ObjectPath, ObjectPlane, PhysicalListEntry,
+    PhysicalListPage, PhysicalVersion, Result, RetryAdvice, StorageToken, StoredMetadata,
+    StoredObject,
 };
 use sha2::{Digest, Sha256};
 
@@ -420,6 +422,7 @@ impl ObjectPlane for AwsS3ObjectPlane {
                         delete_marker: false,
                         user_metadata: BTreeMap::new(),
                     },
+                    is_latest: true,
                 })
             })
             .collect();
@@ -566,6 +569,63 @@ impl ObjectPlane for AwsS3ObjectPlane {
                 sha256: Some(request.checksum_sha256),
                 algorithm_values: Default::default(),
             },
+        })
+    }
+
+    async fn get_native_file(&self, request: NativeFileGet) -> Result<NativeFileGetResult> {
+        self.metrics.get_object.fetch_add(1, Ordering::Relaxed);
+        let output = self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(request.path.as_str())
+            .version_id(&request.version_id)
+            .send()
+            .await
+            .map_err(|error| map_sdk_error("GetObject native transfer", error))?;
+        if output.version_id() != Some(request.version_id.as_str()) {
+            return Err(Error::new(
+                ErrorCode::ProviderNotQualified,
+                "native transfer GET omitted or changed the requested VersionId",
+            ));
+        }
+        let mut file = std::fs::File::create(&request.body_path).map_err(|error| {
+            Error::new(
+                ErrorCode::Transport,
+                format!("native transfer spool could not be created: {error}"),
+            )
+        })?;
+        let mut body = output.body;
+        let mut size = 0_u64;
+        let mut sha256 = Sha256::new();
+        let mut md5 = Md5::new();
+        while let Some(chunk) = body.next().await {
+            let chunk = chunk.map_err(|error| transport_error("native transfer body", error))?;
+            size = size.checked_add(chunk.len() as u64).ok_or_else(|| {
+                Error::new(ErrorCode::EntityTooLarge, "native transfer length overflow")
+            })?;
+            file.write_all(&chunk).map_err(|error| {
+                Error::new(
+                    ErrorCode::Transport,
+                    format!("native transfer spool write failed: {error}"),
+                )
+            })?;
+            sha256.update(&chunk);
+            md5.update(&chunk);
+        }
+        file.flush().map_err(|error| {
+            Error::new(
+                ErrorCode::Transport,
+                format!("native transfer spool flush failed: {error}"),
+            )
+        })?;
+        self.metrics
+            .downloaded_body_bytes
+            .fetch_add(size, Ordering::Relaxed);
+        Ok(NativeFileGetResult {
+            size,
+            checksum_sha256: sha256.finalize().into(),
+            checksum_md5: md5.finalize().into(),
         })
     }
 
@@ -1092,6 +1152,7 @@ impl AwsS3ObjectPlane {
                     delete_marker: false,
                     user_metadata: BTreeMap::new(),
                 },
+                is_latest: version.is_latest().unwrap_or(false),
             });
         }
         for marker in output.delete_markers() {
@@ -1119,6 +1180,7 @@ impl AwsS3ObjectPlane {
                     delete_marker: true,
                     user_metadata: BTreeMap::new(),
                 },
+                is_latest: marker.is_latest().unwrap_or(false),
             });
         }
         let continuation = if output.is_truncated().unwrap_or(false) {

--- a/extensions/s3/client/src/aws_object.rs
+++ b/extensions/s3/client/src/aws_object.rs
@@ -16,6 +16,10 @@ use md5::Md5;
 use prolly_s3_core::{
     Checksums, CompareExchange, CompareExchangeOutcome, DeleteOutcome, Error, ErrorCode,
     GetRequest, ImmutablePut, ImmutablePutOutcome, ListRequest, NativeCopy, NativeDelete,
+    NativeFilePut, NativeMultipartAbort, NativeMultipartComplete, NativeMultipartCreate,
+    NativeMultipartFilePart, NativeMultipartListParts, NativeMultipartListPartsPage,
+    NativeMultipartListUploads, NativeMultipartListUploadsPage, NativeMultipartPartResult,
+    NativeMultipartUploadEntry, NativeMultipartUploadPart, NativeMultipartUploadPartCopy,
     NativeObjectBindingV1, NativeObjectWriteResult, NativePut, ObjectPath, ObjectPlane,
     PhysicalListEntry, PhysicalListPage, PhysicalVersion, Result, RetryAdvice, StorageToken,
     StoredMetadata, StoredObject,
@@ -34,6 +38,13 @@ pub struct S3OperationMetrics {
     pub list_objects_v2: u64,
     pub list_object_versions: u64,
     pub delete_object: u64,
+    pub create_multipart_upload: u64,
+    pub upload_part: u64,
+    pub upload_part_copy: u64,
+    pub complete_multipart_upload: u64,
+    pub abort_multipart_upload: u64,
+    pub list_parts: u64,
+    pub list_multipart_uploads: u64,
     pub uploaded_body_bytes: u64,
     pub downloaded_body_bytes: u64,
 }
@@ -47,6 +58,13 @@ impl S3OperationMetrics {
             + self.list_objects_v2
             + self.list_object_versions
             + self.delete_object
+            + self.create_multipart_upload
+            + self.upload_part
+            + self.upload_part_copy
+            + self.complete_multipart_upload
+            + self.abort_multipart_upload
+            + self.list_parts
+            + self.list_multipart_uploads
     }
 }
 
@@ -59,6 +77,13 @@ struct AtomicS3OperationMetrics {
     list_objects_v2: AtomicU64,
     list_object_versions: AtomicU64,
     delete_object: AtomicU64,
+    create_multipart_upload: AtomicU64,
+    upload_part: AtomicU64,
+    upload_part_copy: AtomicU64,
+    complete_multipart_upload: AtomicU64,
+    abort_multipart_upload: AtomicU64,
+    list_parts: AtomicU64,
+    list_multipart_uploads: AtomicU64,
     uploaded_body_bytes: AtomicU64,
     downloaded_body_bytes: AtomicU64,
 }
@@ -73,6 +98,13 @@ impl AtomicS3OperationMetrics {
             list_objects_v2: self.list_objects_v2.load(Ordering::Relaxed),
             list_object_versions: self.list_object_versions.load(Ordering::Relaxed),
             delete_object: self.delete_object.load(Ordering::Relaxed),
+            create_multipart_upload: self.create_multipart_upload.load(Ordering::Relaxed),
+            upload_part: self.upload_part.load(Ordering::Relaxed),
+            upload_part_copy: self.upload_part_copy.load(Ordering::Relaxed),
+            complete_multipart_upload: self.complete_multipart_upload.load(Ordering::Relaxed),
+            abort_multipart_upload: self.abort_multipart_upload.load(Ordering::Relaxed),
+            list_parts: self.list_parts.load(Ordering::Relaxed),
+            list_multipart_uploads: self.list_multipart_uploads.load(Ordering::Relaxed),
             uploaded_body_bytes: self.uploaded_body_bytes.load(Ordering::Relaxed),
             downloaded_body_bytes: self.downloaded_body_bytes.load(Ordering::Relaxed),
         }
@@ -87,6 +119,13 @@ impl AtomicS3OperationMetrics {
             list_objects_v2: self.list_objects_v2.swap(0, Ordering::Relaxed),
             list_object_versions: self.list_object_versions.swap(0, Ordering::Relaxed),
             delete_object: self.delete_object.swap(0, Ordering::Relaxed),
+            create_multipart_upload: self.create_multipart_upload.swap(0, Ordering::Relaxed),
+            upload_part: self.upload_part.swap(0, Ordering::Relaxed),
+            upload_part_copy: self.upload_part_copy.swap(0, Ordering::Relaxed),
+            complete_multipart_upload: self.complete_multipart_upload.swap(0, Ordering::Relaxed),
+            abort_multipart_upload: self.abort_multipart_upload.swap(0, Ordering::Relaxed),
+            list_parts: self.list_parts.swap(0, Ordering::Relaxed),
+            list_multipart_uploads: self.list_multipart_uploads.swap(0, Ordering::Relaxed),
             uploaded_body_bytes: self.uploaded_body_bytes.swap(0, Ordering::Relaxed),
             downloaded_body_bytes: self.downloaded_body_bytes.swap(0, Ordering::Relaxed),
         }
@@ -428,7 +467,7 @@ impl ObjectPlane for AwsS3ObjectPlane {
             request.repository.to_string(),
             request.operation.to_string(),
             request.writer_fence_generation,
-            checksum_sha256,
+            Some(checksum_sha256),
         )?;
         let mut operation = self
             .client
@@ -473,6 +512,63 @@ impl ObjectPlane for AwsS3ObjectPlane {
         })
     }
 
+    async fn put_native_file(&self, request: NativeFilePut) -> Result<NativeObjectWriteResult> {
+        self.metrics.put_object.fetch_add(1, Ordering::Relaxed);
+        self.metrics
+            .uploaded_body_bytes
+            .fetch_add(request.size, Ordering::Relaxed);
+        let metadata = native_metadata(
+            request.user_metadata,
+            request.repository.to_string(),
+            request.operation.to_string(),
+            request.writer_fence_generation,
+            Some(request.checksum_sha256),
+        )?;
+        let logical_etag = format!("\"{}\"", hex::encode(request.checksum_md5));
+        let body = ByteStream::from_path(&request.body_path)
+            .await
+            .map_err(|error| transport_error("native spool open", error))?;
+        let mut operation = self
+            .client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(request.path.as_str())
+            .set_cache_control(request.headers.cache_control)
+            .set_content_disposition(request.headers.content_disposition)
+            .set_content_encoding(request.headers.content_encoding)
+            .set_content_language(request.headers.content_language)
+            .set_content_type(request.headers.content_type)
+            .set_expires(
+                request
+                    .headers
+                    .expires_at_millis
+                    .and_then(|millis| i64::try_from(millis / 1_000).ok())
+                    .map(DateTime::from_secs),
+            )
+            .set_metadata(Some(metadata))
+            .checksum_sha256(STANDARD.encode(request.checksum_sha256))
+            .body(body);
+        operation = operation.metadata("prolly-logical-etag", &logical_etag);
+        let output = operation
+            .send()
+            .await
+            .map_err(|error| map_sdk_error("PutObject native spool", error))?;
+        Ok(NativeObjectWriteResult {
+            binding: NativeObjectBindingV1::Live {
+                version_id: required_version_id("PutObject", output.version_id())?,
+                provider_etag: output.e_tag().unwrap_or_default().to_string(),
+                checksum_sha256: request.checksum_sha256,
+            },
+            size: request.size,
+            logical_etag,
+            checksums: Checksums {
+                md5: Some(request.checksum_md5),
+                sha256: Some(request.checksum_sha256),
+                algorithm_values: Default::default(),
+            },
+        })
+    }
+
     async fn copy_native(&self, request: NativeCopy) -> Result<NativeObjectWriteResult> {
         self.metrics.copy_object.fetch_add(1, Ordering::Relaxed);
         let metadata = native_metadata(
@@ -480,7 +576,7 @@ impl ObjectPlane for AwsS3ObjectPlane {
             request.repository.to_string(),
             request.operation.to_string(),
             request.writer_fence_generation,
-            request.checksum_sha256,
+            Some(request.checksum_sha256),
         )?;
         let copy_source = format!(
             "{}/{}?versionId={}",
@@ -548,6 +644,400 @@ impl ObjectPlane for AwsS3ObjectPlane {
         }
         Ok(NativeObjectBindingV1::DeleteMarker {
             version_id: required_version_id("DeleteObject", output.version_id())?,
+        })
+    }
+
+    async fn create_native_multipart(&self, request: NativeMultipartCreate) -> Result<String> {
+        self.metrics
+            .create_multipart_upload
+            .fetch_add(1, Ordering::Relaxed);
+        let metadata = native_metadata(
+            request.user_metadata,
+            request.repository.to_string(),
+            request.operation.to_string(),
+            request.writer_fence_generation,
+            None,
+        )?;
+        let output = self
+            .client
+            .create_multipart_upload()
+            .bucket(&self.bucket)
+            .key(request.path.as_str())
+            .set_cache_control(request.headers.cache_control)
+            .set_content_disposition(request.headers.content_disposition)
+            .set_content_encoding(request.headers.content_encoding)
+            .set_content_language(request.headers.content_language)
+            .set_content_type(request.headers.content_type)
+            .set_expires(
+                request
+                    .headers
+                    .expires_at_millis
+                    .and_then(|millis| i64::try_from(millis / 1_000).ok())
+                    .map(DateTime::from_secs),
+            )
+            .set_metadata(Some(metadata))
+            .checksum_algorithm(aws_sdk_s3::types::ChecksumAlgorithm::Sha256)
+            .send()
+            .await
+            .map_err(|error| map_sdk_error("CreateMultipartUpload native", error))?;
+        output
+            .upload_id()
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::ProviderNotQualified,
+                    "CreateMultipartUpload succeeded without an upload ID",
+                )
+            })
+    }
+
+    async fn upload_native_multipart_part(
+        &self,
+        request: NativeMultipartUploadPart,
+    ) -> Result<NativeMultipartPartResult> {
+        self.metrics.upload_part.fetch_add(1, Ordering::Relaxed);
+        let size = request.bytes.len() as u64;
+        self.metrics
+            .uploaded_body_bytes
+            .fetch_add(size, Ordering::Relaxed);
+        let checksum_sha256: [u8; 32] = Sha256::digest(&request.bytes).into();
+        let output = self
+            .client
+            .upload_part()
+            .bucket(&self.bucket)
+            .key(request.path.as_str())
+            .upload_id(request.upload_id)
+            .part_number(i32::try_from(request.part_number).map_err(|_| {
+                Error::new(
+                    ErrorCode::InvalidRequest,
+                    "multipart part number is invalid",
+                )
+            })?)
+            .checksum_sha256(STANDARD.encode(checksum_sha256))
+            .body(ByteStream::from(request.bytes))
+            .send()
+            .await
+            .map_err(|error| map_sdk_error("UploadPart native", error))?;
+        let etag = output
+            .e_tag()
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::ProviderNotQualified,
+                    "UploadPart succeeded without an ETag",
+                )
+            })?;
+        if output.checksum_sha256().is_some_and(|value| {
+            STANDARD.decode(value).ok().as_deref() != Some(checksum_sha256.as_slice())
+        }) {
+            return Err(Error::new(
+                ErrorCode::ChecksumMismatch,
+                "UploadPart returned a different SHA-256 checksum",
+            ));
+        }
+        Ok(NativeMultipartPartResult {
+            part_number: request.part_number,
+            etag: etag.to_string(),
+            checksum_sha256: Some(checksum_sha256),
+            size,
+        })
+    }
+
+    async fn upload_native_multipart_file_part(
+        &self,
+        request: NativeMultipartFilePart,
+    ) -> Result<NativeMultipartPartResult> {
+        self.metrics.upload_part.fetch_add(1, Ordering::Relaxed);
+        self.metrics
+            .uploaded_body_bytes
+            .fetch_add(request.size, Ordering::Relaxed);
+        let body = ByteStream::from_path(&request.body_path)
+            .await
+            .map_err(|error| transport_error("native multipart spool open", error))?;
+        let output = self
+            .client
+            .upload_part()
+            .bucket(&self.bucket)
+            .key(request.path.as_str())
+            .upload_id(request.upload_id)
+            .part_number(i32::try_from(request.part_number).map_err(|_| {
+                Error::new(
+                    ErrorCode::InvalidRequest,
+                    "multipart part number is invalid",
+                )
+            })?)
+            .checksum_sha256(STANDARD.encode(request.checksum_sha256))
+            .body(body)
+            .send()
+            .await
+            .map_err(|error| map_sdk_error("UploadPart native spool", error))?;
+        let etag = output
+            .e_tag()
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::ProviderNotQualified,
+                    "UploadPart succeeded without an ETag",
+                )
+            })?;
+        if output.checksum_sha256().is_some_and(|value| {
+            STANDARD.decode(value).ok().as_deref() != Some(request.checksum_sha256.as_slice())
+        }) {
+            return Err(Error::new(
+                ErrorCode::ChecksumMismatch,
+                "UploadPart returned a different SHA-256 checksum",
+            ));
+        }
+        Ok(NativeMultipartPartResult {
+            part_number: request.part_number,
+            etag: etag.to_string(),
+            checksum_sha256: Some(request.checksum_sha256),
+            size: request.size,
+        })
+    }
+
+    async fn upload_native_multipart_part_copy(
+        &self,
+        request: NativeMultipartUploadPartCopy,
+    ) -> Result<NativeMultipartPartResult> {
+        self.metrics
+            .upload_part_copy
+            .fetch_add(1, Ordering::Relaxed);
+        let copy_source = format!(
+            "{}/{}?versionId={}",
+            self.bucket,
+            request.source.as_str(),
+            request.source_version_id
+        );
+        let mut operation = self
+            .client
+            .upload_part_copy()
+            .bucket(&self.bucket)
+            .key(request.destination.as_str())
+            .upload_id(request.upload_id)
+            .part_number(i32::try_from(request.part_number).map_err(|_| {
+                Error::new(
+                    ErrorCode::InvalidRequest,
+                    "multipart part number is invalid",
+                )
+            })?)
+            .copy_source(copy_source);
+        if let Some(range) = request.range.as_ref() {
+            operation = operation.copy_source_range(format_range(range));
+        }
+        let output = operation
+            .send()
+            .await
+            .map_err(|error| map_sdk_error("UploadPartCopy native", error))?;
+        let result = output.copy_part_result().ok_or_else(|| {
+            Error::new(
+                ErrorCode::ProviderNotQualified,
+                "UploadPartCopy succeeded without a result",
+            )
+        })?;
+        let checksum = result.checksum_sha256().ok_or_else(|| {
+            Error::new(
+                ErrorCode::ProviderNotQualified,
+                "UploadPartCopy omitted the requested SHA-256 checksum",
+            )
+        })?;
+        let checksum_sha256 = STANDARD
+            .decode(checksum)
+            .ok()
+            .and_then(|bytes| bytes.try_into().ok())
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::ProviderNotQualified,
+                    "UploadPartCopy returned an invalid SHA-256 checksum",
+                )
+            })?;
+        Ok(NativeMultipartPartResult {
+            part_number: request.part_number,
+            etag: result.e_tag().unwrap_or_default().to_string(),
+            checksum_sha256: Some(checksum_sha256),
+            size: request.size,
+        })
+    }
+
+    async fn complete_native_multipart(
+        &self,
+        request: NativeMultipartComplete,
+    ) -> Result<NativeObjectWriteResult> {
+        self.metrics
+            .complete_multipart_upload
+            .fetch_add(1, Ordering::Relaxed);
+        let parts = request
+            .parts
+            .iter()
+            .map(|part| {
+                Ok(aws_sdk_s3::types::CompletedPart::builder()
+                    .part_number(i32::try_from(part.part_number).map_err(|_| {
+                        Error::new(
+                            ErrorCode::InvalidRequest,
+                            "multipart part number is invalid",
+                        )
+                    })?)
+                    .e_tag(&part.etag)
+                    .checksum_sha256(STANDARD.encode(part.checksum_sha256))
+                    .build())
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let output = self
+            .client
+            .complete_multipart_upload()
+            .bucket(&self.bucket)
+            .key(request.path.as_str())
+            .upload_id(request.upload_id)
+            .multipart_upload(
+                aws_sdk_s3::types::CompletedMultipartUpload::builder()
+                    .set_parts(Some(parts))
+                    .build(),
+            )
+            .send()
+            .await
+            .map_err(|error| map_sdk_error("CompleteMultipartUpload native", error))?;
+        let version_id = required_version_id("CompleteMultipartUpload", output.version_id())?;
+        let provider_etag = output.e_tag().unwrap_or_default().to_string();
+        Ok(NativeObjectWriteResult {
+            binding: NativeObjectBindingV1::Live {
+                version_id,
+                provider_etag: provider_etag.clone(),
+                checksum_sha256: request.checksum_sha256,
+            },
+            size: request.size,
+            logical_etag: format!("\"{}\"", hex::encode(request.checksum_md5)),
+            checksums: Checksums {
+                md5: Some(request.checksum_md5),
+                sha256: Some(request.checksum_sha256),
+                algorithm_values: Default::default(),
+            },
+        })
+    }
+
+    async fn abort_native_multipart(&self, request: NativeMultipartAbort) -> Result<()> {
+        self.metrics
+            .abort_multipart_upload
+            .fetch_add(1, Ordering::Relaxed);
+        self.client
+            .abort_multipart_upload()
+            .bucket(&self.bucket)
+            .key(request.path.as_str())
+            .upload_id(request.upload_id)
+            .send()
+            .await
+            .map_err(|error| map_sdk_error("AbortMultipartUpload native", error))?;
+        Ok(())
+    }
+
+    async fn list_native_multipart_parts(
+        &self,
+        request: NativeMultipartListParts,
+    ) -> Result<NativeMultipartListPartsPage> {
+        self.metrics.list_parts.fetch_add(1, Ordering::Relaxed);
+        let output = self
+            .client
+            .list_parts()
+            .bucket(&self.bucket)
+            .key(request.path.as_str())
+            .upload_id(request.upload_id)
+            .part_number_marker(request.after_part_number.to_string())
+            .max_parts(i32::try_from(request.limit.min(1_000)).unwrap_or(1_000))
+            .send()
+            .await
+            .map_err(|error| map_sdk_error("ListParts native", error))?;
+        let parts = output
+            .parts()
+            .iter()
+            .map(|part| {
+                let part_number = part
+                    .part_number()
+                    .and_then(|value| u32::try_from(value).ok())
+                    .ok_or_else(|| {
+                        Error::new(
+                            ErrorCode::ProviderNotQualified,
+                            "ListParts returned an invalid part number",
+                        )
+                    })?;
+                let checksum_sha256 = part
+                    .checksum_sha256()
+                    .map(|checksum| {
+                        STANDARD
+                            .decode(checksum)
+                            .ok()
+                            .and_then(|bytes| bytes.try_into().ok())
+                            .ok_or_else(|| {
+                                Error::new(
+                                    ErrorCode::ProviderNotQualified,
+                                    "ListParts returned an invalid part SHA-256 checksum",
+                                )
+                            })
+                    })
+                    .transpose()?;
+                Ok(NativeMultipartPartResult {
+                    part_number,
+                    etag: part.e_tag().unwrap_or_default().to_string(),
+                    checksum_sha256,
+                    size: part
+                        .size()
+                        .and_then(|value| u64::try_from(value).ok())
+                        .ok_or_else(|| {
+                            Error::new(
+                                ErrorCode::ProviderNotQualified,
+                                "ListParts omitted a valid part size",
+                            )
+                        })?,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(NativeMultipartListPartsPage {
+            parts,
+            next_part_number: output
+                .next_part_number_marker()
+                .and_then(|value| value.parse().ok()),
+        })
+    }
+
+    async fn list_native_multipart_uploads(
+        &self,
+        request: NativeMultipartListUploads,
+    ) -> Result<NativeMultipartListUploadsPage> {
+        self.metrics
+            .list_multipart_uploads
+            .fetch_add(1, Ordering::Relaxed);
+        let output = self
+            .client
+            .list_multipart_uploads()
+            .bucket(&self.bucket)
+            .prefix(request.prefix)
+            .set_key_marker(request.key_marker)
+            .set_upload_id_marker(request.upload_id_marker)
+            .max_uploads(i32::try_from(request.limit.min(1_000)).unwrap_or(1_000))
+            .send()
+            .await
+            .map_err(|error| map_sdk_error("ListMultipartUploads native", error))?;
+        let uploads = output
+            .uploads()
+            .iter()
+            .filter_map(|upload| {
+                let path = ObjectPath::new(upload.key()?).ok()?;
+                let upload_id = upload.upload_id()?.to_string();
+                let initiated_at_millis = upload
+                    .initiated()
+                    .and_then(|value| u64::try_from(value.secs()).ok())
+                    .and_then(|seconds| seconds.checked_mul(1_000))
+                    .unwrap_or_default();
+                Some(NativeMultipartUploadEntry {
+                    path,
+                    upload_id,
+                    initiated_at_millis,
+                })
+            })
+            .collect();
+        Ok(NativeMultipartListUploadsPage {
+            uploads,
+            next_key_marker: output.next_key_marker().map(ToString::to_string),
+            next_upload_id_marker: output.next_upload_id_marker().map(ToString::to_string),
         })
     }
 }
@@ -651,7 +1141,7 @@ fn native_metadata(
     repository: String,
     operation: String,
     writer_fence_generation: u64,
-    checksum_sha256: [u8; 32],
+    checksum_sha256: Option<[u8; 32]>,
 ) -> Result<std::collections::HashMap<String, String>> {
     if user_metadata
         .keys()
@@ -671,7 +1161,9 @@ fn native_metadata(
         "prolly-writer-fence".to_string(),
         writer_fence_generation.to_string(),
     );
-    metadata.insert("prolly-sha256".to_string(), hex::encode(checksum_sha256));
+    if let Some(checksum_sha256) = checksum_sha256 {
+        metadata.insert("prolly-sha256".to_string(), hex::encode(checksum_sha256));
+    }
     Ok(metadata)
 }
 

--- a/extensions/s3/client/src/client.rs
+++ b/extensions/s3/client/src/client.rs
@@ -34,13 +34,14 @@ use futures_util::stream::BoxStream;
 use hmac::{Hmac, Mac};
 use http_body::{Body, Frame, SizeHint};
 use prolly_s3_core::{
-    decode_canonical, version_cursor_after_key, ChecksumExpectation, CommitId, CommitReceipt,
-    Error, ErrorCode, EtagPredicateV1, GetRequest, ListRequest, MultipartCatalogSnapshotId,
-    ObjectHeaders, ObjectPath, ObjectPlane, ObjectSummary, ObjectVersionId, ObjectVersionKindV1,
-    ObjectWriteConditionV1, OperationId, PhysicalVersion, PhysicalVersioning,
-    ProviderAttestationV1, ProviderProfileId, RefValueV1, Repository, RepositoryOptions,
-    RepositoryStorageProfile, Result, RetryAdvice, UploadId, VersionSummary, WorkspaceId,
-    WorkspaceManifestV1, MAX_LOGICAL_RETRY_LIMIT,
+    decode_canonical, encode_canonical, version_cursor_after_key, ChecksumExpectation, CommitId,
+    CommitReceipt, Error, ErrorCode, EtagPredicateV1, GetRequest, ListRequest,
+    MultipartCatalogSnapshotId, NativeMultipartCompletedPart, NativeMultipartPartResult,
+    NativeMultipartSessionV1, ObjectHeaders, ObjectPath, ObjectPlane, ObjectSummary,
+    ObjectVersionId, ObjectVersionKindV1, ObjectWriteConditionV1, OperationId, PhysicalVersion,
+    PhysicalVersioning, ProviderAttestationV1, ProviderProfileId, RefValueV1, Repository,
+    RepositoryOptions, RepositoryStorageProfile, Result, RetryAdvice, UploadId, VersionSummary,
+    WorkspaceId, WorkspaceManifestV1, MAX_LOGICAL_RETRY_LIMIT,
 };
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -546,6 +547,8 @@ pub struct Client {
     provider_identity: ProviderIdentity,
     attestation_signer: Arc<dyn AttestationSigner>,
     provider_attestation: Arc<RwLock<ProviderAttestationV1>>,
+    native_multipart_parts: Arc<RwLock<BTreeMap<(String, u32), NativeMultipartPartResult>>>,
+    native_multipart_sessions: Arc<RwLock<BTreeMap<String, NativeMultipartSessionV1>>>,
 }
 
 #[derive(Default)]
@@ -619,6 +622,8 @@ impl Client {
             provider_identity: self.provider_identity.clone(),
             attestation_signer: self.attestation_signer.clone(),
             provider_attestation: self.provider_attestation.clone(),
+            native_multipart_parts: self.native_multipart_parts.clone(),
+            native_multipart_sessions: self.native_multipart_sessions.clone(),
         })
     }
 
@@ -1764,6 +1769,8 @@ impl ClientBuilder {
             provider_identity,
             attestation_signer,
             provider_attestation: Arc::new(RwLock::new(attestation)),
+            native_multipart_parts: Arc::new(RwLock::new(BTreeMap::new())),
+            native_multipart_sessions: Arc::new(RwLock::new(BTreeMap::new())),
         })
     }
 }
@@ -2806,6 +2813,7 @@ pub struct CreateMultipartUploadBuilder {
     key: Option<String>,
     content_type: Option<String>,
     metadata: Option<HashMap<String, String>>,
+    operation_id: Option<OperationId>,
 }
 
 pub struct ListMultipartUploadsBuilder {
@@ -2864,6 +2872,93 @@ impl ListMultipartUploadsBuilder {
                 .set_key_marker(self.key_marker)
                 .set_upload_id_marker(self.upload_id_marker)
                 .set_uploads(Some(Vec::new()))
+                .build());
+        }
+        if self.client.repository.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            let page = self
+                .client
+                .repository
+                .plane()
+                .list_native_multipart_uploads(prolly_s3_core::NativeMultipartListUploads {
+                    prefix: prefix.clone(),
+                    key_marker: self.key_marker.clone(),
+                    upload_id_marker: self.upload_id_marker.clone(),
+                    limit,
+                })
+                .await?;
+            let mut uploads = page
+                .uploads
+                .iter()
+                .map(|upload| {
+                    let key = upload.path.as_str().to_string();
+                    let handle = encode_native_multipart_session(&NativeMultipartSessionV1 {
+                        repository: self.client.repository_id(),
+                        branch: self.client.branch.clone(),
+                        key: key.as_bytes().to_vec(),
+                        headers: ObjectHeaders::default(),
+                        user_metadata: BTreeMap::new(),
+                        provider_upload_id: upload.upload_id.clone(),
+                        operation: OperationId::nil(),
+                        writer_fence_generation: 0,
+                        created_at_millis: upload.initiated_at_millis,
+                        discovered: true,
+                    })?;
+                    Ok(MultipartUpload::builder()
+                        .key(key)
+                        .upload_id(handle)
+                        .initiated(datetime(upload.initiated_at_millis)?)
+                        .build())
+                })
+                .collect::<Result<Vec<_>>>()?;
+            if page.next_key_marker.is_none() {
+                let sessions = self.client.native_multipart_sessions.read().map_err(|_| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "native multipart session cache lock poisoned",
+                    )
+                })?;
+                for (handle, session) in sessions.iter() {
+                    let key = std::str::from_utf8(&session.key).map_err(|_| {
+                        Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+                    })?;
+                    if session.branch == self.client.branch
+                        && key.starts_with(&prefix)
+                        && !page.uploads.iter().any(|upload| {
+                            upload.path.as_str() == key
+                                && upload.upload_id == session.provider_upload_id
+                        })
+                    {
+                        uploads.push(
+                            MultipartUpload::builder()
+                                .key(key)
+                                .upload_id(handle)
+                                .initiated(datetime(session.created_at_millis)?)
+                                .build(),
+                        );
+                    }
+                }
+            }
+            uploads.sort_by(|left, right| {
+                (
+                    left.key().unwrap_or_default(),
+                    left.upload_id().unwrap_or_default(),
+                )
+                    .cmp(&(
+                        right.key().unwrap_or_default(),
+                        right.upload_id().unwrap_or_default(),
+                    ))
+            });
+            uploads.truncate(limit);
+            return Ok(ListMultipartUploadsOutput::builder()
+                .bucket(&self.client.bucket)
+                .prefix(prefix)
+                .max_uploads(i32::try_from(limit).unwrap_or(i32::MAX))
+                .is_truncated(page.next_key_marker.is_some())
+                .set_key_marker(self.key_marker)
+                .set_upload_id_marker(self.upload_id_marker)
+                .set_next_key_marker(page.next_key_marker)
+                .set_next_upload_id_marker(page.next_upload_id_marker)
+                .set_uploads(Some(uploads))
                 .build());
         }
 
@@ -3004,6 +3099,7 @@ impl CreateMultipartUploadBuilder {
             key: None,
             content_type: None,
             metadata: None,
+            operation_id: None,
         }
     }
     pub fn bucket(mut self, value: impl Into<String>) -> Self {
@@ -3024,26 +3120,60 @@ impl CreateMultipartUploadBuilder {
             .insert(key.into(), value.into());
         self
     }
+    pub fn operation_id(mut self, value: OperationId) -> Self {
+        self.operation_id = Some(value);
+        self
+    }
     pub async fn send(self) -> Result<CreateMultipartUploadOutput> {
         self.client.validate_bucket(self.bucket.as_deref())?;
         let key = required(self.key.as_deref(), "key")?;
-        let upload = self
-            .client
-            .repository
-            .create_multipart_upload(
-                &self.client.branch,
-                key.as_bytes().to_vec(),
-                ObjectHeaders {
-                    content_type: self.content_type,
-                    ..ObjectHeaders::default()
-                },
-                self.metadata.unwrap_or_default().into_iter().collect(),
-            )
-            .await?;
+        let headers = ObjectHeaders {
+            content_type: self.content_type,
+            ..ObjectHeaders::default()
+        };
+        let metadata = self.metadata.unwrap_or_default().into_iter().collect();
+        let upload_id = if self.client.repository.storage_profile()
+            == RepositoryStorageProfile::NativeVersionedV1
+        {
+            let session = self
+                .client
+                .repository
+                .create_native_multipart_upload(
+                    &self.client.branch,
+                    key.as_bytes().to_vec(),
+                    headers,
+                    metadata,
+                    self.operation_id,
+                )
+                .await?;
+            let handle = encode_native_multipart_session(&session)?;
+            self.client
+                .native_multipart_sessions
+                .write()
+                .map_err(|_| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "native multipart session cache lock poisoned",
+                    )
+                })?
+                .insert(handle.clone(), session);
+            handle
+        } else {
+            self.client
+                .repository
+                .create_multipart_upload(
+                    &self.client.branch,
+                    key.as_bytes().to_vec(),
+                    headers,
+                    metadata,
+                )
+                .await?
+                .to_string()
+        };
         Ok(CreateMultipartUploadOutput::builder()
             .bucket(&self.client.bucket)
             .key(key)
-            .upload_id(upload.to_string())
+            .upload_id(upload_id)
             .build())
     }
 }
@@ -3097,8 +3227,7 @@ impl UploadPartCopyBuilder {
     pub async fn send(self) -> Result<UploadPartCopyOutput> {
         self.client.validate_bucket(self.bucket.as_deref())?;
         let destination = required(self.key.as_deref(), "key")?;
-        let upload = UploadId::from_str(required(self.upload_id.as_deref(), "upload_id")?)?;
-        validate_upload_binding(&self.client, upload, destination).await?;
+        let upload_text = required(self.upload_id.as_deref(), "upload_id")?;
         let part_number = u32::try_from(
             self.part_number
                 .ok_or_else(|| invalid("part_number is required"))?,
@@ -3131,6 +3260,43 @@ impl UploadPartCopyBuilder {
         } else {
             None
         };
+        if self.client.repository.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            let session = decode_native_multipart_session(&self.client, upload_text, destination)?;
+            let part = self
+                .client
+                .repository
+                .upload_native_multipart_part_copy(
+                    &session,
+                    part_number,
+                    &self.client.branch,
+                    source_key.as_bytes(),
+                    source_version,
+                    range,
+                )
+                .await?;
+            self.client
+                .native_multipart_parts
+                .write()
+                .map_err(|_| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "native multipart part cache lock poisoned",
+                    )
+                })?
+                .insert((upload_text.to_string(), part_number), part.clone());
+            return Ok(UploadPartCopyOutput::builder()
+                .copy_part_result(
+                    CopyPartResult::builder()
+                        .e_tag(part.etag)
+                        .set_checksum_sha256(
+                            part.checksum_sha256.map(|value| STANDARD.encode(value)),
+                        )
+                        .build(),
+                )
+                .build());
+        }
+        let upload = UploadId::from_str(upload_text)?;
+        validate_upload_binding(&self.client, upload, destination).await?;
         let part = self
             .client
             .repository
@@ -3196,14 +3362,40 @@ impl UploadPartBuilder {
     pub async fn send(self) -> Result<UploadPartOutput> {
         self.client.validate_bucket(self.bucket.as_deref())?;
         let key = required(self.key.as_deref(), "key")?;
-        let upload = UploadId::from_str(required(self.upload_id.as_deref(), "upload_id")?)?;
-        validate_upload_binding(&self.client, upload, key).await?;
+        let upload_text = required(self.upload_id.as_deref(), "upload_id")?;
         let part_number = u32::try_from(
             self.part_number
                 .ok_or_else(|| invalid("part_number is required"))?,
         )
         .map_err(|_| invalid("part_number must be positive"))?;
         let body = self.body.ok_or_else(|| invalid("body is required"))?;
+        if self.client.repository.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            let session = decode_native_multipart_session(&self.client, upload_text, key)?;
+            let stream = futures_util::stream::unfold(body, |mut body| async move {
+                body.next().await.map(|item| (item, body))
+            });
+            let part = self
+                .client
+                .repository
+                .upload_native_multipart_part_stream(&session, part_number, stream)
+                .await?;
+            self.client
+                .native_multipart_parts
+                .write()
+                .map_err(|_| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "native multipart part cache lock poisoned",
+                    )
+                })?
+                .insert((upload_text.to_string(), part_number), part.clone());
+            return Ok(UploadPartOutput::builder()
+                .e_tag(part.etag)
+                .set_checksum_sha256(part.checksum_sha256.map(|value| STANDARD.encode(value)))
+                .build());
+        }
+        let upload = UploadId::from_str(upload_text)?;
+        validate_upload_binding(&self.client, upload, key).await?;
         let stream = futures_util::stream::unfold(body, |mut body| async move {
             body.next().await.map(|item| (item, body))
         });
@@ -3259,6 +3451,67 @@ impl ListPartsBuilder {
         self.client.validate_bucket(self.bucket.as_deref())?;
         let key = required(self.key.as_deref(), "key")?;
         let upload_text = required(self.upload_id.as_deref(), "upload_id")?;
+        if self.client.repository.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            let session = decode_native_multipart_session(&self.client, upload_text, key)?;
+            let marker = self
+                .part_number_marker
+                .as_deref()
+                .map(str::parse::<u32>)
+                .transpose()
+                .map_err(|_| invalid("part_number_marker must be an integer"))?
+                .unwrap_or(0);
+            let limit = validate_limit(self.max_parts)?;
+            let page = self
+                .client
+                .repository
+                .plane()
+                .list_native_multipart_parts(prolly_s3_core::NativeMultipartListParts {
+                    path: ObjectPath::new(key)?,
+                    upload_id: session.provider_upload_id,
+                    after_part_number: marker,
+                    limit,
+                })
+                .await?;
+            let mut cache = self.client.native_multipart_parts.write().map_err(|_| {
+                Error::new(
+                    ErrorCode::InternalInvariant,
+                    "native multipart part cache lock poisoned",
+                )
+            })?;
+            for part in &page.parts {
+                let key = (upload_text.to_string(), part.part_number);
+                let mut merged = part.clone();
+                if merged.checksum_sha256.is_none() {
+                    merged.checksum_sha256 = cache.get(&key).and_then(|part| part.checksum_sha256);
+                }
+                cache.insert(key, merged);
+            }
+            drop(cache);
+            let parts = page
+                .parts
+                .into_iter()
+                .map(|part| {
+                    Part::builder()
+                        .part_number(i32::try_from(part.part_number).unwrap_or(i32::MAX))
+                        .e_tag(part.etag)
+                        .set_checksum_sha256(
+                            part.checksum_sha256.map(|value| STANDARD.encode(value)),
+                        )
+                        .size(i64_len(part.size).expect("provider part size is valid"))
+                        .build()
+                })
+                .collect();
+            return Ok(ListPartsOutput::builder()
+                .bucket(&self.client.bucket)
+                .key(key)
+                .upload_id(upload_text)
+                .set_part_number_marker(self.part_number_marker)
+                .set_next_part_number_marker(page.next_part_number.map(|value| value.to_string()))
+                .max_parts(i32::try_from(limit).unwrap_or(i32::MAX))
+                .is_truncated(page.next_part_number.is_some())
+                .set_parts(Some(parts))
+                .build());
+        }
         let upload = UploadId::from_str(upload_text)?;
         validate_upload_binding(&self.client, upload, key).await?;
         let marker = self
@@ -3318,6 +3571,10 @@ pub struct CompleteMultipartUploadBuilder {
     upload_id: Option<String>,
     multipart_upload: Option<CompletedMultipartUpload>,
     operation_id: Option<OperationId>,
+    checksum_sha256: Option<String>,
+    checksum_md5: Option<String>,
+    expected_size: Option<u64>,
+    part_sizes: BTreeMap<u32, u64>,
 }
 impl CompleteMultipartUploadBuilder {
     fn new(client: Client) -> Self {
@@ -3328,6 +3585,10 @@ impl CompleteMultipartUploadBuilder {
             upload_id: None,
             multipart_upload: None,
             operation_id: None,
+            checksum_sha256: None,
+            checksum_md5: None,
+            expected_size: None,
+            part_sizes: BTreeMap::new(),
         }
     }
     pub fn bucket(mut self, value: impl Into<String>) -> Self {
@@ -3350,11 +3611,26 @@ impl CompleteMultipartUploadBuilder {
         self.operation_id = Some(value);
         self
     }
+    pub fn checksum_sha256(mut self, value: impl Into<String>) -> Self {
+        self.checksum_sha256 = Some(value.into());
+        self
+    }
+    pub fn checksum_md5(mut self, value: impl Into<String>) -> Self {
+        self.checksum_md5 = Some(value.into());
+        self
+    }
+    pub fn expected_size(mut self, value: u64) -> Self {
+        self.expected_size = Some(value);
+        self
+    }
+    pub fn part_size(mut self, part_number: u32, size: u64) -> Self {
+        self.part_sizes.insert(part_number, size);
+        self
+    }
     pub async fn send(self) -> Result<Versioned<CompleteMultipartUploadOutput>> {
         self.client.validate_bucket(self.bucket.as_deref())?;
         let key = required(self.key.as_deref(), "key")?;
-        let upload = UploadId::from_str(required(self.upload_id.as_deref(), "upload_id")?)?;
-        validate_upload_binding(&self.client, upload, key).await?;
+        let upload_text = required(self.upload_id.as_deref(), "upload_id")?;
         let completed = self
             .multipart_upload
             .ok_or_else(|| invalid("multipart_upload is required"))?;
@@ -3368,11 +3644,117 @@ impl CompleteMultipartUploadBuilder {
             let etag = required(part.e_tag(), "completed e_tag")?.to_string();
             requested.push((number, etag));
         }
-        let receipt = self
-            .client
-            .repository
-            .complete_multipart_upload(upload, requested, self.operation_id)
-            .await?;
+        let receipt = if self.client.repository.storage_profile()
+            == RepositoryStorageProfile::NativeVersionedV1
+        {
+            let session = decode_native_multipart_session(&self.client, upload_text, key)?;
+            let checksum_sha256 = decode_checksum::<32>(
+                required(self.checksum_sha256.as_deref(), "checksum_sha256")?,
+                "checksum_sha256",
+            )?;
+            let checksum_md5 = decode_checksum::<16>(
+                required(self.checksum_md5.as_deref(), "checksum_md5")?,
+                "checksum_md5",
+            )?;
+            let expected_size = self
+                .expected_size
+                .ok_or_else(|| invalid("expected_size is required for native multipart"))?;
+            let native_parts = {
+                let cached = self.client.native_multipart_parts.read().map_err(|_| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "native multipart part cache lock poisoned",
+                    )
+                })?;
+                let mut native_parts = Vec::with_capacity(completed.parts().len());
+                for part in completed.parts() {
+                    let part_number = u32::try_from(
+                        part.part_number()
+                            .ok_or_else(|| invalid("completed part_number is required"))?,
+                    )
+                    .map_err(|_| invalid("completed part_number must be positive"))?;
+                    let etag = required(part.e_tag(), "completed e_tag")?.to_string();
+                    let cached_part = cached.get(&(upload_text.to_string(), part_number));
+                    let checksum = match part.checksum_sha256() {
+                        Some(value) => decode_checksum::<32>(value, "completed checksum_sha256")?,
+                        None => cached_part
+                            .and_then(|part| part.checksum_sha256)
+                            .ok_or_else(|| {
+                                invalid(
+                                    "completed checksum_sha256 is required after a process restart",
+                                )
+                            })?,
+                    };
+                    let size = self
+                        .part_sizes
+                        .get(&part_number)
+                        .copied()
+                        .or_else(|| cached_part.map(|part| part.size))
+                        .ok_or_else(|| {
+                            invalid(
+                                "part_size is required after a native multipart process restart",
+                            )
+                        })?;
+                    if cached_part.is_some_and(|part| {
+                        part.etag != etag
+                            || part.checksum_sha256 != Some(checksum)
+                            || part.size != size
+                    }) {
+                        return Err(Error::new(
+                            ErrorCode::ChecksumMismatch,
+                            "completed native multipart part differs from its upload receipt",
+                        ));
+                    }
+                    native_parts.push(NativeMultipartCompletedPart {
+                        part_number,
+                        etag,
+                        checksum_sha256: checksum,
+                        size,
+                    });
+                }
+                native_parts
+            };
+            let receipt = self
+                .client
+                .repository
+                .complete_native_multipart_upload(
+                    session,
+                    native_parts,
+                    checksum_sha256,
+                    checksum_md5,
+                    expected_size,
+                    self.operation_id,
+                )
+                .await?;
+            self.client
+                .native_multipart_parts
+                .write()
+                .map_err(|_| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "native multipart part cache lock poisoned",
+                    )
+                })?
+                .retain(|(upload, _), _| upload != upload_text);
+            self.client
+                .native_multipart_sessions
+                .write()
+                .map_err(|_| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "native multipart session cache lock poisoned",
+                    )
+                })?
+                .remove(upload_text);
+            receipt
+        } else {
+            let upload = UploadId::from_str(upload_text)?;
+            validate_upload_binding(&self.client, upload, key).await?;
+            self.client
+                .repository
+                .complete_multipart_upload(upload, requested, self.operation_id)
+                .await?
+        };
         self.client.record_advisory(&receipt).await;
         let summary = self
             .client
@@ -3430,12 +3812,41 @@ impl AbortMultipartUploadBuilder {
     pub async fn send(self) -> Result<AbortMultipartUploadOutput> {
         self.client.validate_bucket(self.bucket.as_deref())?;
         let key = required(self.key.as_deref(), "key")?;
-        let upload = UploadId::from_str(required(self.upload_id.as_deref(), "upload_id")?)?;
-        validate_upload_binding(&self.client, upload, key).await?;
-        self.client
-            .repository
-            .abort_multipart_upload(upload)
-            .await?;
+        let upload_text = required(self.upload_id.as_deref(), "upload_id")?;
+        if self.client.repository.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            let session = decode_native_multipart_session(&self.client, upload_text, key)?;
+            self.client
+                .repository
+                .abort_native_multipart_upload(&session)
+                .await?;
+            self.client
+                .native_multipart_parts
+                .write()
+                .map_err(|_| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "native multipart part cache lock poisoned",
+                    )
+                })?
+                .retain(|(upload, _), _| upload != upload_text);
+            self.client
+                .native_multipart_sessions
+                .write()
+                .map_err(|_| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "native multipart session cache lock poisoned",
+                    )
+                })?
+                .remove(upload_text);
+        } else {
+            let upload = UploadId::from_str(upload_text)?;
+            validate_upload_binding(&self.client, upload, key).await?;
+            self.client
+                .repository
+                .abort_multipart_upload(upload)
+                .await?;
+        }
         Ok(AbortMultipartUploadOutput::builder().build())
     }
 }
@@ -4212,6 +4623,50 @@ async fn validate_upload_binding(client: &Client, upload: UploadId, key: &str) -
         ));
     }
     Ok(())
+}
+
+const NATIVE_MULTIPART_HANDLE_PREFIX: &str = "nmu1_";
+
+fn encode_native_multipart_session(session: &NativeMultipartSessionV1) -> Result<String> {
+    Ok(format!(
+        "{NATIVE_MULTIPART_HANDLE_PREFIX}{}",
+        URL_SAFE_NO_PAD.encode(encode_canonical(session)?)
+    ))
+}
+
+fn decode_native_multipart_session(
+    client: &Client,
+    value: &str,
+    key: &str,
+) -> Result<NativeMultipartSessionV1> {
+    let encoded = value
+        .strip_prefix(NATIVE_MULTIPART_HANDLE_PREFIX)
+        .ok_or_else(|| {
+            Error::new(
+                ErrorCode::NoSuchUpload,
+                "native multipart handle is invalid",
+            )
+        })?;
+    let bytes = URL_SAFE_NO_PAD.decode(encoded).map_err(|_| {
+        Error::new(
+            ErrorCode::NoSuchUpload,
+            "native multipart handle is not canonical base64url",
+        )
+    })?;
+    let session: NativeMultipartSessionV1 = decode_canonical(&bytes).map_err(|_| {
+        Error::new(
+            ErrorCode::NoSuchUpload,
+            "native multipart handle is malformed",
+        )
+    })?;
+    session.validate_address(client.repository_id())?;
+    if session.branch != client.branch || session.key != key.as_bytes() {
+        return Err(Error::new(
+            ErrorCode::NoSuchUpload,
+            "native multipart upload does not belong to this branch and key",
+        ));
+    }
+    Ok(session)
 }
 fn utf8_key(key: &[u8]) -> Result<String> {
     String::from_utf8(key.to_vec())

--- a/extensions/s3/client/src/client.rs
+++ b/extensions/s3/client/src/client.rs
@@ -41,7 +41,7 @@ use prolly_s3_core::{
     ObjectVersionId, ObjectVersionKindV1, ObjectWriteConditionV1, OperationId, PhysicalVersion,
     PhysicalVersioning, ProviderAttestationV1, ProviderProfileId, RefValueV1, Repository,
     RepositoryOptions, RepositoryStorageProfile, Result, RetryAdvice, UploadId, VersionSummary,
-    WorkspaceId, WorkspaceManifestV1, MAX_LOGICAL_RETRY_LIMIT,
+    WorkspaceId, WorkspaceManifestV1, WriterLeaseMaintenance, MAX_LOGICAL_RETRY_LIMIT,
 };
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -549,6 +549,7 @@ pub struct Client {
     provider_attestation: Arc<RwLock<ProviderAttestationV1>>,
     native_multipart_parts: Arc<RwLock<BTreeMap<(String, u32), NativeMultipartPartResult>>>,
     native_multipart_sessions: Arc<RwLock<BTreeMap<String, NativeMultipartSessionV1>>>,
+    writer_lease_maintenance: Option<Arc<WriterLeaseMaintenance>>,
 }
 
 #[derive(Default)]
@@ -624,6 +625,7 @@ impl Client {
             provider_attestation: self.provider_attestation.clone(),
             native_multipart_parts: self.native_multipart_parts.clone(),
             native_multipart_sessions: self.native_multipart_sessions.clone(),
+            writer_lease_maintenance: self.writer_lease_maintenance.clone(),
         })
     }
 
@@ -1708,6 +1710,9 @@ impl ClientBuilder {
         if let Some(value) = self.gc_delete_rate_limit_per_second {
             options.gc_delete_rate_limit_per_second = value;
         }
+        let maintain_native_writer = options.storage_profile
+            == RepositoryStorageProfile::NativeVersionedV1
+            && !options.read_only;
         let branch = options.default_branch.clone();
         let plane = Arc::new(AwsS3ObjectPlane::new(aws, bucket.clone()));
         let provider_identity = self
@@ -1758,8 +1763,13 @@ impl ClientBuilder {
             validate_profile_capabilities(repository.storage_profile(), &attestation)?;
             (repository, attestation)
         };
+        let repository = Arc::new(repository);
+        let writer_lease_maintenance = maintain_native_writer
+            .then(|| repository.start_writer_lease_maintenance())
+            .transpose()?
+            .map(Arc::new);
         Ok(Client {
-            repository: Arc::new(repository),
+            repository,
             bucket,
             branch,
             token_signer: self.token_signer,
@@ -1771,6 +1781,7 @@ impl ClientBuilder {
             provider_attestation: Arc::new(RwLock::new(attestation)),
             native_multipart_parts: Arc::new(RwLock::new(BTreeMap::new())),
             native_multipart_sessions: Arc::new(RwLock::new(BTreeMap::new())),
+            writer_lease_maintenance,
         })
     }
 }

--- a/extensions/s3/client/src/client.rs
+++ b/extensions/s3/client/src/client.rs
@@ -38,9 +38,9 @@ use prolly_s3_core::{
     Error, ErrorCode, EtagPredicateV1, GetRequest, ListRequest, MultipartCatalogSnapshotId,
     ObjectHeaders, ObjectPath, ObjectPlane, ObjectSummary, ObjectVersionId, ObjectVersionKindV1,
     ObjectWriteConditionV1, OperationId, PhysicalVersion, PhysicalVersioning,
-    ProviderAttestationV1, ProviderProfileId, RefValueV1, Repository, RepositoryOptions, Result,
-    RetryAdvice, UploadId, VersionSummary, WorkspaceId, WorkspaceManifestV1,
-    MAX_LOGICAL_RETRY_LIMIT,
+    ProviderAttestationV1, ProviderProfileId, RefValueV1, Repository, RepositoryOptions,
+    RepositoryStorageProfile, Result, RetryAdvice, UploadId, VersionSummary, WorkspaceId,
+    WorkspaceManifestV1, MAX_LOGICAL_RETRY_LIMIT,
 };
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -555,6 +555,9 @@ pub struct ClientBuilder {
     repository_prefix: Option<String>,
     default_branch: Option<String>,
     writer: Option<String>,
+    storage_profile: Option<RepositoryStorageProfile>,
+    writer_lease_duration: Option<Duration>,
+    read_only: bool,
     logical_retry_limit: Option<u8>,
     gc_delete_rate_limit_per_second: Option<u32>,
     token_signer: Option<Arc<dyn TokenSigner>>,
@@ -730,6 +733,7 @@ impl Client {
         Ok(CommitSession {
             client: self.clone(),
             manifest,
+            native_mutations: None,
         })
     }
     pub async fn at(&self, commit: CommitId) -> Result<Snapshot> {
@@ -1147,6 +1151,7 @@ impl Client {
             None,
         )
         .await?;
+        validate_profile_capabilities(self.repository.storage_profile(), &attestation)?;
         let id = attestation.id;
         *self
             .provider_attestation
@@ -1338,7 +1343,8 @@ impl Client {
             .provider_attestation
             .read()
             .map_err(|_| Error::new(ErrorCode::InternalInvariant, "attestation lock poisoned"))?;
-        ensure_attestation_current(&attestation)
+        ensure_attestation_current(&attestation)?;
+        validate_profile_capabilities(self.repository.storage_profile(), &attestation)
     }
 
     fn ensure_native_version_recovery_supported(&self) -> Result<()> {
@@ -1554,6 +1560,22 @@ impl ClientBuilder {
         self.writer = Some(writer.into());
         self
     }
+    pub fn storage_profile(mut self, profile: RepositoryStorageProfile) -> Self {
+        self.storage_profile = Some(profile);
+        self
+    }
+    pub fn native_versioned(mut self) -> Self {
+        self.storage_profile = Some(RepositoryStorageProfile::NativeVersionedV1);
+        self
+    }
+    pub fn writer_lease_duration(mut self, duration: Duration) -> Self {
+        self.writer_lease_duration = Some(duration);
+        self
+    }
+    pub fn read_only(mut self, value: bool) -> Self {
+        self.read_only = value;
+        self
+    }
     pub fn logical_retry_limit(mut self, attempts: u8) -> Self {
         self.logical_retry_limit = Some(attempts);
         self
@@ -1630,6 +1652,11 @@ impl ClientBuilder {
 
     async fn finish(self, initialize: bool) -> Result<Client> {
         validate_logical_retry_limit(self.logical_retry_limit)?;
+        if initialize && self.read_only {
+            return Err(invalid(
+                "repository initialization requires a writable client",
+            ));
+        }
         let cursor_ttl = self.cursor_ttl.unwrap_or(Duration::from_secs(15 * 60));
         let cursor_clock_skew = self
             .cursor_clock_skew
@@ -1662,6 +1689,14 @@ impl ClientBuilder {
         if let Some(value) = self.writer {
             options.writer = value;
         }
+        if let Some(value) = self.storage_profile {
+            options.storage_profile = value;
+        }
+        if let Some(value) = self.writer_lease_duration {
+            options.writer_lease_millis = u64::try_from(value.as_millis())
+                .map_err(|_| invalid("writer lease duration exceeds u64 milliseconds"))?;
+        }
+        options.read_only = self.read_only;
         if let Some(value) = self.logical_retry_limit {
             options.logical_retry_limit = value;
         }
@@ -1703,6 +1738,7 @@ impl ClientBuilder {
                 }
                 Err(error) => return Err(error),
             };
+            validate_profile_capabilities(options.storage_profile, &attestation)?;
             (Repository::initialize(plane, options).await?, attestation)
         } else {
             let repository = Repository::open(plane.clone(), options).await?;
@@ -1714,6 +1750,7 @@ impl ClientBuilder {
                 selected_attestation,
             )
             .await?;
+            validate_profile_capabilities(repository.storage_profile(), &attestation)?;
             (repository, attestation)
         };
         Ok(Client {
@@ -1749,14 +1786,23 @@ impl CommitBuilder {
         self.client.ensure_provider_qualified()?;
         let millis = u64::try_from(self.expires_after.as_millis())
             .map_err(|_| invalid("workspace expiry exceeds u64 milliseconds"))?;
-        let manifest = self
-            .client
-            .repository
-            .begin_workspace(&self.client.branch, self.message, millis)
-            .await?;
+        let native =
+            self.client.repository.storage_profile() == RepositoryStorageProfile::NativeVersionedV1;
+        let manifest = if native {
+            self.client
+                .repository
+                .begin_native_batch(&self.client.branch, self.message, millis)
+                .await?
+        } else {
+            self.client
+                .repository
+                .begin_workspace(&self.client.branch, self.message, millis)
+                .await?
+        };
         Ok(CommitSession {
             client: self.client,
             manifest,
+            native_mutations: native.then(BTreeMap::new),
         })
     }
 }
@@ -1764,6 +1810,7 @@ impl CommitBuilder {
 pub struct CommitSession {
     client: Client,
     manifest: WorkspaceManifestV1,
+    native_mutations: Option<BTreeMap<Vec<u8>, prolly_s3_core::NativeBatchMutationV1>>,
 }
 impl CommitSession {
     pub fn id(&self) -> WorkspaceId {
@@ -1791,16 +1838,25 @@ impl CommitSession {
     }
     pub async fn publish(self) -> Result<CommitReceipt> {
         self.client.ensure_provider_qualified()?;
-        let receipt = self
-            .client
-            .repository
-            .publish_workspace(self.manifest.id)
-            .await?;
+        let receipt = if let Some(mutations) = self.native_mutations {
+            self.client
+                .repository
+                .publish_native_batch(self.manifest, mutations.into_values().collect())
+                .await?
+        } else {
+            self.client
+                .repository
+                .publish_workspace(self.manifest.id)
+                .await?
+        };
         self.client.record_advisory(&receipt).await;
         Ok(receipt)
     }
     pub async fn abort(self) -> Result<()> {
         self.client.ensure_provider_qualified()?;
+        if self.native_mutations.is_some() {
+            return Ok(());
+        }
         self.client
             .repository
             .abort_workspace(self.manifest.id)
@@ -1845,6 +1901,27 @@ impl<'a> StagedPutObjectBuilder<'a> {
             .validate_bucket(self.bucket.as_deref())?;
         let key = required(self.key.as_deref(), "key")?;
         let body = self.body.ok_or_else(|| invalid("body is required"))?;
+        if let Some(mutations) = self.session.native_mutations.as_mut() {
+            let bytes = body.collect().await.map_err(|error| {
+                Error::new(
+                    ErrorCode::Transport,
+                    format!("native staged body failed: {error}"),
+                )
+            })?;
+            mutations.insert(
+                key.as_bytes().to_vec(),
+                prolly_s3_core::NativeBatchMutationV1::Put {
+                    key: key.as_bytes().to_vec(),
+                    bytes: bytes.into_bytes().to_vec(),
+                    headers: ObjectHeaders {
+                        content_type: self.content_type,
+                        ..ObjectHeaders::default()
+                    },
+                    user_metadata: self.metadata.unwrap_or_default().into_iter().collect(),
+                },
+            );
+            return Ok(());
+        }
         let stream = futures_util::stream::unfold(body, |mut body| async move {
             body.next().await.map(|item| (item, body))
         });
@@ -1886,6 +1963,15 @@ impl<'a> StagedDeleteObjectBuilder<'a> {
             .client
             .validate_bucket(self.bucket.as_deref())?;
         let key = required(self.key.as_deref(), "key")?;
+        if let Some(mutations) = self.session.native_mutations.as_mut() {
+            mutations.insert(
+                key.as_bytes().to_vec(),
+                prolly_s3_core::NativeBatchMutationV1::Delete {
+                    key: key.as_bytes().to_vec(),
+                },
+            );
+            return Ok(());
+        }
         self.session.manifest = self
             .session
             .client
@@ -2264,7 +2350,7 @@ impl GetObjectBuilder {
         )?;
         validate_checksum_mode(self.checksum_mode.as_ref())?;
         let (body, response_len, content_range) = match &summary.version.body.kind {
-            ObjectVersionKindV1::Live { content, size, .. } => {
+            ObjectVersionKindV1::Live { size, .. } => {
                 let selected_range = self
                     .range
                     .as_deref()
@@ -2275,10 +2361,11 @@ impl GetObjectBuilder {
                     .unwrap_or(*size);
                 let content_range =
                     selected_range.map(|(start, end)| format!("bytes {start}-{end}/{size}"));
-                let stream = self
-                    .client
-                    .repository
-                    .read_content_stream(content.clone(), selected_range);
+                let stream = self.client.repository.read_version_stream(
+                    key.as_bytes(),
+                    summary.version.clone(),
+                    selected_range,
+                );
                 (
                     streaming_body(stream, response_len),
                     response_len,
@@ -3986,6 +4073,20 @@ where
 }
 fn invalid(message: impl Into<String>) -> Error {
     Error::new(ErrorCode::InvalidRequest, message)
+}
+
+fn validate_profile_capabilities(
+    profile: RepositoryStorageProfile,
+    attestation: &ProviderAttestationV1,
+) -> Result<()> {
+    match profile {
+        RepositoryStorageProfile::DistributedContentAddressedV1 => {
+            attestation.body.capabilities.validate_distributed()
+        }
+        RepositoryStorageProfile::NativeVersionedV1 => {
+            attestation.body.capabilities.validate_native_versioned()
+        }
+    }
 }
 fn validate_branch_name(branch: &str) -> Result<()> {
     if branch.is_empty()

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -6096,6 +6096,147 @@ async fn rustfs_native_versioned_whole_object_write_uses_four_calls() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rustfs_native_clone_rebinds_exact_versions_and_preserves_history() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+
+    let (aws, bucket) = rustfs_client().await;
+    aws.put_bucket_versioning()
+        .bucket(&bucket)
+        .versioning_configuration(
+            VersioningConfiguration::builder()
+                .status(BucketVersioningStatus::Enabled)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let source_prefix = unique_prefix("native-clone-source");
+    let destination_prefix = unique_prefix("native-clone-destination");
+    let key = format!("{}/history.bin", unique_prefix("native-clone-object"));
+    let source_plane = Arc::new(AwsS3ObjectPlane::new(aws.clone(), &bucket));
+    let source = Repository::initialize(
+        source_plane,
+        RepositoryOptions {
+            repository_prefix: source_prefix,
+            storage_profile: RepositoryStorageProfile::NativeVersionedV1,
+            writer: "rustfs-native-clone-writer".to_string(),
+            ..RepositoryOptions::default()
+        },
+    )
+    .await
+    .unwrap();
+    let first = source
+        .put_bytes(
+            "main",
+            key.as_bytes().to_vec(),
+            b"first native version".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    source
+        .put_bytes(
+            "main",
+            key.as_bytes().to_vec(),
+            b"second native version".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let destination_plane = Arc::new(AwsS3ObjectPlane::new(aws, &bucket));
+    let clone = source
+        .clone_to(destination_plane.clone(), &destination_prefix)
+        .await
+        .unwrap();
+    assert_eq!(clone.refs, 1);
+    let destination = Repository::open(
+        destination_plane,
+        RepositoryOptions {
+            repository_prefix: destination_prefix,
+            storage_profile: RepositoryStorageProfile::NativeVersionedV1,
+            writer: "rustfs-native-clone-writer".to_string(),
+            ..RepositoryOptions::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(destination.repository_id(), source.repository_id());
+    assert_eq!(
+        destination
+            .get_current("main", key.as_bytes())
+            .await
+            .unwrap()
+            .bytes,
+        b"second native version"
+    );
+    let source_historical = source
+        .head_version("main", key.as_bytes(), first.object_versions[0])
+        .await
+        .unwrap()
+        .1
+        .version;
+    let destination_historical = destination
+        .head_version("main", key.as_bytes(), first.object_versions[0])
+        .await
+        .unwrap()
+        .1
+        .version;
+    assert_eq!(source_historical.id, destination_historical.id);
+    assert_ne!(
+        source_historical.native_binding,
+        destination_historical.native_binding
+    );
+    assert_eq!(
+        destination
+            .get_version("main", key.as_bytes(), first.object_versions[0])
+            .await
+            .unwrap()
+            .bytes,
+        b"first native version"
+    );
+    let expected_destination = destination.head("main").await.unwrap();
+    source
+        .put_bytes(
+            "main",
+            key.as_bytes().to_vec(),
+            b"third native version".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let push = source
+        .push_to(
+            &destination,
+            "main",
+            "main",
+            expected_destination,
+            "RustFS incremental native push",
+        )
+        .await
+        .unwrap();
+    assert_eq!(push.copied_objects, 3);
+    assert_eq!(push.copied_bytes, b"third native version".len() as u64);
+    assert_eq!(
+        destination
+            .get_current("main", key.as_bytes())
+            .await
+            .unwrap()
+            .bytes,
+        b"third native version"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn rustfs_native_versioned_multipart_uses_n_plus_five_calls() {
     if !rustfs_enabled() {
         eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -23,15 +23,16 @@ use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 #[cfg(feature = "slatedb-index")]
 use futures_util::{StreamExt, TryStreamExt};
+use md5::Md5;
 use prolly_s3_client::{
     core::{
         decode_canonical, encode_canonical, CanonicalLimits, CommitId, CompareExchange,
         CompareExchangeOutcome, ContentStore, DeleteOutcome, Error, ErrorCode, FixedClock,
         GetRequest, ImmutablePut, ImmutablePutOutcome, ListRequest, MergePolicy, MultipartStateV1,
-        MultipartUploadV1, ObjectHeaders, ObjectPath, ObjectPlane, ObjectVersionKindV1,
-        OperationId, PhysicalListPage, PhysicalVersion, PhysicalVersioning, Repository,
-        RepositoryOptions, RepositoryStorageProfile, RetryAdvice, StoredMetadata, StoredObject,
-        MAX_LOGICAL_RETRY_LIMIT,
+        MultipartUploadV1, NativeMultipartCompletedPart, ObjectHeaders, ObjectPath, ObjectPlane,
+        ObjectVersionKindV1, OperationId, PhysicalListPage, PhysicalVersion, PhysicalVersioning,
+        Repository, RepositoryOptions, RepositoryStorageProfile, RetryAdvice, StoredMetadata,
+        StoredObject, MAX_LOGICAL_RETRY_LIMIT,
     },
     AwsS3ObjectPlane, Client, HmacAttestationSigner, HmacTokenSigner, ProviderIdentity,
     S3OperationMetrics, S3WireAttemptInterceptor, S3WireAttemptMetrics, WriteOptions,
@@ -1381,6 +1382,21 @@ fn combine_s3_metrics(left: S3OperationMetrics, right: S3OperationMetrics) -> S3
             .list_object_versions
             .saturating_add(right.list_object_versions),
         delete_object: left.delete_object.saturating_add(right.delete_object),
+        create_multipart_upload: left
+            .create_multipart_upload
+            .saturating_add(right.create_multipart_upload),
+        upload_part: left.upload_part.saturating_add(right.upload_part),
+        upload_part_copy: left.upload_part_copy.saturating_add(right.upload_part_copy),
+        complete_multipart_upload: left
+            .complete_multipart_upload
+            .saturating_add(right.complete_multipart_upload),
+        abort_multipart_upload: left
+            .abort_multipart_upload
+            .saturating_add(right.abort_multipart_upload),
+        list_parts: left.list_parts.saturating_add(right.list_parts),
+        list_multipart_uploads: left
+            .list_multipart_uploads
+            .saturating_add(right.list_multipart_uploads),
         uploaded_body_bytes: left
             .uploaded_body_bytes
             .saturating_add(right.uploaded_body_bytes),
@@ -6077,6 +6093,284 @@ async fn rustfs_native_versioned_whole_object_write_uses_four_calls() {
             .bytes,
         vec![2; 64 * 1024]
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rustfs_native_versioned_multipart_uses_n_plus_five_calls() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+
+    let (aws, bucket, wire) = rustfs_client_with_wire_metrics().await;
+    aws.put_bucket_versioning()
+        .bucket(&bucket)
+        .versioning_configuration(
+            VersioningConfiguration::builder()
+                .status(BucketVersioningStatus::Enabled)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let prefix = unique_prefix("native-versioned-multipart");
+    let key = format!(
+        "{}/multipart.bin",
+        unique_prefix("native-versioned-objects")
+    );
+    let plane = Arc::new(AwsS3ObjectPlane::new(aws, &bucket));
+    let repository = Repository::initialize(
+        plane.clone(),
+        RepositoryOptions {
+            repository_prefix: prefix,
+            storage_profile: RepositoryStorageProfile::NativeVersionedV1,
+            writer: "rustfs-native-multipart-writer".to_string(),
+            ..RepositoryOptions::default()
+        },
+    )
+    .await
+    .unwrap();
+    repository
+        .put_bytes(
+            "main",
+            format!("{key}.warmup").into_bytes(),
+            b"warm".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let first_bytes = vec![3; 5 * 1024 * 1024];
+    let second_bytes = vec![5; 1024];
+    let mut whole = first_bytes.clone();
+    whole.extend_from_slice(&second_bytes);
+    let checksum_sha256: [u8; 32] = Sha256::digest(&whole).into();
+    let checksum_md5: [u8; 16] = Md5::digest(&whole).into();
+
+    plane.reset_metrics();
+    wire.reset();
+    let session = repository
+        .create_native_multipart_upload(
+            "main",
+            key.as_bytes().to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let first = repository
+        .upload_native_multipart_part(&session, 1, first_bytes)
+        .await
+        .unwrap();
+    let second = repository
+        .upload_native_multipart_part(&session, 2, second_bytes)
+        .await
+        .unwrap();
+    let parts = [&first, &second]
+        .into_iter()
+        .map(|part| NativeMultipartCompletedPart {
+            part_number: part.part_number,
+            etag: part.etag.clone(),
+            checksum_sha256: part.checksum_sha256.unwrap(),
+            size: part.size,
+        })
+        .collect();
+    repository
+        .complete_native_multipart_upload(
+            session.clone(),
+            parts,
+            checksum_sha256,
+            checksum_md5,
+            whole.len() as u64,
+            Some(session.operation),
+        )
+        .await
+        .unwrap();
+    let sdk = plane.reset_metrics();
+    let wire = wire.reset();
+    assert_eq!(sdk.create_multipart_upload, 1);
+    assert_eq!(sdk.upload_part, 2);
+    assert_eq!(sdk.complete_multipart_upload, 1);
+    assert_eq!(sdk.put_object, 3);
+    assert_eq!(sdk.total_calls(), 7, "unexpected SDK calls: {sdk:?}");
+    assert_eq!(wire.executions, 7, "unexpected SDK executions: {wire:?}");
+    assert_eq!(wire.transmissions, 7, "unexpected wire calls: {wire:?}");
+    assert_eq!(
+        repository
+            .get_current("main", key.as_bytes())
+            .await
+            .unwrap()
+            .bytes,
+        whole
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rustfs_native_multipart_client_lists_completes_and_aborts() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+    let (aws, bucket) = rustfs_client().await;
+    aws.put_bucket_versioning()
+        .bucket(&bucket)
+        .versioning_configuration(
+            VersioningConfiguration::builder()
+                .status(BucketVersioningStatus::Enabled)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let repository_prefix = unique_prefix("native-multipart-client");
+    let writer = "native-multipart-client-writer";
+    let client = Client::builder()
+        .aws_client(aws.clone())
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer(writer)
+        .native_versioned()
+        .provider_identity(rustfs_provider_identity())
+        .attestation_signer(test_attestation_signer())
+        .initialize()
+        .await
+        .unwrap();
+    let key_root = unique_prefix("native-multipart-client-objects");
+    let key = format!("{key_root}/complete.bin");
+    let create = client
+        .create_multipart_upload()
+        .bucket(&bucket)
+        .key(&key)
+        .send()
+        .await
+        .unwrap();
+    let upload_id = create.upload_id().unwrap();
+    let first_bytes = vec![11; 5 * 1024 * 1024];
+    let second_bytes = vec![13; 1024];
+    let first = client
+        .upload_part()
+        .bucket(&bucket)
+        .key(&key)
+        .upload_id(upload_id)
+        .part_number(1)
+        .body(ByteStream::from(first_bytes.clone()))
+        .send()
+        .await
+        .unwrap();
+    let second = client
+        .upload_part()
+        .bucket(&bucket)
+        .key(&key)
+        .upload_id(upload_id)
+        .part_number(2)
+        .body(ByteStream::from(second_bytes.clone()))
+        .send()
+        .await
+        .unwrap();
+    let listed = client
+        .list_parts()
+        .bucket(&bucket)
+        .key(&key)
+        .upload_id(upload_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(listed.parts().len(), 2);
+
+    drop(client);
+    let client = Client::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer(writer)
+        .native_versioned()
+        .provider_identity(rustfs_provider_identity())
+        .attestation_signer(test_attestation_signer())
+        .open()
+        .await
+        .unwrap();
+
+    let mut whole = first_bytes;
+    whole.extend_from_slice(&second_bytes);
+    client
+        .complete_multipart_upload()
+        .bucket(&bucket)
+        .key(&key)
+        .upload_id(upload_id)
+        .checksum_sha256(STANDARD.encode(Sha256::digest(&whole)))
+        .checksum_md5(STANDARD.encode(Md5::digest(&whole)))
+        .expected_size(whole.len() as u64)
+        .part_size(1, 5 * 1024 * 1024)
+        .part_size(2, 1024)
+        .multipart_upload(
+            CompletedMultipartUpload::builder()
+                .parts(
+                    CompletedPart::builder()
+                        .part_number(1)
+                        .e_tag(first.e_tag().unwrap())
+                        .checksum_sha256(first.checksum_sha256().unwrap())
+                        .build(),
+                )
+                .parts(
+                    CompletedPart::builder()
+                        .part_number(2)
+                        .e_tag(second.e_tag().unwrap())
+                        .checksum_sha256(second.checksum_sha256().unwrap())
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        client
+            .get_object()
+            .bucket(&bucket)
+            .key(&key)
+            .send()
+            .await
+            .unwrap()
+            .output
+            .body
+            .collect()
+            .await
+            .unwrap()
+            .into_bytes(),
+        whole.as_slice()
+    );
+
+    let abort_key = format!("{key_root}/abort.bin");
+    client
+        .create_multipart_upload()
+        .bucket(&bucket)
+        .key(&abort_key)
+        .send()
+        .await
+        .unwrap();
+    let uploads = client
+        .list_multipart_uploads()
+        .bucket(&bucket)
+        .prefix(&key_root)
+        .send()
+        .await
+        .unwrap();
+    let discovered = uploads
+        .uploads()
+        .iter()
+        .find(|upload| upload.key() == Some(abort_key.as_str()))
+        .unwrap_or_else(|| panic!("abort upload missing from listing: {uploads:?}"));
+    client
+        .abort_multipart_upload()
+        .bucket(&bucket)
+        .key(&abort_key)
+        .upload_id(discovered.upload_id().unwrap())
+        .send()
+        .await
+        .unwrap();
 }
 
 async fn rustfs_client() -> (aws_sdk_s3::Client, String) {

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -30,7 +30,8 @@ use prolly_s3_client::{
         GetRequest, ImmutablePut, ImmutablePutOutcome, ListRequest, MergePolicy, MultipartStateV1,
         MultipartUploadV1, ObjectHeaders, ObjectPath, ObjectPlane, ObjectVersionKindV1,
         OperationId, PhysicalListPage, PhysicalVersion, PhysicalVersioning, Repository,
-        RepositoryOptions, RetryAdvice, StoredMetadata, StoredObject, MAX_LOGICAL_RETRY_LIMIT,
+        RepositoryOptions, RepositoryStorageProfile, RetryAdvice, StoredMetadata, StoredObject,
+        MAX_LOGICAL_RETRY_LIMIT,
     },
     AwsS3ObjectPlane, Client, HmacAttestationSigner, HmacTokenSigner, ProviderIdentity,
     S3OperationMetrics, S3WireAttemptInterceptor, S3WireAttemptMetrics, WriteOptions,
@@ -1374,6 +1375,7 @@ fn combine_s3_metrics(left: S3OperationMetrics, right: S3OperationMetrics) -> S3
         get_object: left.get_object.saturating_add(right.get_object),
         head_object: left.head_object.saturating_add(right.head_object),
         put_object: left.put_object.saturating_add(right.put_object),
+        copy_object: left.copy_object.saturating_add(right.copy_object),
         list_objects_v2: left.list_objects_v2.saturating_add(right.list_objects_v2),
         list_object_versions: left
             .list_object_versions
@@ -5983,6 +5985,98 @@ fn rustfs_provider_identity() -> ProviderIdentity {
 
 fn test_attestation_signer() -> Arc<HmacAttestationSigner> {
     Arc::new(HmacAttestationSigner::single("integration-attestation-v1", vec![11_u8; 32]).unwrap())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rustfs_native_versioned_whole_object_write_uses_four_calls() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+
+    let (aws, bucket, wire) = rustfs_client_with_wire_metrics().await;
+    aws.put_bucket_versioning()
+        .bucket(&bucket)
+        .versioning_configuration(
+            VersioningConfiguration::builder()
+                .status(BucketVersioningStatus::Enabled)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let prefix = unique_prefix("native-versioned-four-calls");
+    let object_root = unique_prefix("native-versioned-objects");
+    let plane = Arc::new(AwsS3ObjectPlane::new(aws, &bucket));
+    let repository = Repository::initialize(
+        plane.clone(),
+        RepositoryOptions {
+            repository_prefix: prefix,
+            storage_profile: RepositoryStorageProfile::NativeVersionedV1,
+            writer: "rustfs-native-writer".to_string(),
+            ..RepositoryOptions::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    repository
+        .put_bytes(
+            "main",
+            format!("{object_root}/warmup.bin").into_bytes(),
+            vec![1; 64 * 1024],
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    plane.reset_metrics();
+    wire.reset();
+    let measured_key = format!("{object_root}/measured.bin");
+    let first = repository
+        .put_bytes(
+            "main",
+            measured_key.as_bytes().to_vec(),
+            vec![2; 64 * 1024],
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let sdk = plane.reset_metrics();
+    let wire = wire.reset();
+    assert_eq!(sdk.total_calls(), 4, "unexpected SDK calls: {sdk:?}");
+    assert_eq!(sdk.put_object, 4, "every publication step is one put");
+    assert_eq!(wire.executions, 4, "unexpected SDK executions: {wire:?}");
+    assert_eq!(
+        wire.transmissions, 4,
+        "RustFS should not retry the measured write: {wire:?}"
+    );
+
+    let first_version = first.object_versions[0];
+    repository
+        .put_bytes(
+            "main",
+            measured_key.as_bytes().to_vec(),
+            b"new current value".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        repository
+            .get_version("main", measured_key.as_bytes(), first_version)
+            .await
+            .unwrap()
+            .bytes,
+        vec![2; 64 * 1024]
+    );
 }
 
 async fn rustfs_client() -> (aws_sdk_s3::Client, String) {

--- a/extensions/s3/core/Cargo.toml
+++ b/extensions/s3/core/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 sha2 = "0.10"
 thiserror = "2.0"
+tempfile = "3.23"
 tokio = { version = "1.45", features = ["sync", "time"] }
 uuid = { version = "1.18", features = ["v4", "serde"] }
 

--- a/extensions/s3/core/Cargo.toml
+++ b/extensions/s3/core/Cargo.toml
@@ -21,7 +21,7 @@ serde_cbor = "0.11"
 sha2 = "0.10"
 thiserror = "2.0"
 tempfile = "3.23"
-tokio = { version = "1.45", features = ["sync", "time"] }
+tokio = { version = "1.45", features = ["rt", "sync", "time"] }
 uuid = { version = "1.18", features = ["v4", "serde"] }
 
 [dev-dependencies]

--- a/extensions/s3/core/src/lib.rs
+++ b/extensions/s3/core/src/lib.rs
@@ -20,7 +20,7 @@ pub use repository::{
     version_cursor_after_key, BranchHead, CloneReport, FsckReport, GcDryRun, GcSweepReport,
     MergeConflict, MergePlan, MergePolicy, MultipartUploadSummary, ObjectDiff, ObjectSummary,
     RefMoveReceipt, RepairReport, Repository, RepositoryOptions, SyncReport, Tag, VersionSummary,
-    MAX_LOGICAL_RETRY_LIMIT,
+    WriterLeaseMaintenance, MAX_LOGICAL_RETRY_LIMIT,
 };
 pub use runtime::*;
 pub use store::ProllyObjectStore;

--- a/extensions/s3/core/src/model.rs
+++ b/extensions/s3/core/src/model.rs
@@ -9,7 +9,10 @@ use prolly::{Cid, Tree, TreeFormat};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{codec::domain_hash, encode_canonical, Error, ErrorCode, ObjectPath, Result};
+use crate::{
+    codec::{domain_hash, sha256},
+    decode_canonical, encode_canonical, Error, ErrorCode, ObjectPath, Result,
+};
 
 macro_rules! hash_id {
     ($name:ident, $prefix:literal) => {
@@ -88,6 +91,8 @@ hash_id!(ProviderProfileId, "ppf1_");
 hash_id!(ProtectionSegmentId, "pps1_");
 hash_id!(GcPlanId, "pgc1_");
 hash_id!(MultipartCatalogSnapshotId, "pmc1_");
+hash_id!(NodePackId, "pnp1_");
+hash_id!(NodeIndexCheckpointId, "nic1_");
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct UploadId(pub Uuid);
@@ -221,6 +226,48 @@ pub struct CanonicalLimits {
     pub content_chunk_bytes: u32,
 }
 
+/// Persisted storage and writer topology selected when a repository is
+/// created. Repositories never switch profiles in place.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RepositoryStorageProfile {
+    #[default]
+    DistributedContentAddressedV1,
+    NativeVersionedV1,
+}
+
+impl RepositoryStorageProfile {
+    pub const fn capability_profile(self) -> u16 {
+        match self {
+            Self::DistributedContentAddressedV1 => {
+                RepositoryFormatV1::DISTRIBUTED_S3_CAPABILITY_PROFILE
+            }
+            Self::NativeVersionedV1 => RepositoryFormatV1::NATIVE_VERSIONED_S3_CAPABILITY_PROFILE,
+        }
+    }
+
+    pub fn from_capability_profile(value: u16) -> Result<Self> {
+        match value {
+            RepositoryFormatV1::DISTRIBUTED_S3_CAPABILITY_PROFILE => {
+                Ok(Self::DistributedContentAddressedV1)
+            }
+            RepositoryFormatV1::NATIVE_VERSIONED_S3_CAPABILITY_PROFILE => {
+                Ok(Self::NativeVersionedV1)
+            }
+            _ => Err(Error::new(
+                ErrorCode::UnsupportedRepositoryFormat,
+                format!("unknown repository capability profile {value}"),
+            )),
+        }
+    }
+
+    pub const fn minimum_protocol_version(self) -> u32 {
+        match self {
+            Self::DistributedContentAddressedV1 => RepositoryFormatV1::DISTRIBUTED_PROTOCOL_VERSION,
+            Self::NativeVersionedV1 => RepositoryFormatV1::NATIVE_VERSIONED_PROTOCOL_VERSION,
+        }
+    }
+}
+
 impl Default for CanonicalLimits {
     fn default() -> Self {
         Self {
@@ -257,8 +304,22 @@ pub struct RepositoryFormatV1 {
 impl RepositoryFormatV1 {
     pub const VERSION: u16 = 1;
     pub const DISTRIBUTED_S3_CAPABILITY_PROFILE: u16 = 1;
-    pub const CURRENT_READER_VERSION: u32 = 1;
-    pub const CURRENT_WRITER_VERSION: u32 = 1;
+    pub const NATIVE_VERSIONED_S3_CAPABILITY_PROFILE: u16 = 2;
+    pub const DISTRIBUTED_PROTOCOL_VERSION: u32 = 1;
+    pub const NATIVE_VERSIONED_PROTOCOL_VERSION: u32 = 2;
+    pub const CURRENT_READER_VERSION: u32 = 2;
+    pub const CURRENT_WRITER_VERSION: u32 = 2;
+
+    pub fn storage_profile(&self) -> Result<RepositoryStorageProfile> {
+        #[cfg(not(prolly_s3_legacy_v1_codec))]
+        {
+            RepositoryStorageProfile::from_capability_profile(self.required_capability_profile)
+        }
+        #[cfg(prolly_s3_legacy_v1_codec)]
+        {
+            Ok(RepositoryStorageProfile::DistributedContentAddressedV1)
+        }
+    }
 }
 
 #[cfg(not(prolly_s3_legacy_v1_codec))]
@@ -338,6 +399,23 @@ impl ProviderCapabilities {
             return Err(Error::new(
                 ErrorCode::ProviderNotQualified,
                 "provider bucket has default Object Lock retention",
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn validate_native_versioned(&self) -> Result<()> {
+        self.validate_distributed()?;
+        if self.physical_versioning != PhysicalVersioning::Enabled {
+            return Err(Error::new(
+                ErrorCode::ProviderNotQualified,
+                "native-versioned repositories require bucket versioning to be enabled",
+            ));
+        }
+        if self.max_single_put_bytes == 0 || self.max_object_bytes == 0 {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "provider did not report usable native object size limits",
             ));
         }
         Ok(())
@@ -527,6 +605,114 @@ pub struct ObjectVersionOrder {
     pub mutation_ordinal: u32,
 }
 
+/// Provider binding for a logical object version in the native-versioned
+/// profile. The key is deliberately absent: it is always the logical UTF-8
+/// key under which this record is stored.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NativeObjectBindingV1 {
+    Live {
+        version_id: String,
+        provider_etag: String,
+        checksum_sha256: [u8; 32],
+    },
+    DeleteMarker {
+        version_id: String,
+    },
+}
+
+// Keep the canonical wire shape direct. Boxing the live variant would change
+// the public persisted model only to reduce its in-memory enum size.
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LogicalObjectVersionKindV2 {
+    Live {
+        size: u64,
+        logical_etag: String,
+        headers: ObjectHeaders,
+        checksums: Checksums,
+        user_metadata: BTreeMap<String, String>,
+        tags: BTreeMap<String, String>,
+    },
+    DeleteMarker,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LogicalObjectVersionBodyV2 {
+    pub order: ObjectVersionOrder,
+    pub created_at_millis: u64,
+    pub kind: LogicalObjectVersionKindV2,
+}
+
+/// Native-profile object version. Its logical ID excludes the provider
+/// binding so a verified clone may preserve logical identity while rebinding
+/// to destination-issued S3 VersionIds.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObjectVersionV2 {
+    pub id: ObjectVersionId,
+    pub body: LogicalObjectVersionBodyV2,
+    pub binding: NativeObjectBindingV1,
+}
+
+impl ObjectVersionV2 {
+    pub fn derive(
+        repository: RepositoryId,
+        key: &[u8],
+        operation: OperationId,
+        body: LogicalObjectVersionBodyV2,
+        binding: NativeObjectBindingV1,
+    ) -> Result<Self> {
+        validate_native_object_version(&body, &binding)?;
+        let body_bytes = encode_canonical(&body)?;
+        let id = ObjectVersionId(domain_hash(
+            b"prolly-s3/object-version/v2",
+            &[
+                repository.as_bytes(),
+                key,
+                operation.as_bytes(),
+                &body_bytes,
+            ],
+        ));
+        Ok(Self { id, body, binding })
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        validate_native_object_version(&self.body, &self.binding)
+    }
+}
+
+fn validate_native_object_version(
+    body: &LogicalObjectVersionBodyV2,
+    binding: &NativeObjectBindingV1,
+) -> Result<()> {
+    let valid = match (&body.kind, binding) {
+        (
+            LogicalObjectVersionKindV2::Live { checksums, .. },
+            NativeObjectBindingV1::Live {
+                version_id,
+                checksum_sha256,
+                ..
+            },
+        ) => {
+            !version_id.is_empty()
+                && checksums
+                    .sha256
+                    .is_some_and(|logical| logical == *checksum_sha256)
+        }
+        (
+            LogicalObjectVersionKindV2::DeleteMarker,
+            NativeObjectBindingV1::DeleteMarker { version_id },
+        ) => !version_id.is_empty(),
+        _ => false,
+    };
+    if !valid {
+        return Err(Error::new(
+            ErrorCode::CorruptCommit,
+            "native object version has an invalid logical-to-physical binding",
+        ));
+    }
+    Ok(())
+}
+
 // Keep the canonical model direct and language-neutral. Boxing only one
 // variant would complicate every binding without changing persisted size.
 #[allow(clippy::large_enum_variant)]
@@ -555,6 +741,11 @@ pub struct ObjectVersionBodyV1 {
 pub struct ObjectVersionV1 {
     pub id: ObjectVersionId,
     pub body: ObjectVersionBodyV1,
+    /// Present only for the native-versioned profile. Keeping the binding
+    /// outside `body` prevents a destination-assigned VersionId from changing
+    /// the logical object-version identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native_binding: Option<NativeObjectBindingV1>,
 }
 
 impl ObjectVersionV1 {
@@ -574,7 +765,98 @@ impl ObjectVersionV1 {
                 &body_bytes,
             ],
         ));
-        Ok(Self { id, body })
+        Ok(Self {
+            id,
+            body,
+            native_binding: None,
+        })
+    }
+
+    pub fn derive_native(
+        repository: RepositoryId,
+        key: &[u8],
+        operation: OperationId,
+        body: ObjectVersionBodyV1,
+        binding: NativeObjectBindingV1,
+    ) -> Result<Self> {
+        let logical_kind = match &body.kind {
+            ObjectVersionKindV1::Live {
+                content,
+                size,
+                logical_etag,
+                headers,
+                checksums,
+                user_metadata,
+                tags,
+            } if *content == ContentRef::Empty => LogicalObjectVersionKindV2::Live {
+                size: *size,
+                logical_etag: logical_etag.clone(),
+                headers: headers.clone(),
+                checksums: checksums.clone(),
+                user_metadata: user_metadata.clone(),
+                tags: tags.clone(),
+            },
+            ObjectVersionKindV1::DeleteMarker => LogicalObjectVersionKindV2::DeleteMarker,
+            ObjectVersionKindV1::Live { .. } => {
+                return Err(Error::new(
+                    ErrorCode::InternalInvariant,
+                    "native object version must not contain a repository content reference",
+                ))
+            }
+        };
+        let logical_body = LogicalObjectVersionBodyV2 {
+            order: body.order,
+            created_at_millis: body.created_at_millis,
+            kind: logical_kind,
+        };
+        let native = ObjectVersionV2::derive(repository, key, operation, logical_body, binding)?;
+        Ok(Self {
+            id: native.id,
+            body,
+            native_binding: Some(native.binding),
+        })
+    }
+
+    pub fn validate_native(&self) -> Result<()> {
+        let binding = self.native_binding.as_ref().ok_or_else(|| {
+            Error::new(
+                ErrorCode::CorruptCommit,
+                "native object version is missing its provider binding",
+            )
+        })?;
+        let logical_kind = match &self.body.kind {
+            ObjectVersionKindV1::Live {
+                content,
+                size,
+                logical_etag,
+                headers,
+                checksums,
+                user_metadata,
+                tags,
+            } if *content == ContentRef::Empty => LogicalObjectVersionKindV2::Live {
+                size: *size,
+                logical_etag: logical_etag.clone(),
+                headers: headers.clone(),
+                checksums: checksums.clone(),
+                user_metadata: user_metadata.clone(),
+                tags: tags.clone(),
+            },
+            ObjectVersionKindV1::DeleteMarker => LogicalObjectVersionKindV2::DeleteMarker,
+            ObjectVersionKindV1::Live { .. } => {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "native object version contains a repository content reference",
+                ))
+            }
+        };
+        validate_native_object_version(
+            &LogicalObjectVersionBodyV2 {
+                order: self.body.order,
+                created_at_millis: self.body.created_at_millis,
+                kind: logical_kind,
+            },
+            binding,
+        )
     }
 }
 
@@ -623,6 +905,336 @@ pub struct BucketDeltaV1 {
     pub changes: Vec<ObjectTransition>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodePackEntryV1 {
+    pub cid: Cid,
+    pub offset: u64,
+    pub len: u32,
+    pub sha256: [u8; 32],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NodePackAttachmentKindV1 {
+    BucketDelta,
+    Reflog,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodePackAttachmentV1 {
+    pub kind: NodePackAttachmentKindV1,
+    pub digest: [u8; 32],
+    pub offset: u64,
+    pub len: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodePackV1 {
+    pub format_digest: TreeFormatDigest,
+    /// Sorted strictly by CID.
+    pub entries: Vec<NodePackEntryV1>,
+    pub attachments: Vec<NodePackAttachmentV1>,
+    /// Concatenated canonical node and attachment bytes.
+    pub payload: Vec<u8>,
+}
+
+const NODE_PACK_MAGIC: &[u8; 8] = b"PLYPACK1";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodePackTocV1 {
+    pub format_digest: TreeFormatDigest,
+    pub entries: Vec<NodePackEntryV1>,
+    pub attachments: Vec<NodePackAttachmentV1>,
+    pub payload_len: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodePackRefV1 {
+    pub id: NodePackId,
+    pub object_len: u64,
+    pub node_count: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeIndexEntryV1 {
+    pub cid: Cid,
+    pub pack: NodePackId,
+    pub absolute_offset: u64,
+    pub len: u32,
+    pub sha256: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeIndexCheckpointV1 {
+    pub id: NodeIndexCheckpointId,
+    pub repository: RepositoryId,
+    pub branch: String,
+    pub head: CommitId,
+    pub generation: CommitGeneration,
+    pub entries: Vec<NodeIndexEntryV1>,
+    pub created_at_millis: u64,
+}
+
+impl NodeIndexCheckpointV1 {
+    pub fn derive(
+        repository: RepositoryId,
+        branch: String,
+        head: CommitId,
+        generation: CommitGeneration,
+        entries: Vec<NodeIndexEntryV1>,
+        created_at_millis: u64,
+    ) -> Result<Self> {
+        let body = encode_canonical(&(
+            repository,
+            &branch,
+            head,
+            generation,
+            &entries,
+            created_at_millis,
+        ))?;
+        Ok(Self {
+            id: NodeIndexCheckpointId(domain_hash(b"prolly-s3/node-index-checkpoint/v1", &[&body])),
+            repository,
+            branch,
+            head,
+            generation,
+            entries,
+            created_at_millis,
+        })
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        let expected = Self::derive(
+            self.repository,
+            self.branch.clone(),
+            self.head,
+            self.generation,
+            self.entries.clone(),
+            self.created_at_millis,
+        )?;
+        if expected.id != self.id
+            || self
+                .entries
+                .windows(2)
+                .any(|pair| pair[0].cid >= pair[1].cid)
+            || self.entries.iter().any(|entry| {
+                entry.len == 0 || entry.cid.as_bytes() != entry.sha256 || entry.absolute_offset < 12
+            })
+        {
+            return Err(Error::new(
+                ErrorCode::CorruptNode,
+                "node-index checkpoint is invalid",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl NodePackV1 {
+    /// Encode a range-readable pack: fixed magic and header length, canonical
+    /// CBOR table of contents, then the raw concatenated payload.
+    pub fn encode_object(&self) -> Result<Vec<u8>> {
+        self.validate()?;
+        let header = encode_canonical(&NodePackTocV1 {
+            format_digest: self.format_digest,
+            entries: self.entries.clone(),
+            attachments: self.attachments.clone(),
+            payload_len: self.payload.len() as u64,
+        })?;
+        let header_len = u32::try_from(header.len())
+            .map_err(|_| Error::new(ErrorCode::InvalidLimit, "node-pack header exceeds u32"))?;
+        let mut object = Vec::with_capacity(12 + header.len() + self.payload.len());
+        object.extend_from_slice(NODE_PACK_MAGIC);
+        object.extend_from_slice(&header_len.to_be_bytes());
+        object.extend_from_slice(&header);
+        object.extend_from_slice(&self.payload);
+        Ok(object)
+    }
+
+    pub fn decode_object(object: &[u8]) -> Result<Self> {
+        if object.len() < 12 || &object[..8] != NODE_PACK_MAGIC {
+            return Err(Error::new(
+                ErrorCode::CorruptNode,
+                "node pack has an invalid wire header",
+            ));
+        }
+        let header_len =
+            u32::from_be_bytes(object[8..12].try_into().expect("fixed range")) as usize;
+        let payload_start = 12usize.checked_add(header_len).ok_or_else(|| {
+            Error::new(ErrorCode::CorruptNode, "node-pack header length overflow")
+        })?;
+        if payload_start > object.len() {
+            return Err(Error::new(
+                ErrorCode::CorruptNode,
+                "node-pack header is truncated",
+            ));
+        }
+        let header: NodePackTocV1 = decode_canonical(&object[12..payload_start])?;
+        let payload = object[payload_start..].to_vec();
+        if payload.len() as u64 != header.payload_len {
+            return Err(Error::new(
+                ErrorCode::CorruptNode,
+                "node-pack payload length mismatch",
+            ));
+        }
+        let pack = Self {
+            format_digest: header.format_digest,
+            entries: header.entries,
+            attachments: header.attachments,
+            payload,
+        };
+        pack.validate()?;
+        Ok(pack)
+    }
+
+    pub fn object_payload_offset(object_prefix: &[u8]) -> Result<u64> {
+        if object_prefix.len() < 12 || &object_prefix[..8] != NODE_PACK_MAGIC {
+            return Err(Error::new(
+                ErrorCode::CorruptNode,
+                "node pack has an invalid wire header",
+            ));
+        }
+        Ok(12
+            + u64::from(u32::from_be_bytes(
+                object_prefix[8..12].try_into().expect("fixed range"),
+            )))
+    }
+
+    pub fn decode_toc(bytes: &[u8]) -> Result<NodePackTocV1> {
+        let toc: NodePackTocV1 = decode_canonical(bytes)?;
+        for pair in toc.entries.windows(2) {
+            if pair[0].cid >= pair[1].cid {
+                return Err(Error::new(
+                    ErrorCode::CorruptNode,
+                    "node-pack table of contents is not CID-sorted",
+                ));
+            }
+        }
+        for entry in &toc.entries {
+            let end = entry
+                .offset
+                .checked_add(u64::from(entry.len))
+                .ok_or_else(|| {
+                    Error::new(ErrorCode::CorruptNode, "node-pack entry range overflow")
+                })?;
+            if end > toc.payload_len || entry.cid.as_bytes() != entry.sha256 {
+                return Err(Error::new(
+                    ErrorCode::CorruptNode,
+                    "node-pack table of contents contains an invalid node range",
+                ));
+            }
+        }
+        for attachment in &toc.attachments {
+            if attachment
+                .offset
+                .checked_add(u64::from(attachment.len))
+                .is_none_or(|end| end > toc.payload_len)
+            {
+                return Err(Error::new(
+                    ErrorCode::CorruptNode,
+                    "node-pack attachment range is invalid",
+                ));
+            }
+        }
+        Ok(toc)
+    }
+
+    pub fn id(&self) -> Result<NodePackId> {
+        let bytes = self.encode_object()?;
+        Ok(NodePackId(domain_hash(
+            b"prolly-s3/node-pack/v1",
+            &[&bytes],
+        )))
+    }
+
+    pub fn reference(&self) -> Result<NodePackRefV1> {
+        Ok(NodePackRefV1 {
+            id: self.id()?,
+            object_len: u64::try_from(self.encode_object()?.len())
+                .map_err(|_| Error::new(ErrorCode::InvalidLimit, "node pack length exceeds u64"))?,
+            node_count: u32::try_from(self.entries.len()).map_err(|_| {
+                Error::new(ErrorCode::InvalidLimit, "node pack contains too many nodes")
+            })?,
+        })
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        for pair in self.entries.windows(2) {
+            if pair[0].cid >= pair[1].cid {
+                return Err(Error::new(
+                    ErrorCode::CorruptNode,
+                    "node pack entries are not strictly CID-sorted",
+                ));
+            }
+        }
+        for entry in &self.entries {
+            let bytes = self.payload_slice(entry.offset, entry.len)?;
+            if sha256(bytes) != entry.sha256 || entry.cid.as_bytes() != entry.sha256 {
+                return Err(Error::new(
+                    ErrorCode::CorruptNode,
+                    "node pack entry does not match its CID and checksum",
+                ));
+            }
+        }
+        for attachment in &self.attachments {
+            let bytes = self.payload_slice(attachment.offset, attachment.len)?;
+            if sha256(bytes) != attachment.digest {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "node pack attachment checksum mismatch",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn node(&self, cid: &Cid) -> Result<Option<&[u8]>> {
+        let Ok(index) = self.entries.binary_search_by(|entry| entry.cid.cmp(cid)) else {
+            return Ok(None);
+        };
+        let entry = &self.entries[index];
+        Ok(Some(self.payload_slice(entry.offset, entry.len)?))
+    }
+
+    fn payload_slice(&self, offset: u64, len: u32) -> Result<&[u8]> {
+        let start = usize::try_from(offset)
+            .map_err(|_| Error::new(ErrorCode::CorruptNode, "node pack offset overflow"))?;
+        let end = start
+            .checked_add(len as usize)
+            .filter(|end| *end <= self.payload.len())
+            .ok_or_else(|| {
+                Error::new(ErrorCode::CorruptNode, "node pack range is out of bounds")
+            })?;
+        Ok(&self.payload[start..end])
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BucketChangeSummaryV2 {
+    Inline(BucketDeltaV1),
+    Packed { digest: [u8; 32], len: u32 },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BucketCommitV2 {
+    pub state: BucketStateV1,
+    pub parents: Vec<CommitId>,
+    pub generation: CommitGeneration,
+    pub changes: BucketChangeSummaryV2,
+    pub node_pack: Option<NodePackRefV1>,
+    pub writer_fence_generation: u64,
+    pub author: String,
+    pub message: Option<String>,
+    pub created_at_millis: u64,
+    pub metadata: BTreeMap<String, Vec<u8>>,
+}
+
+impl BucketCommitV2 {
+    pub fn id(&self) -> Result<CommitId> {
+        let bytes = encode_canonical(self)?;
+        Ok(CommitId(domain_hash(b"prolly-s3/commit/v2", &[&bytes])))
+    }
+}
+
 impl BucketDeltaV1 {
     pub fn id(&self) -> Result<DeltaId> {
         let bytes = encode_canonical(self)?;
@@ -640,6 +1252,15 @@ pub struct BucketCommitV1 {
     pub message: Option<String>,
     pub created_at_millis: u64,
     pub metadata: BTreeMap<String, Vec<u8>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native: Option<NativeCommitExtensionV1>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NativeCommitExtensionV1 {
+    pub node_pack: Option<NodePackRefV1>,
+    pub inline_delta: BucketDeltaV1,
+    pub writer_fence_generation: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -817,6 +1438,53 @@ pub struct RefValueV1 {
     pub writer: String,
     pub updated_at_millis: u64,
     pub tombstone: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native: Option<NativeRefExtensionV1>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NativeRefExtensionV1 {
+    pub writer_fence_generation: u64,
+    pub inline_reflog: ReflogEntryV1,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefValueV2 {
+    pub target: CommitId,
+    pub previous_target: Option<CommitId>,
+    pub generation: RefGeneration,
+    pub operation: OperationId,
+    pub writer_id: String,
+    pub writer_fence_generation: u64,
+    pub updated_at_millis: u64,
+    pub tombstone: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExclusiveWriterLeaseV1 {
+    pub repository: RepositoryId,
+    pub writer_id: String,
+    pub generation: u64,
+    pub fencing_token: [u8; 32],
+    pub expires_at_millis: u64,
+    pub updated_at_millis: u64,
+}
+
+impl ExclusiveWriterLeaseV1 {
+    pub fn validate(&self, repository: RepositoryId) -> Result<()> {
+        if self.repository != repository
+            || self.writer_id.is_empty()
+            || self.generation == 0
+            || self.fencing_token == [0; 32]
+            || self.expires_at_millis <= self.updated_at_millis
+        {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "exclusive writer lease is malformed",
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -947,12 +1615,47 @@ pub enum WorkspaceMutationV1 {
     Delete {
         key: Vec<u8>,
     },
+    NativePut {
+        key: Vec<u8>,
+        content: crate::StoredContent,
+        headers: ObjectHeaders,
+        user_metadata: BTreeMap<String, String>,
+        binding: NativeObjectBindingV1,
+    },
+    NativeDelete {
+        key: Vec<u8>,
+        binding: NativeObjectBindingV1,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NativeBatchMutationV1 {
+    Put {
+        key: Vec<u8>,
+        bytes: Vec<u8>,
+        headers: ObjectHeaders,
+        user_metadata: BTreeMap<String, String>,
+    },
+    Delete {
+        key: Vec<u8>,
+    },
+}
+
+impl NativeBatchMutationV1 {
+    pub fn key(&self) -> &[u8] {
+        match self {
+            Self::Put { key, .. } | Self::Delete { key } => key,
+        }
+    }
 }
 
 impl WorkspaceMutationV1 {
     pub fn key(&self) -> &[u8] {
         match self {
-            Self::Put { key, .. } | Self::Delete { key } => key,
+            Self::Put { key, .. }
+            | Self::Delete { key }
+            | Self::NativePut { key, .. }
+            | Self::NativeDelete { key, .. } => key,
         }
     }
 }

--- a/extensions/s3/core/src/model.rs
+++ b/extensions/s3/core/src/model.rs
@@ -183,6 +183,14 @@ impl OperationId {
     pub fn as_bytes(&self) -> &[u8; 16] {
         self.0.as_bytes()
     }
+
+    pub const fn nil() -> Self {
+        Self(Uuid::nil())
+    }
+
+    pub const fn is_nil(self) -> bool {
+        self.0.is_nil()
+    }
 }
 
 impl Default for OperationId {
@@ -1549,6 +1557,51 @@ pub struct MultipartUploadV1 {
     /// means "no automatic expiry".
     #[serde(default)]
     pub expires_at_millis: u64,
+}
+
+/// Durable caller-held handle for native provider multipart state. The handle
+/// contains no secret credentials; callers must persist the exact value
+/// returned by create if they intend to complete after a process restart.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NativeMultipartSessionV1 {
+    pub repository: RepositoryId,
+    pub branch: String,
+    pub key: Vec<u8>,
+    pub headers: ObjectHeaders,
+    pub user_metadata: BTreeMap<String, String>,
+    pub provider_upload_id: String,
+    pub operation: OperationId,
+    pub writer_fence_generation: u64,
+    pub created_at_millis: u64,
+    #[serde(default)]
+    pub discovered: bool,
+}
+
+impl NativeMultipartSessionV1 {
+    pub fn validate_address(&self, repository: RepositoryId) -> Result<()> {
+        crate::repository::validate_branch(&self.branch)?;
+        if self.repository != repository
+            || self.key.is_empty()
+            || self.provider_upload_id.is_empty()
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "native multipart session is malformed or belongs to another repository",
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn validate(&self, repository: RepositoryId) -> Result<()> {
+        self.validate_address(repository)?;
+        if self.discovered || self.operation.is_nil() || self.writer_fence_generation == 0 {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "native multipart completion requires the original create handle",
+            ));
+        }
+        Ok(())
+    }
 }
 
 /// Immutable entry captured for stable pagination of active multipart uploads.

--- a/extensions/s3/core/src/object_plane.rs
+++ b/extensions/s3/core/src/object_plane.rs
@@ -115,6 +115,20 @@ pub struct NativeFilePut {
 }
 
 #[derive(Clone, Debug)]
+pub struct NativeFileGet {
+    pub path: ObjectPath,
+    pub version_id: String,
+    pub body_path: PathBuf,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NativeFileGetResult {
+    pub size: u64,
+    pub checksum_sha256: [u8; 32],
+    pub checksum_md5: [u8; 16],
+}
+
+#[derive(Clone, Debug)]
 pub struct NativeCopy {
     pub source: ObjectPath,
     pub source_version_id: String,
@@ -284,6 +298,7 @@ pub struct ListRequest {
 pub struct PhysicalListEntry {
     pub path: ObjectPath,
     pub metadata: StoredMetadata,
+    pub is_latest: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -347,6 +362,35 @@ pub trait ObjectPlane: Send + Sync + 'static {
             writer_fence_generation: request.writer_fence_generation,
         })
         .await
+    }
+
+    async fn get_native_file(&self, request: NativeFileGet) -> Result<NativeFileGetResult> {
+        let object = self
+            .get(GetRequest {
+                path: request.path,
+                range: None,
+                physical_version: Some(PhysicalVersion::Versioned {
+                    version_id: request.version_id,
+                }),
+            })
+            .await?
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::MissingClosure,
+                    "native source object version is missing",
+                )
+            })?;
+        std::fs::write(&request.body_path, &object.bytes).map_err(|error| {
+            Error::new(
+                ErrorCode::Transport,
+                format!("native transfer spool could not be written: {error}"),
+            )
+        })?;
+        Ok(NativeFileGetResult {
+            size: object.bytes.len() as u64,
+            checksum_sha256: sha256(&object.bytes),
+            checksum_md5: Md5::digest(&object.bytes).into(),
+        })
     }
 
     async fn copy_native(&self, _request: NativeCopy) -> Result<NativeObjectWriteResult> {
@@ -459,6 +503,7 @@ pub struct MemoryObjectPlane {
     versioned: bool,
     requests: Arc<MemoryRequestCounters>,
     lose_next_native_put_response: Arc<AtomicBool>,
+    lose_next_native_delete_response: Arc<AtomicBool>,
 }
 
 #[derive(Default)]
@@ -549,11 +594,17 @@ impl MemoryObjectPlane {
             versioned,
             requests: Arc::new(MemoryRequestCounters::default()),
             lose_next_native_put_response: Arc::new(AtomicBool::new(false)),
+            lose_next_native_delete_response: Arc::new(AtomicBool::new(false)),
         }
     }
 
     pub fn lose_next_native_put_response(&self) {
         self.lose_next_native_put_response
+            .store(true, Ordering::Relaxed);
+    }
+
+    pub fn lose_next_native_delete_response(&self) {
+        self.lose_next_native_delete_response
             .store(true, Ordering::Relaxed);
     }
 
@@ -808,6 +859,9 @@ impl ObjectPlane for MemoryObjectPlane {
                     entries.push(PhysicalListEntry {
                         path: path.clone(),
                         metadata: version.metadata.clone(),
+                        is_latest: versions
+                            .last()
+                            .is_some_and(|latest| latest.metadata.token == version.metadata.token),
                     });
                 }
                 if entries.len() == limit {
@@ -1009,6 +1063,15 @@ impl ObjectPlane for MemoryObjectPlane {
                 bytes: None,
                 metadata,
             });
+        if self
+            .lose_next_native_delete_response
+            .swap(false, Ordering::Relaxed)
+        {
+            return Err(Error::new(
+                ErrorCode::Transport,
+                "injected lost native DeleteObject response",
+            ));
+        }
         Ok(NativeObjectBindingV1::DeleteMarker { version_id })
     }
 

--- a/extensions/s3/core/src/object_plane.rs
+++ b/extensions/s3/core/src/object_plane.rs
@@ -1,12 +1,19 @@
 use std::{
     collections::BTreeMap,
     ops::RangeInclusive,
-    sync::{Arc, RwLock},
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc, RwLock,
+    },
 };
 
+use md5::{Digest as _, Md5};
 use serde::{Deserialize, Serialize};
 
-use crate::{codec::sha256, Error, ErrorCode, Result};
+use crate::{
+    codec::sha256, Checksums, Error, ErrorCode, NativeObjectBindingV1, ObjectHeaders, OperationId,
+    RepositoryId, Result,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ObjectPath(String);
@@ -58,6 +65,7 @@ pub struct StoredMetadata {
     pub sha256: [u8; 32],
     pub last_modified_millis: u64,
     pub delete_marker: bool,
+    pub user_metadata: BTreeMap<String, String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -78,6 +86,49 @@ pub struct ImmutablePut {
     pub path: ObjectPath,
     pub bytes: Vec<u8>,
     pub expected_sha256: [u8; 32],
+}
+
+#[derive(Clone, Debug)]
+pub struct NativePut {
+    pub path: ObjectPath,
+    pub bytes: Vec<u8>,
+    pub headers: ObjectHeaders,
+    pub user_metadata: BTreeMap<String, String>,
+    pub repository: RepositoryId,
+    pub operation: OperationId,
+    pub writer_fence_generation: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct NativeCopy {
+    pub source: ObjectPath,
+    pub source_version_id: String,
+    pub destination: ObjectPath,
+    pub headers: ObjectHeaders,
+    pub user_metadata: BTreeMap<String, String>,
+    pub repository: RepositoryId,
+    pub operation: OperationId,
+    pub writer_fence_generation: u64,
+    pub checksum_sha256: [u8; 32],
+    pub size: u64,
+    pub logical_etag: String,
+    pub checksums: Checksums,
+}
+
+#[derive(Clone, Debug)]
+pub struct NativeDelete {
+    pub path: ObjectPath,
+    pub repository: RepositoryId,
+    pub operation: OperationId,
+    pub writer_fence_generation: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NativeObjectWriteResult {
+    pub binding: NativeObjectBindingV1,
+    pub size: u64,
+    pub logical_etag: String,
+    pub checksums: Checksums,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -140,12 +191,75 @@ pub trait ObjectPlane: Send + Sync + 'static {
         path: &ObjectPath,
         version: PhysicalVersion,
     ) -> Result<DeleteOutcome>;
+
+    async fn put_native(&self, _request: NativePut) -> Result<NativeObjectWriteResult> {
+        Err(Error::new(
+            ErrorCode::MissingCapability,
+            "object plane does not support native object writes",
+        ))
+    }
+
+    async fn copy_native(&self, _request: NativeCopy) -> Result<NativeObjectWriteResult> {
+        Err(Error::new(
+            ErrorCode::MissingCapability,
+            "object plane does not support native object copies",
+        ))
+    }
+
+    async fn delete_native(&self, _request: NativeDelete) -> Result<NativeObjectBindingV1> {
+        Err(Error::new(
+            ErrorCode::MissingCapability,
+            "object plane does not support native delete markers",
+        ))
+    }
 }
 
 #[derive(Clone)]
 pub struct MemoryObjectPlane {
     inner: Arc<RwLock<MemoryState>>,
     versioned: bool,
+    requests: Arc<MemoryRequestCounters>,
+    lose_next_native_put_response: Arc<AtomicBool>,
+}
+
+#[derive(Default)]
+struct MemoryRequestCounters {
+    get: AtomicU64,
+    head: AtomicU64,
+    immutable_put: AtomicU64,
+    compare_exchange: AtomicU64,
+    list: AtomicU64,
+    delete_exact: AtomicU64,
+    native_put: AtomicU64,
+    native_copy: AtomicU64,
+    native_delete: AtomicU64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MemoryRequestSnapshot {
+    pub get: u64,
+    pub head: u64,
+    pub immutable_put: u64,
+    pub compare_exchange: u64,
+    pub list: u64,
+    pub delete_exact: u64,
+    pub native_put: u64,
+    pub native_copy: u64,
+    pub native_delete: u64,
+}
+
+impl MemoryRequestSnapshot {
+    pub fn total(&self) -> u64 {
+        self.get
+            + self.head
+            + self.immutable_put
+            + self.compare_exchange
+            + self.list
+            + self.delete_exact
+            + self.native_put
+            + self.native_copy
+            + self.native_delete
+    }
 }
 
 #[derive(Default)]
@@ -165,6 +279,44 @@ impl MemoryObjectPlane {
         Self {
             inner: Arc::new(RwLock::new(MemoryState::default())),
             versioned,
+            requests: Arc::new(MemoryRequestCounters::default()),
+            lose_next_native_put_response: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn lose_next_native_put_response(&self) {
+        self.lose_next_native_put_response
+            .store(true, Ordering::Relaxed);
+    }
+
+    pub fn request_snapshot(&self) -> MemoryRequestSnapshot {
+        let load = |counter: &AtomicU64| counter.load(Ordering::Relaxed);
+        MemoryRequestSnapshot {
+            get: load(&self.requests.get),
+            head: load(&self.requests.head),
+            immutable_put: load(&self.requests.immutable_put),
+            compare_exchange: load(&self.requests.compare_exchange),
+            list: load(&self.requests.list),
+            delete_exact: load(&self.requests.delete_exact),
+            native_put: load(&self.requests.native_put),
+            native_copy: load(&self.requests.native_copy),
+            native_delete: load(&self.requests.native_delete),
+        }
+    }
+
+    pub fn reset_request_counts(&self) {
+        for counter in [
+            &self.requests.get,
+            &self.requests.head,
+            &self.requests.immutable_put,
+            &self.requests.compare_exchange,
+            &self.requests.list,
+            &self.requests.delete_exact,
+            &self.requests.native_put,
+            &self.requests.native_copy,
+            &self.requests.native_delete,
+        ] {
+            counter.store(0, Ordering::Relaxed);
         }
     }
 
@@ -180,6 +332,7 @@ impl MemoryObjectPlane {
             sha256: digest,
             last_modified_millis: state.sequence,
             delete_marker: false,
+            user_metadata: BTreeMap::new(),
         }
     }
 
@@ -204,6 +357,7 @@ impl Default for MemoryObjectPlane {
 #[async_trait::async_trait]
 impl ObjectPlane for MemoryObjectPlane {
     async fn get(&self, request: GetRequest) -> Result<Option<StoredObject>> {
+        self.requests.get.fetch_add(1, Ordering::Relaxed);
         let state = self
             .inner
             .read()
@@ -244,6 +398,7 @@ impl ObjectPlane for MemoryObjectPlane {
     }
 
     async fn head(&self, path: &ObjectPath) -> Result<Option<StoredMetadata>> {
+        self.requests.head.fetch_add(1, Ordering::Relaxed);
         let state = self
             .inner
             .read()
@@ -257,6 +412,7 @@ impl ObjectPlane for MemoryObjectPlane {
     }
 
     async fn put_immutable(&self, request: ImmutablePut) -> Result<ImmutablePutOutcome> {
+        self.requests.immutable_put.fetch_add(1, Ordering::Relaxed);
         if sha256(&request.bytes) != request.expected_sha256 {
             return Err(Error::new(
                 ErrorCode::ChecksumMismatch,
@@ -304,6 +460,9 @@ impl ObjectPlane for MemoryObjectPlane {
     }
 
     async fn compare_exchange(&self, request: CompareExchange) -> Result<CompareExchangeOutcome> {
+        self.requests
+            .compare_exchange
+            .fetch_add(1, Ordering::Relaxed);
         let mut state = self
             .inner
             .write()
@@ -339,6 +498,7 @@ impl ObjectPlane for MemoryObjectPlane {
     }
 
     async fn list(&self, request: ListRequest) -> Result<PhysicalListPage> {
+        self.requests.list.fetch_add(1, Ordering::Relaxed);
         let state = self
             .inner
             .read()
@@ -358,7 +518,9 @@ impl ObjectPlane for MemoryObjectPlane {
                 Self::current_raw(versions).into_iter().collect()
             };
             for version in candidates {
-                if version.bytes.is_some() {
+                if version.bytes.is_some()
+                    || (request.include_versions && version.metadata.delete_marker)
+                {
                     entries.push(PhysicalListEntry {
                         path: path.clone(),
                         metadata: version.metadata.clone(),
@@ -384,6 +546,7 @@ impl ObjectPlane for MemoryObjectPlane {
         path: &ObjectPath,
         version: PhysicalVersion,
     ) -> Result<DeleteOutcome> {
+        self.requests.delete_exact.fetch_add(1, Ordering::Relaxed);
         let mut state = self
             .inner
             .write()
@@ -417,5 +580,151 @@ impl ObjectPlane for MemoryObjectPlane {
             state.objects.remove(path);
         }
         Ok(DeleteOutcome::Deleted)
+    }
+
+    async fn put_native(&self, request: NativePut) -> Result<NativeObjectWriteResult> {
+        self.requests.native_put.fetch_add(1, Ordering::Relaxed);
+        if !self.versioned {
+            return Err(Error::new(
+                ErrorCode::ProviderNotQualified,
+                "native writes require a versioned memory object plane",
+            ));
+        }
+        let size = request.bytes.len() as u64;
+        let sha256 = sha256(&request.bytes);
+        let md5: [u8; 16] = Md5::digest(&request.bytes).into();
+        let logical_etag = format!("\"{}\"", hex::encode(md5));
+        let mut state = self
+            .inner
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "memory lock poisoned"))?;
+        let mut metadata = Self::next_metadata(&mut state, &request.bytes, true);
+        metadata.user_metadata = request.user_metadata.clone();
+        metadata.user_metadata.insert(
+            "prolly-repository-id".to_string(),
+            request.repository.to_string(),
+        );
+        metadata.user_metadata.insert(
+            "prolly-operation-id".to_string(),
+            request.operation.to_string(),
+        );
+        metadata.user_metadata.insert(
+            "prolly-writer-fence".to_string(),
+            request.writer_fence_generation.to_string(),
+        );
+        metadata
+            .user_metadata
+            .insert("prolly-sha256".to_string(), hex::encode(sha256));
+        let version_id = metadata.token.version_id.clone().ok_or_else(|| {
+            Error::new(
+                ErrorCode::ProviderNotQualified,
+                "versioned memory object plane omitted VersionId",
+            )
+        })?;
+        let provider_etag = metadata.token.etag.clone();
+        state
+            .objects
+            .entry(request.path)
+            .or_default()
+            .push(MemoryVersion {
+                bytes: Some(request.bytes),
+                metadata,
+            });
+        let result = NativeObjectWriteResult {
+            binding: NativeObjectBindingV1::Live {
+                version_id,
+                provider_etag,
+                checksum_sha256: sha256,
+            },
+            size,
+            logical_etag,
+            checksums: Checksums {
+                md5: Some(md5),
+                sha256: Some(sha256),
+                algorithm_values: BTreeMap::new(),
+            },
+        };
+        if self
+            .lose_next_native_put_response
+            .swap(false, Ordering::Relaxed)
+        {
+            return Err(Error::new(
+                ErrorCode::Transport,
+                "injected lost native PutObject response",
+            ));
+        }
+        Ok(result)
+    }
+
+    async fn copy_native(&self, request: NativeCopy) -> Result<NativeObjectWriteResult> {
+        self.requests.native_copy.fetch_add(1, Ordering::Relaxed);
+        if !self.versioned {
+            return Err(Error::new(
+                ErrorCode::ProviderNotQualified,
+                "native copies require a versioned memory object plane",
+            ));
+        }
+        let bytes = {
+            let state = self
+                .inner
+                .read()
+                .map_err(|_| Error::new(ErrorCode::InternalInvariant, "memory lock poisoned"))?;
+            state
+                .objects
+                .get(&request.source)
+                .and_then(|versions| {
+                    versions.iter().find(|version| {
+                        version.metadata.token.version_id.as_deref()
+                            == Some(request.source_version_id.as_str())
+                    })
+                })
+                .and_then(|version| version.bytes.clone())
+                .ok_or_else(|| Error::new(ErrorCode::NoSuchVersion, "native copy source missing"))?
+        };
+        let result = self
+            .put_native(NativePut {
+                path: request.destination,
+                bytes,
+                headers: request.headers,
+                user_metadata: request.user_metadata,
+                repository: request.repository,
+                operation: request.operation,
+                writer_fence_generation: request.writer_fence_generation,
+            })
+            .await;
+        self.requests.native_put.fetch_sub(1, Ordering::Relaxed);
+        result
+    }
+
+    async fn delete_native(&self, request: NativeDelete) -> Result<NativeObjectBindingV1> {
+        self.requests.native_delete.fetch_add(1, Ordering::Relaxed);
+        if !self.versioned {
+            return Err(Error::new(
+                ErrorCode::ProviderNotQualified,
+                "native delete markers require a versioned memory object plane",
+            ));
+        }
+        let mut state = self
+            .inner
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "memory lock poisoned"))?;
+        let mut metadata = Self::next_metadata(&mut state, &[], true);
+        metadata.delete_marker = true;
+        metadata.len = 0;
+        let version_id = metadata.token.version_id.clone().ok_or_else(|| {
+            Error::new(
+                ErrorCode::ProviderNotQualified,
+                "versioned memory delete omitted VersionId",
+            )
+        })?;
+        state
+            .objects
+            .entry(request.path)
+            .or_default()
+            .push(MemoryVersion {
+                bytes: None,
+                metadata,
+            });
+        Ok(NativeObjectBindingV1::DeleteMarker { version_id })
     }
 }

--- a/extensions/s3/core/src/object_plane.rs
+++ b/extensions/s3/core/src/object_plane.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::BTreeMap,
     ops::RangeInclusive,
+    path::PathBuf,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, RwLock,
@@ -100,6 +101,20 @@ pub struct NativePut {
 }
 
 #[derive(Clone, Debug)]
+pub struct NativeFilePut {
+    pub path: ObjectPath,
+    pub body_path: PathBuf,
+    pub size: u64,
+    pub checksum_sha256: [u8; 32],
+    pub checksum_md5: [u8; 16],
+    pub headers: ObjectHeaders,
+    pub user_metadata: BTreeMap<String, String>,
+    pub repository: RepositoryId,
+    pub operation: OperationId,
+    pub writer_fence_generation: u64,
+}
+
+#[derive(Clone, Debug)]
 pub struct NativeCopy {
     pub source: ObjectPath,
     pub source_version_id: String,
@@ -121,6 +136,113 @@ pub struct NativeDelete {
     pub repository: RepositoryId,
     pub operation: OperationId,
     pub writer_fence_generation: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct NativeMultipartCreate {
+    pub path: ObjectPath,
+    pub headers: ObjectHeaders,
+    pub user_metadata: BTreeMap<String, String>,
+    pub repository: RepositoryId,
+    pub operation: OperationId,
+    pub writer_fence_generation: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct NativeMultipartUploadPart {
+    pub path: ObjectPath,
+    pub upload_id: String,
+    pub part_number: u32,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Clone, Debug)]
+pub struct NativeMultipartFilePart {
+    pub path: ObjectPath,
+    pub upload_id: String,
+    pub part_number: u32,
+    pub body_path: PathBuf,
+    pub size: u64,
+    pub checksum_sha256: [u8; 32],
+}
+
+#[derive(Clone, Debug)]
+pub struct NativeMultipartUploadPartCopy {
+    pub source: ObjectPath,
+    pub source_version_id: String,
+    pub destination: ObjectPath,
+    pub upload_id: String,
+    pub part_number: u32,
+    pub range: Option<RangeInclusive<u64>>,
+    pub size: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NativeMultipartCompletedPart {
+    pub part_number: u32,
+    pub etag: String,
+    pub checksum_sha256: [u8; 32],
+    pub size: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NativeMultipartPartResult {
+    pub part_number: u32,
+    pub etag: String,
+    pub checksum_sha256: Option<[u8; 32]>,
+    pub size: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct NativeMultipartComplete {
+    pub path: ObjectPath,
+    pub upload_id: String,
+    pub parts: Vec<NativeMultipartCompletedPart>,
+    pub checksum_sha256: [u8; 32],
+    pub checksum_md5: [u8; 16],
+    pub size: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct NativeMultipartAbort {
+    pub path: ObjectPath,
+    pub upload_id: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct NativeMultipartListParts {
+    pub path: ObjectPath,
+    pub upload_id: String,
+    pub after_part_number: u32,
+    pub limit: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NativeMultipartListPartsPage {
+    pub parts: Vec<NativeMultipartPartResult>,
+    pub next_part_number: Option<u32>,
+}
+
+#[derive(Clone, Debug)]
+pub struct NativeMultipartListUploads {
+    pub prefix: String,
+    pub key_marker: Option<String>,
+    pub upload_id_marker: Option<String>,
+    pub limit: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NativeMultipartUploadEntry {
+    pub path: ObjectPath,
+    pub upload_id: String,
+    pub initiated_at_millis: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NativeMultipartListUploadsPage {
+    pub uploads: Vec<NativeMultipartUploadEntry>,
+    pub next_key_marker: Option<String>,
+    pub next_upload_id_marker: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -199,6 +321,34 @@ pub trait ObjectPlane: Send + Sync + 'static {
         ))
     }
 
+    async fn put_native_file(&self, request: NativeFilePut) -> Result<NativeObjectWriteResult> {
+        let bytes = std::fs::read(&request.body_path).map_err(|error| {
+            Error::new(
+                ErrorCode::Transport,
+                format!("native spool could not be read: {error}"),
+            )
+        })?;
+        if bytes.len() as u64 != request.size
+            || sha256(&bytes) != request.checksum_sha256
+            || <[u8; 16]>::from(Md5::digest(&bytes)) != request.checksum_md5
+        {
+            return Err(Error::new(
+                ErrorCode::ChecksumMismatch,
+                "native spool identity changed before upload",
+            ));
+        }
+        self.put_native(NativePut {
+            path: request.path,
+            bytes,
+            headers: request.headers,
+            user_metadata: request.user_metadata,
+            repository: request.repository,
+            operation: request.operation,
+            writer_fence_generation: request.writer_fence_generation,
+        })
+        .await
+    }
+
     async fn copy_native(&self, _request: NativeCopy) -> Result<NativeObjectWriteResult> {
         Err(Error::new(
             ErrorCode::MissingCapability,
@@ -210,6 +360,95 @@ pub trait ObjectPlane: Send + Sync + 'static {
         Err(Error::new(
             ErrorCode::MissingCapability,
             "object plane does not support native delete markers",
+        ))
+    }
+
+    async fn create_native_multipart(&self, _request: NativeMultipartCreate) -> Result<String> {
+        Err(Error::new(
+            ErrorCode::MissingCapability,
+            "object plane does not support native multipart creation",
+        ))
+    }
+
+    async fn upload_native_multipart_part(
+        &self,
+        _request: NativeMultipartUploadPart,
+    ) -> Result<NativeMultipartPartResult> {
+        Err(Error::new(
+            ErrorCode::MissingCapability,
+            "object plane does not support native multipart parts",
+        ))
+    }
+
+    async fn upload_native_multipart_file_part(
+        &self,
+        request: NativeMultipartFilePart,
+    ) -> Result<NativeMultipartPartResult> {
+        let bytes = std::fs::read(&request.body_path).map_err(|error| {
+            Error::new(
+                ErrorCode::Transport,
+                format!("native multipart spool could not be read: {error}"),
+            )
+        })?;
+        if bytes.len() as u64 != request.size || sha256(&bytes) != request.checksum_sha256 {
+            return Err(Error::new(
+                ErrorCode::ChecksumMismatch,
+                "native multipart spool identity changed before upload",
+            ));
+        }
+        self.upload_native_multipart_part(NativeMultipartUploadPart {
+            path: request.path,
+            upload_id: request.upload_id,
+            part_number: request.part_number,
+            bytes,
+        })
+        .await
+    }
+
+    async fn upload_native_multipart_part_copy(
+        &self,
+        _request: NativeMultipartUploadPartCopy,
+    ) -> Result<NativeMultipartPartResult> {
+        Err(Error::new(
+            ErrorCode::MissingCapability,
+            "object plane does not support native multipart part copy",
+        ))
+    }
+
+    async fn complete_native_multipart(
+        &self,
+        _request: NativeMultipartComplete,
+    ) -> Result<NativeObjectWriteResult> {
+        Err(Error::new(
+            ErrorCode::MissingCapability,
+            "object plane does not support native multipart completion",
+        ))
+    }
+
+    async fn abort_native_multipart(&self, _request: NativeMultipartAbort) -> Result<()> {
+        Err(Error::new(
+            ErrorCode::MissingCapability,
+            "object plane does not support native multipart abort",
+        ))
+    }
+
+    async fn list_native_multipart_parts(
+        &self,
+        _request: NativeMultipartListParts,
+    ) -> Result<NativeMultipartListPartsPage> {
+        Err(Error::new(
+            ErrorCode::MissingCapability,
+            "object plane does not support native multipart part listing",
+        ))
+    }
+
+    async fn list_native_multipart_uploads(
+        &self,
+        _request: NativeMultipartListUploads,
+    ) -> Result<NativeMultipartListUploadsPage> {
+        Err(Error::new(
+            ErrorCode::MissingCapability,
+            "object plane does not support native multipart upload listing",
         ))
     }
 }
@@ -233,6 +472,13 @@ struct MemoryRequestCounters {
     native_put: AtomicU64,
     native_copy: AtomicU64,
     native_delete: AtomicU64,
+    native_multipart_create: AtomicU64,
+    native_multipart_upload_part: AtomicU64,
+    native_multipart_upload_part_copy: AtomicU64,
+    native_multipart_complete: AtomicU64,
+    native_multipart_abort: AtomicU64,
+    native_multipart_list_parts: AtomicU64,
+    native_multipart_list_uploads: AtomicU64,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -246,6 +492,13 @@ pub struct MemoryRequestSnapshot {
     pub native_put: u64,
     pub native_copy: u64,
     pub native_delete: u64,
+    pub native_multipart_create: u64,
+    pub native_multipart_upload_part: u64,
+    pub native_multipart_upload_part_copy: u64,
+    pub native_multipart_complete: u64,
+    pub native_multipart_abort: u64,
+    pub native_multipart_list_parts: u64,
+    pub native_multipart_list_uploads: u64,
 }
 
 impl MemoryRequestSnapshot {
@@ -259,13 +512,28 @@ impl MemoryRequestSnapshot {
             + self.native_put
             + self.native_copy
             + self.native_delete
+            + self.native_multipart_create
+            + self.native_multipart_upload_part
+            + self.native_multipart_upload_part_copy
+            + self.native_multipart_complete
+            + self.native_multipart_abort
+            + self.native_multipart_list_parts
+            + self.native_multipart_list_uploads
     }
 }
 
 #[derive(Default)]
 struct MemoryState {
     objects: BTreeMap<ObjectPath, Vec<MemoryVersion>>,
+    multipart: BTreeMap<String, MemoryMultipartUpload>,
     sequence: u64,
+}
+
+#[derive(Clone)]
+struct MemoryMultipartUpload {
+    request: NativeMultipartCreate,
+    parts: BTreeMap<u32, Vec<u8>>,
+    initiated_at_millis: u64,
 }
 
 #[derive(Clone)]
@@ -301,6 +569,15 @@ impl MemoryObjectPlane {
             native_put: load(&self.requests.native_put),
             native_copy: load(&self.requests.native_copy),
             native_delete: load(&self.requests.native_delete),
+            native_multipart_create: load(&self.requests.native_multipart_create),
+            native_multipart_upload_part: load(&self.requests.native_multipart_upload_part),
+            native_multipart_upload_part_copy: load(
+                &self.requests.native_multipart_upload_part_copy,
+            ),
+            native_multipart_complete: load(&self.requests.native_multipart_complete),
+            native_multipart_abort: load(&self.requests.native_multipart_abort),
+            native_multipart_list_parts: load(&self.requests.native_multipart_list_parts),
+            native_multipart_list_uploads: load(&self.requests.native_multipart_list_uploads),
         }
     }
 
@@ -315,6 +592,13 @@ impl MemoryObjectPlane {
             &self.requests.native_put,
             &self.requests.native_copy,
             &self.requests.native_delete,
+            &self.requests.native_multipart_create,
+            &self.requests.native_multipart_upload_part,
+            &self.requests.native_multipart_upload_part_copy,
+            &self.requests.native_multipart_complete,
+            &self.requests.native_multipart_abort,
+            &self.requests.native_multipart_list_parts,
+            &self.requests.native_multipart_list_uploads,
         ] {
             counter.store(0, Ordering::Relaxed);
         }
@@ -726,5 +1010,334 @@ impl ObjectPlane for MemoryObjectPlane {
                 metadata,
             });
         Ok(NativeObjectBindingV1::DeleteMarker { version_id })
+    }
+
+    async fn create_native_multipart(&self, request: NativeMultipartCreate) -> Result<String> {
+        self.requests
+            .native_multipart_create
+            .fetch_add(1, Ordering::Relaxed);
+        if !self.versioned {
+            return Err(Error::new(
+                ErrorCode::ProviderNotQualified,
+                "native multipart requires a versioned memory object plane",
+            ));
+        }
+        let mut state = self
+            .inner
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "memory lock poisoned"))?;
+        state.sequence = state.sequence.saturating_add(1);
+        let upload_id = format!("memory-multipart-{}", state.sequence);
+        let initiated_at_millis = state.sequence;
+        state.multipart.insert(
+            upload_id.clone(),
+            MemoryMultipartUpload {
+                request,
+                parts: BTreeMap::new(),
+                initiated_at_millis,
+            },
+        );
+        Ok(upload_id)
+    }
+
+    async fn upload_native_multipart_part(
+        &self,
+        request: NativeMultipartUploadPart,
+    ) -> Result<NativeMultipartPartResult> {
+        self.requests
+            .native_multipart_upload_part
+            .fetch_add(1, Ordering::Relaxed);
+        if !(1..=10_000).contains(&request.part_number) {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "part number must be between 1 and 10000",
+            ));
+        }
+        let checksum_sha256 = sha256(&request.bytes);
+        let md5: [u8; 16] = Md5::digest(&request.bytes).into();
+        let size = request.bytes.len() as u64;
+        let mut state = self
+            .inner
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "memory lock poisoned"))?;
+        let upload = state
+            .multipart
+            .get_mut(&request.upload_id)
+            .filter(|upload| upload.request.path == request.path)
+            .ok_or_else(|| {
+                Error::new(ErrorCode::NoSuchUpload, "native multipart upload missing")
+            })?;
+        upload.parts.insert(request.part_number, request.bytes);
+        Ok(NativeMultipartPartResult {
+            part_number: request.part_number,
+            etag: format!("\"{}\"", hex::encode(md5)),
+            checksum_sha256: Some(checksum_sha256),
+            size,
+        })
+    }
+
+    async fn upload_native_multipart_part_copy(
+        &self,
+        request: NativeMultipartUploadPartCopy,
+    ) -> Result<NativeMultipartPartResult> {
+        self.requests
+            .native_multipart_upload_part_copy
+            .fetch_add(1, Ordering::Relaxed);
+        let bytes = {
+            let state = self
+                .inner
+                .read()
+                .map_err(|_| Error::new(ErrorCode::InternalInvariant, "memory lock poisoned"))?;
+            let bytes = state
+                .objects
+                .get(&request.source)
+                .and_then(|versions| {
+                    versions.iter().find(|version| {
+                        version.metadata.token.version_id.as_deref()
+                            == Some(request.source_version_id.as_str())
+                    })
+                })
+                .and_then(|version| version.bytes.clone())
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::NoSuchVersion,
+                        "native multipart copy source missing",
+                    )
+                })?;
+            match request.range {
+                Some(range)
+                    if !bytes.is_empty()
+                        && range.start() <= range.end()
+                        && *range.start() < bytes.len() as u64 =>
+                {
+                    let end = (*range.end()).min(bytes.len() as u64 - 1);
+                    bytes[*range.start() as usize..=end as usize].to_vec()
+                }
+                Some(_) => {
+                    return Err(Error::new(
+                        ErrorCode::InvalidRange,
+                        "native multipart copy range is unsatisfiable",
+                    ))
+                }
+                None => bytes,
+            }
+        };
+        let checksum_sha256 = sha256(&bytes);
+        let md5: [u8; 16] = Md5::digest(&bytes).into();
+        let size = bytes.len() as u64;
+        let mut state = self
+            .inner
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "memory lock poisoned"))?;
+        let upload = state
+            .multipart
+            .get_mut(&request.upload_id)
+            .filter(|upload| upload.request.path == request.destination)
+            .ok_or_else(|| {
+                Error::new(ErrorCode::NoSuchUpload, "native multipart upload missing")
+            })?;
+        upload.parts.insert(request.part_number, bytes);
+        Ok(NativeMultipartPartResult {
+            part_number: request.part_number,
+            etag: format!("\"{}\"", hex::encode(md5)),
+            checksum_sha256: Some(checksum_sha256),
+            size,
+        })
+    }
+
+    async fn complete_native_multipart(
+        &self,
+        request: NativeMultipartComplete,
+    ) -> Result<NativeObjectWriteResult> {
+        self.requests
+            .native_multipart_complete
+            .fetch_add(1, Ordering::Relaxed);
+        let upload = {
+            let state = self
+                .inner
+                .read()
+                .map_err(|_| Error::new(ErrorCode::InternalInvariant, "memory lock poisoned"))?;
+            state
+                .multipart
+                .get(&request.upload_id)
+                .filter(|upload| upload.request.path == request.path)
+                .cloned()
+                .ok_or_else(|| {
+                    Error::new(ErrorCode::NoSuchUpload, "native multipart upload missing")
+                })?
+        };
+        let mut bytes = Vec::new();
+        for completed in &request.parts {
+            let part = upload.parts.get(&completed.part_number).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InvalidRequest,
+                    "completed multipart part is missing",
+                )
+            })?;
+            if sha256(part) != completed.checksum_sha256 || part.len() as u64 != completed.size {
+                return Err(Error::new(
+                    ErrorCode::ChecksumMismatch,
+                    "completed multipart part does not match its receipt",
+                ));
+            }
+            bytes.extend_from_slice(part);
+        }
+        if bytes.len() as u64 != request.size || sha256(&bytes) != request.checksum_sha256 {
+            return Err(Error::new(
+                ErrorCode::ChecksumMismatch,
+                "completed multipart object does not match its declared checksum or size",
+            ));
+        }
+        if <[u8; 16]>::from(Md5::digest(&bytes)) != request.checksum_md5 {
+            return Err(Error::new(
+                ErrorCode::ChecksumMismatch,
+                "completed multipart object does not match its declared MD5 checksum",
+            ));
+        }
+        let result = self
+            .put_native(NativePut {
+                path: request.path,
+                bytes,
+                headers: upload.request.headers,
+                user_metadata: upload.request.user_metadata,
+                repository: upload.request.repository,
+                operation: upload.request.operation,
+                writer_fence_generation: upload.request.writer_fence_generation,
+            })
+            .await;
+        self.requests.native_put.fetch_sub(1, Ordering::Relaxed);
+        if result.is_ok() {
+            let mut state = self
+                .inner
+                .write()
+                .map_err(|_| Error::new(ErrorCode::InternalInvariant, "memory lock poisoned"))?;
+            state.multipart.remove(&request.upload_id);
+        }
+        result
+    }
+
+    async fn abort_native_multipart(&self, request: NativeMultipartAbort) -> Result<()> {
+        self.requests
+            .native_multipart_abort
+            .fetch_add(1, Ordering::Relaxed);
+        let mut state = self
+            .inner
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "memory lock poisoned"))?;
+        match state.multipart.get(&request.upload_id) {
+            Some(upload) if upload.request.path == request.path => {
+                state.multipart.remove(&request.upload_id);
+                Ok(())
+            }
+            _ => Err(Error::new(
+                ErrorCode::NoSuchUpload,
+                "native multipart upload missing",
+            )),
+        }
+    }
+
+    async fn list_native_multipart_parts(
+        &self,
+        request: NativeMultipartListParts,
+    ) -> Result<NativeMultipartListPartsPage> {
+        self.requests
+            .native_multipart_list_parts
+            .fetch_add(1, Ordering::Relaxed);
+        let state = self
+            .inner
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "memory lock poisoned"))?;
+        let upload = state
+            .multipart
+            .get(&request.upload_id)
+            .filter(|upload| upload.request.path == request.path)
+            .ok_or_else(|| {
+                Error::new(ErrorCode::NoSuchUpload, "native multipart upload missing")
+            })?;
+        let limit = request.limit.min(1_000);
+        let mut parts = upload
+            .parts
+            .iter()
+            .filter(|(part_number, _)| **part_number > request.after_part_number)
+            .take(limit.saturating_add(1))
+            .map(|(part_number, bytes)| {
+                let md5: [u8; 16] = Md5::digest(bytes).into();
+                NativeMultipartPartResult {
+                    part_number: *part_number,
+                    etag: format!("\"{}\"", hex::encode(md5)),
+                    checksum_sha256: Some(sha256(bytes)),
+                    size: bytes.len() as u64,
+                }
+            })
+            .collect::<Vec<_>>();
+        let next_part_number = (parts.len() > limit)
+            .then(|| {
+                parts
+                    .get(limit.saturating_sub(1))
+                    .map(|part| part.part_number)
+            })
+            .flatten();
+        parts.truncate(limit);
+        Ok(NativeMultipartListPartsPage {
+            parts,
+            next_part_number,
+        })
+    }
+
+    async fn list_native_multipart_uploads(
+        &self,
+        request: NativeMultipartListUploads,
+    ) -> Result<NativeMultipartListUploadsPage> {
+        self.requests
+            .native_multipart_list_uploads
+            .fetch_add(1, Ordering::Relaxed);
+        let state = self
+            .inner
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "memory lock poisoned"))?;
+        let mut uploads = state
+            .multipart
+            .iter()
+            .filter(|(_, upload)| upload.request.path.as_str().starts_with(&request.prefix))
+            .map(|(upload_id, upload)| NativeMultipartUploadEntry {
+                path: upload.request.path.clone(),
+                upload_id: upload_id.clone(),
+                initiated_at_millis: upload.initiated_at_millis,
+            })
+            .collect::<Vec<_>>();
+        uploads.sort_by(|left, right| {
+            (left.path.as_str(), left.upload_id.as_str())
+                .cmp(&(right.path.as_str(), right.upload_id.as_str()))
+        });
+        uploads.retain(|upload| match request.key_marker.as_deref() {
+            None => true,
+            Some(marker) if upload.path.as_str() > marker => true,
+            Some(marker) if upload.path.as_str() == marker => request
+                .upload_id_marker
+                .as_deref()
+                .is_some_and(|upload_marker| upload.upload_id.as_str() > upload_marker),
+            Some(_) => false,
+        });
+        let limit = request.limit.min(1_000);
+        let has_more = uploads.len() > limit;
+        uploads.truncate(limit);
+        let (next_key_marker, next_upload_id_marker) = if has_more {
+            uploads
+                .last()
+                .map(|upload| {
+                    (
+                        Some(upload.path.as_str().to_string()),
+                        Some(upload.upload_id.clone()),
+                    )
+                })
+                .unwrap_or_default()
+        } else {
+            (None, None)
+        };
+        Ok(NativeMultipartListUploadsPage {
+            uploads,
+            next_key_marker,
+            next_upload_id_marker,
+        })
     }
 }

--- a/extensions/s3/core/src/repository.rs
+++ b/extensions/s3/core/src/repository.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
-    sync::Arc,
+    sync::{Arc, RwLock},
     time::Duration,
 };
 
@@ -18,11 +18,12 @@ use crate::{
     ObjectVersionKindV1, ObjectVersionOrder, ObjectVersionV1, ObjectWriteConditionV1, OperationId,
     OperationKind, OperationRecordV1, PhysicalVersion, ProllyObjectStore, ProtectionSink,
     PublicationLease, RandomIdSource, RefGeneration, ReflogEntryV1, RepositoryFormatV1,
-    RepositoryId, Result, RetentionPinV1, RetryAdvice, StorageToken, StoredContent, SyncRunStateV1,
-    SyncRunV1, SystemClock, TreeRootV1, UploadId, WorkspaceId, WorkspaceManifestV1,
-    WorkspaceMutationV1, WorkspaceStateV1,
+    RepositoryId, RepositoryStorageProfile, Result, RetentionPinV1, RetryAdvice, StorageToken,
+    StoredContent, SyncRunStateV1, SyncRunV1, SystemClock, TreeRootV1, UploadId, WorkspaceId,
+    WorkspaceManifestV1, WorkspaceMutationV1, WorkspaceStateV1,
 };
 use futures_util::{stream::BoxStream, Stream, StreamExt};
+use md5::{Digest as _, Md5};
 use prolly::{AsyncProlly, Cid, Config, RuntimeConfig, Tree, TreeFormat};
 
 const MIN_NONFINAL_MULTIPART_PART_BYTES: u64 = 5 * 1024 * 1024;
@@ -34,11 +35,17 @@ pub struct RepositoryOptions {
     pub repository_prefix: String,
     pub default_branch: String,
     pub writer: String,
+    pub storage_profile: RepositoryStorageProfile,
     pub logical_retry_limit: u8,
     pub limits: CanonicalLimits,
     pub state_tree_format: TreeFormat,
     pub content_index_format: TreeFormat,
     pub publication_lease_millis: u64,
+    /// Duration of the repository-scoped native writer lease. Renewal is
+    /// amortized and is not part of an ordinary operation's foreground calls.
+    pub writer_lease_millis: u64,
+    /// Open without acquiring mutation authority.
+    pub read_only: bool,
     pub multipart_upload_ttl_millis: u64,
     pub reflog_retention_millis: u64,
     pub history_traversal_limit: usize,
@@ -55,11 +62,14 @@ impl Default for RepositoryOptions {
             repository_prefix: ".prolly/v1".to_string(),
             default_branch: "main".to_string(),
             writer: "anonymous".to_string(),
+            storage_profile: RepositoryStorageProfile::DistributedContentAddressedV1,
             logical_retry_limit: 3,
             limits: CanonicalLimits::default(),
             state_tree_format: TreeFormat::default(),
             content_index_format: TreeFormat::default(),
             publication_lease_millis: 60 * 60 * 1_000,
+            writer_lease_millis: 60_000,
+            read_only: false,
             multipart_upload_ttl_millis: 7 * 24 * 60 * 60 * 1_000,
             reflog_retention_millis: 90 * 24 * 60 * 60 * 1_000,
             history_traversal_limit: 100_000,
@@ -218,6 +228,39 @@ struct LoadedRef {
     token: StorageToken,
 }
 
+#[derive(Clone)]
+struct HeldWriterLease {
+    value: crate::ExclusiveWriterLeaseV1,
+    token: StorageToken,
+}
+
+#[derive(Clone)]
+struct WarmBranchState {
+    reference: crate::RefValueV1,
+    token: StorageToken,
+    commit: BucketCommitV1,
+}
+
+#[derive(Default)]
+struct RetainedClosure {
+    paths: BTreeSet<ObjectPath>,
+    native_versions: BTreeSet<(ObjectPath, String)>,
+}
+
+impl RetainedClosure {
+    fn contains(&self, path: &ObjectPath, version: Option<&str>) -> bool {
+        self.paths.contains(path)
+            || version.is_some_and(|version| {
+                self.native_versions
+                    .contains(&(path.clone(), version.to_string()))
+            })
+    }
+
+    fn len(&self) -> usize {
+        self.paths.len() + self.native_versions.len()
+    }
+}
+
 struct LoadedUpload {
     value: MultipartUploadV1,
     token: StorageToken,
@@ -247,8 +290,13 @@ pub struct Repository<P: ObjectPlane> {
     plane: Arc<P>,
     options: RepositoryOptions,
     format: RepositoryFormatV1,
+    node_store: ProllyObjectStore<P>,
     engine: AsyncProlly<ProllyObjectStore<P>>,
     content: ContentStore<P>,
+    writer_lease: Arc<RwLock<Option<HeldWriterLease>>>,
+    warm_branches: Arc<RwLock<BTreeMap<String, WarmBranchState>>>,
+    commit_cache: Arc<RwLock<BTreeMap<CommitId, BucketCommitV1>>>,
+    native_publication: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl<P: ObjectPlane> Repository<P> {
@@ -271,11 +319,11 @@ impl<P: ObjectPlane> Repository<P> {
             state_tree_format: options.state_tree_format.clone(),
             content_index_format: options.content_index_format.clone(),
             canonical_limits: options.limits.clone(),
-            min_reader_version: RepositoryFormatV1::CURRENT_READER_VERSION,
-            min_writer_version: RepositoryFormatV1::CURRENT_WRITER_VERSION,
+            min_reader_version: options.storage_profile.minimum_protocol_version(),
+            min_writer_version: options.storage_profile.minimum_protocol_version(),
             created_at_millis,
             #[cfg(not(prolly_s3_legacy_v1_codec))]
-            required_capability_profile: RepositoryFormatV1::DISTRIBUTED_S3_CAPABILITY_PROFILE,
+            required_capability_profile: options.storage_profile.capability_profile(),
         };
         let proposed_intent = InitializationIntentV1 {
             repository_id,
@@ -301,7 +349,9 @@ impl<P: ObjectPlane> Repository<P> {
             }
         };
         validate_format_compatibility(&intent.format, &options)?;
-        let repository = Self::from_format(plane.clone(), options.clone(), intent.format.clone())?;
+        let mut repository =
+            Self::from_format(plane.clone(), options.clone(), intent.format.clone())?;
+        repository.acquire_native_writer().await?;
 
         let empty = repository.engine.create();
         let empty_state = BucketStateV1 {
@@ -313,7 +363,13 @@ impl<P: ObjectPlane> Repository<P> {
             operation_ids: Vec::new(),
             changes: Vec::new(),
         };
-        let delta_id = repository.store_delta(&delta).await?;
+        let native_profile = options.storage_profile == RepositoryStorageProfile::NativeVersionedV1;
+        let delta_id = if native_profile {
+            delta.id()?
+        } else {
+            repository.store_delta(&delta).await?
+        };
+        let writer_fence_generation = repository.writer_fence_generation()?;
         let commit = BucketCommitV1 {
             state: empty_state,
             parents: Vec::new(),
@@ -323,6 +379,11 @@ impl<P: ObjectPlane> Repository<P> {
             message: Some("initialize versioned S3 repository".to_string()),
             created_at_millis: intent.format.created_at_millis,
             metadata: BTreeMap::new(),
+            native: native_profile.then(|| crate::NativeCommitExtensionV1 {
+                node_pack: None,
+                inline_delta: delta.clone(),
+                writer_fence_generation,
+            }),
         };
         let commit_id = repository.store_commit(&commit).await?;
 
@@ -335,7 +396,11 @@ impl<P: ObjectPlane> Repository<P> {
             message: "initialize".to_string(),
             created_at_millis: intent.format.created_at_millis,
         };
-        let reflog_id = repository.store_reflog(&reflog).await?;
+        let reflog_id = if native_profile {
+            reflog.id()?
+        } else {
+            repository.store_reflog(&reflog).await?
+        };
 
         let format_bytes = encode_canonical(&intent.format)?;
         match plane
@@ -365,6 +430,10 @@ impl<P: ObjectPlane> Repository<P> {
             writer: options.writer.clone(),
             updated_at_millis: intent.format.created_at_millis,
             tombstone: false,
+            native: native_profile.then_some(crate::NativeRefExtensionV1 {
+                writer_fence_generation,
+                inline_reflog: reflog,
+            }),
         };
         let initial_ref_bytes = encode_canonical(&initial_ref)?;
         match plane
@@ -375,7 +444,15 @@ impl<P: ObjectPlane> Repository<P> {
             })
             .await?
         {
-            CompareExchangeOutcome::Applied(_) => Ok(repository),
+            CompareExchangeOutcome::Applied(metadata) => {
+                repository.cache_branch(
+                    &options.default_branch,
+                    initial_ref,
+                    metadata.token,
+                    commit,
+                )?;
+                Ok(repository)
+            }
             CompareExchangeOutcome::Conflict(Some(existing)) => {
                 let existing: crate::RefValueV1 = decode_canonical(&existing.bytes)?;
                 if existing.target != commit_id || existing.tombstone {
@@ -384,6 +461,15 @@ impl<P: ObjectPlane> Repository<P> {
                         "default branch exists with a divergent initial value",
                     ));
                 }
+                let loaded = repository
+                    .load_ref_including_tombstone(&options.default_branch)
+                    .await?;
+                repository.cache_branch(
+                    &options.default_branch,
+                    loaded.value,
+                    loaded.token,
+                    commit,
+                )?;
                 Ok(repository)
             }
             CompareExchangeOutcome::Conflict(None) => Err(Error::new(
@@ -410,7 +496,10 @@ impl<P: ObjectPlane> Repository<P> {
             })?;
         let format = decode_repository_format(&object.bytes)?;
         validate_format_compatibility(&format, &options)?;
-        Self::from_format(plane, options, format)
+        let mut repository = Self::from_format(plane, options, format)?;
+        repository.load_latest_node_index_checkpoint().await?;
+        repository.acquire_native_writer().await?;
+        Ok(repository)
     }
 
     fn from_format(
@@ -422,10 +511,15 @@ impl<P: ObjectPlane> Repository<P> {
             format: format.state_tree_format.clone(),
             runtime: RuntimeConfig::default(),
         };
-        let engine = AsyncProlly::new(
-            ProllyObjectStore::new(plane.clone(), options.repository_prefix.clone()),
-            config,
-        );
+        let node_store = match format.storage_profile()? {
+            RepositoryStorageProfile::DistributedContentAddressedV1 => {
+                ProllyObjectStore::new(plane.clone(), options.repository_prefix.clone())
+            }
+            RepositoryStorageProfile::NativeVersionedV1 => {
+                ProllyObjectStore::new_packed(plane.clone(), options.repository_prefix.clone())
+            }
+        };
+        let engine = AsyncProlly::new(node_store.clone(), config);
         let content = ContentStore::new(
             plane.clone(),
             options.repository_prefix.clone(),
@@ -436,8 +530,13 @@ impl<P: ObjectPlane> Repository<P> {
             plane,
             options,
             format,
+            node_store,
             engine,
             content,
+            writer_lease: Arc::new(RwLock::new(None)),
+            warm_branches: Arc::new(RwLock::new(BTreeMap::new())),
+            commit_cache: Arc::new(RwLock::new(BTreeMap::new())),
+            native_publication: Arc::new(tokio::sync::Mutex::new(())),
         })
     }
 
@@ -449,12 +548,526 @@ impl<P: ObjectPlane> Repository<P> {
         &self.format
     }
 
+    pub fn storage_profile(&self) -> RepositoryStorageProfile {
+        self.format
+            .storage_profile()
+            .expect("repository format was validated before construction")
+    }
+
     pub fn plane(&self) -> Arc<P> {
         self.plane.clone()
     }
 
+    /// Persist an advisory packed-node locator. It is safe to delete: cold
+    /// reads and repair can deterministically rebuild it from immutable packs.
+    pub async fn create_node_index_checkpoint(
+        &self,
+        branch: &str,
+    ) -> Result<crate::NodeIndexCheckpointV1> {
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1 {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "node-index checkpoints apply only to native-versioned repositories",
+            ));
+        }
+        validate_branch(branch)?;
+        self.node_store.rebuild_node_index().await?;
+        let head = self.head(branch).await?;
+        let commit = self.load_commit(head).await?;
+        let checkpoint = crate::NodeIndexCheckpointV1::derive(
+            self.format.repository_id,
+            branch.to_string(),
+            head,
+            commit.generation,
+            self.node_store.export_node_index()?,
+            self.now_millis()?,
+        )?;
+        checkpoint.validate()?;
+        self.store_immutable(
+            node_checkpoint_path(
+                &self.options.repository_prefix,
+                checkpoint.generation,
+                checkpoint.id,
+            )?,
+            encode_canonical(&checkpoint)?,
+        )
+        .await?;
+        Ok(checkpoint)
+    }
+
+    async fn load_latest_node_index_checkpoint(&self) -> Result<()> {
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1 {
+            return Ok(());
+        }
+        let prefix = format!("{}/node-index/checkpoints/", self.options.repository_prefix);
+        let mut continuation = None;
+        let mut paths = Vec::new();
+        loop {
+            let page = self
+                .plane
+                .list(ListRequest {
+                    prefix: prefix.clone(),
+                    continuation,
+                    limit: 1_000,
+                    include_versions: false,
+                })
+                .await?;
+            paths.extend(page.entries.into_iter().map(|entry| entry.path));
+            continuation = page.continuation;
+            if continuation.is_none() {
+                break;
+            }
+        }
+        paths.sort_by(|left, right| right.cmp(left));
+        for path in paths {
+            let Some(object) = self
+                .plane
+                .get(GetRequest {
+                    path,
+                    range: None,
+                    physical_version: None,
+                })
+                .await?
+            else {
+                continue;
+            };
+            let Ok(checkpoint) = decode_canonical::<crate::NodeIndexCheckpointV1>(&object.bytes)
+            else {
+                continue;
+            };
+            if checkpoint.repository != self.format.repository_id || checkpoint.validate().is_err()
+            {
+                continue;
+            }
+            self.node_store.import_node_index(&checkpoint.entries)?;
+            return Ok(());
+        }
+        Ok(())
+    }
+
     fn now_millis(&self) -> Result<u64> {
         self.options.clock.now_millis()
+    }
+
+    async fn acquire_native_writer(&mut self) -> Result<()> {
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1
+            || self.options.read_only
+        {
+            return Ok(());
+        }
+        let path = writer_lease_path(&self.options.repository_prefix)?;
+        let now = self.now_millis()?;
+        let expires_at_millis = now
+            .checked_add(self.options.writer_lease_millis)
+            .ok_or_else(|| Error::new(ErrorCode::InvalidLimit, "writer lease expiry overflow"))?;
+        let existing = self.plane.load_mutable(&path).await?;
+        let (next, expected) = match existing {
+            None => {
+                let operation = self.new_operation();
+                let fencing_token = crate::codec::sha256(
+                    &[
+                        self.format.repository_id.as_bytes().as_slice(),
+                        self.options.writer.as_bytes(),
+                        operation.as_bytes().as_slice(),
+                    ]
+                    .concat(),
+                );
+                (
+                    crate::ExclusiveWriterLeaseV1 {
+                        repository: self.format.repository_id,
+                        writer_id: self.options.writer.clone(),
+                        generation: 1,
+                        fencing_token,
+                        expires_at_millis,
+                        updated_at_millis: now,
+                    },
+                    None,
+                )
+            }
+            Some(stored) => {
+                let current: crate::ExclusiveWriterLeaseV1 = decode_canonical(&stored.bytes)?;
+                current.validate(self.format.repository_id)?;
+                if current.writer_id != self.options.writer {
+                    return Err(Error::new(
+                        ErrorCode::PreconditionFailed,
+                        "native repository is owned by another writer; takeover requires an explicit credential-isolated handoff",
+                    ));
+                }
+                if current.expires_at_millis <= now {
+                    return Err(Error::new(
+                        ErrorCode::PreconditionFailed,
+                        "native writer lease expired; automatic reacquisition is forbidden",
+                    ));
+                }
+                let mut renewed = current;
+                renewed.updated_at_millis = now;
+                renewed.expires_at_millis = expires_at_millis;
+                (renewed, Some(stored.metadata.token))
+            }
+        };
+        match self
+            .plane
+            .compare_exchange(CompareExchange {
+                path,
+                expected,
+                bytes: encode_canonical(&next)?,
+            })
+            .await?
+        {
+            CompareExchangeOutcome::Applied(metadata) => {
+                *self.writer_lease.write().map_err(|_| {
+                    Error::new(ErrorCode::InternalInvariant, "writer-lease lock poisoned")
+                })? = Some(HeldWriterLease {
+                    value: next,
+                    token: metadata.token,
+                });
+                Ok(())
+            }
+            CompareExchangeOutcome::Conflict(_) => Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "native writer lease changed during acquisition",
+            )),
+        }
+    }
+
+    /// Renew the repository-scoped exclusive writer lease. Services should
+    /// call this from an independent maintenance loop; mutations also renew
+    /// opportunistically near the deadline.
+    pub async fn renew_writer_lease(&self) -> Result<()> {
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1 {
+            return Ok(());
+        }
+        let held = self
+            .writer_lease
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "writer-lease lock poisoned"))?
+            .clone()
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::PreconditionFailed,
+                    "repository was opened read-only or has no writer lease",
+                )
+            })?;
+        let now = self.now_millis()?;
+        if held.value.expires_at_millis <= now {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "native writer lease expired; publication is fenced",
+            ));
+        }
+        let mut renewed = held.value;
+        renewed.updated_at_millis = now;
+        renewed.expires_at_millis = now
+            .checked_add(self.options.writer_lease_millis)
+            .ok_or_else(|| Error::new(ErrorCode::InvalidLimit, "writer lease expiry overflow"))?;
+        match self
+            .plane
+            .compare_exchange(CompareExchange {
+                path: writer_lease_path(&self.options.repository_prefix)?,
+                expected: Some(held.token),
+                bytes: encode_canonical(&renewed)?,
+            })
+            .await?
+        {
+            CompareExchangeOutcome::Applied(metadata) => {
+                *self.writer_lease.write().map_err(|_| {
+                    Error::new(ErrorCode::InternalInvariant, "writer-lease lock poisoned")
+                })? = Some(HeldWriterLease {
+                    value: renewed,
+                    token: metadata.token,
+                });
+                Ok(())
+            }
+            CompareExchangeOutcome::Conflict(_) => Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "native writer lease was lost; publication is fenced",
+            )),
+        }
+    }
+
+    /// Explicitly take over an expired or credential-revoked native writer.
+    /// The caller must have independently stopped/revoked the old writer; S3
+    /// cannot make ref CAS conditional on this separate lease object.
+    pub async fn takeover_native_writer(
+        &mut self,
+        expected_writer: &str,
+        expected_generation: u64,
+        handoff_evidence: &str,
+    ) -> Result<u64> {
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1 {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "exclusive writer takeover applies only to native-versioned repositories",
+            ));
+        }
+        if !self.options.read_only || handoff_evidence.trim().is_empty() {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "takeover requires a read-only open and non-empty credential-isolation evidence",
+            ));
+        }
+        let path = writer_lease_path(&self.options.repository_prefix)?;
+        let stored = self.plane.load_mutable(&path).await?.ok_or_else(|| {
+            Error::new(ErrorCode::MissingClosure, "native writer lease is missing")
+        })?;
+        let current: crate::ExclusiveWriterLeaseV1 = decode_canonical(&stored.bytes)?;
+        current.validate(self.format.repository_id)?;
+        let next_generation = expected_generation.checked_add(1).ok_or_else(|| {
+            Error::new(ErrorCode::InternalInvariant, "writer generation overflow")
+        })?;
+        let (next, token) = if current.writer_id == self.options.writer
+            && current.generation == next_generation
+        {
+            // Resume a barrier that acquired the lease but did not finish all refs.
+            (current, stored.metadata.token)
+        } else {
+            if current.writer_id != expected_writer || current.generation != expected_generation {
+                return Err(Error::new(
+                    ErrorCode::PreconditionFailed,
+                    "writer lease does not match the explicit takeover expectation",
+                ));
+            }
+            let now = self.now_millis()?;
+            let operation = self.new_operation();
+            let fencing_token = crate::codec::sha256(
+                &[
+                    self.format.repository_id.as_bytes().as_slice(),
+                    self.options.writer.as_bytes(),
+                    operation.as_bytes().as_slice(),
+                    handoff_evidence.as_bytes(),
+                ]
+                .concat(),
+            );
+            let next = crate::ExclusiveWriterLeaseV1 {
+                repository: self.format.repository_id,
+                writer_id: self.options.writer.clone(),
+                generation: next_generation,
+                fencing_token,
+                expires_at_millis: now
+                    .checked_add(self.options.writer_lease_millis)
+                    .ok_or_else(|| {
+                        Error::new(ErrorCode::InvalidLimit, "writer lease expiry overflow")
+                    })?,
+                updated_at_millis: now,
+            };
+            let token = match self
+                .plane
+                .compare_exchange(CompareExchange {
+                    path: path.clone(),
+                    expected: Some(stored.metadata.token),
+                    bytes: encode_canonical(&next)?,
+                })
+                .await?
+            {
+                CompareExchangeOutcome::Applied(metadata) => metadata.token,
+                CompareExchangeOutcome::Conflict(_) => {
+                    return Err(Error::new(
+                        ErrorCode::PreconditionFailed,
+                        "writer lease changed during explicit takeover",
+                    ))
+                }
+            };
+            (next, token)
+        };
+
+        for branch in self.list_branches().await? {
+            let loaded = self.load_ref_including_tombstone(&branch.name).await?;
+            let observed_fence = loaded
+                .value
+                .native
+                .as_ref()
+                .map(|native| native.writer_fence_generation)
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::CorruptCommit,
+                        "native branch ref is missing its writer fence",
+                    )
+                })?;
+            if observed_fence == next_generation {
+                continue;
+            }
+            if observed_fence > expected_generation {
+                return Err(Error::new(
+                    ErrorCode::PreconditionFailed,
+                    "branch ref carries a writer fence newer than the takeover expectation",
+                ));
+            }
+            let operation = self.new_operation();
+            let now = self.now_millis()?;
+            let reflog = ReflogEntryV1 {
+                branch: branch.name.clone(),
+                old_target: Some(loaded.value.target),
+                new_target: loaded.value.target,
+                operation,
+                actor: self.options.writer.clone(),
+                message: format!("writer takeover: {}", handoff_evidence.trim()),
+                created_at_millis: now,
+            };
+            let mut barrier = loaded.value;
+            barrier.previous_target = Some(barrier.target);
+            barrier.generation =
+                RefGeneration(barrier.generation.0.checked_add(1).ok_or_else(|| {
+                    Error::new(ErrorCode::InternalInvariant, "ref generation overflow")
+                })?);
+            barrier.operation = operation;
+            barrier.reflog = reflog.id()?;
+            barrier.writer = self.options.writer.clone();
+            barrier.updated_at_millis = now;
+            barrier.native = Some(crate::NativeRefExtensionV1 {
+                writer_fence_generation: next_generation,
+                inline_reflog: reflog,
+            });
+            match self
+                .plane
+                .compare_exchange(CompareExchange {
+                    path: branch_path(&self.options.repository_prefix, &branch.name)?,
+                    expected: Some(loaded.token),
+                    bytes: encode_canonical(&barrier)?,
+                })
+                .await?
+            {
+                CompareExchangeOutcome::Applied(_) => {}
+                CompareExchangeOutcome::Conflict(_) => {
+                    return Err(Error::new(
+                        ErrorCode::PreconditionFailed,
+                        "branch changed during writer takeover barrier",
+                    ))
+                }
+            }
+        }
+        *self.writer_lease.write().map_err(|_| {
+            Error::new(ErrorCode::InternalInvariant, "writer-lease lock poisoned")
+        })? = Some(HeldWriterLease { value: next, token });
+        self.options.read_only = false;
+        self.warm_branches
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "branch-cache lock poisoned"))?
+            .clear();
+        Ok(next_generation)
+    }
+
+    async fn native_writer_generation_for_mutation(&self) -> Result<u64> {
+        let held = self
+            .writer_lease
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "writer-lease lock poisoned"))?
+            .clone()
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::PreconditionFailed,
+                    "native repository has no exclusive writer authority",
+                )
+            })?;
+        let now = self.now_millis()?;
+        if held.value.expires_at_millis <= now {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "native writer lease expired; publication is fenced",
+            ));
+        }
+        let renew_at = held
+            .value
+            .expires_at_millis
+            .saturating_sub(self.options.writer_lease_millis / 3);
+        if now >= renew_at {
+            self.renew_writer_lease().await?;
+        }
+        self.writer_fence_generation()
+    }
+
+    fn writer_fence_generation(&self) -> Result<u64> {
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1 {
+            return Ok(0);
+        }
+        self.writer_lease
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "writer-lease lock poisoned"))?
+            .as_ref()
+            .map(|lease| lease.value.generation)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::PreconditionFailed,
+                    "native repository has no exclusive writer authority",
+                )
+            })
+    }
+
+    fn cache_branch(
+        &self,
+        branch: &str,
+        reference: crate::RefValueV1,
+        token: StorageToken,
+        commit: BucketCommitV1,
+    ) -> Result<()> {
+        self.warm_branches
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "branch-cache lock poisoned"))?
+            .insert(
+                branch.to_string(),
+                WarmBranchState {
+                    reference,
+                    token,
+                    commit,
+                },
+            );
+        Ok(())
+    }
+
+    async fn warm_branch_state(&self, branch: &str) -> Result<WarmBranchState> {
+        if let Some(cached) = self
+            .warm_branches
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "branch-cache lock poisoned"))?
+            .get(branch)
+            .cloned()
+        {
+            return Ok(cached);
+        }
+        let loaded = self.load_ref(branch).await?;
+        let commit = self.load_commit(loaded.value.target).await?;
+        let state = WarmBranchState {
+            reference: loaded.value,
+            token: loaded.token,
+            commit,
+        };
+        self.warm_branches
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "branch-cache lock poisoned"))?
+            .insert(branch.to_string(), state.clone());
+        Ok(state)
+    }
+
+    async fn replay_warm_operation(
+        &self,
+        branch: &str,
+        operation: OperationId,
+        input_digest: [u8; 32],
+    ) -> Result<Option<CommitReceipt>> {
+        let warm = self.warm_branch_state(branch).await?;
+        let operations = self.tree_from_root(
+            &warm.commit.state.operations,
+            &self.format.state_tree_format,
+        )?;
+        let Some(value) = self.engine.get(&operations, operation.as_bytes()).await? else {
+            return Ok(None);
+        };
+        let record: OperationRecordV1 = decode_canonical(&value)?;
+        if record.input_digest != input_digest {
+            return Err(Error::new(
+                ErrorCode::IdempotencyConflict,
+                "operation ID was already used with different input",
+            )
+            .operation(operation.to_string()));
+        }
+        Ok(Some(CommitReceipt {
+            id: warm.reference.target,
+            operation,
+            branch: branch.to_string(),
+            parents: warm.commit.parents,
+            changed_keys: record.result.changed_keys,
+            object_versions: record.result.object_versions,
+            idempotent_replay: true,
+        }))
     }
 
     fn new_operation(&self) -> OperationId {
@@ -478,6 +1091,12 @@ impl<P: ObjectPlane> Repository<P> {
         destination: Arc<Q>,
         destination_prefix: &str,
     ) -> Result<CloneReport> {
+        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "native-versioned clone requires logical history replay and destination VersionId rebinding",
+            ));
+        }
         let probe_prefix = format!("{destination_prefix}/");
         ObjectPath::new(format!("{destination_prefix}/format/v1.cbor"))?;
         let mut destination_continuation = None;
@@ -861,6 +1480,14 @@ impl<P: ObjectPlane> Repository<P> {
     }
 
     fn validate_sync_identity<Q: ObjectPlane>(&self, other: &Repository<Q>) -> Result<()> {
+        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1
+            || other.storage_profile() == RepositoryStorageProfile::NativeVersionedV1
+        {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "native-versioned fetch, push, and repair require destination VersionId rebinding",
+            ));
+        }
         if self.format != other.format {
             return Err(Error::new(
                 ErrorCode::RepositoryFormatConflict,
@@ -987,10 +1614,26 @@ impl<P: ObjectPlane> Repository<P> {
 
     pub async fn create_branch(&self, name: &str, from: CommitId) -> Result<BranchHead> {
         validate_branch(name)?;
-        self.load_commit(from).await?;
+        let commit = self.load_commit(from).await?;
         let operation = self.new_operation();
-        let lease = self.publication_lease(operation).await?;
-        lease.set_proposal(from).await?;
+        let native_profile = self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1;
+        let _native_publication = if native_profile {
+            Some(self.native_publication.lock().await)
+        } else {
+            None
+        };
+        let writer_fence_generation = if native_profile {
+            self.native_writer_generation_for_mutation().await?
+        } else {
+            0
+        };
+        let lease = if native_profile {
+            None
+        } else {
+            let lease = self.publication_lease(operation).await?;
+            lease.set_proposal(from).await?;
+            Some(lease)
+        };
         let created_at_millis = self.now_millis()?;
         let reflog = ReflogEntryV1 {
             branch: name.to_string(),
@@ -1001,18 +1644,24 @@ impl<P: ObjectPlane> Repository<P> {
             message: "create branch".to_string(),
             created_at_millis,
         };
-        let reflog = self.store_reflog(&reflog).await?;
+        let reflog_id = self.store_reflog(&reflog).await?;
         let value = crate::RefValueV1 {
             target: from,
             previous_target: None,
             generation: RefGeneration(0),
             operation,
-            reflog,
+            reflog: reflog_id,
             writer: self.options.writer.clone(),
             updated_at_millis: created_at_millis,
             tombstone: false,
+            native: native_profile.then_some(crate::NativeRefExtensionV1 {
+                writer_fence_generation,
+                inline_reflog: reflog,
+            }),
         };
-        self.ensure_publication_allowed(&lease).await?;
+        if let Some(lease) = &lease {
+            self.ensure_publication_allowed(lease).await?;
+        }
         let publication = self
             .plane
             .compare_exchange(CompareExchange {
@@ -1022,8 +1671,13 @@ impl<P: ObjectPlane> Repository<P> {
             })
             .await;
         match publication {
-            Ok(CompareExchangeOutcome::Applied(_)) => {
-                let _ = lease.complete(from).await;
+            Ok(CompareExchangeOutcome::Applied(metadata)) => {
+                if native_profile {
+                    self.cache_branch(name, value.clone(), metadata.token, commit)?;
+                }
+                if let Some(lease) = &lease {
+                    let _ = lease.complete(from).await;
+                }
                 Ok(BranchHead {
                     name: name.to_string(),
                     target: from,
@@ -1057,6 +1711,17 @@ impl<P: ObjectPlane> Repository<P> {
     }
 
     pub async fn delete_branch(&self, name: &str, expected: CommitId) -> Result<()> {
+        let native_profile = self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1;
+        let _native_publication = if native_profile {
+            Some(self.native_publication.lock().await)
+        } else {
+            None
+        };
+        let writer_fence_generation = if native_profile {
+            self.native_writer_generation_for_mutation().await?
+        } else {
+            0
+        };
         let loaded = self.load_ref(name).await?;
         if loaded.value.target != expected {
             return Err(Error::new(
@@ -1066,17 +1731,16 @@ impl<P: ObjectPlane> Repository<P> {
         }
         let operation = self.new_operation();
         let created_at_millis = self.now_millis()?;
-        let reflog = self
-            .store_reflog(&ReflogEntryV1 {
-                branch: name.to_string(),
-                old_target: Some(expected),
-                new_target: expected,
-                operation,
-                actor: self.options.writer.clone(),
-                message: "delete branch".to_string(),
-                created_at_millis,
-            })
-            .await?;
+        let reflog_entry = ReflogEntryV1 {
+            branch: name.to_string(),
+            old_target: Some(expected),
+            new_target: expected,
+            operation,
+            actor: self.options.writer.clone(),
+            message: "delete branch".to_string(),
+            created_at_millis,
+        };
+        let reflog = self.store_reflog(&reflog_entry).await?;
         let value = crate::RefValueV1 {
             target: expected,
             previous_target: Some(expected),
@@ -1088,6 +1752,10 @@ impl<P: ObjectPlane> Repository<P> {
             writer: self.options.writer.clone(),
             updated_at_millis: created_at_millis,
             tombstone: true,
+            native: native_profile.then_some(crate::NativeRefExtensionV1 {
+                writer_fence_generation,
+                inline_reflog: reflog_entry,
+            }),
         };
         let publication = self
             .plane
@@ -1098,7 +1766,15 @@ impl<P: ObjectPlane> Repository<P> {
             })
             .await;
         match publication {
-            Ok(CompareExchangeOutcome::Applied(_)) => Ok(()),
+            Ok(CompareExchangeOutcome::Applied(_)) => {
+                self.warm_branches
+                    .write()
+                    .map_err(|_| {
+                        Error::new(ErrorCode::InternalInvariant, "branch-cache lock poisoned")
+                    })?
+                    .remove(name);
+                Ok(())
+            }
             Ok(CompareExchangeOutcome::Conflict(_)) => Err(Error::new(
                 ErrorCode::RefConflict,
                 "branch moved while deleting",
@@ -1191,16 +1867,31 @@ impl<P: ObjectPlane> Repository<P> {
                 range: None,
                 physical_version: None,
             })
-            .await?
-            .ok_or_else(|| Error::new(ErrorCode::InvalidRevision, "reflog entry is missing"))?;
-        let entry: ReflogEntryV1 = decode_canonical(&object.bytes)?;
-        if entry.id()? != id || entry.branch != branch {
-            return Err(Error::new(
-                ErrorCode::CorruptCommit,
-                "reflog entry identity mismatch",
-            ));
+            .await?;
+        if let Some(object) = object {
+            let entry: ReflogEntryV1 = decode_canonical(&object.bytes)?;
+            if entry.id()? != id || entry.branch != branch {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "reflog entry identity mismatch",
+                ));
+            }
+            return Ok(entry);
         }
-        Ok(entry)
+        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            if let Some((_, entry)) = self
+                .native_reflog_history(branch)
+                .await?
+                .into_iter()
+                .find(|(entry_id, _)| *entry_id == id)
+            {
+                return Ok(entry);
+            }
+        }
+        Err(Error::new(
+            ErrorCode::InvalidRevision,
+            "reflog entry is missing",
+        ))
     }
 
     pub async fn list_reflog(
@@ -1214,7 +1905,11 @@ impl<P: ObjectPlane> Repository<P> {
             hex::encode(branch.as_bytes())
         );
         let mut continuation = None;
-        let mut entries = Vec::new();
+        let mut entries = if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            self.native_reflog_history(branch).await?
+        } else {
+            Vec::new()
+        };
         loop {
             let page = self
                 .plane
@@ -1247,7 +1942,10 @@ impl<P: ObjectPlane> Repository<P> {
                         "reflog entry escaped its branch namespace",
                     ));
                 }
-                entries.push((entry.id()?, entry));
+                let id = entry.id()?;
+                if !entries.iter().any(|(existing, _)| *existing == id) {
+                    entries.push((id, entry));
+                }
             }
             continuation = page.continuation;
             if continuation.is_none() {
@@ -1263,6 +1961,58 @@ impl<P: ObjectPlane> Repository<P> {
         Ok(entries)
     }
 
+    async fn native_reflog_history(
+        &self,
+        branch: &str,
+    ) -> Result<Vec<(crate::ReflogEntryId, ReflogEntryV1)>> {
+        validate_branch(branch)?;
+        let loaded = self.load_ref_including_tombstone(branch).await?;
+        let mut entries = BTreeMap::new();
+        if let Some(native) = &loaded.value.native {
+            if native.inline_reflog.branch != branch
+                || native.inline_reflog.id()? != loaded.value.reflog
+            {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "native ref inline reflog identity mismatch",
+                ));
+            }
+            entries.insert(loaded.value.reflog, native.inline_reflog.clone());
+        }
+        let mut next = Some(loaded.value.target);
+        let mut seen = BTreeSet::new();
+        while let Some(id) = next {
+            if !seen.insert(id) {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "native first-parent history contains a cycle",
+                ));
+            }
+            if seen.len() > self.options.history_traversal_limit {
+                return Err(Error::new(
+                    ErrorCode::HistoryLimitExceeded,
+                    "native reflog traversal exceeded its configured limit",
+                ));
+            }
+            let commit = self.load_commit(id).await?;
+            let delta = self.load_commit_delta(&commit).await?;
+            if let Some(operation) = delta.operation_ids.first().copied() {
+                let entry = ReflogEntryV1 {
+                    branch: branch.to_string(),
+                    old_target: commit.parents.first().copied(),
+                    new_target: id,
+                    operation,
+                    actor: commit.author.clone(),
+                    message: commit.message.clone().unwrap_or_default(),
+                    created_at_millis: commit.created_at_millis,
+                };
+                entries.entry(entry.id()?).or_insert(entry);
+            }
+            next = commit.parents.first().copied();
+        }
+        Ok(entries.into_iter().collect())
+    }
+
     async fn move_ref(
         &self,
         branch: &str,
@@ -1270,30 +2020,47 @@ impl<P: ObjectPlane> Repository<P> {
         target: CommitId,
         reason: &str,
     ) -> Result<RefMoveReceipt> {
+        let native_profile = self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1;
+        let _native_publication = if native_profile {
+            Some(self.native_publication.lock().await)
+        } else {
+            None
+        };
+        let writer_fence_generation = if native_profile {
+            self.native_writer_generation_for_mutation().await?
+        } else {
+            0
+        };
         let operation = self.new_operation();
         let created_at_millis = self.now_millis()?;
-        let lease = self.publication_lease(operation).await?;
-        lease
-            .protect(commit_path(&self.options.repository_prefix, target)?)
-            .await?;
-        let reflog = self
-            .store_reflog(&ReflogEntryV1 {
-                branch: branch.to_string(),
-                old_target: Some(loaded.value.target),
-                new_target: target,
-                operation,
-                actor: self.options.writer.clone(),
-                message: reason.to_string(),
-                created_at_millis,
-            })
-            .await?;
-        lease
-            .protect(reflog_path(
-                &self.options.repository_prefix,
-                branch,
-                reflog,
-            )?)
-            .await?;
+        let lease = if native_profile {
+            None
+        } else {
+            let lease = self.publication_lease(operation).await?;
+            lease
+                .protect(commit_path(&self.options.repository_prefix, target)?)
+                .await?;
+            Some(lease)
+        };
+        let reflog_entry = ReflogEntryV1 {
+            branch: branch.to_string(),
+            old_target: Some(loaded.value.target),
+            new_target: target,
+            operation,
+            actor: self.options.writer.clone(),
+            message: reason.to_string(),
+            created_at_millis,
+        };
+        let reflog = self.store_reflog(&reflog_entry).await?;
+        if let Some(lease) = &lease {
+            lease
+                .protect(reflog_path(
+                    &self.options.repository_prefix,
+                    branch,
+                    reflog,
+                )?)
+                .await?;
+        }
         let generation =
             RefGeneration(loaded.value.generation.0.checked_add(1).ok_or_else(|| {
                 Error::new(ErrorCode::InternalInvariant, "ref generation overflow")
@@ -1307,9 +2074,15 @@ impl<P: ObjectPlane> Repository<P> {
             writer: self.options.writer.clone(),
             updated_at_millis: created_at_millis,
             tombstone: false,
+            native: native_profile.then_some(crate::NativeRefExtensionV1 {
+                writer_fence_generation,
+                inline_reflog: reflog_entry,
+            }),
         };
-        lease.set_proposal(target).await?;
-        self.ensure_publication_allowed(&lease).await?;
+        if let Some(lease) = &lease {
+            lease.set_proposal(target).await?;
+            self.ensure_publication_allowed(lease).await?;
+        }
         let publication = self
             .plane
             .compare_exchange(CompareExchange {
@@ -1319,8 +2092,14 @@ impl<P: ObjectPlane> Repository<P> {
             })
             .await;
         match publication {
-            Ok(CompareExchangeOutcome::Applied(_)) => {
-                let _ = lease.complete(target).await;
+            Ok(CompareExchangeOutcome::Applied(metadata)) => {
+                if native_profile {
+                    let commit = self.load_commit(target).await?;
+                    self.cache_branch(branch, value, metadata.token, commit)?;
+                }
+                if let Some(lease) = &lease {
+                    let _ = lease.complete(target).await;
+                }
                 Ok(RefMoveReceipt {
                     branch: branch.to_string(),
                     old_target: Some(loaded.value.target),
@@ -1340,7 +2119,9 @@ impl<P: ObjectPlane> Repository<P> {
                     && current.value.target == target
                     && !current.value.tombstone
                 {
-                    let _ = lease.complete(target).await;
+                    if let Some(lease) = &lease {
+                        let _ = lease.complete(target).await;
+                    }
                     return Ok(RefMoveReceipt {
                         branch: branch.to_string(),
                         old_target: Some(loaded.value.target),
@@ -1936,6 +2717,21 @@ impl<P: ObjectPlane> Repository<P> {
     ) -> Result<CommitReceipt> {
         self.validate_key(&key)?;
         let operation = operation.unwrap_or_else(|| self.new_operation());
+        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            return self
+                .put_native_bytes_checked(
+                    branch,
+                    key,
+                    bytes,
+                    headers,
+                    user_metadata,
+                    operation,
+                    ObjectWriteConditionV1::default(),
+                    ChecksumExpectation::default(),
+                    None,
+                )
+                .await;
+        }
         let lease = self.publication_lease(operation).await?;
         let stored = self
             .content
@@ -2052,6 +2848,42 @@ impl<P: ObjectPlane> Repository<P> {
         }
         self.validate_key(&key)?;
         let operation = operation.unwrap_or_else(|| self.new_operation());
+        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            futures_util::pin_mut!(stream);
+            let mut bytes = Vec::new();
+            while let Some(next) = stream.next().await {
+                let next = next.map_err(|error| {
+                    Error::new(
+                        ErrorCode::Transport,
+                        format!("native object input stream failed: {error}"),
+                    )
+                })?;
+                let next = next.as_ref();
+                let new_len = bytes.len().checked_add(next.len()).ok_or_else(|| {
+                    Error::new(ErrorCode::EntityTooLarge, "native object length overflow")
+                })?;
+                if new_len > self.format.canonical_limits.max_object_bytes as usize {
+                    return Err(Error::new(
+                        ErrorCode::EntityTooLarge,
+                        "native object exceeds the repository size limit",
+                    ));
+                }
+                bytes.extend_from_slice(next);
+            }
+            return self
+                .put_native_bytes_checked(
+                    branch,
+                    key,
+                    bytes,
+                    headers,
+                    user_metadata,
+                    operation,
+                    condition,
+                    expected_checksums,
+                    logical_retry_limit,
+                )
+                .await;
+        }
         let lease = self.publication_lease(operation).await?;
         let stored = self
             .content
@@ -2078,6 +2910,114 @@ impl<P: ObjectPlane> Repository<P> {
             user_metadata,
             operation,
             Some(lease),
+            condition,
+            logical_retry_limit,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn put_native_bytes_checked(
+        &self,
+        branch: &str,
+        key: Vec<u8>,
+        bytes: Vec<u8>,
+        headers: ObjectHeaders,
+        user_metadata: BTreeMap<String, String>,
+        operation: OperationId,
+        condition: ObjectWriteConditionV1,
+        expected_checksums: ChecksumExpectation,
+        logical_retry_limit: Option<u8>,
+    ) -> Result<CommitReceipt> {
+        let _publication = self.native_publication.lock().await;
+        let expected_size = bytes.len() as u64;
+        let expected_sha256 = crate::codec::sha256(&bytes);
+        let expected_md5: [u8; 16] = Md5::digest(&bytes).into();
+        if expected_checksums
+            .md5
+            .is_some_and(|expected| expected != expected_md5)
+            || expected_checksums
+                .sha256
+                .is_some_and(|expected| expected != expected_sha256)
+        {
+            return Err(Error::new(
+                ErrorCode::ChecksumMismatch,
+                "request checksum does not match the native object body",
+            ));
+        }
+        let kind = ObjectVersionKindV1::Live {
+            content: crate::ContentRef::Empty,
+            size: expected_size,
+            logical_etag: format!("\"{}\"", hex::encode(expected_md5)),
+            headers: headers.clone(),
+            checksums: crate::Checksums {
+                md5: Some(expected_md5),
+                sha256: Some(expected_sha256),
+                algorithm_values: BTreeMap::new(),
+            },
+            user_metadata: user_metadata.clone(),
+            tags: BTreeMap::new(),
+        };
+        let input_digest = derive_input_digest(&[
+            self.format.repository_id.as_bytes(),
+            branch.as_bytes(),
+            b"put",
+            &key,
+            &encode_canonical(&kind)?,
+            &encode_canonical(&condition)?,
+        ]);
+        if let Some(receipt) = self
+            .replay_warm_operation(branch, operation, input_digest)
+            .await?
+        {
+            return Ok(receipt);
+        }
+        let writer_fence_generation = self.native_writer_generation_for_mutation().await?;
+        let path =
+            ObjectPath::new(std::str::from_utf8(&key).map_err(|_| {
+                Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+            })?)?;
+        let native = self
+            .plane
+            .put_native(crate::NativePut {
+                path: path.clone(),
+                bytes,
+                headers: headers.clone(),
+                user_metadata: user_metadata.clone(),
+                repository: self.format.repository_id,
+                operation,
+                writer_fence_generation,
+            })
+            .await;
+        let native = match native {
+            Ok(value) => value,
+            Err(error) => match self
+                .reconcile_native_payload(&path, operation, expected_sha256)
+                .await?
+            {
+                Some(value) => value,
+                None => return Err(error),
+            },
+        };
+        if native.size != expected_size
+            || native.checksums.sha256 != Some(expected_sha256)
+            || native.checksums.md5 != Some(expected_md5)
+        {
+            return Err(Error::new(
+                ErrorCode::ProviderNotQualified,
+                "native provider result disagrees with the uploaded object identity",
+            ));
+        }
+        self.commit_one(
+            branch,
+            key,
+            kind,
+            Some(native.binding),
+            OperationKind::Put,
+            operation,
+            input_digest,
+            "PutObject",
+            None,
             condition,
             logical_retry_limit,
         )
@@ -2123,11 +3063,12 @@ impl<P: ObjectPlane> Repository<P> {
             branch,
             key,
             kind,
+            None,
             OperationKind::Put,
             operation,
             input_digest,
             "PutObject",
-            lease,
+            Some(lease),
             condition,
             logical_retry_limit,
         )
@@ -2142,6 +3083,47 @@ impl<P: ObjectPlane> Repository<P> {
         self.content.read_stream(reference, range)
     }
 
+    pub fn read_version_stream(
+        &self,
+        key: &[u8],
+        version: ObjectVersionV1,
+        range: Option<(u64, u64)>,
+    ) -> BoxStream<'static, Result<bytes::Bytes>> {
+        let Some(crate::NativeObjectBindingV1::Live {
+            version_id,
+            checksum_sha256,
+            ..
+        }) = version.native_binding
+        else {
+            return match version.body.kind {
+                ObjectVersionKindV1::Live { content, .. } => {
+                    self.content.read_stream(content, range)
+                }
+                ObjectVersionKindV1::DeleteMarker => Box::pin(futures_util::stream::empty()),
+            };
+        };
+        let plane = self.plane.clone();
+        let path = ObjectPath::new(String::from_utf8_lossy(key).into_owned());
+        Box::pin(async_stream::try_stream! {
+            let path = path?;
+            let object = plane
+                .get(GetRequest {
+                    path,
+                    range: range.map(|(start, end)| start..=end),
+                    physical_version: Some(PhysicalVersion::Versioned { version_id }),
+                })
+                .await?
+                .ok_or_else(|| Error::new(ErrorCode::MissingClosure, "native object version is missing"))?;
+            if range.is_none() && object.metadata.sha256 != checksum_sha256 {
+                Err(Error::new(
+                    ErrorCode::CorruptContent,
+                    "native object bytes do not match the committed checksum",
+                ))?;
+            }
+            yield bytes::Bytes::from(object.bytes);
+        })
+    }
+
     pub async fn create_multipart_upload(
         &self,
         branch: &str,
@@ -2149,6 +3131,12 @@ impl<P: ObjectPlane> Repository<P> {
         headers: ObjectHeaders,
         user_metadata: BTreeMap<String, String>,
     ) -> Result<UploadId> {
+        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "native-versioned multipart requires direct provider multipart completion and VersionId capture",
+            ));
+        }
         validate_branch(branch)?;
         self.validate_key(&key)?;
         let id = self.new_upload();
@@ -3001,6 +3989,148 @@ impl<P: ObjectPlane> Repository<P> {
         }
     }
 
+    /// Create an in-memory atomic session descriptor for the native profile.
+    /// Staging remains local so publishing N objects costs N payload calls plus
+    /// one pack, one commit, and one ref CAS.
+    pub async fn begin_native_batch(
+        &self,
+        branch: &str,
+        message: impl Into<String>,
+        expires_after_millis: u64,
+    ) -> Result<WorkspaceManifestV1> {
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1 {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "ephemeral native batches require the native-versioned profile",
+            ));
+        }
+        validate_branch(branch)?;
+        let base_commit = self.warm_branch_state(branch).await?.reference.target;
+        let now = self.now_millis()?;
+        Ok(WorkspaceManifestV1 {
+            id: self.new_workspace(),
+            branch: branch.to_string(),
+            base_commit,
+            operation: self.new_operation(),
+            message: message.into(),
+            mutations: BTreeMap::new(),
+            generation: 0,
+            state: WorkspaceStateV1::Active,
+            created_at_millis: now,
+            updated_at_millis: now,
+            expires_at_millis: now.checked_add(expires_after_millis).ok_or_else(|| {
+                Error::new(ErrorCode::InvalidRequest, "native batch expiry overflow")
+            })?,
+        })
+    }
+
+    pub async fn publish_native_batch(
+        &self,
+        mut batch: WorkspaceManifestV1,
+        mutations: Vec<crate::NativeBatchMutationV1>,
+    ) -> Result<CommitReceipt> {
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1 {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "native batch publication requires the native-versioned profile",
+            ));
+        }
+        if mutations.is_empty()
+            || mutations.len() > self.format.canonical_limits.max_mutations_per_commit as usize
+            || batch.expires_at_millis < self.now_millis()?
+            || !matches!(batch.state, WorkspaceStateV1::Active)
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "native batch is empty, expired, closed, or exceeds the mutation limit",
+            ));
+        }
+        for mutation in &mutations {
+            self.validate_key(mutation.key())?;
+        }
+        let request_digest = derive_input_digest(&[
+            b"native-batch",
+            &encode_canonical(&mutations)?,
+            batch.base_commit.as_bytes(),
+        ]);
+        let _publication = self.native_publication.lock().await;
+        let warm = self.warm_branch_state(&batch.branch).await?;
+        if warm.reference.target != batch.base_commit {
+            if let Some(receipt) = self
+                .reconcile_operation(&batch.branch, batch.operation, request_digest)
+                .await?
+            {
+                return Ok(receipt);
+            }
+            return Err(Error::new(
+                ErrorCode::WorkspaceConflict,
+                "branch moved since native batch creation",
+            ));
+        }
+        let writer_fence_generation = self.native_writer_generation_for_mutation().await?;
+        for mutation in mutations {
+            match mutation {
+                crate::NativeBatchMutationV1::Put {
+                    key,
+                    bytes,
+                    headers,
+                    user_metadata,
+                } => {
+                    let path = ObjectPath::new(std::str::from_utf8(&key).map_err(|_| {
+                        Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+                    })?)?;
+                    let native = self
+                        .plane
+                        .put_native(crate::NativePut {
+                            path,
+                            bytes,
+                            headers: headers.clone(),
+                            user_metadata: user_metadata.clone(),
+                            repository: self.format.repository_id,
+                            operation: batch.operation,
+                            writer_fence_generation,
+                        })
+                        .await?;
+                    batch.mutations.insert(
+                        key.clone(),
+                        WorkspaceMutationV1::NativePut {
+                            key,
+                            content: StoredContent {
+                                reference: crate::ContentRef::Empty,
+                                size: native.size,
+                                logical_etag: native.logical_etag,
+                                checksums: native.checksums,
+                            },
+                            headers,
+                            user_metadata,
+                            binding: native.binding,
+                        },
+                    );
+                }
+                crate::NativeBatchMutationV1::Delete { key } => {
+                    let path = ObjectPath::new(std::str::from_utf8(&key).map_err(|_| {
+                        Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+                    })?)?;
+                    let binding = self
+                        .plane
+                        .delete_native(crate::NativeDelete {
+                            path,
+                            repository: self.format.repository_id,
+                            operation: batch.operation,
+                            writer_fence_generation,
+                        })
+                        .await?;
+                    batch.mutations.insert(
+                        key.clone(),
+                        WorkspaceMutationV1::NativeDelete { key, binding },
+                    );
+                }
+            }
+        }
+        batch.state = WorkspaceStateV1::Publishing { request_digest };
+        self.commit_workspace(&batch, request_digest, None).await
+    }
+
     pub async fn resume_workspace(&self, id: WorkspaceId) -> Result<WorkspaceManifestV1> {
         let workspace = self.load_workspace(id).await?.value;
         if workspace.expires_at_millis < self.now_millis()?
@@ -3028,6 +4158,62 @@ impl<P: ObjectPlane> Repository<P> {
         E: std::fmt::Display,
     {
         self.validate_key(&key)?;
+        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            let manifest = self.resume_workspace(workspace).await?;
+            let writer_fence_generation = self.native_writer_generation_for_mutation().await?;
+            futures_util::pin_mut!(stream);
+            let mut bytes = Vec::new();
+            while let Some(next) = stream.next().await {
+                let next = next.map_err(|error| {
+                    Error::new(
+                        ErrorCode::Transport,
+                        format!("native workspace input stream failed: {error}"),
+                    )
+                })?;
+                let next = next.as_ref();
+                if bytes.len().saturating_add(next.len())
+                    > self.format.canonical_limits.max_object_bytes as usize
+                {
+                    return Err(Error::new(
+                        ErrorCode::EntityTooLarge,
+                        "native workspace object exceeds the repository size limit",
+                    ));
+                }
+                bytes.extend_from_slice(next);
+            }
+            let path = ObjectPath::new(std::str::from_utf8(&key).map_err(|_| {
+                Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+            })?)?;
+            let native = self
+                .plane
+                .put_native(crate::NativePut {
+                    path,
+                    bytes,
+                    headers: headers.clone(),
+                    user_metadata: user_metadata.clone(),
+                    repository: self.format.repository_id,
+                    operation: manifest.operation,
+                    writer_fence_generation,
+                })
+                .await?;
+            return self
+                .update_workspace_mutation(
+                    workspace,
+                    WorkspaceMutationV1::NativePut {
+                        key,
+                        content: StoredContent {
+                            reference: crate::ContentRef::Empty,
+                            size: native.size,
+                            logical_etag: native.logical_etag,
+                            checksums: native.checksums,
+                        },
+                        headers,
+                        user_metadata,
+                        binding: native.binding,
+                    },
+                )
+                .await;
+        }
         let content = self
             .content
             .write_stream(stream, self.format.canonical_limits.max_object_bytes)
@@ -3050,6 +4236,28 @@ impl<P: ObjectPlane> Repository<P> {
         key: Vec<u8>,
     ) -> Result<WorkspaceManifestV1> {
         self.validate_key(&key)?;
+        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            let manifest = self.resume_workspace(workspace).await?;
+            let writer_fence_generation = self.native_writer_generation_for_mutation().await?;
+            let path = ObjectPath::new(std::str::from_utf8(&key).map_err(|_| {
+                Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+            })?)?;
+            let binding = self
+                .plane
+                .delete_native(crate::NativeDelete {
+                    path,
+                    repository: self.format.repository_id,
+                    operation: manifest.operation,
+                    writer_fence_generation,
+                })
+                .await?;
+            return self
+                .update_workspace_mutation(
+                    workspace,
+                    WorkspaceMutationV1::NativeDelete { key, binding },
+                )
+                .await;
+        }
         self.update_workspace_mutation(workspace, WorkspaceMutationV1::Delete { key })
             .await
     }
@@ -3173,7 +4381,17 @@ impl<P: ObjectPlane> Repository<P> {
                 "workspace publication race lost",
             ));
         }
-        let lease = self.publication_lease(loaded.value.operation).await?;
+        let native_profile = self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1;
+        let _native_publication = if native_profile {
+            Some(self.native_publication.lock().await)
+        } else {
+            None
+        };
+        let lease = if native_profile {
+            None
+        } else {
+            Some(self.publication_lease(loaded.value.operation).await?)
+        };
         let receipt = self
             .commit_workspace(&loaded.value, request_digest, lease)
             .await?;
@@ -3281,11 +4499,51 @@ impl<P: ObjectPlane> Repository<P> {
             b"delete",
             &key,
         ]);
-        let lease = self.publication_lease(operation).await?;
+        let native_profile = self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1;
+        let _native_publication = if native_profile {
+            Some(self.native_publication.lock().await)
+        } else {
+            None
+        };
+        if native_profile {
+            if let Some(receipt) = self
+                .replay_warm_operation(branch, operation, input_digest)
+                .await?
+            {
+                return Ok(receipt);
+            }
+        }
+        let lease = if native_profile {
+            None
+        } else {
+            Some(self.publication_lease(operation).await?)
+        };
+        let native_binding = if native_profile {
+            let writer_fence_generation = self.native_writer_generation_for_mutation().await?;
+            let path = ObjectPath::new(std::str::from_utf8(&key).map_err(|_| {
+                Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+            })?)?;
+            match self
+                .plane
+                .delete_native(crate::NativeDelete {
+                    path,
+                    repository: self.format.repository_id,
+                    operation,
+                    writer_fence_generation,
+                })
+                .await
+            {
+                Ok(binding) => Some(binding),
+                Err(error) => return Err(error),
+            }
+        } else {
+            None
+        };
         self.commit_one(
             branch,
             key,
             kind,
+            native_binding,
             OperationKind::Delete,
             operation,
             input_digest,
@@ -3328,6 +4586,11 @@ impl<P: ObjectPlane> Repository<P> {
             b"multi-delete",
             &encoded_keys,
         ]);
+        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            return self
+                .delete_objects_native(branch, keys, operation, input_digest)
+                .await;
+        }
         let lease = self.publication_lease(operation).await?;
         let engine = self.protected_engine(Arc::new(lease.clone()));
         let created_at_millis = self.now_millis()?;
@@ -3441,6 +4704,7 @@ impl<P: ObjectPlane> Repository<P> {
                 message: Some("DeleteObjects".to_string()),
                 created_at_millis,
                 metadata: BTreeMap::new(),
+                native: None,
             };
             let commit_id = self.store_commit(&commit).await?;
             lease
@@ -3483,6 +4747,7 @@ impl<P: ObjectPlane> Repository<P> {
                 writer: self.options.writer.clone(),
                 updated_at_millis: created_at_millis,
                 tombstone: false,
+                native: None,
             };
             self.ensure_publication_allowed(&lease).await?;
             let publication = self
@@ -3499,7 +4764,7 @@ impl<P: ObjectPlane> Repository<P> {
                         id: commit_id,
                         operation,
                         branch: branch.to_string(),
-                        parents: commit.parents,
+                        parents: commit.parents.clone(),
                         changed_keys: keys.len() as u64,
                         object_versions,
                         idempotent_replay: false,
@@ -3533,6 +4798,218 @@ impl<P: ObjectPlane> Repository<P> {
         .operation(operation.to_string()))
     }
 
+    async fn delete_objects_native(
+        &self,
+        branch: &str,
+        keys: Vec<Vec<u8>>,
+        operation: OperationId,
+        input_digest: [u8; 32],
+    ) -> Result<CommitReceipt> {
+        let _publication = self.native_publication.lock().await;
+        let writer_fence_generation = self.native_writer_generation_for_mutation().await?;
+        let warm = self.warm_branch_state(branch).await?;
+        let loaded_ref = LoadedRef {
+            value: warm.reference,
+            token: warm.token,
+        };
+        let base = warm.commit;
+        let engine = AsyncProlly::new(
+            self.node_store.clone(),
+            Config {
+                format: self.format.state_tree_format.clone(),
+                runtime: RuntimeConfig::default(),
+            },
+        );
+        let mut objects =
+            self.tree_from_root(&base.state.objects, &self.format.state_tree_format)?;
+        let mut versions =
+            self.tree_from_root(&base.state.versions, &self.format.state_tree_format)?;
+        let operations =
+            self.tree_from_root(&base.state.operations, &self.format.state_tree_format)?;
+        if let Some(existing) = engine.get(&operations, operation.as_bytes()).await? {
+            let existing: OperationRecordV1 = decode_canonical(&existing)?;
+            if existing.input_digest != input_digest {
+                return Err(Error::new(
+                    ErrorCode::IdempotencyConflict,
+                    "operation ID was already used with different input",
+                )
+                .operation(operation.to_string()));
+            }
+            return Ok(CommitReceipt {
+                id: loaded_ref.value.target,
+                operation,
+                branch: branch.to_string(),
+                parents: base.parents,
+                changed_keys: existing.result.changed_keys,
+                object_versions: existing.result.object_versions,
+                idempotent_replay: true,
+            });
+        }
+        let created_at_millis = self.now_millis()?;
+        let generation = CommitGeneration(base.generation.0.checked_add(1).ok_or_else(|| {
+            Error::new(ErrorCode::InternalInvariant, "commit generation overflow")
+        })?);
+        let mut transitions = Vec::with_capacity(keys.len());
+        let mut object_versions = Vec::with_capacity(keys.len());
+        for (ordinal, key) in keys.iter().enumerate() {
+            let previous = engine
+                .get(&objects, key)
+                .await?
+                .map(|bytes| decode_canonical::<CurrentObjectV1>(&bytes))
+                .transpose()?
+                .map(|current| current.version);
+            let path = ObjectPath::new(std::str::from_utf8(key).map_err(|_| {
+                Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+            })?)?;
+            let binding = self
+                .plane
+                .delete_native(crate::NativeDelete {
+                    path,
+                    repository: self.format.repository_id,
+                    operation,
+                    writer_fence_generation,
+                })
+                .await?;
+            let body = ObjectVersionBodyV1 {
+                order: ObjectVersionOrder {
+                    commit_generation: generation,
+                    mutation_ordinal: u32::try_from(ordinal).map_err(|_| {
+                        Error::new(ErrorCode::InvalidLimit, "mutation ordinal overflow")
+                    })?,
+                },
+                created_at_millis,
+                kind: ObjectVersionKindV1::DeleteMarker,
+            };
+            let version = ObjectVersionV1::derive_native(
+                self.format.repository_id,
+                key,
+                operation,
+                body,
+                binding,
+            )?;
+            objects = engine.delete(&objects, key).await?;
+            versions = engine
+                .put(
+                    &versions,
+                    version_tree_key(key, version.body.order, version.id),
+                    encode_canonical(&version)?,
+                )
+                .await?;
+            transitions.push(ObjectTransition {
+                key: key.clone(),
+                previous,
+                next: version.id,
+                delete_marker: true,
+            });
+            object_versions.push(version.id);
+        }
+        let result = CanonicalOperationResult {
+            kind: OperationKind::MultiDelete,
+            object_versions: object_versions.clone(),
+            changed_keys: keys.len() as u64,
+        };
+        let operations = engine
+            .put(
+                &operations,
+                operation.as_bytes().to_vec(),
+                encode_canonical(&OperationRecordV1 {
+                    input_digest,
+                    result: result.clone(),
+                    commit_generation: generation,
+                    created_at_millis,
+                })?,
+            )
+            .await?;
+        let delta = BucketDeltaV1 {
+            operation_ids: vec![operation],
+            changes: transitions,
+        };
+        let node_pack = self
+            .node_store
+            .flush_node_pack(
+                tree_format_digest(&self.format.state_tree_format)?,
+                Vec::new(),
+            )
+            .await?;
+        let commit = BucketCommitV1 {
+            state: BucketStateV1 {
+                objects: TreeRootV1::from_tree(&objects)?,
+                versions: TreeRootV1::from_tree(&versions)?,
+                operations: TreeRootV1::from_tree(&operations)?,
+            },
+            parents: vec![loaded_ref.value.target],
+            generation,
+            delta: delta.id()?,
+            author: self.options.writer.clone(),
+            message: Some("DeleteObjects".to_string()),
+            created_at_millis,
+            metadata: BTreeMap::new(),
+            native: Some(crate::NativeCommitExtensionV1 {
+                node_pack,
+                inline_delta: delta,
+                writer_fence_generation,
+            }),
+        };
+        let commit_id = self.store_commit(&commit).await?;
+        let reflog = ReflogEntryV1 {
+            branch: branch.to_string(),
+            old_target: Some(loaded_ref.value.target),
+            new_target: commit_id,
+            operation,
+            actor: self.options.writer.clone(),
+            message: "DeleteObjects".to_string(),
+            created_at_millis,
+        };
+        let next_ref = crate::RefValueV1 {
+            target: commit_id,
+            previous_target: Some(loaded_ref.value.target),
+            generation: RefGeneration(loaded_ref.value.generation.0.checked_add(1).ok_or_else(
+                || Error::new(ErrorCode::InternalInvariant, "ref generation overflow"),
+            )?),
+            operation,
+            reflog: reflog.id()?,
+            writer: self.options.writer.clone(),
+            updated_at_millis: created_at_millis,
+            tombstone: false,
+            native: Some(crate::NativeRefExtensionV1 {
+                writer_fence_generation,
+                inline_reflog: reflog,
+            }),
+        };
+        if self.native_writer_generation_for_mutation().await? != writer_fence_generation {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "native writer fence changed during multi-delete publication",
+            ));
+        }
+        match self
+            .plane
+            .compare_exchange(CompareExchange {
+                path: branch_path(&self.options.repository_prefix, branch)?,
+                expected: Some(loaded_ref.token),
+                bytes: encode_canonical(&next_ref)?,
+            })
+            .await?
+        {
+            CompareExchangeOutcome::Applied(metadata) => {
+                self.cache_branch(branch, next_ref, metadata.token, commit.clone())?;
+                Ok(CommitReceipt {
+                    id: commit_id,
+                    operation,
+                    branch: branch.to_string(),
+                    parents: commit.parents,
+                    changed_keys: keys.len() as u64,
+                    object_versions,
+                    idempotent_replay: false,
+                })
+            }
+            CompareExchangeOutcome::Conflict(_) => Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "native branch CAS conflicted; writer is fenced and must reopen",
+            )),
+        }
+    }
+
     pub async fn copy_object(
         &self,
         branch: &str,
@@ -3547,14 +5024,14 @@ impl<P: ObjectPlane> Repository<P> {
             Some(version) => self.head_version(branch, source_key, version).await?,
             None => self.head_current_at(branch, source_key).await?,
         };
-        let ObjectVersionKindV1::Live { .. } = source.version.body.kind else {
+        let ObjectVersionKindV1::Live { .. } = &source.version.body.kind else {
             return Err(Error::new(
                 ErrorCode::NoSuchKey,
                 "copy source is a delete marker",
             ));
         };
         let operation = operation.unwrap_or_else(|| self.new_operation());
-        let kind = source.version.body.kind;
+        let kind = source.version.body.kind.clone();
         let kind_bytes = encode_canonical(&kind)?;
         let input_digest = derive_input_digest(&[
             self.format.repository_id.as_bytes(),
@@ -3565,11 +5042,90 @@ impl<P: ObjectPlane> Repository<P> {
             &destination_key,
             &kind_bytes,
         ]);
-        let lease = self.publication_lease(operation).await?;
+        let native_profile = self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1;
+        let _native_publication = if native_profile {
+            Some(self.native_publication.lock().await)
+        } else {
+            None
+        };
+        if native_profile {
+            if let Some(receipt) = self
+                .replay_warm_operation(branch, operation, input_digest)
+                .await?
+            {
+                return Ok(receipt);
+            }
+        }
+        let lease = if native_profile {
+            None
+        } else {
+            Some(self.publication_lease(operation).await?)
+        };
+        let native_binding = if native_profile {
+            let writer_fence_generation = self.native_writer_generation_for_mutation().await?;
+            let crate::NativeObjectBindingV1::Live {
+                version_id,
+                checksum_sha256,
+                ..
+            } = source.version.native_binding.clone().ok_or_else(|| {
+                Error::new(
+                    ErrorCode::CorruptCommit,
+                    "native copy source is missing its physical binding",
+                )
+            })?
+            else {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "native copy source points to a delete marker",
+                ));
+            };
+            let ObjectVersionKindV1::Live {
+                size,
+                logical_etag,
+                headers,
+                checksums,
+                user_metadata,
+                ..
+            } = &kind
+            else {
+                unreachable!("copy source was validated as live")
+            };
+            let source_path = ObjectPath::new(std::str::from_utf8(source_key).map_err(|_| {
+                Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+            })?)?;
+            let destination_path =
+                ObjectPath::new(std::str::from_utf8(&destination_key).map_err(|_| {
+                    Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+                })?)?;
+            match self
+                .plane
+                .copy_native(crate::NativeCopy {
+                    source: source_path,
+                    source_version_id: version_id,
+                    destination: destination_path,
+                    headers: headers.clone(),
+                    user_metadata: user_metadata.clone(),
+                    repository: self.format.repository_id,
+                    operation,
+                    writer_fence_generation,
+                    checksum_sha256,
+                    size: *size,
+                    logical_etag: logical_etag.clone(),
+                    checksums: checksums.clone(),
+                })
+                .await
+            {
+                Ok(result) => Some(result.binding),
+                Err(error) => return Err(error),
+            }
+        } else {
+            None
+        };
         self.commit_one(
             branch,
             destination_key,
             kind,
+            native_binding,
             OperationKind::Copy,
             operation,
             input_digest,
@@ -3587,21 +5143,69 @@ impl<P: ObjectPlane> Repository<P> {
         branch: &str,
         key: Vec<u8>,
         kind: ObjectVersionKindV1,
+        native_binding: Option<crate::NativeObjectBindingV1>,
         operation_kind: OperationKind,
         operation: OperationId,
         input_digest: [u8; 32],
         message: &str,
-        lease: PublicationLease<P>,
+        lease: Option<PublicationLease<P>>,
         condition: ObjectWriteConditionV1,
         logical_retry_limit: Option<u8>,
     ) -> Result<CommitReceipt> {
         validate_branch(branch)?;
+        let native_profile = self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1;
+        match (self.storage_profile(), native_binding.as_ref()) {
+            (RepositoryStorageProfile::DistributedContentAddressedV1, None)
+            | (RepositoryStorageProfile::NativeVersionedV1, Some(_)) => {}
+            (RepositoryStorageProfile::DistributedContentAddressedV1, Some(_)) => {
+                return Err(Error::new(
+                    ErrorCode::InternalInvariant,
+                    "distributed-profile publication received a native binding",
+                ))
+            }
+            (RepositoryStorageProfile::NativeVersionedV1, None) => {
+                return Err(Error::new(
+                    ErrorCode::InternalInvariant,
+                    "native-profile publication omitted its native binding",
+                ))
+            }
+        }
         let created_at_millis = self.now_millis()?;
-        let engine = self.protected_engine(Arc::new(lease.clone()));
-        for _attempt in
-            0..=effective_logical_retry_limit(self.options.logical_retry_limit, logical_retry_limit)
-        {
-            let loaded_ref = self.load_ref(branch).await?;
+        let writer_fence_generation = if native_profile {
+            self.native_writer_generation_for_mutation().await?
+        } else {
+            0
+        };
+        let engine = match lease.as_ref() {
+            Some(lease) => self.protected_engine(Arc::new(lease.clone())),
+            None => AsyncProlly::new(
+                self.node_store.clone(),
+                Config {
+                    format: self.format.state_tree_format.clone(),
+                    runtime: RuntimeConfig::default(),
+                },
+            ),
+        };
+        let retry_limit = if native_profile {
+            0
+        } else {
+            effective_logical_retry_limit(self.options.logical_retry_limit, logical_retry_limit)
+        };
+        for _attempt in 0..=retry_limit {
+            let (loaded_ref, base) = if native_profile {
+                let warm = self.warm_branch_state(branch).await?;
+                (
+                    LoadedRef {
+                        value: warm.reference,
+                        token: warm.token,
+                    },
+                    warm.commit,
+                )
+            } else {
+                let loaded = self.load_ref(branch).await?;
+                let base = self.load_commit(loaded.value.target).await?;
+                (loaded, base)
+            };
             if condition
                 .expected_head
                 .is_some_and(|expected| expected != loaded_ref.value.target)
@@ -3611,7 +5215,6 @@ impl<P: ObjectPlane> Repository<P> {
                     "branch head does not match the atomic write expectation",
                 ));
             }
-            let base = self.load_commit(loaded_ref.value.target).await?;
             let objects =
                 self.tree_from_root(&base.state.objects, &self.format.state_tree_format)?;
             let versions =
@@ -3637,7 +5240,9 @@ impl<P: ObjectPlane> Repository<P> {
                     object_versions: existing.result.object_versions,
                     idempotent_replay: true,
                 };
-                let _ = lease.complete(receipt.id).await;
+                if let Some(lease) = &lease {
+                    let _ = lease.complete(receipt.id).await;
+                }
                 return Ok(receipt);
             }
 
@@ -3670,8 +5275,16 @@ impl<P: ObjectPlane> Repository<P> {
                 created_at_millis,
                 kind: kind.clone(),
             };
-            let version =
-                ObjectVersionV1::derive(self.format.repository_id, &key, operation, body)?;
+            let version = match native_binding.clone() {
+                Some(binding) => ObjectVersionV1::derive_native(
+                    self.format.repository_id,
+                    &key,
+                    operation,
+                    body,
+                    binding,
+                )?,
+                None => ObjectVersionV1::derive(self.format.repository_id, &key, operation, body)?,
+            };
             let version_key = version_tree_key(&key, version.body.order, version.id);
 
             let objects = match &version.body.kind {
@@ -3724,10 +5337,27 @@ impl<P: ObjectPlane> Repository<P> {
                     delete_marker: matches!(version.body.kind, ObjectVersionKindV1::DeleteMarker),
                 }],
             };
-            let delta_id = self.store_delta(&delta).await?;
-            lease
-                .protect(delta_path(&self.options.repository_prefix, delta_id)?)
-                .await?;
+            let delta_id = if native_profile {
+                delta.id()?
+            } else {
+                let id = self.store_delta(&delta).await?;
+                lease
+                    .as_ref()
+                    .expect("distributed publication has a lease")
+                    .protect(delta_path(&self.options.repository_prefix, id)?)
+                    .await?;
+                id
+            };
+            let node_pack = if native_profile {
+                self.node_store
+                    .flush_node_pack(
+                        tree_format_digest(&self.format.state_tree_format)?,
+                        Vec::new(),
+                    )
+                    .await?
+            } else {
+                None
+            };
             let commit = BucketCommitV1 {
                 state,
                 parents: vec![loaded_ref.value.target],
@@ -3737,12 +5367,19 @@ impl<P: ObjectPlane> Repository<P> {
                 message: Some(message.to_string()),
                 created_at_millis,
                 metadata: BTreeMap::new(),
+                native: native_profile.then(|| crate::NativeCommitExtensionV1 {
+                    node_pack,
+                    inline_delta: delta.clone(),
+                    writer_fence_generation,
+                }),
             };
             let commit_id = self.store_commit(&commit).await?;
-            lease
-                .protect(commit_path(&self.options.repository_prefix, commit_id)?)
-                .await?;
-            lease.set_proposal(commit_id).await?;
+            if let Some(lease) = &lease {
+                lease
+                    .protect(commit_path(&self.options.repository_prefix, commit_id)?)
+                    .await?;
+                lease.set_proposal(commit_id).await?;
+            }
             let reflog = ReflogEntryV1 {
                 branch: branch.to_string(),
                 old_target: Some(loaded_ref.value.target),
@@ -3752,14 +5389,17 @@ impl<P: ObjectPlane> Repository<P> {
                 message: message.to_string(),
                 created_at_millis,
             };
-            let reflog_id = self.store_reflog(&reflog).await?;
-            lease
-                .protect(reflog_path(
-                    &self.options.repository_prefix,
-                    branch,
-                    reflog_id,
-                )?)
-                .await?;
+            let reflog_id = if native_profile {
+                reflog.id()?
+            } else {
+                let id = self.store_reflog(&reflog).await?;
+                lease
+                    .as_ref()
+                    .expect("distributed publication has a lease")
+                    .protect(reflog_path(&self.options.repository_prefix, branch, id)?)
+                    .await?;
+                id
+            };
             let next_ref = crate::RefValueV1 {
                 target: commit_id,
                 previous_target: Some(loaded_ref.value.target),
@@ -3778,8 +5418,25 @@ impl<P: ObjectPlane> Repository<P> {
                 writer: self.options.writer.clone(),
                 updated_at_millis: created_at_millis,
                 tombstone: false,
+                native: native_profile.then_some(crate::NativeRefExtensionV1 {
+                    writer_fence_generation,
+                    inline_reflog: reflog,
+                }),
             };
-            self.ensure_publication_allowed(&lease).await?;
+            if native_profile {
+                let current_fence = self.native_writer_generation_for_mutation().await?;
+                if current_fence != writer_fence_generation {
+                    return Err(Error::new(
+                        ErrorCode::PreconditionFailed,
+                        "native writer fence changed during publication",
+                    ));
+                }
+            } else {
+                self.ensure_publication_allowed(
+                    lease.as_ref().expect("distributed publication has a lease"),
+                )
+                .await?;
+            }
             let publication = self
                 .plane
                 .compare_exchange(CompareExchange {
@@ -3789,18 +5446,35 @@ impl<P: ObjectPlane> Repository<P> {
                 })
                 .await;
             match publication {
-                Ok(CompareExchangeOutcome::Applied(_)) => {
+                Ok(CompareExchangeOutcome::Applied(metadata)) => {
                     let receipt = CommitReceipt {
                         id: commit_id,
                         operation,
                         branch: branch.to_string(),
-                        parents: commit.parents,
+                        parents: commit.parents.clone(),
                         changed_keys: 1,
                         object_versions: operation_result.object_versions,
                         idempotent_replay: false,
                     };
-                    let _ = lease.complete(commit_id).await;
+                    if native_profile {
+                        self.cache_branch(branch, next_ref, metadata.token, commit.clone())?;
+                    }
+                    if let Some(lease) = &lease {
+                        let _ = lease.complete(commit_id).await;
+                    }
                     return Ok(receipt);
+                }
+                Ok(CompareExchangeOutcome::Conflict(_)) if native_profile => {
+                    self.warm_branches
+                        .write()
+                        .map_err(|_| {
+                            Error::new(ErrorCode::InternalInvariant, "branch-cache lock poisoned")
+                        })?
+                        .remove(branch);
+                    return Err(Error::new(
+                        ErrorCode::PreconditionFailed,
+                        "native branch CAS conflicted; writer is fenced and must reopen",
+                    ));
                 }
                 Ok(CompareExchangeOutcome::Conflict(_)) => continue,
                 Err(error) => {
@@ -3808,7 +5482,9 @@ impl<P: ObjectPlane> Repository<P> {
                         .reconcile_operation(branch, operation, input_digest)
                         .await?
                     {
-                        let _ = lease.complete(receipt.id).await;
+                        if let Some(lease) = &lease {
+                            let _ = lease.complete(receipt.id).await;
+                        }
                         return Ok(receipt);
                     }
                     return Err(Error::new(
@@ -3832,15 +5508,31 @@ impl<P: ObjectPlane> Repository<P> {
         &self,
         workspace: &WorkspaceManifestV1,
         input_digest: [u8; 32],
-        lease: PublicationLease<P>,
+        lease: Option<PublicationLease<P>>,
     ) -> Result<CommitReceipt> {
-        let loaded_ref = self.load_ref(&workspace.branch).await?;
+        let native_profile = self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1;
+        let (loaded_ref, base) = if native_profile {
+            let warm = self.warm_branch_state(&workspace.branch).await?;
+            (
+                LoadedRef {
+                    value: warm.reference,
+                    token: warm.token,
+                },
+                warm.commit,
+            )
+        } else {
+            let loaded = self.load_ref(&workspace.branch).await?;
+            let base = self.load_commit(workspace.base_commit).await?;
+            (loaded, base)
+        };
         if loaded_ref.value.target != workspace.base_commit {
             if let Some(receipt) = self
                 .reconcile_operation(&workspace.branch, workspace.operation, input_digest)
                 .await?
             {
-                let _ = lease.complete(receipt.id).await;
+                if let Some(lease) = &lease {
+                    let _ = lease.complete(receipt.id).await;
+                }
                 return Ok(receipt);
             }
             return Err(Error::new(
@@ -3848,8 +5540,21 @@ impl<P: ObjectPlane> Repository<P> {
                 "branch moved since workspace creation",
             ));
         }
-        let base = self.load_commit(workspace.base_commit).await?;
-        let engine = self.protected_engine(Arc::new(lease.clone()));
+        let writer_fence_generation = if native_profile {
+            self.native_writer_generation_for_mutation().await?
+        } else {
+            0
+        };
+        let engine = match &lease {
+            Some(lease) => self.protected_engine(Arc::new(lease.clone())),
+            None => AsyncProlly::new(
+                self.node_store.clone(),
+                Config {
+                    format: self.format.state_tree_format.clone(),
+                    runtime: RuntimeConfig::default(),
+                },
+            ),
+        };
         let mut objects =
             self.tree_from_root(&base.state.objects, &self.format.state_tree_format)?;
         let mut versions =
@@ -3870,38 +5575,78 @@ impl<P: ObjectPlane> Repository<P> {
                 .map(|bytes| decode_canonical::<CurrentObjectV1>(&bytes))
                 .transpose()?
                 .map(|current| current.version);
-            let kind = match mutation {
+            let (kind, native_binding) = match mutation {
                 WorkspaceMutationV1::Put {
                     content,
                     headers,
                     user_metadata,
                     ..
-                } => ObjectVersionKindV1::Live {
-                    content: content.reference.clone(),
-                    size: content.size,
-                    logical_etag: content.logical_etag.clone(),
-                    headers: headers.clone(),
-                    checksums: content.checksums.clone(),
-                    user_metadata: user_metadata.clone(),
-                    tags: BTreeMap::new(),
-                },
-                WorkspaceMutationV1::Delete { .. } => ObjectVersionKindV1::DeleteMarker,
-            };
-            let version = ObjectVersionV1::derive(
-                self.format.repository_id,
-                key,
-                workspace.operation,
-                ObjectVersionBodyV1 {
-                    order: ObjectVersionOrder {
-                        commit_generation: generation,
-                        mutation_ordinal: u32::try_from(ordinal).map_err(|_| {
-                            Error::new(ErrorCode::InvalidLimit, "workspace ordinal overflow")
-                        })?,
+                } => (
+                    ObjectVersionKindV1::Live {
+                        content: content.reference.clone(),
+                        size: content.size,
+                        logical_etag: content.logical_etag.clone(),
+                        headers: headers.clone(),
+                        checksums: content.checksums.clone(),
+                        user_metadata: user_metadata.clone(),
+                        tags: BTreeMap::new(),
                     },
-                    created_at_millis: now,
-                    kind,
+                    None,
+                ),
+                WorkspaceMutationV1::Delete { .. } => (ObjectVersionKindV1::DeleteMarker, None),
+                WorkspaceMutationV1::NativePut {
+                    content,
+                    headers,
+                    user_metadata,
+                    binding,
+                    ..
+                } => (
+                    ObjectVersionKindV1::Live {
+                        content: crate::ContentRef::Empty,
+                        size: content.size,
+                        logical_etag: content.logical_etag.clone(),
+                        headers: headers.clone(),
+                        checksums: content.checksums.clone(),
+                        user_metadata: user_metadata.clone(),
+                        tags: BTreeMap::new(),
+                    },
+                    Some(binding.clone()),
+                ),
+                WorkspaceMutationV1::NativeDelete { binding, .. } => {
+                    (ObjectVersionKindV1::DeleteMarker, Some(binding.clone()))
+                }
+            };
+            let body = ObjectVersionBodyV1 {
+                order: ObjectVersionOrder {
+                    commit_generation: generation,
+                    mutation_ordinal: u32::try_from(ordinal).map_err(|_| {
+                        Error::new(ErrorCode::InvalidLimit, "workspace ordinal overflow")
+                    })?,
                 },
-            )?;
+                created_at_millis: now,
+                kind,
+            };
+            let version = match (native_profile, native_binding) {
+                (true, Some(binding)) => ObjectVersionV1::derive_native(
+                    self.format.repository_id,
+                    key,
+                    workspace.operation,
+                    body,
+                    binding,
+                )?,
+                (false, None) => ObjectVersionV1::derive(
+                    self.format.repository_id,
+                    key,
+                    workspace.operation,
+                    body,
+                )?,
+                _ => {
+                    return Err(Error::new(
+                        ErrorCode::CorruptCommit,
+                        "workspace mutation does not match the repository storage profile",
+                    ))
+                }
+            };
             objects = if matches!(version.body.kind, ObjectVersionKindV1::DeleteMarker) {
                 engine.delete(&objects, key).await?
             } else {
@@ -3947,6 +5692,50 @@ impl<P: ObjectPlane> Repository<P> {
                 })?,
             )
             .await?;
+        if native_profile {
+            let delta = BucketDeltaV1 {
+                operation_ids: vec![workspace.operation],
+                changes: transitions.clone(),
+            };
+            let node_pack = self
+                .node_store
+                .flush_node_pack(
+                    tree_format_digest(&self.format.state_tree_format)?,
+                    Vec::new(),
+                )
+                .await?;
+            let commit = BucketCommitV1 {
+                state: BucketStateV1 {
+                    objects: TreeRootV1::from_tree(&objects)?,
+                    versions: TreeRootV1::from_tree(&versions)?,
+                    operations: TreeRootV1::from_tree(&operations)?,
+                },
+                parents: vec![workspace.base_commit],
+                generation,
+                delta: delta.id()?,
+                author: self.options.writer.clone(),
+                message: Some(workspace.message.clone()),
+                created_at_millis: now,
+                metadata: BTreeMap::new(),
+                native: Some(crate::NativeCommitExtensionV1 {
+                    node_pack,
+                    inline_delta: delta,
+                    writer_fence_generation,
+                }),
+            };
+            return self
+                .publish_prepared_commit(
+                    &workspace.branch,
+                    loaded_ref,
+                    workspace.operation,
+                    commit,
+                    result,
+                    None,
+                    &workspace.message,
+                )
+                .await;
+        }
+        let lease = lease.expect("distributed workspace has a publication lease");
         let delta = self
             .store_delta(&BucketDeltaV1 {
                 operation_ids: vec![workspace.operation],
@@ -3969,6 +5758,7 @@ impl<P: ObjectPlane> Repository<P> {
             message: Some(workspace.message.clone()),
             created_at_millis: now,
             metadata: BTreeMap::new(),
+            native: None,
         };
         let commit_id = self.store_commit(&commit).await?;
         lease
@@ -4004,6 +5794,7 @@ impl<P: ObjectPlane> Repository<P> {
             writer: self.options.writer.clone(),
             updated_at_millis: now,
             tombstone: false,
+            native: None,
         };
         self.ensure_publication_allowed(&lease).await?;
         let publication = self
@@ -4240,10 +6031,53 @@ impl<P: ObjectPlane> Repository<P> {
             let current: CurrentObjectV1 = decode_canonical(&current)?;
             self.find_version(&commit, key, current.version).await?
         };
-        let bytes = match &version.body.kind {
-            ObjectVersionKindV1::Live { content, .. } => self.content.read_all(content).await?,
-            ObjectVersionKindV1::DeleteMarker if selected.is_some() => Vec::new(),
-            ObjectVersionKindV1::DeleteMarker => {
+        let bytes = match (&version.body.kind, &version.native_binding) {
+            (
+                ObjectVersionKindV1::Live { .. },
+                Some(crate::NativeObjectBindingV1::Live {
+                    version_id,
+                    checksum_sha256,
+                    ..
+                }),
+            ) => {
+                let path = ObjectPath::new(std::str::from_utf8(key).map_err(|_| {
+                    Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+                })?)?;
+                let object = self
+                    .plane
+                    .get(GetRequest {
+                        path,
+                        range: None,
+                        physical_version: Some(PhysicalVersion::Versioned {
+                            version_id: version_id.clone(),
+                        }),
+                    })
+                    .await?
+                    .ok_or_else(|| {
+                        Error::new(
+                            ErrorCode::MissingClosure,
+                            "native object version is missing",
+                        )
+                    })?;
+                if object.metadata.sha256 != *checksum_sha256 {
+                    return Err(Error::new(
+                        ErrorCode::CorruptContent,
+                        "native object bytes do not match the committed checksum",
+                    ));
+                }
+                object.bytes
+            }
+            (ObjectVersionKindV1::Live { content, .. }, None) => {
+                self.content.read_all(content).await?
+            }
+            (ObjectVersionKindV1::Live { .. }, Some(_)) => {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "live logical object has a delete-marker native binding",
+                ))
+            }
+            (ObjectVersionKindV1::DeleteMarker, _) if selected.is_some() => Vec::new(),
+            (ObjectVersionKindV1::DeleteMarker, _) => {
                 return Err(Error::new(
                     ErrorCode::NoSuchKey,
                     "current version is a delete marker",
@@ -4689,14 +6523,40 @@ impl<P: ObjectPlane> Repository<P> {
             base.as_bytes(),
             &[policy_byte],
         ]);
-        if let Some(receipt) = self
-            .reconcile_operation(target, operation, input_digest)
-            .await?
-        {
-            return Ok(receipt);
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1 {
+            if let Some(receipt) = self
+                .reconcile_operation(target, operation, input_digest)
+                .await?
+            {
+                return Ok(receipt);
+            }
         }
-        let lease = self.publication_lease(operation).await?;
-        let engine = self.protected_engine(Arc::new(lease.clone()));
+        let native_profile = self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1;
+        let _native_publication = if native_profile {
+            Some(self.native_publication.lock().await)
+        } else {
+            None
+        };
+        let writer_fence_generation = if native_profile {
+            self.native_writer_generation_for_mutation().await?
+        } else {
+            0
+        };
+        let lease = if native_profile {
+            None
+        } else {
+            Some(self.publication_lease(operation).await?)
+        };
+        let engine = match &lease {
+            Some(lease) => self.protected_engine(Arc::new(lease.clone())),
+            None => AsyncProlly::new(
+                self.node_store.clone(),
+                Config {
+                    format: self.format.state_tree_format.clone(),
+                    runtime: RuntimeConfig::default(),
+                },
+            ),
+        };
         let ours_objects =
             self.tree_from_root(&ours_commit.state.objects, &self.format.state_tree_format)?;
         let ours_versions =
@@ -4758,21 +6618,56 @@ impl<P: ObjectPlane> Repository<P> {
                 }
                 None => {
                     objects = engine.delete(&objects, &change.key).await?;
-                    let version = ObjectVersionV1::derive(
-                        self.format.repository_id,
-                        &change.key,
-                        operation,
-                        ObjectVersionBodyV1 {
-                            order: ObjectVersionOrder {
-                                commit_generation: generation,
-                                mutation_ordinal: u32::try_from(ordinal).map_err(|_| {
-                                    Error::new(ErrorCode::InvalidLimit, "merge ordinal overflow")
-                                })?,
-                            },
-                            created_at_millis,
-                            kind: ObjectVersionKindV1::DeleteMarker,
+                    let body = ObjectVersionBodyV1 {
+                        order: ObjectVersionOrder {
+                            commit_generation: generation,
+                            mutation_ordinal: u32::try_from(ordinal).map_err(|_| {
+                                Error::new(ErrorCode::InvalidLimit, "merge ordinal overflow")
+                            })?,
                         },
-                    )?;
+                        created_at_millis,
+                        kind: ObjectVersionKindV1::DeleteMarker,
+                    };
+                    let version = if native_profile {
+                        let binding = match self
+                            .latest_native_delete_binding(&theirs_commit, &change.key)
+                            .await?
+                        {
+                            Some(binding) => binding,
+                            None => {
+                                let path = ObjectPath::new(
+                                    std::str::from_utf8(&change.key).map_err(|_| {
+                                        Error::new(
+                                            ErrorCode::InvalidKey,
+                                            "logical key is not valid UTF-8",
+                                        )
+                                    })?,
+                                )?;
+                                self.plane
+                                    .delete_native(crate::NativeDelete {
+                                        path,
+                                        repository: self.format.repository_id,
+                                        operation,
+                                        writer_fence_generation,
+                                    })
+                                    .await?
+                            }
+                        };
+                        ObjectVersionV1::derive_native(
+                            self.format.repository_id,
+                            &change.key,
+                            operation,
+                            body,
+                            binding,
+                        )?
+                    } else {
+                        ObjectVersionV1::derive(
+                            self.format.repository_id,
+                            &change.key,
+                            operation,
+                            body,
+                        )?
+                    };
                     versions = engine
                         .put(
                             &versions,
@@ -4812,10 +6707,27 @@ impl<P: ObjectPlane> Repository<P> {
             operation_ids: vec![operation],
             changes: transitions,
         };
-        let delta_id = self.store_delta(&delta).await?;
-        lease
-            .protect(delta_path(&self.options.repository_prefix, delta_id)?)
-            .await?;
+        let delta_id = if native_profile {
+            delta.id()?
+        } else {
+            let id = self.store_delta(&delta).await?;
+            lease
+                .as_ref()
+                .expect("distributed merge has a lease")
+                .protect(delta_path(&self.options.repository_prefix, id)?)
+                .await?;
+            id
+        };
+        let node_pack = if native_profile {
+            self.node_store
+                .flush_node_pack(
+                    tree_format_digest(&self.format.state_tree_format)?,
+                    Vec::new(),
+                )
+                .await?
+        } else {
+            None
+        };
         let commit = BucketCommitV1 {
             state: BucketStateV1 {
                 objects: TreeRootV1::from_tree(&objects)?,
@@ -4829,6 +6741,11 @@ impl<P: ObjectPlane> Repository<P> {
             message: Some(message.unwrap_or_else(|| "merge".to_string())),
             created_at_millis,
             metadata: BTreeMap::new(),
+            native: native_profile.then_some(crate::NativeCommitExtensionV1 {
+                node_pack,
+                inline_delta: delta,
+                writer_fence_generation,
+            }),
         };
         self.publish_prepared_commit(
             target,
@@ -4855,6 +6772,7 @@ impl<P: ObjectPlane> Repository<P> {
     ) -> Result<CommitReceipt> {
         validate_branch(branch)?;
         let source_commit = self.load_commit(source).await?;
+        let supplied_operation = operation;
         let operation = operation.unwrap_or_else(|| self.new_operation());
         let input_digest = derive_input_digest(&[
             self.format.repository_id.as_bytes(),
@@ -4863,11 +6781,15 @@ impl<P: ObjectPlane> Repository<P> {
             source.as_bytes(),
             expected_head.as_bytes(),
         ]);
-        if let Some(receipt) = self
-            .reconcile_operation(branch, operation, input_digest)
-            .await?
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1
+            || supplied_operation.is_some()
         {
-            return Ok(receipt);
+            if let Some(receipt) = self
+                .reconcile_operation(branch, operation, input_digest)
+                .await?
+            {
+                return Ok(receipt);
+            }
         }
         let loaded_ref = self.load_ref(branch).await?;
         if loaded_ref.value.target != expected_head {
@@ -4886,8 +6808,32 @@ impl<P: ObjectPlane> Repository<P> {
             .into_iter()
             .filter(|key| ours_map.get(key) != source_map.get(key))
             .collect();
-        let lease = self.publication_lease(operation).await?;
-        let engine = self.protected_engine(Arc::new(lease.clone()));
+        let native_profile = self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1;
+        let _native_publication = if native_profile {
+            Some(self.native_publication.lock().await)
+        } else {
+            None
+        };
+        let writer_fence_generation = if native_profile {
+            self.native_writer_generation_for_mutation().await?
+        } else {
+            0
+        };
+        let lease = if native_profile {
+            None
+        } else {
+            Some(self.publication_lease(operation).await?)
+        };
+        let engine = match &lease {
+            Some(lease) => self.protected_engine(Arc::new(lease.clone())),
+            None => AsyncProlly::new(
+                self.node_store.clone(),
+                Config {
+                    format: self.format.state_tree_format.clone(),
+                    runtime: RuntimeConfig::default(),
+                },
+            ),
+        };
         let mut objects =
             self.tree_from_root(&ours_commit.state.objects, &self.format.state_tree_format)?;
         let mut versions =
@@ -4914,13 +6860,16 @@ impl<P: ObjectPlane> Repository<P> {
         let mut transitions = Vec::with_capacity(changed.len());
         let mut version_ids = Vec::with_capacity(changed.len());
         for (ordinal, key) in changed.iter().enumerate() {
-            let kind = match source_map.get(key).copied() {
+            let (kind, native_binding) = match source_map.get(key).copied() {
                 Some(source_version) => {
                     let source_version = self
                         .find_version(&source_commit, key, source_version)
                         .await?;
-                    match source_version.body.kind {
-                        ObjectVersionKindV1::Live { .. } => source_version.body.kind,
+                    match &source_version.body.kind {
+                        ObjectVersionKindV1::Live { .. } => (
+                            source_version.body.kind.clone(),
+                            source_version.native_binding.clone(),
+                        ),
                         ObjectVersionKindV1::DeleteMarker => {
                             return Err(Error::new(
                                 ErrorCode::CorruptCommit,
@@ -4929,23 +6878,65 @@ impl<P: ObjectPlane> Repository<P> {
                         }
                     }
                 }
-                None => ObjectVersionKindV1::DeleteMarker,
+                None => {
+                    let binding = if native_profile {
+                        match self
+                            .latest_native_delete_binding(&source_commit, key)
+                            .await?
+                        {
+                            Some(binding) => Some(binding),
+                            None => {
+                                let path =
+                                    ObjectPath::new(std::str::from_utf8(key).map_err(|_| {
+                                        Error::new(
+                                            ErrorCode::InvalidKey,
+                                            "logical key is not valid UTF-8",
+                                        )
+                                    })?)?;
+                                Some(
+                                    self.plane
+                                        .delete_native(crate::NativeDelete {
+                                            path,
+                                            repository: self.format.repository_id,
+                                            operation,
+                                            writer_fence_generation,
+                                        })
+                                        .await?,
+                                )
+                            }
+                        }
+                    } else {
+                        None
+                    };
+                    (ObjectVersionKindV1::DeleteMarker, binding)
+                }
             };
-            let version = ObjectVersionV1::derive(
-                self.format.repository_id,
-                key,
-                operation,
-                ObjectVersionBodyV1 {
-                    order: ObjectVersionOrder {
-                        commit_generation: generation,
-                        mutation_ordinal: u32::try_from(ordinal).map_err(|_| {
-                            Error::new(ErrorCode::InvalidLimit, "restore ordinal overflow")
-                        })?,
-                    },
-                    created_at_millis,
-                    kind,
+            let body = ObjectVersionBodyV1 {
+                order: ObjectVersionOrder {
+                    commit_generation: generation,
+                    mutation_ordinal: u32::try_from(ordinal).map_err(|_| {
+                        Error::new(ErrorCode::InvalidLimit, "restore ordinal overflow")
+                    })?,
                 },
-            )?;
+                created_at_millis,
+                kind,
+            };
+            let version = if native_profile {
+                ObjectVersionV1::derive_native(
+                    self.format.repository_id,
+                    key,
+                    operation,
+                    body,
+                    native_binding.ok_or_else(|| {
+                        Error::new(
+                            ErrorCode::CorruptCommit,
+                            "native restore source omitted its physical binding",
+                        )
+                    })?,
+                )?
+            } else {
+                ObjectVersionV1::derive(self.format.repository_id, key, operation, body)?
+            };
             objects = if matches!(version.body.kind, ObjectVersionKindV1::DeleteMarker) {
                 engine.delete(&objects, key).await?
             } else {
@@ -4995,10 +6986,27 @@ impl<P: ObjectPlane> Repository<P> {
             operation_ids: vec![operation],
             changes: transitions,
         };
-        let delta_id = self.store_delta(&delta).await?;
-        lease
-            .protect(delta_path(&self.options.repository_prefix, delta_id)?)
-            .await?;
+        let delta_id = if native_profile {
+            delta.id()?
+        } else {
+            let id = self.store_delta(&delta).await?;
+            lease
+                .as_ref()
+                .expect("distributed restore has a lease")
+                .protect(delta_path(&self.options.repository_prefix, id)?)
+                .await?;
+            id
+        };
+        let node_pack = if native_profile {
+            self.node_store
+                .flush_node_pack(
+                    tree_format_digest(&self.format.state_tree_format)?,
+                    Vec::new(),
+                )
+                .await?
+        } else {
+            None
+        };
         let commit = BucketCommitV1 {
             state: BucketStateV1 {
                 objects: TreeRootV1::from_tree(&objects)?,
@@ -5012,6 +7020,11 @@ impl<P: ObjectPlane> Repository<P> {
             message: Some(message.unwrap_or_else(|| format!("restore {source}"))),
             created_at_millis,
             metadata: BTreeMap::new(),
+            native: native_profile.then_some(crate::NativeCommitExtensionV1 {
+                node_pack,
+                inline_delta: delta,
+                writer_fence_generation,
+            }),
         };
         self.publish_prepared_commit(
             branch,
@@ -5116,32 +7129,57 @@ impl<P: ObjectPlane> Repository<P> {
         operation: OperationId,
         commit: BucketCommitV1,
         operation_result: CanonicalOperationResult,
-        lease: PublicationLease<P>,
+        lease: Option<PublicationLease<P>>,
         reflog_message: &str,
     ) -> Result<CommitReceipt> {
+        let native_profile = self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1;
+        let writer_fence_generation = if native_profile {
+            commit
+                .native
+                .as_ref()
+                .map(|native| native.writer_fence_generation)
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "native prepared commit omitted its publication extension",
+                    )
+                })?
+        } else {
+            if commit.native.is_some() {
+                return Err(Error::new(
+                    ErrorCode::InternalInvariant,
+                    "distributed prepared commit contains a native extension",
+                ));
+            }
+            0
+        };
         let commit_id = self.store_commit(&commit).await?;
-        lease
-            .protect(commit_path(&self.options.repository_prefix, commit_id)?)
-            .await?;
-        lease.set_proposal(commit_id).await?;
-        let reflog_id = self
-            .store_reflog(&ReflogEntryV1 {
-                branch: branch.to_string(),
-                old_target: Some(loaded_ref.value.target),
-                new_target: commit_id,
-                operation,
-                actor: self.options.writer.clone(),
-                message: reflog_message.to_string(),
-                created_at_millis: commit.created_at_millis,
-            })
-            .await?;
-        lease
-            .protect(reflog_path(
-                &self.options.repository_prefix,
-                branch,
-                reflog_id,
-            )?)
-            .await?;
+        if let Some(lease) = &lease {
+            lease
+                .protect(commit_path(&self.options.repository_prefix, commit_id)?)
+                .await?;
+            lease.set_proposal(commit_id).await?;
+        }
+        let reflog = ReflogEntryV1 {
+            branch: branch.to_string(),
+            old_target: Some(loaded_ref.value.target),
+            new_target: commit_id,
+            operation,
+            actor: self.options.writer.clone(),
+            message: reflog_message.to_string(),
+            created_at_millis: commit.created_at_millis,
+        };
+        let reflog_id = if native_profile {
+            reflog.id()?
+        } else {
+            let id = self.store_reflog(&reflog).await?;
+            lease
+                .as_ref()
+                .expect("distributed prepared publication has a lease")
+                .protect(reflog_path(&self.options.repository_prefix, branch, id)?)
+                .await?;
+            id
+        };
         let next_ref = crate::RefValueV1 {
             target: commit_id,
             previous_target: Some(loaded_ref.value.target),
@@ -5153,8 +7191,26 @@ impl<P: ObjectPlane> Repository<P> {
             writer: self.options.writer.clone(),
             updated_at_millis: commit.created_at_millis,
             tombstone: false,
+            native: native_profile.then_some(crate::NativeRefExtensionV1 {
+                writer_fence_generation,
+                inline_reflog: reflog,
+            }),
         };
-        self.ensure_publication_allowed(&lease).await?;
+        if native_profile {
+            if self.native_writer_generation_for_mutation().await? != writer_fence_generation {
+                return Err(Error::new(
+                    ErrorCode::PreconditionFailed,
+                    "native writer fence changed during prepared publication",
+                ));
+            }
+        } else {
+            self.ensure_publication_allowed(
+                lease
+                    .as_ref()
+                    .expect("distributed prepared publication has a lease"),
+            )
+            .await?;
+        }
         let publication = self
             .plane
             .compare_exchange(CompareExchange {
@@ -5164,22 +7220,35 @@ impl<P: ObjectPlane> Repository<P> {
             })
             .await;
         match publication {
-            Ok(CompareExchangeOutcome::Applied(_)) => {
+            Ok(CompareExchangeOutcome::Applied(metadata)) => {
                 let receipt = CommitReceipt {
                     id: commit_id,
                     operation,
                     branch: branch.to_string(),
-                    parents: commit.parents,
+                    parents: commit.parents.clone(),
                     changed_keys: operation_result.changed_keys,
                     object_versions: operation_result.object_versions,
                     idempotent_replay: false,
                 };
-                let _ = lease.complete(commit_id).await;
+                if native_profile {
+                    self.cache_branch(branch, next_ref, metadata.token, commit)?;
+                }
+                if let Some(lease) = &lease {
+                    let _ = lease.complete(commit_id).await;
+                }
                 Ok(receipt)
             }
             Ok(CompareExchangeOutcome::Conflict(_)) => Err(Error::new(
-                ErrorCode::RefConflict,
-                "branch moved during publication",
+                if native_profile {
+                    ErrorCode::PreconditionFailed
+                } else {
+                    ErrorCode::RefConflict
+                },
+                if native_profile {
+                    "native branch CAS conflicted; writer is fenced and must reopen"
+                } else {
+                    "branch moved during publication"
+                },
             )
             .retry(RetryAdvice::ReloadHead)
             .operation(operation.to_string())),
@@ -5252,7 +7321,7 @@ impl<P: ObjectPlane> Repository<P> {
                 continue;
             }
             let commit = self.load_commit(id).await?;
-            self.load_delta(commit.delta).await?;
+            self.load_commit_delta(&commit).await?;
             report.commits += 1;
             report.deltas += 1;
             roots.push(self.tree_from_root(&commit.state.objects, &self.format.state_tree_format)?);
@@ -5275,12 +7344,26 @@ impl<P: ObjectPlane> Repository<P> {
                 self.tree_from_root(&commit.state.versions, &self.format.state_tree_format)?;
             let mut iter = self.engine.range(&versions, &[], None).await?;
             while let Some(entry) = iter.next().await {
-                let (_, bytes) = entry?;
+                let (encoded_key, bytes) = entry?;
                 let version: ObjectVersionV1 = decode_canonical(&bytes)?;
                 if !versions_seen.insert(version.id) {
                     continue;
                 }
                 report.logical_versions += 1;
+                if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+                    let key = decode_version_tree_logical_key(&encoded_key)?;
+                    let verified = self.verify_native_version(&key, &version).await?;
+                    report.content_bytes_verified = report
+                        .content_bytes_verified
+                        .checked_add(verified)
+                        .ok_or_else(|| {
+                            Error::new(
+                                ErrorCode::EntityTooLarge,
+                                "fsck native byte counter overflow",
+                            )
+                        })?;
+                    continue;
+                }
                 let ObjectVersionKindV1::Live { content, size, .. } = version.body.kind else {
                     continue;
                 };
@@ -5323,6 +7406,163 @@ impl<P: ObjectPlane> Repository<P> {
         Ok(report)
     }
 
+    async fn verify_native_version(&self, key: &[u8], version: &ObjectVersionV1) -> Result<u64> {
+        version.validate_native()?;
+        let path = ObjectPath::new(std::str::from_utf8(key).map_err(|_| {
+            Error::new(ErrorCode::CorruptCommit, "native logical key is not UTF-8")
+        })?)?;
+        match version.native_binding.as_ref().expect("validated binding") {
+            crate::NativeObjectBindingV1::Live {
+                version_id,
+                checksum_sha256,
+                ..
+            } => {
+                let object = self
+                    .plane
+                    .get(GetRequest {
+                        path,
+                        range: None,
+                        physical_version: Some(PhysicalVersion::Versioned {
+                            version_id: version_id.clone(),
+                        }),
+                    })
+                    .await?
+                    .ok_or_else(|| {
+                        Error::new(
+                            ErrorCode::MissingClosure,
+                            "retained native object version is missing",
+                        )
+                    })?;
+                if crate::codec::sha256(&object.bytes) != *checksum_sha256 {
+                    return Err(Error::new(
+                        ErrorCode::CorruptContent,
+                        "retained native object version checksum mismatch",
+                    ));
+                }
+                let expected_size = match version.body.kind {
+                    ObjectVersionKindV1::Live { size, .. } => size,
+                    ObjectVersionKindV1::DeleteMarker => unreachable!("binding was validated"),
+                };
+                if object.bytes.len() as u64 != expected_size {
+                    return Err(Error::new(
+                        ErrorCode::CorruptContent,
+                        "retained native object version size mismatch",
+                    ));
+                }
+                Ok(expected_size)
+            }
+            crate::NativeObjectBindingV1::DeleteMarker { version_id } => {
+                let mut continuation = None;
+                loop {
+                    let page = self
+                        .plane
+                        .list(ListRequest {
+                            prefix: path.as_str().to_string(),
+                            continuation,
+                            limit: 1_000,
+                            include_versions: true,
+                        })
+                        .await?;
+                    if page.entries.iter().any(|entry| {
+                        entry.path == path
+                            && entry.metadata.delete_marker
+                            && entry.metadata.token.version_id.as_deref()
+                                == Some(version_id.as_str())
+                    }) {
+                        return Ok(0);
+                    }
+                    continuation = page.continuation;
+                    if continuation.is_none() {
+                        return Err(Error::new(
+                            ErrorCode::MissingClosure,
+                            "retained native delete marker is missing",
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    async fn reconcile_native_payload(
+        &self,
+        path: &ObjectPath,
+        operation: OperationId,
+        expected_sha256: [u8; 32],
+    ) -> Result<Option<crate::NativeObjectWriteResult>> {
+        let mut continuation = None;
+        let mut matches = Vec::new();
+        loop {
+            let page = self
+                .plane
+                .list(ListRequest {
+                    prefix: path.as_str().to_string(),
+                    continuation,
+                    limit: 1_000,
+                    include_versions: true,
+                })
+                .await?;
+            for entry in page.entries {
+                if entry.path != *path || entry.metadata.delete_marker {
+                    continue;
+                }
+                let Some(version_id) = entry.metadata.token.version_id else {
+                    continue;
+                };
+                let Some(object) = self
+                    .plane
+                    .get(GetRequest {
+                        path: path.clone(),
+                        range: None,
+                        physical_version: Some(PhysicalVersion::Versioned {
+                            version_id: version_id.clone(),
+                        }),
+                    })
+                    .await?
+                else {
+                    continue;
+                };
+                let metadata = &object.metadata.user_metadata;
+                if metadata.get("prolly-repository-id")
+                    != Some(&self.format.repository_id.to_string())
+                    || metadata.get("prolly-operation-id") != Some(&operation.to_string())
+                    || metadata.get("prolly-sha256") != Some(&hex::encode(expected_sha256))
+                    || crate::codec::sha256(&object.bytes) != expected_sha256
+                {
+                    continue;
+                }
+                let md5: [u8; 16] = Md5::digest(&object.bytes).into();
+                matches.push(crate::NativeObjectWriteResult {
+                    binding: crate::NativeObjectBindingV1::Live {
+                        version_id,
+                        provider_etag: object.metadata.token.etag,
+                        checksum_sha256: expected_sha256,
+                    },
+                    size: object.bytes.len() as u64,
+                    logical_etag: format!("\"{}\"", hex::encode(md5)),
+                    checksums: crate::Checksums {
+                        md5: Some(md5),
+                        sha256: Some(expected_sha256),
+                        algorithm_values: BTreeMap::new(),
+                    },
+                });
+            }
+            continuation = page.continuation;
+            if continuation.is_none() {
+                break;
+            }
+        }
+        match matches.len() {
+            0 => Ok(None),
+            1 => Ok(matches.pop()),
+            _ => Err(Error::new(
+                ErrorCode::OutcomeUnknown,
+                "multiple native versions match one operation; manual repair is required",
+            )
+            .retry(RetryAdvice::ReconcileOperation)
+            .operation(operation.to_string())),
+        }
+    }
+
     /// Persist a deterministic, immutable GC dry-run. Only objects older than
     /// `grace_millis` and outside the complete retained set become candidates.
     pub async fn plan_gc(&self, grace_millis: u64, max_candidates: usize) -> Result<GcDryRun> {
@@ -5332,9 +7572,13 @@ impl<P: ObjectPlane> Repository<P> {
     }
 
     fn validate_gc_plan_limits(&self, grace_millis: u64, max_candidates: usize) -> Result<()> {
-        let minimum_grace = self
-            .options
-            .publication_lease_millis
+        let lease_window = if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1
+        {
+            self.options.writer_lease_millis
+        } else {
+            self.options.publication_lease_millis
+        };
+        let minimum_grace = lease_window
             .checked_mul(2)
             .ok_or_else(|| Error::new(ErrorCode::InvalidLimit, "GC grace overflow"))?;
         if grace_millis < minimum_grace || max_candidates == 0 {
@@ -5358,7 +7602,11 @@ impl<P: ObjectPlane> Repository<P> {
         let (retained, branches, tags) = self.retained_paths(planned_at_millis).await?;
         let mut candidates = Vec::new();
         let mut continuation = None;
-        let prefix = format!("{}/", self.options.repository_prefix);
+        let prefix = if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            String::new()
+        } else {
+            format!("{}/", self.options.repository_prefix)
+        };
         loop {
             let page = self
                 .plane
@@ -5370,8 +7618,15 @@ impl<P: ObjectPlane> Repository<P> {
                 })
                 .await?;
             for entry in page.entries {
-                if !is_gc_data_path(&self.options.repository_prefix, &entry.path)
-                    || retained.contains(&entry.path)
+                let version_id = entry.metadata.token.version_id.as_deref();
+                let managed_data = is_gc_data_path(&self.options.repository_prefix, &entry.path)
+                    || (self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1
+                        && !entry
+                            .path
+                            .as_str()
+                            .starts_with(&format!("{}/", self.options.repository_prefix)));
+                if !managed_data
+                    || retained.contains(&entry.path, version_id)
                     || entry.metadata.last_modified_millis > cutoff_millis
                 {
                     continue;
@@ -5694,7 +7949,11 @@ impl<P: ObjectPlane> Repository<P> {
                         "GC plan contains a candidate newer than its cutoff",
                     ));
                 }
-                if retained.contains(&candidate.path) {
+                let version_id = match &candidate.physical_version {
+                    PhysicalVersion::Versioned { version_id } => Some(version_id.as_str()),
+                    PhysicalVersion::Unversioned { .. } => None,
+                };
+                if retained.contains(&candidate.path, version_id) {
                     next.skipped_reachable += 1;
                     continue;
                 }
@@ -5866,7 +8125,7 @@ impl<P: ObjectPlane> Repository<P> {
         &self,
         at_millis: u64,
     ) -> Result<(
-        BTreeSet<ObjectPath>,
+        RetainedClosure,
         BTreeMap<String, CommitId>,
         BTreeMap<String, CommitId>,
     )> {
@@ -5882,7 +8141,7 @@ impl<P: ObjectPlane> Repository<P> {
             .into_iter()
             .map(|tag| (tag.name, tag.target))
             .collect::<BTreeMap<_, _>>();
-        let mut retained = BTreeSet::new();
+        let mut retained = RetainedClosure::default();
         let mut commit_roots = Vec::new();
         commit_roots.extend(branches.values().copied());
         commit_roots.extend(tags.values().copied());
@@ -5901,7 +8160,7 @@ impl<P: ObjectPlane> Repository<P> {
                 .await?;
             for listed in page.entries {
                 if !is_gc_data_path(&self.options.repository_prefix, &listed.path) {
-                    retained.insert(listed.path.clone());
+                    retained.paths.insert(listed.path.clone());
                 }
                 let path = listed.path.as_str();
                 let Some(object) = self
@@ -5958,19 +8217,38 @@ impl<P: ObjectPlane> Repository<P> {
                         ));
                     }
                     if value.body.expires_at_millis >= at_millis {
-                        retained.insert(listed.path.clone());
+                        retained.paths.insert(listed.path.clone());
                     }
                 } else if path.contains("/workspaces/") {
                     let value: WorkspaceManifestV1 = decode_canonical(&object.bytes)?;
                     commit_roots.push(value.base_commit);
                     for mutation in value.mutations.values() {
-                        if let WorkspaceMutationV1::Put {
-                            content: stored, ..
-                        } = mutation
-                        {
-                            if let crate::ContentRef::Chunks(reference) = stored.reference {
-                                content.insert(reference);
+                        match mutation {
+                            WorkspaceMutationV1::Put {
+                                content: stored, ..
+                            } => {
+                                if let crate::ContentRef::Chunks(reference) = stored.reference {
+                                    content.insert(reference);
+                                }
                             }
+                            WorkspaceMutationV1::NativePut { key, binding, .. }
+                            | WorkspaceMutationV1::NativeDelete { key, binding } => {
+                                let path =
+                                    ObjectPath::new(std::str::from_utf8(key).map_err(|_| {
+                                        Error::new(
+                                            ErrorCode::CorruptCommit,
+                                            "native workspace key is not UTF-8",
+                                        )
+                                    })?)?;
+                                let version_id = match binding {
+                                    crate::NativeObjectBindingV1::Live { version_id, .. }
+                                    | crate::NativeObjectBindingV1::DeleteMarker { version_id } => {
+                                        version_id
+                                    }
+                                };
+                                retained.native_versions.insert((path, version_id.clone()));
+                            }
+                            WorkspaceMutationV1::Delete { .. } => {}
                         }
                     }
                 } else if path.ends_with("/lease") && path.contains("/publications/") {
@@ -5981,7 +8259,7 @@ impl<P: ObjectPlane> Repository<P> {
                         commit_roots.extend(lease.proposal);
                         let mut segment = lease.protection_head;
                         while let Some(id) = segment {
-                            retained.insert(publication_segment_path(
+                            retained.paths.insert(publication_segment_path(
                                 &self.options.repository_prefix,
                                 id,
                             )?);
@@ -5997,7 +8275,7 @@ impl<P: ObjectPlane> Repository<P> {
                                     "active publication lease segment is missing",
                                 )
                             })?;
-                            retained.extend(loaded.paths);
+                            retained.paths.extend(loaded.paths);
                             segment = loaded.previous;
                         }
                     }
@@ -6022,8 +8300,26 @@ impl<P: ObjectPlane> Repository<P> {
                 ));
             }
             let commit = self.load_commit(id).await?;
-            retained.insert(commit_path(&self.options.repository_prefix, id)?);
-            retained.insert(delta_path(&self.options.repository_prefix, commit.delta)?);
+            retained
+                .paths
+                .insert(commit_path(&self.options.repository_prefix, id)?);
+            if let Some(native) = &commit.native {
+                if native.inline_delta.id()? != commit.delta {
+                    return Err(Error::new(
+                        ErrorCode::CorruptCommit,
+                        "native commit inline delta identity mismatch",
+                    ));
+                }
+                if let Some(pack) = &native.node_pack {
+                    retained
+                        .paths
+                        .insert(node_pack_path(&self.options.repository_prefix, pack.id)?);
+                }
+            } else {
+                retained
+                    .paths
+                    .insert(delta_path(&self.options.repository_prefix, commit.delta)?);
+            }
             let objects =
                 self.tree_from_root(&commit.state.objects, &self.format.state_tree_format)?;
             let versions =
@@ -6033,8 +8329,20 @@ impl<P: ObjectPlane> Repository<P> {
             state_roots.extend([objects, versions.clone(), operations]);
             let mut iter = self.engine.range(&versions, &[], None).await?;
             while let Some(entry) = iter.next().await {
-                let (_, value) = entry?;
+                let (encoded_key, value) = entry?;
                 let version: ObjectVersionV1 = decode_canonical(&value)?;
+                if let Some(binding) = &version.native_binding {
+                    let key = decode_version_tree_logical_key(&encoded_key)?;
+                    let path = ObjectPath::new(std::str::from_utf8(&key).map_err(|_| {
+                        Error::new(ErrorCode::CorruptCommit, "native logical key is not UTF-8")
+                    })?)?;
+                    let version_id = match binding {
+                        crate::NativeObjectBindingV1::Live { version_id, .. }
+                        | crate::NativeObjectBindingV1::DeleteMarker { version_id } => version_id,
+                    };
+                    retained.native_versions.insert((path, version_id.clone()));
+                    continue;
+                }
                 if let ObjectVersionKindV1::Live {
                     content: crate::ContentRef::Chunks(reference),
                     ..
@@ -6046,11 +8354,15 @@ impl<P: ObjectPlane> Repository<P> {
             commit_roots.extend(commit.parents);
         }
         let nodes = self.engine.mark_reachable(&state_roots).await?;
-        for cid in nodes.cids() {
-            retained.insert(node_path(&self.options.repository_prefix, cid)?);
+        if self.storage_profile() == RepositoryStorageProfile::DistributedContentAddressedV1 {
+            for cid in nodes.cids() {
+                retained
+                    .paths
+                    .insert(node_path(&self.options.repository_prefix, cid)?);
+            }
         }
         for reference in content {
-            retained.extend(
+            retained.paths.extend(
                 self.content
                     .retained_paths(&crate::ContentRef::Chunks(reference))
                     .await?,
@@ -6073,6 +8385,17 @@ impl<P: ObjectPlane> Repository<P> {
             let (_, value) = entry?;
             let version: ObjectVersionV1 = decode_canonical(&value)?;
             if version.id == selected {
+                match self.storage_profile() {
+                    RepositoryStorageProfile::DistributedContentAddressedV1 => {
+                        if version.native_binding.is_some() {
+                            return Err(Error::new(
+                                ErrorCode::CorruptCommit,
+                                "distributed-profile object version contains a native binding",
+                            ));
+                        }
+                    }
+                    RepositoryStorageProfile::NativeVersionedV1 => version.validate_native()?,
+                }
                 return Ok(version);
             }
         }
@@ -6080,6 +8403,28 @@ impl<P: ObjectPlane> Repository<P> {
             ErrorCode::NoSuchVersion,
             "object version is not reachable",
         ))
+    }
+
+    async fn latest_native_delete_binding(
+        &self,
+        commit: &BucketCommitV1,
+        key: &[u8],
+    ) -> Result<Option<crate::NativeObjectBindingV1>> {
+        let versions =
+            self.tree_from_root(&commit.state.versions, &self.format.state_tree_format)?;
+        let mut iter = self
+            .engine
+            .prefix(&versions, &version_tree_prefix(key))
+            .await?;
+        while let Some(entry) = iter.next().await {
+            let (_, value) = entry?;
+            let version: ObjectVersionV1 = decode_canonical(&value)?;
+            if matches!(version.body.kind, ObjectVersionKindV1::DeleteMarker) {
+                version.validate_native()?;
+                return Ok(version.native_binding);
+            }
+        }
+        Ok(None)
     }
 
     async fn load_ref(&self, branch: &str) -> Result<LoadedRef> {
@@ -6092,6 +8437,22 @@ impl<P: ObjectPlane> Repository<P> {
 
     async fn load_ref_including_tombstone(&self, branch: &str) -> Result<LoadedRef> {
         validate_branch(branch)?;
+        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            if let Some(warm) = self
+                .warm_branches
+                .read()
+                .map_err(|_| {
+                    Error::new(ErrorCode::InternalInvariant, "branch-cache lock poisoned")
+                })?
+                .get(branch)
+                .cloned()
+            {
+                return Ok(LoadedRef {
+                    value: warm.reference,
+                    token: warm.token,
+                });
+            }
+        }
         let object = self
             .plane
             .load_mutable(&branch_path(&self.options.repository_prefix, branch)?)
@@ -6221,6 +8582,15 @@ impl<P: ObjectPlane> Repository<P> {
     }
 
     async fn load_commit(&self, id: CommitId) -> Result<BucketCommitV1> {
+        if let Some(commit) = self
+            .commit_cache
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "commit-cache lock poisoned"))?
+            .get(&id)
+            .cloned()
+        {
+            return Ok(commit);
+        }
         let object = self
             .plane
             .get(GetRequest {
@@ -6234,6 +8604,10 @@ impl<P: ObjectPlane> Repository<P> {
         if commit.id()? != id {
             return Err(Error::new(ErrorCode::CorruptCommit, "commit ID mismatch"));
         }
+        self.commit_cache
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "commit-cache lock poisoned"))?
+            .insert(id, commit.clone());
         Ok(commit)
     }
 
@@ -6254,11 +8628,34 @@ impl<P: ObjectPlane> Repository<P> {
         Ok(delta)
     }
 
+    async fn load_commit_delta(&self, commit: &BucketCommitV1) -> Result<BucketDeltaV1> {
+        if let Some(native) = &commit.native {
+            if native.inline_delta.id()? != commit.delta {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "native commit inline delta identity mismatch",
+                ));
+            }
+            if native.writer_fence_generation == 0 {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "native commit has a zero writer fence generation",
+                ));
+            }
+            return Ok(native.inline_delta.clone());
+        }
+        self.load_delta(commit.delta).await
+    }
+
     async fn store_commit(&self, commit: &BucketCommitV1) -> Result<CommitId> {
         let bytes = encode_canonical(commit)?;
         let id = commit.id()?;
         self.store_immutable(commit_path(&self.options.repository_prefix, id)?, bytes)
             .await?;
+        self.commit_cache
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "commit-cache lock poisoned"))?
+            .insert(id, commit.clone());
         Ok(id)
     }
 
@@ -6371,6 +8768,15 @@ impl<P: ObjectPlane> Repository<P> {
     }
 
     fn protected_engine(&self, sink: Arc<dyn ProtectionSink>) -> AsyncProlly<ProllyObjectStore<P>> {
+        if self.node_store.is_packed() {
+            return AsyncProlly::new(
+                self.node_store.clone(),
+                Config {
+                    format: self.format.state_tree_format.clone(),
+                    runtime: RuntimeConfig::default(),
+                },
+            );
+        }
         AsyncProlly::new(
             ProllyObjectStore::new(self.plane.clone(), self.options.repository_prefix.clone())
                 .with_protection_sink(sink),
@@ -6388,8 +8794,17 @@ impl<P: ObjectPlane> Repository<P> {
                 "logical key must contain 1 to 1,024 UTF-8 bytes",
             ));
         }
-        std::str::from_utf8(key)
+        let key = std::str::from_utf8(key)
             .map_err(|_| Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8"))?;
+        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1
+            && (key == self.options.repository_prefix
+                || key.starts_with(&format!("{}/", self.options.repository_prefix)))
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidKey,
+                "logical key overlaps the native-versioned repository metadata prefix",
+            ));
+        }
         Ok(())
     }
 }
@@ -6469,6 +8884,12 @@ fn validate_options(options: &RepositoryOptions) -> Result<()> {
         return Err(Error::new(
             ErrorCode::InvalidLimit,
             "publication lease must be between 5 minutes and 24 hours",
+        ));
+    }
+    if !(10_000..=24 * 60 * 60 * 1_000).contains(&options.writer_lease_millis) {
+        return Err(Error::new(
+            ErrorCode::InvalidLimit,
+            "writer lease must be between 10 seconds and 24 hours",
         ));
     }
     if options.history_traversal_limit == 0 {
@@ -6623,14 +9044,13 @@ fn validate_format_compatibility(
             ),
         ));
     }
-    #[cfg(not(prolly_s3_legacy_v1_codec))]
-    if format.required_capability_profile != RepositoryFormatV1::DISTRIBUTED_S3_CAPABILITY_PROFILE {
+    let storage_profile = format.storage_profile()?;
+    if storage_profile != options.storage_profile {
         return Err(Error::new(
-            ErrorCode::UnsupportedRepositoryFormat,
+            ErrorCode::RepositoryFormatConflict,
             format!(
-                "repository requires capability profile {}, client supports profile {}",
-                format.required_capability_profile,
-                RepositoryFormatV1::DISTRIBUTED_S3_CAPABILITY_PROFILE
+                "repository uses storage profile {storage_profile:?}, requested {requested:?}",
+                requested = options.storage_profile
             ),
         ));
     }
@@ -6803,6 +9223,10 @@ fn intent_path(prefix: &str) -> Result<ObjectPath> {
     ObjectPath::new(format!("{prefix}/format/initialization.cbor"))
 }
 
+fn writer_lease_path(prefix: &str) -> Result<ObjectPath> {
+    ObjectPath::new(format!("{prefix}/writers/lease.cbor"))
+}
+
 fn branch_path(prefix: &str, branch: &str) -> Result<ObjectPath> {
     validate_branch(branch)?;
     ObjectPath::new(format!(
@@ -6897,6 +9321,28 @@ fn node_path(prefix: &str, cid: &Cid) -> Result<ObjectPath> {
         &encoded[..2],
         &encoded[2..4],
         encoded
+    ))
+}
+
+fn node_pack_path(prefix: &str, id: crate::NodePackId) -> Result<ObjectPath> {
+    let encoded = hex::encode(id.as_bytes());
+    ObjectPath::new(format!(
+        "{prefix}/node-packs/sha256/{}/{}/{}.pack",
+        &encoded[..2],
+        &encoded[2..4],
+        encoded
+    ))
+}
+
+fn node_checkpoint_path(
+    prefix: &str,
+    generation: CommitGeneration,
+    id: crate::NodeIndexCheckpointId,
+) -> Result<ObjectPath> {
+    ObjectPath::new(format!(
+        "{prefix}/node-index/checkpoints/{:020}-{}.cbor",
+        generation.0,
+        hex::encode(id.as_bytes())
     ))
 }
 

--- a/extensions/s3/core/src/repository.rs
+++ b/extensions/s3/core/src/repository.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
+    io::Write as _,
     sync::{Arc, RwLock},
     time::Duration,
 };
@@ -25,6 +26,7 @@ use crate::{
 use futures_util::{stream::BoxStream, Stream, StreamExt};
 use md5::{Digest as _, Md5};
 use prolly::{AsyncProlly, Cid, Config, RuntimeConfig, Tree, TreeFormat};
+use sha2::Sha256;
 
 const MIN_NONFINAL_MULTIPART_PART_BYTES: u64 = 5 * 1024 * 1024;
 const MAX_MULTIPART_PART_BYTES: u64 = 5 * 1024 * 1024 * 1024;
@@ -2850,7 +2852,15 @@ impl<P: ObjectPlane> Repository<P> {
         let operation = operation.unwrap_or_else(|| self.new_operation());
         if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
             futures_util::pin_mut!(stream);
-            let mut bytes = Vec::new();
+            let mut spool = tempfile::NamedTempFile::new().map_err(|error| {
+                Error::new(
+                    ErrorCode::Transport,
+                    format!("could not create native upload spool: {error}"),
+                )
+            })?;
+            let mut size = 0_u64;
+            let mut sha256 = Sha256::new();
+            let mut md5 = Md5::new();
             while let Some(next) = stream.next().await {
                 let next = next.map_err(|error| {
                     Error::new(
@@ -2859,22 +2869,40 @@ impl<P: ObjectPlane> Repository<P> {
                     )
                 })?;
                 let next = next.as_ref();
-                let new_len = bytes.len().checked_add(next.len()).ok_or_else(|| {
+                size = size.checked_add(next.len() as u64).ok_or_else(|| {
                     Error::new(ErrorCode::EntityTooLarge, "native object length overflow")
                 })?;
-                if new_len > self.format.canonical_limits.max_object_bytes as usize {
+                if size > self.format.canonical_limits.max_object_bytes {
                     return Err(Error::new(
                         ErrorCode::EntityTooLarge,
                         "native object exceeds the repository size limit",
                     ));
                 }
-                bytes.extend_from_slice(next);
+                spool.write_all(next).map_err(|error| {
+                    Error::new(
+                        ErrorCode::Transport,
+                        format!("native upload spool write failed: {error}"),
+                    )
+                })?;
+                sha256.update(next);
+                md5.update(next);
             }
+            spool.flush().map_err(|error| {
+                Error::new(
+                    ErrorCode::Transport,
+                    format!("native upload spool flush failed: {error}"),
+                )
+            })?;
+            let checksum_sha256: [u8; 32] = sha256.finalize().into();
+            let checksum_md5: [u8; 16] = md5.finalize().into();
             return self
-                .put_native_bytes_checked(
+                .put_native_file_checked(
                     branch,
                     key,
-                    bytes,
+                    spool.path().to_path_buf(),
+                    size,
+                    checksum_sha256,
+                    checksum_md5,
                     headers,
                     user_metadata,
                     operation,
@@ -2982,6 +3010,117 @@ impl<P: ObjectPlane> Repository<P> {
             .put_native(crate::NativePut {
                 path: path.clone(),
                 bytes,
+                headers: headers.clone(),
+                user_metadata: user_metadata.clone(),
+                repository: self.format.repository_id,
+                operation,
+                writer_fence_generation,
+            })
+            .await;
+        let native = match native {
+            Ok(value) => value,
+            Err(error) => match self
+                .reconcile_native_payload(&path, operation, expected_sha256)
+                .await?
+            {
+                Some(value) => value,
+                None => return Err(error),
+            },
+        };
+        if native.size != expected_size
+            || native.checksums.sha256 != Some(expected_sha256)
+            || native.checksums.md5 != Some(expected_md5)
+        {
+            return Err(Error::new(
+                ErrorCode::ProviderNotQualified,
+                "native provider result disagrees with the uploaded object identity",
+            ));
+        }
+        self.commit_one(
+            branch,
+            key,
+            kind,
+            Some(native.binding),
+            OperationKind::Put,
+            operation,
+            input_digest,
+            "PutObject",
+            None,
+            condition,
+            logical_retry_limit,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn put_native_file_checked(
+        &self,
+        branch: &str,
+        key: Vec<u8>,
+        body_path: std::path::PathBuf,
+        expected_size: u64,
+        expected_sha256: [u8; 32],
+        expected_md5: [u8; 16],
+        headers: ObjectHeaders,
+        user_metadata: BTreeMap<String, String>,
+        operation: OperationId,
+        condition: ObjectWriteConditionV1,
+        expected_checksums: ChecksumExpectation,
+        logical_retry_limit: Option<u8>,
+    ) -> Result<CommitReceipt> {
+        let _publication = self.native_publication.lock().await;
+        if expected_checksums
+            .md5
+            .is_some_and(|expected| expected != expected_md5)
+            || expected_checksums
+                .sha256
+                .is_some_and(|expected| expected != expected_sha256)
+        {
+            return Err(Error::new(
+                ErrorCode::ChecksumMismatch,
+                "request checksum does not match the native object body",
+            ));
+        }
+        let kind = ObjectVersionKindV1::Live {
+            content: crate::ContentRef::Empty,
+            size: expected_size,
+            logical_etag: format!("\"{}\"", hex::encode(expected_md5)),
+            headers: headers.clone(),
+            checksums: crate::Checksums {
+                md5: Some(expected_md5),
+                sha256: Some(expected_sha256),
+                algorithm_values: BTreeMap::new(),
+            },
+            user_metadata: user_metadata.clone(),
+            tags: BTreeMap::new(),
+        };
+        let input_digest = derive_input_digest(&[
+            self.format.repository_id.as_bytes(),
+            branch.as_bytes(),
+            b"put",
+            &key,
+            &encode_canonical(&kind)?,
+            &encode_canonical(&condition)?,
+        ]);
+        if let Some(receipt) = self
+            .replay_warm_operation(branch, operation, input_digest)
+            .await?
+        {
+            return Ok(receipt);
+        }
+        let writer_fence_generation = self.native_writer_generation_for_mutation().await?;
+        let path =
+            ObjectPath::new(std::str::from_utf8(&key).map_err(|_| {
+                Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+            })?)?;
+        let native = self
+            .plane
+            .put_native_file(crate::NativeFilePut {
+                path: path.clone(),
+                body_path,
+                size: expected_size,
+                checksum_sha256: expected_sha256,
+                checksum_md5: expected_md5,
                 headers: headers.clone(),
                 user_metadata: user_metadata.clone(),
                 repository: self.format.repository_id,
@@ -3175,6 +3314,437 @@ impl<P: ObjectPlane> Repository<P> {
                 Err(Error::new(ErrorCode::UploadConflict, "upload ID collision"))
             }
         }
+    }
+
+    pub async fn create_native_multipart_upload(
+        &self,
+        branch: &str,
+        key: Vec<u8>,
+        headers: ObjectHeaders,
+        user_metadata: BTreeMap<String, String>,
+        operation: Option<OperationId>,
+    ) -> Result<crate::NativeMultipartSessionV1> {
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1 {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "direct native multipart requires the native-versioned profile",
+            ));
+        }
+        validate_branch(branch)?;
+        self.validate_key(&key)?;
+        let operation = operation.unwrap_or_else(|| self.new_operation());
+        let writer_fence_generation = self.native_writer_generation_for_mutation().await?;
+        let path =
+            ObjectPath::new(std::str::from_utf8(&key).map_err(|_| {
+                Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+            })?)?;
+        let provider_upload_id = self
+            .plane
+            .create_native_multipart(crate::NativeMultipartCreate {
+                path,
+                headers: headers.clone(),
+                user_metadata: user_metadata.clone(),
+                repository: self.format.repository_id,
+                operation,
+                writer_fence_generation,
+            })
+            .await?;
+        let session = crate::NativeMultipartSessionV1 {
+            repository: self.format.repository_id,
+            branch: branch.to_string(),
+            key,
+            headers,
+            user_metadata,
+            provider_upload_id,
+            operation,
+            writer_fence_generation,
+            created_at_millis: self.now_millis()?,
+            discovered: false,
+        };
+        session.validate_address(self.format.repository_id)?;
+        Ok(session)
+    }
+
+    pub async fn upload_native_multipart_part(
+        &self,
+        session: &crate::NativeMultipartSessionV1,
+        part_number: u32,
+        bytes: Vec<u8>,
+    ) -> Result<crate::NativeMultipartPartResult> {
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1 {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "direct native multipart requires the native-versioned profile",
+            ));
+        }
+        session.validate_address(self.format.repository_id)?;
+        if !(1..=10_000).contains(&part_number) || bytes.len() as u64 > MAX_MULTIPART_PART_BYTES {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "native multipart part number or size is invalid",
+            ));
+        }
+        let path =
+            ObjectPath::new(std::str::from_utf8(&session.key).map_err(|_| {
+                Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+            })?)?;
+        self.plane
+            .upload_native_multipart_part(crate::NativeMultipartUploadPart {
+                path,
+                upload_id: session.provider_upload_id.clone(),
+                part_number,
+                bytes,
+            })
+            .await
+    }
+
+    pub async fn upload_native_multipart_part_stream<S, B, E>(
+        &self,
+        session: &crate::NativeMultipartSessionV1,
+        part_number: u32,
+        stream: S,
+    ) -> Result<crate::NativeMultipartPartResult>
+    where
+        S: Stream<Item = std::result::Result<B, E>>,
+        B: AsRef<[u8]>,
+        E: std::fmt::Display,
+    {
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1 {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "direct native multipart requires the native-versioned profile",
+            ));
+        }
+        session.validate_address(self.format.repository_id)?;
+        if !(1..=10_000).contains(&part_number) {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "part number must be between 1 and 10000",
+            ));
+        }
+        futures_util::pin_mut!(stream);
+        let mut spool = tempfile::NamedTempFile::new().map_err(|error| {
+            Error::new(
+                ErrorCode::Transport,
+                format!("could not create native multipart spool: {error}"),
+            )
+        })?;
+        let mut size = 0_u64;
+        let mut checksum = Sha256::new();
+        while let Some(next) = stream.next().await {
+            let next = next.map_err(|error| {
+                Error::new(
+                    ErrorCode::Transport,
+                    format!("native multipart part body failed: {error}"),
+                )
+            })?;
+            let next = next.as_ref();
+            size = size.checked_add(next.len() as u64).ok_or_else(|| {
+                Error::new(ErrorCode::EntityTooLarge, "multipart part length overflow")
+            })?;
+            if size > MAX_MULTIPART_PART_BYTES {
+                return Err(Error::new(
+                    ErrorCode::EntityTooLarge,
+                    "multipart part exceeds the 5 GiB S3 limit",
+                ));
+            }
+            spool.write_all(next).map_err(|error| {
+                Error::new(
+                    ErrorCode::Transport,
+                    format!("native multipart spool write failed: {error}"),
+                )
+            })?;
+            checksum.update(next);
+        }
+        spool.flush().map_err(|error| {
+            Error::new(
+                ErrorCode::Transport,
+                format!("native multipart spool flush failed: {error}"),
+            )
+        })?;
+        let path =
+            ObjectPath::new(std::str::from_utf8(&session.key).map_err(|_| {
+                Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+            })?)?;
+        self.plane
+            .upload_native_multipart_file_part(crate::NativeMultipartFilePart {
+                path,
+                upload_id: session.provider_upload_id.clone(),
+                part_number,
+                body_path: spool.path().to_path_buf(),
+                size,
+                checksum_sha256: checksum.finalize().into(),
+            })
+            .await
+    }
+
+    pub async fn upload_native_multipart_part_copy(
+        &self,
+        session: &crate::NativeMultipartSessionV1,
+        part_number: u32,
+        source_branch: &str,
+        source_key: &[u8],
+        source_version: Option<ObjectVersionId>,
+        range: Option<(u64, u64)>,
+    ) -> Result<crate::NativeMultipartPartResult> {
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1 {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "direct native multipart requires the native-versioned profile",
+            ));
+        }
+        session.validate_address(self.format.repository_id)?;
+        if !(1..=10_000).contains(&part_number) {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "part number must be between 1 and 10000",
+            ));
+        }
+        let (_, source) = match source_version {
+            Some(version) => {
+                self.head_version(source_branch, source_key, version)
+                    .await?
+            }
+            None => self.head_current_at(source_branch, source_key).await?,
+        };
+        let ObjectVersionKindV1::Live {
+            size, checksums, ..
+        } = &source.version.body.kind
+        else {
+            return Err(Error::new(
+                ErrorCode::NoSuchKey,
+                "multipart copy source is a delete marker",
+            ));
+        };
+        let crate::NativeObjectBindingV1::Live { version_id, .. } =
+            source.version.native_binding.as_ref().ok_or_else(|| {
+                Error::new(
+                    ErrorCode::CorruptCommit,
+                    "native multipart copy source has no provider binding",
+                )
+            })?
+        else {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "native multipart live source has a delete-marker binding",
+            ));
+        };
+        let (physical_range, part_size) = match range {
+            None if *size <= MAX_MULTIPART_PART_BYTES => (None, *size),
+            None => {
+                return Err(Error::new(
+                    ErrorCode::EntityTooLarge,
+                    "multipart copy part exceeds 5 GiB",
+                ))
+            }
+            Some((start, end)) if start <= end && end < *size => {
+                let part_size = end
+                    .checked_sub(start)
+                    .and_then(|value| value.checked_add(1))
+                    .ok_or_else(|| {
+                        Error::new(ErrorCode::EntityTooLarge, "multipart copy range overflow")
+                    })?;
+                if part_size > MAX_MULTIPART_PART_BYTES {
+                    return Err(Error::new(
+                        ErrorCode::EntityTooLarge,
+                        "multipart copy part exceeds 5 GiB",
+                    ));
+                }
+                (Some(start..=end), part_size)
+            }
+            Some(_) => {
+                return Err(Error::new(
+                    ErrorCode::InvalidRequest,
+                    "multipart copy range is not satisfiable",
+                ))
+            }
+        };
+        let result = self
+            .plane
+            .upload_native_multipart_part_copy(crate::NativeMultipartUploadPartCopy {
+                source: ObjectPath::new(std::str::from_utf8(source_key).map_err(|_| {
+                    Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+                })?)?,
+                source_version_id: version_id.clone(),
+                destination: ObjectPath::new(std::str::from_utf8(&session.key).map_err(|_| {
+                    Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+                })?)?,
+                upload_id: session.provider_upload_id.clone(),
+                part_number,
+                range: physical_range,
+                size: part_size,
+            })
+            .await?;
+        if range.is_none()
+            && checksums.sha256.is_some()
+            && checksums.sha256 != result.checksum_sha256
+        {
+            return Err(Error::new(
+                ErrorCode::ChecksumMismatch,
+                "native multipart copied part checksum differs from its source",
+            ));
+        }
+        Ok(result)
+    }
+
+    pub async fn complete_native_multipart_upload(
+        &self,
+        session: crate::NativeMultipartSessionV1,
+        parts: Vec<crate::NativeMultipartCompletedPart>,
+        checksum_sha256: [u8; 32],
+        checksum_md5: [u8; 16],
+        size: u64,
+        operation: Option<OperationId>,
+    ) -> Result<CommitReceipt> {
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1 {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "direct native multipart requires the native-versioned profile",
+            ));
+        }
+        session.validate(self.format.repository_id)?;
+        if operation.is_some_and(|operation| operation != session.operation) {
+            return Err(Error::new(
+                ErrorCode::IdempotencyConflict,
+                "native multipart completion must reuse its create operation ID",
+            ));
+        }
+        if parts.is_empty()
+            || parts.len() > 10_000
+            || parts
+                .windows(2)
+                .any(|pair| pair[0].part_number >= pair[1].part_number)
+            || parts
+                .iter()
+                .take(parts.len().saturating_sub(1))
+                .any(|part| part.size < MIN_NONFINAL_MULTIPART_PART_BYTES)
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "native multipart completion has invalid ordering, count, or nonfinal part size",
+            ));
+        }
+        let summed_size = parts.iter().try_fold(0_u64, |total, part| {
+            total.checked_add(part.size).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::EntityTooLarge,
+                    "multipart object length overflow",
+                )
+            })
+        })?;
+        if summed_size != size || size > self.format.canonical_limits.max_object_bytes {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "native multipart declared size does not match its part receipts",
+            ));
+        }
+        let kind = ObjectVersionKindV1::Live {
+            content: crate::ContentRef::Empty,
+            size,
+            logical_etag: format!("\"{}\"", hex::encode(checksum_md5)),
+            headers: session.headers.clone(),
+            checksums: crate::Checksums {
+                md5: Some(checksum_md5),
+                sha256: Some(checksum_sha256),
+                algorithm_values: BTreeMap::new(),
+            },
+            user_metadata: session.user_metadata.clone(),
+            tags: BTreeMap::new(),
+        };
+        let input_digest = derive_input_digest(&[
+            self.format.repository_id.as_bytes(),
+            session.branch.as_bytes(),
+            b"native-multipart-complete",
+            &session.key,
+            session.provider_upload_id.as_bytes(),
+            &encode_canonical(&parts)?,
+            &encode_canonical(&kind)?,
+        ]);
+        let _publication = self.native_publication.lock().await;
+        if let Some(receipt) = self
+            .replay_warm_operation(&session.branch, session.operation, input_digest)
+            .await?
+        {
+            return Ok(receipt);
+        }
+        if self.native_writer_generation_for_mutation().await? != session.writer_fence_generation {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "native multipart upload belongs to an older writer fence",
+            ));
+        }
+        let path =
+            ObjectPath::new(std::str::from_utf8(&session.key).map_err(|_| {
+                Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+            })?)?;
+        let completed = self
+            .plane
+            .complete_native_multipart(crate::NativeMultipartComplete {
+                path: path.clone(),
+                upload_id: session.provider_upload_id,
+                parts,
+                checksum_sha256,
+                checksum_md5,
+                size,
+            })
+            .await;
+        let completed = match completed {
+            Ok(value) => value,
+            Err(error) => match self
+                .reconcile_native_payload(&path, session.operation, checksum_sha256)
+                .await?
+            {
+                Some(value) => value,
+                None => return Err(error),
+            },
+        };
+        if completed.size != size
+            || completed.logical_etag != format!("\"{}\"", hex::encode(checksum_md5))
+            || completed.checksums.sha256 != Some(checksum_sha256)
+            || completed.checksums.md5 != Some(checksum_md5)
+        {
+            return Err(Error::new(
+                ErrorCode::ProviderNotQualified,
+                "native multipart result disagrees with its declared object identity",
+            ));
+        }
+        self.commit_one(
+            &session.branch,
+            session.key,
+            kind,
+            Some(completed.binding),
+            OperationKind::Put,
+            session.operation,
+            input_digest,
+            "CompleteMultipartUpload",
+            None,
+            ObjectWriteConditionV1::default(),
+            None,
+        )
+        .await
+    }
+
+    pub async fn abort_native_multipart_upload(
+        &self,
+        session: &crate::NativeMultipartSessionV1,
+    ) -> Result<()> {
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1 {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "direct native multipart requires the native-versioned profile",
+            ));
+        }
+        session.validate_address(self.format.repository_id)?;
+        let path =
+            ObjectPath::new(std::str::from_utf8(&session.key).map_err(|_| {
+                Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
+            })?)?;
+        self.plane
+            .abort_native_multipart(crate::NativeMultipartAbort {
+                path,
+                upload_id: session.provider_upload_id.clone(),
+            })
+            .await
     }
 
     pub async fn upload_part_stream<S, B, E>(
@@ -7525,7 +8095,9 @@ impl<P: ObjectPlane> Repository<P> {
                 if metadata.get("prolly-repository-id")
                     != Some(&self.format.repository_id.to_string())
                     || metadata.get("prolly-operation-id") != Some(&operation.to_string())
-                    || metadata.get("prolly-sha256") != Some(&hex::encode(expected_sha256))
+                    || metadata
+                        .get("prolly-sha256")
+                        .is_some_and(|value| value != &hex::encode(expected_sha256))
                     || crate::codec::sha256(&object.bytes) != expected_sha256
                 {
                     continue;

--- a/extensions/s3/core/src/repository.rs
+++ b/extensions/s3/core/src/repository.rs
@@ -288,6 +288,16 @@ struct LoadedSyncRun {
     token: StorageToken,
 }
 
+pub struct WriterLeaseMaintenance {
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for WriterLeaseMaintenance {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
 pub struct Repository<P: ObjectPlane> {
     plane: Arc<P>,
     options: RepositoryOptions,
@@ -762,16 +772,16 @@ impl<P: ObjectPlane> Repository<P> {
         renewed.expires_at_millis = now
             .checked_add(self.options.writer_lease_millis)
             .ok_or_else(|| Error::new(ErrorCode::InvalidLimit, "writer lease expiry overflow"))?;
-        match self
+        let renewal = self
             .plane
             .compare_exchange(CompareExchange {
                 path: writer_lease_path(&self.options.repository_prefix)?,
                 expected: Some(held.token),
                 bytes: encode_canonical(&renewed)?,
             })
-            .await?
-        {
-            CompareExchangeOutcome::Applied(metadata) => {
+            .await;
+        match renewal {
+            Ok(CompareExchangeOutcome::Applied(metadata)) => {
                 *self.writer_lease.write().map_err(|_| {
                     Error::new(ErrorCode::InternalInvariant, "writer-lease lock poisoned")
                 })? = Some(HeldWriterLease {
@@ -780,11 +790,54 @@ impl<P: ObjectPlane> Repository<P> {
                 });
                 Ok(())
             }
-            CompareExchangeOutcome::Conflict(_) => Err(Error::new(
-                ErrorCode::PreconditionFailed,
-                "native writer lease was lost; publication is fenced",
-            )),
+            Ok(CompareExchangeOutcome::Conflict(_)) => {
+                *self.writer_lease.write().map_err(|_| {
+                    Error::new(ErrorCode::InternalInvariant, "writer-lease lock poisoned")
+                })? = None;
+                Err(Error::new(
+                    ErrorCode::PreconditionFailed,
+                    "native writer lease was lost; publication is fenced",
+                ))
+            }
+            Err(error) => {
+                *self.writer_lease.write().map_err(|_| {
+                    Error::new(ErrorCode::InternalInvariant, "writer-lease lock poisoned")
+                })? = None;
+                Err(Error::new(
+                    ErrorCode::OutcomeUnknown,
+                    format!("writer lease renewal outcome is unknown; writer is fenced: {error}"),
+                )
+                .retry(RetryAdvice::ReconcileOperation))
+            }
         }
+    }
+
+    /// Run independent native-writer lease renewal until the returned handle
+    /// is dropped. A failed or ambiguous renewal fences this repository before
+    /// the task exits.
+    pub fn start_writer_lease_maintenance(self: &Arc<Self>) -> Result<WriterLeaseMaintenance> {
+        if self.storage_profile() != RepositoryStorageProfile::NativeVersionedV1
+            || self.options.read_only
+        {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "writer lease maintenance requires a writable native repository",
+            ));
+        }
+        let interval = Duration::from_millis((self.options.writer_lease_millis / 3).max(100));
+        let weak = Arc::downgrade(self);
+        let task = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(interval).await;
+                let Some(repository) = weak.upgrade() else {
+                    break;
+                };
+                if repository.renew_writer_lease().await.is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(WriterLeaseMaintenance { task })
     }
 
     /// Explicitly take over an expired or credential-revoked native writer.
@@ -1094,10 +1147,7 @@ impl<P: ObjectPlane> Repository<P> {
         destination_prefix: &str,
     ) -> Result<CloneReport> {
         if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
-            return Err(Error::new(
-                ErrorCode::MissingCapability,
-                "native-versioned clone requires logical history replay and destination VersionId rebinding",
-            ));
+            return self.clone_native_to(destination, destination_prefix).await;
         }
         let probe_prefix = format!("{destination_prefix}/");
         ObjectPath::new(format!("{destination_prefix}/format/v1.cbor"))?;
@@ -1216,6 +1266,706 @@ impl<P: ObjectPlane> Repository<P> {
         Ok(report)
     }
 
+    async fn clone_native_to<Q: ObjectPlane>(
+        &self,
+        destination: Arc<Q>,
+        destination_prefix: &str,
+    ) -> Result<CloneReport> {
+        let format_path = format_path(destination_prefix)?;
+        let existing_format = destination
+            .get(GetRequest {
+                path: format_path.clone(),
+                range: None,
+                physical_version: None,
+            })
+            .await?;
+        let format_created = if let Some(existing) = existing_format {
+            let format = decode_repository_format(&existing.bytes)?;
+            if format != self.format {
+                return Err(Error::new(
+                    ErrorCode::RepositoryFormatConflict,
+                    "native clone destination has a different repository format",
+                ));
+            }
+            false
+        } else {
+            let prefix = format!("{destination_prefix}/");
+            let mut continuation = None;
+            loop {
+                let page = destination
+                    .list(ListRequest {
+                        prefix: prefix.clone(),
+                        continuation,
+                        limit: 1_000,
+                        include_versions: false,
+                    })
+                    .await?;
+                if page.entries.iter().any(|entry| {
+                    entry
+                        .path
+                        .as_str()
+                        .strip_prefix(&prefix)
+                        .is_some_and(|relative| {
+                            is_portable_clone_path(relative)
+                                || relative.starts_with("node-packs/")
+                                || relative.starts_with("writers/")
+                        })
+                }) {
+                    return Err(Error::new(
+                        ErrorCode::RepositoryFormatConflict,
+                        "native clone destination contains repository data without a format marker",
+                    ));
+                }
+                continuation = page.continuation;
+                if continuation.is_none() {
+                    break;
+                }
+            }
+            match destination
+                .compare_exchange(CompareExchange {
+                    path: format_path,
+                    expected: None,
+                    bytes: encode_canonical(&self.format)?,
+                })
+                .await?
+            {
+                CompareExchangeOutcome::Applied(_) => true,
+                CompareExchangeOutcome::Conflict(Some(existing))
+                    if decode_repository_format(&existing.bytes)? == self.format =>
+                {
+                    false
+                }
+                CompareExchangeOutcome::Conflict(_) => {
+                    return Err(Error::new(
+                        ErrorCode::RepositoryFormatConflict,
+                        "native clone destination format was created concurrently",
+                    ))
+                }
+            }
+        };
+
+        let mut target_options = self.options.clone();
+        target_options.repository_prefix = destination_prefix.to_string();
+        target_options.storage_profile = RepositoryStorageProfile::NativeVersionedV1;
+        target_options.read_only = false;
+        let mut target =
+            Repository::<Q>::from_format(destination, target_options, self.format.clone())?;
+        target.acquire_native_writer().await?;
+        let target = Arc::new(target);
+        let _lease_maintenance = target.start_writer_lease_maintenance()?;
+
+        let branches = self.list_branches().await?;
+        let tags = self.list_tags().await?;
+        let roots = branches
+            .iter()
+            .map(|branch| branch.target)
+            .chain(tags.iter().map(|tag| tag.target))
+            .collect::<Vec<_>>();
+        let (commit_map, sync) = self
+            .replay_native_history_to(target.as_ref(), &roots, false)
+            .await?;
+        let writer_fence_generation = target.native_writer_generation_for_mutation().await?;
+        let mut report = CloneReport {
+            immutable_objects: sync.copied_objects + usize::from(format_created),
+            immutable_bytes: sync.copied_bytes,
+            refs: 0,
+        };
+
+        for branch in branches {
+            let target_id = *commit_map.get(&branch.target).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::MissingClosure,
+                    "native clone branch target was not replayed",
+                )
+            })?;
+            let path = branch_path(destination_prefix, &branch.name)?;
+            if let Some(existing) = target.plane.load_mutable(&path).await? {
+                let value: crate::RefValueV1 = decode_canonical(&existing.bytes)?;
+                if value.target != target_id || value.tombstone {
+                    return Err(Error::new(
+                        ErrorCode::RefConflict,
+                        "native clone destination branch has a divergent target",
+                    ));
+                }
+                report.refs += 1;
+                continue;
+            }
+            let operation = target.new_operation();
+            let created_at_millis = target.now_millis()?;
+            let reflog = ReflogEntryV1 {
+                branch: branch.name.clone(),
+                old_target: None,
+                new_target: target_id,
+                operation,
+                actor: target.options.writer.clone(),
+                message: "native logical clone".to_string(),
+                created_at_millis,
+            };
+            let value = crate::RefValueV1 {
+                target: target_id,
+                previous_target: None,
+                generation: branch.generation,
+                operation,
+                reflog: reflog.id()?,
+                writer: target.options.writer.clone(),
+                updated_at_millis: created_at_millis,
+                tombstone: false,
+                native: Some(crate::NativeRefExtensionV1 {
+                    writer_fence_generation,
+                    inline_reflog: reflog,
+                }),
+            };
+            match target
+                .plane
+                .compare_exchange(CompareExchange {
+                    path,
+                    expected: None,
+                    bytes: encode_canonical(&value)?,
+                })
+                .await?
+            {
+                CompareExchangeOutcome::Applied(metadata) => {
+                    let commit = target.load_commit(target_id).await?;
+                    target.cache_branch(&branch.name, value, metadata.token, commit)?;
+                    report.refs += 1;
+                }
+                CompareExchangeOutcome::Conflict(Some(existing)) => {
+                    let current: crate::RefValueV1 = decode_canonical(&existing.bytes)?;
+                    if current.target != target_id || current.tombstone {
+                        return Err(Error::new(
+                            ErrorCode::RefConflict,
+                            "native clone destination branch was created concurrently",
+                        ));
+                    }
+                    report.refs += 1;
+                }
+                CompareExchangeOutcome::Conflict(None) => {
+                    return Err(Error::new(
+                        ErrorCode::RefConflict,
+                        "native clone branch create returned an empty conflict",
+                    ))
+                }
+            }
+        }
+        for tag in tags {
+            let target_id = *commit_map.get(&tag.target).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::MissingClosure,
+                    "native clone tag target was not replayed",
+                )
+            })?;
+            let path = tag_path(destination_prefix, &tag.name)?;
+            if let Some(existing) = target.plane.load_mutable(&path).await? {
+                let value: crate::TagValueV1 = decode_canonical(&existing.bytes)?;
+                if value.target != target_id || value.tombstone {
+                    return Err(Error::new(
+                        ErrorCode::RefConflict,
+                        "native clone destination tag has a divergent target",
+                    ));
+                }
+                report.refs += 1;
+                continue;
+            }
+            let operation = target.new_operation();
+            let created_at_millis = target.now_millis()?;
+            let reflog = ReflogEntryV1 {
+                branch: tag.name.clone(),
+                old_target: None,
+                new_target: target_id,
+                operation,
+                actor: target.options.writer.clone(),
+                message: "native logical clone tag".to_string(),
+                created_at_millis,
+            };
+            let reflog_id = target.store_tag_reflog(&reflog).await?;
+            report.immutable_objects += 1;
+            let value = crate::TagValueV1 {
+                target: target_id,
+                previous_target: None,
+                generation: RefGeneration(0),
+                operation,
+                reflog: reflog_id,
+                writer: target.options.writer.clone(),
+                created_at_millis,
+                tombstone: false,
+            };
+            match target
+                .plane
+                .compare_exchange(CompareExchange {
+                    path,
+                    expected: None,
+                    bytes: encode_canonical(&value)?,
+                })
+                .await?
+            {
+                CompareExchangeOutcome::Applied(_) => report.refs += 1,
+                CompareExchangeOutcome::Conflict(Some(existing)) => {
+                    let current: crate::TagValueV1 = decode_canonical(&existing.bytes)?;
+                    if current.target != target_id || current.tombstone {
+                        return Err(Error::new(
+                            ErrorCode::RefConflict,
+                            "native clone destination tag was created concurrently",
+                        ));
+                    }
+                    report.refs += 1;
+                }
+                CompareExchangeOutcome::Conflict(None) => {
+                    return Err(Error::new(
+                        ErrorCode::RefConflict,
+                        "native clone tag create returned an empty conflict",
+                    ))
+                }
+            }
+        }
+        target.fsck().await?;
+        Ok(report)
+    }
+
+    async fn clone_native_version_binding<Q: ObjectPlane>(
+        &self,
+        target: &Repository<Q>,
+        key: &[u8],
+        version: &ObjectVersionV1,
+        operation: OperationId,
+        writer_fence_generation: u64,
+    ) -> Result<crate::NativeObjectBindingV1> {
+        let path =
+            ObjectPath::new(std::str::from_utf8(key).map_err(|_| {
+                Error::new(ErrorCode::CorruptCommit, "native clone key is not UTF-8")
+            })?)?;
+        match (&version.body.kind, &version.native_binding) {
+            (
+                ObjectVersionKindV1::Live {
+                    size,
+                    headers,
+                    checksums,
+                    user_metadata,
+                    ..
+                },
+                Some(crate::NativeObjectBindingV1::Live {
+                    version_id,
+                    checksum_sha256,
+                    ..
+                }),
+            ) => {
+                let spool = tempfile::NamedTempFile::new().map_err(|error| {
+                    Error::new(
+                        ErrorCode::Transport,
+                        format!("could not create native clone spool: {error}"),
+                    )
+                })?;
+                let source = self
+                    .plane
+                    .get_native_file(crate::NativeFileGet {
+                        path: path.clone(),
+                        version_id: version_id.clone(),
+                        body_path: spool.path().to_path_buf(),
+                    })
+                    .await?;
+                if source.size != *size
+                    || source.checksum_sha256 != *checksum_sha256
+                    || checksums.sha256 != Some(*checksum_sha256)
+                {
+                    return Err(Error::new(
+                        ErrorCode::ChecksumMismatch,
+                        "native clone source object failed logical checksum verification",
+                    ));
+                }
+                let write = target
+                    .plane
+                    .put_native_file(crate::NativeFilePut {
+                        path,
+                        body_path: spool.path().to_path_buf(),
+                        size: source.size,
+                        checksum_sha256: source.checksum_sha256,
+                        checksum_md5: source.checksum_md5,
+                        headers: headers.clone(),
+                        user_metadata: user_metadata.clone(),
+                        repository: target.format.repository_id,
+                        operation,
+                        writer_fence_generation,
+                    })
+                    .await?;
+                if write.size != *size
+                    || write.checksums.sha256 != Some(*checksum_sha256)
+                    || !matches!(write.binding, crate::NativeObjectBindingV1::Live { .. })
+                {
+                    return Err(Error::new(
+                        ErrorCode::ChecksumMismatch,
+                        "native clone destination object failed logical checksum verification",
+                    ));
+                }
+                Ok(write.binding)
+            }
+            (
+                ObjectVersionKindV1::DeleteMarker,
+                Some(crate::NativeObjectBindingV1::DeleteMarker { .. }),
+            ) => {
+                match target
+                    .plane
+                    .delete_native(crate::NativeDelete {
+                        path: path.clone(),
+                        repository: target.format.repository_id,
+                        operation,
+                        writer_fence_generation,
+                    })
+                    .await
+                {
+                    Ok(binding) => Ok(binding),
+                    Err(error) => match target.reconcile_native_delete(&path).await? {
+                        Some(binding) => Ok(binding),
+                        None => Err(error),
+                    },
+                }
+            }
+            _ => Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "native clone source version has an invalid binding",
+            )),
+        }
+    }
+
+    async fn ordered_native_commit_closure(
+        &self,
+        roots: &[CommitId],
+    ) -> Result<Vec<(CommitId, BucketCommitV1)>> {
+        let mut pending = roots.to_vec();
+        let mut commits = BTreeMap::new();
+        while let Some(id) = pending.pop() {
+            if commits.contains_key(&id) {
+                continue;
+            }
+            if commits.len() >= self.options.history_traversal_limit {
+                return Err(Error::new(
+                    ErrorCode::HistoryLimitExceeded,
+                    "native transfer commit closure exceeded its configured history limit",
+                ));
+            }
+            let commit = self.load_commit(id).await?;
+            pending.extend(commit.parents.iter().copied());
+            commits.insert(id, commit);
+        }
+        let mut ordered = commits.into_iter().collect::<Vec<_>>();
+        ordered.sort_by(|(left_id, left), (right_id, right)| {
+            left.generation
+                .cmp(&right.generation)
+                .then_with(|| left_id.cmp(right_id))
+        });
+        Ok(ordered)
+    }
+
+    async fn all_native_commits(&self) -> Result<Vec<(CommitId, BucketCommitV1)>> {
+        let prefix = format!("{}/commits/sha256/", self.options.repository_prefix);
+        let mut continuation = None;
+        let mut commits = BTreeMap::new();
+        loop {
+            let page = self
+                .plane
+                .list(ListRequest {
+                    prefix: prefix.clone(),
+                    continuation,
+                    limit: 1_000,
+                    include_versions: false,
+                })
+                .await?;
+            for entry in page.entries {
+                let encoded = entry.path.as_str().rsplit('/').next().unwrap_or_default();
+                let raw = hex::decode(encoded).map_err(|_| {
+                    Error::new(
+                        ErrorCode::CorruptCommit,
+                        "native transfer commit path is not canonical hex",
+                    )
+                })?;
+                let id = CommitId::from_hash(raw.try_into().map_err(|_| {
+                    Error::new(
+                        ErrorCode::CorruptCommit,
+                        "native transfer commit path has the wrong ID length",
+                    )
+                })?);
+                let commit = self.load_commit(id).await?;
+                commits.insert(id, commit);
+            }
+            continuation = page.continuation;
+            if continuation.is_none() {
+                break;
+            }
+        }
+        let mut ordered = commits.into_iter().collect::<Vec<_>>();
+        ordered.sort_by(|(left_id, left), (right_id, right)| {
+            left.generation
+                .cmp(&right.generation)
+                .then_with(|| left_id.cmp(right_id))
+        });
+        Ok(ordered)
+    }
+
+    async fn native_logical_commit_fingerprints(
+        &self,
+        ordered: &[(CommitId, BucketCommitV1)],
+    ) -> Result<BTreeMap<CommitId, [u8; 32]>> {
+        let mut fingerprints: BTreeMap<CommitId, [u8; 32]> = BTreeMap::new();
+        for (id, commit) in ordered {
+            let mut parent_bytes = Vec::with_capacity(commit.parents.len() * 32);
+            for parent in &commit.parents {
+                parent_bytes.extend_from_slice(fingerprints.get(parent).ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::CorruptCommit,
+                        "native logical fingerprint encountered a child before its parent",
+                    )
+                })?);
+            }
+            let objects = encode_canonical(&commit.state.objects)?;
+            let operations = encode_canonical(&commit.state.operations)?;
+            let generation = commit.generation.0.to_be_bytes();
+            let delta = commit.delta.as_bytes();
+            let message = encode_canonical(&commit.message)?;
+            let metadata = encode_canonical(&commit.metadata)?;
+            let fingerprint = derive_input_digest(&[
+                b"native-logical-commit-v1",
+                &parent_bytes,
+                &objects,
+                &operations,
+                &generation,
+                delta,
+                commit.author.as_bytes(),
+                &message,
+                &commit.created_at_millis.to_be_bytes(),
+                &metadata,
+            ]);
+            fingerprints.insert(*id, fingerprint);
+        }
+        Ok(fingerprints)
+    }
+
+    async fn replay_native_history_to<Q: ObjectPlane>(
+        &self,
+        target: &Repository<Q>,
+        source_roots: &[CommitId],
+        force_rebind: bool,
+    ) -> Result<(BTreeMap<CommitId, CommitId>, SyncReport)> {
+        let source_ordered = self.ordered_native_commit_closure(source_roots).await?;
+        let source_fingerprints = self
+            .native_logical_commit_fingerprints(&source_ordered)
+            .await?;
+        let target_by_fingerprint = if force_rebind {
+            BTreeMap::new()
+        } else {
+            let target_ordered = target.all_native_commits().await?;
+            let target_fingerprints = target
+                .native_logical_commit_fingerprints(&target_ordered)
+                .await?;
+            target_fingerprints
+                .into_iter()
+                .map(|(id, fingerprint)| (fingerprint, id))
+                .collect::<BTreeMap<_, _>>()
+        };
+        let mut commit_map = BTreeMap::new();
+        let mut report = SyncReport::default();
+        for (source_id, _) in &source_ordered {
+            if let Some(target_id) = target_by_fingerprint.get(
+                source_fingerprints
+                    .get(source_id)
+                    .expect("source fingerprint exists"),
+            ) {
+                commit_map.insert(*source_id, *target_id);
+                report.already_present += 1;
+            }
+        }
+        let writer_fence_generation = target.native_writer_generation_for_mutation().await?;
+        let mut binding_map: BTreeMap<(Vec<u8>, ObjectVersionId), crate::NativeObjectBindingV1> =
+            BTreeMap::new();
+        for (source_id, source_commit) in source_ordered {
+            if commit_map.contains_key(&source_id) {
+                continue;
+            }
+            let mut mapped_parents = Vec::with_capacity(source_commit.parents.len());
+            for parent in &source_commit.parents {
+                mapped_parents.push(*commit_map.get(parent).ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::MissingClosure,
+                        "native transfer parent was not mapped",
+                    )
+                })?);
+            }
+            let base = match mapped_parents.first() {
+                Some(parent) => Some(target.load_commit(*parent).await?),
+                None => None,
+            };
+            let empty = target.engine.create();
+            let mut objects = match &base {
+                Some(commit) => target
+                    .tree_from_root(&commit.state.objects, &target.format.state_tree_format)?,
+                None => empty.clone(),
+            };
+            let mut versions = match &base {
+                Some(commit) => target
+                    .tree_from_root(&commit.state.versions, &target.format.state_tree_format)?,
+                None => empty.clone(),
+            };
+            let mut operations = match &base {
+                Some(commit) => target
+                    .tree_from_root(&commit.state.operations, &target.format.state_tree_format)?,
+                None => empty,
+            };
+            let source_operations = self.tree_from_root(
+                &source_commit.state.operations,
+                &self.format.state_tree_format,
+            )?;
+            let delta = self.load_commit_delta(&source_commit).await?;
+            let physical_operation = delta.operation_ids.first().copied().unwrap_or_else(|| {
+                let mut bytes = [0_u8; 16];
+                bytes.copy_from_slice(&source_id.as_bytes()[..16]);
+                OperationId(uuid::Uuid::from_bytes(bytes))
+            });
+            for transition in &delta.changes {
+                let mut version = self
+                    .find_version(&source_commit, &transition.key, transition.next)
+                    .await?;
+                let binding_key = (transition.key.clone(), version.id);
+                let (binding, copied_payload) = if let Some(binding) = binding_map.get(&binding_key)
+                {
+                    (binding.clone(), false)
+                } else if let Some(base) = &base {
+                    match target
+                        .find_version(base, &transition.key, transition.next)
+                        .await
+                    {
+                        Ok(existing) => (
+                            existing.native_binding.ok_or_else(|| {
+                                Error::new(
+                                    ErrorCode::CorruptCommit,
+                                    "native transfer base version omitted its binding",
+                                )
+                            })?,
+                            false,
+                        ),
+                        Err(error) if error.code == ErrorCode::NoSuchVersion => (
+                            self.clone_native_version_binding(
+                                target,
+                                &transition.key,
+                                &version,
+                                physical_operation,
+                                writer_fence_generation,
+                            )
+                            .await?,
+                            true,
+                        ),
+                        Err(error) => return Err(error),
+                    }
+                } else {
+                    (
+                        self.clone_native_version_binding(
+                            target,
+                            &transition.key,
+                            &version,
+                            physical_operation,
+                            writer_fence_generation,
+                        )
+                        .await?,
+                        true,
+                    )
+                };
+                if copied_payload {
+                    let size = match &version.body.kind {
+                        ObjectVersionKindV1::Live { size, .. } => *size,
+                        ObjectVersionKindV1::DeleteMarker => 0,
+                    };
+                    report.copied_bytes =
+                        report.copied_bytes.checked_add(size).ok_or_else(|| {
+                            Error::new(
+                                ErrorCode::EntityTooLarge,
+                                "native transfer byte count overflow",
+                            )
+                        })?;
+                    report.copied_objects += 1;
+                }
+                binding_map.insert(binding_key, binding.clone());
+                version.native_binding = Some(binding);
+                version.validate_native()?;
+                versions = target
+                    .engine
+                    .put(
+                        &versions,
+                        version_tree_key(&transition.key, version.body.order, version.id),
+                        encode_canonical(&version)?,
+                    )
+                    .await?;
+                objects = if transition.delete_marker {
+                    target.engine.delete(&objects, &transition.key).await?
+                } else {
+                    target
+                        .engine
+                        .put(
+                            &objects,
+                            transition.key.clone(),
+                            encode_canonical(&CurrentObjectV1 {
+                                version: transition.next,
+                            })?,
+                        )
+                        .await?
+                };
+            }
+            for operation in &delta.operation_ids {
+                let record = self
+                    .engine
+                    .get(&source_operations, operation.as_bytes())
+                    .await?
+                    .ok_or_else(|| {
+                        Error::new(
+                            ErrorCode::CorruptCommit,
+                            "native transfer delta names a missing operation",
+                        )
+                    })?;
+                operations = target
+                    .engine
+                    .put(&operations, operation.as_bytes().to_vec(), record)
+                    .await?;
+            }
+            let state = BucketStateV1 {
+                objects: TreeRootV1::from_tree(&objects)?,
+                versions: TreeRootV1::from_tree(&versions)?,
+                operations: TreeRootV1::from_tree(&operations)?,
+            };
+            if state.objects != source_commit.state.objects
+                || state.operations != source_commit.state.operations
+            {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "native transfer replay did not reproduce the logical commit state",
+                ));
+            }
+            let node_pack = target
+                .node_store
+                .flush_node_pack(
+                    tree_format_digest(&target.format.state_tree_format)?,
+                    Vec::new(),
+                )
+                .await?;
+            if node_pack.is_some() {
+                report.copied_objects += 1;
+            }
+            let destination_commit = BucketCommitV1 {
+                state,
+                parents: mapped_parents,
+                generation: source_commit.generation,
+                delta: delta.id()?,
+                author: source_commit.author,
+                message: source_commit.message,
+                created_at_millis: source_commit.created_at_millis,
+                metadata: source_commit.metadata,
+                native: Some(crate::NativeCommitExtensionV1 {
+                    node_pack,
+                    inline_delta: delta,
+                    writer_fence_generation,
+                }),
+            };
+            let destination_id = target.store_commit(&destination_commit).await?;
+            report.copied_objects += 1;
+            commit_map.insert(source_id, destination_id);
+        }
+        Ok((commit_map, report))
+    }
+
     /// Import portable immutable repository objects without moving a local
     /// ref. The returned source head may then be inspected or merged.
     pub async fn fetch_from<Q: ObjectPlane>(
@@ -1224,6 +1974,20 @@ impl<P: ObjectPlane> Repository<P> {
         source_branch: &str,
     ) -> Result<SyncReport> {
         self.validate_sync_identity(source)?;
+        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            let _publication = self.native_publication.lock().await;
+            let source_head = source.head(source_branch).await?;
+            let (mapped, mut report) = source
+                .replay_native_history_to(self, &[source_head], false)
+                .await?;
+            report.source_head = Some(*mapped.get(&source_head).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::MissingClosure,
+                    "native fetch did not map its selected source head",
+                )
+            })?);
+            return Ok(report);
+        }
         let source_head = source.head(source_branch).await?;
         let mut report = source
             .copy_commit_closure_to(
@@ -1254,6 +2018,12 @@ impl<P: ObjectPlane> Repository<P> {
             ));
         }
         self.validate_sync_identity(destination)?;
+        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "native resumable sync requires the logical transfer journal API",
+            ));
+        }
         let id = run.unwrap_or_else(|| self.new_operation());
         let path = sync_run_path(&destination.options.repository_prefix, id)?;
         let existing = destination.load_sync_run_optional(id).await?;
@@ -1461,6 +2231,37 @@ impl<P: ObjectPlane> Repository<P> {
     ) -> Result<SyncReport> {
         self.validate_sync_identity(destination)?;
         let source_head = self.head(source_branch).await?;
+        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            let _publication = destination.native_publication.lock().await;
+            let (mapped, mut report) = self
+                .replay_native_history_to(destination, &[source_head], false)
+                .await?;
+            let mapped_head = *mapped.get(&source_head).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::MissingClosure,
+                    "native push did not map its selected source head",
+                )
+            })?;
+            if reason.trim().is_empty() {
+                return Err(Error::new(
+                    ErrorCode::InvalidRequest,
+                    "administrative ref movement requires a non-empty reason",
+                ));
+            }
+            let loaded = destination.load_ref(destination_branch).await?;
+            if loaded.value.target != expected_destination {
+                return Err(Error::new(
+                    ErrorCode::PreconditionFailed,
+                    "branch head does not match push expectation",
+                ));
+            }
+            let movement = destination
+                .move_ref_inner(destination_branch, loaded, mapped_head, reason)
+                .await?;
+            report.source_head = Some(mapped_head);
+            report.ref_move = Some(movement);
+            return Ok(report);
+        }
         let mut report = self
             .copy_commit_closure_to(
                 destination.plane.clone(),
@@ -1482,12 +2283,10 @@ impl<P: ObjectPlane> Repository<P> {
     }
 
     fn validate_sync_identity<Q: ObjectPlane>(&self, other: &Repository<Q>) -> Result<()> {
-        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1
-            || other.storage_profile() == RepositoryStorageProfile::NativeVersionedV1
-        {
+        if self.storage_profile() != other.storage_profile() {
             return Err(Error::new(
                 ErrorCode::MissingCapability,
-                "native-versioned fetch, push, and repair require destination VersionId rebinding",
+                "sync cannot cross repository storage profiles",
             ));
         }
         if self.format != other.format {
@@ -2028,6 +2827,17 @@ impl<P: ObjectPlane> Repository<P> {
         } else {
             None
         };
+        self.move_ref_inner(branch, loaded, target, reason).await
+    }
+
+    async fn move_ref_inner(
+        &self,
+        branch: &str,
+        loaded: LoadedRef,
+        target: CommitId,
+        reason: &str,
+    ) -> Result<RefMoveReceipt> {
+        let native_profile = self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1;
         let writer_fence_generation = if native_profile {
             self.native_writer_generation_for_mutation().await?
         } else {
@@ -4681,15 +5491,22 @@ impl<P: ObjectPlane> Repository<P> {
                     let path = ObjectPath::new(std::str::from_utf8(&key).map_err(|_| {
                         Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
                     })?)?;
-                    let binding = self
+                    let binding = match self
                         .plane
                         .delete_native(crate::NativeDelete {
-                            path,
+                            path: path.clone(),
                             repository: self.format.repository_id,
                             operation: batch.operation,
                             writer_fence_generation,
                         })
-                        .await?;
+                        .await
+                    {
+                        Ok(binding) => binding,
+                        Err(error) => match self.reconcile_native_delete(&path).await? {
+                            Some(binding) => binding,
+                            None => return Err(error),
+                        },
+                    };
                     batch.mutations.insert(
                         key.clone(),
                         WorkspaceMutationV1::NativeDelete { key, binding },
@@ -4812,15 +5629,22 @@ impl<P: ObjectPlane> Repository<P> {
             let path = ObjectPath::new(std::str::from_utf8(&key).map_err(|_| {
                 Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
             })?)?;
-            let binding = self
+            let binding = match self
                 .plane
                 .delete_native(crate::NativeDelete {
-                    path,
+                    path: path.clone(),
                     repository: self.format.repository_id,
                     operation: manifest.operation,
                     writer_fence_generation,
                 })
-                .await?;
+                .await
+            {
+                Ok(binding) => binding,
+                Err(error) => match self.reconcile_native_delete(&path).await? {
+                    Some(binding) => binding,
+                    None => return Err(error),
+                },
+            };
             return self
                 .update_workspace_mutation(
                     workspace,
@@ -5096,7 +5920,7 @@ impl<P: ObjectPlane> Repository<P> {
             match self
                 .plane
                 .delete_native(crate::NativeDelete {
-                    path,
+                    path: path.clone(),
                     repository: self.format.repository_id,
                     operation,
                     writer_fence_generation,
@@ -5104,7 +5928,10 @@ impl<P: ObjectPlane> Repository<P> {
                 .await
             {
                 Ok(binding) => Some(binding),
-                Err(error) => return Err(error),
+                Err(error) => match self.reconcile_native_delete(&path).await? {
+                    Some(binding) => Some(binding),
+                    None => return Err(error),
+                },
             }
         } else {
             None
@@ -5431,15 +6258,22 @@ impl<P: ObjectPlane> Repository<P> {
             let path = ObjectPath::new(std::str::from_utf8(key).map_err(|_| {
                 Error::new(ErrorCode::InvalidKey, "logical key is not valid UTF-8")
             })?)?;
-            let binding = self
+            let binding = match self
                 .plane
                 .delete_native(crate::NativeDelete {
-                    path,
+                    path: path.clone(),
                     repository: self.format.repository_id,
                     operation,
                     writer_fence_generation,
                 })
-                .await?;
+                .await
+            {
+                Ok(binding) => binding,
+                Err(error) => match self.reconcile_native_delete(&path).await? {
+                    Some(binding) => binding,
+                    None => return Err(error),
+                },
+            };
             let body = ObjectVersionBodyV1 {
                 order: ObjectVersionOrder {
                     commit_generation: generation,
@@ -5672,7 +6506,7 @@ impl<P: ObjectPlane> Repository<P> {
                 .copy_native(crate::NativeCopy {
                     source: source_path,
                     source_version_id: version_id,
-                    destination: destination_path,
+                    destination: destination_path.clone(),
                     headers: headers.clone(),
                     user_metadata: user_metadata.clone(),
                     repository: self.format.repository_id,
@@ -5686,7 +6520,13 @@ impl<P: ObjectPlane> Repository<P> {
                 .await
             {
                 Ok(result) => Some(result.binding),
-                Err(error) => return Err(error),
+                Err(error) => match self
+                    .reconcile_native_payload(&destination_path, operation, checksum_sha256)
+                    .await?
+                {
+                    Some(result) => Some(result.binding),
+                    None => return Err(error),
+                },
             }
         } else {
             None
@@ -7213,14 +8053,24 @@ impl<P: ObjectPlane> Repository<P> {
                                         )
                                     })?,
                                 )?;
-                                self.plane
+                                match self
+                                    .plane
                                     .delete_native(crate::NativeDelete {
-                                        path,
+                                        path: path.clone(),
                                         repository: self.format.repository_id,
                                         operation,
                                         writer_fence_generation,
                                     })
-                                    .await?
+                                    .await
+                                {
+                                    Ok(binding) => binding,
+                                    Err(error) => {
+                                        match self.reconcile_native_delete(&path).await? {
+                                            Some(binding) => binding,
+                                            None => return Err(error),
+                                        }
+                                    }
+                                }
                             }
                         };
                         ObjectVersionV1::derive_native(
@@ -7464,14 +8314,24 @@ impl<P: ObjectPlane> Repository<P> {
                                         )
                                     })?)?;
                                 Some(
-                                    self.plane
+                                    match self
+                                        .plane
                                         .delete_native(crate::NativeDelete {
-                                            path,
+                                            path: path.clone(),
                                             repository: self.format.repository_id,
                                             operation,
                                             writer_fence_generation,
                                         })
-                                        .await?,
+                                        .await
+                                    {
+                                        Ok(binding) => binding,
+                                        Err(error) => {
+                                            match self.reconcile_native_delete(&path).await? {
+                                                Some(binding) => binding,
+                                                None => return Err(error),
+                                            }
+                                        }
+                                    },
                                 )
                             }
                         }
@@ -7863,6 +8723,49 @@ impl<P: ObjectPlane> Repository<P> {
         source_branch: &str,
     ) -> Result<RepairReport> {
         self.validate_sync_identity(source)?;
+        if self.storage_profile() == RepositoryStorageProfile::NativeVersionedV1 {
+            let current = self.head(source_branch).await?;
+            if let Ok(fsck) = self.fsck_commit(current).await {
+                return Ok(RepairReport {
+                    sync: SyncReport {
+                        source_head: Some(current),
+                        already_present: 1,
+                        ..SyncReport::default()
+                    },
+                    fsck,
+                });
+            }
+            let _publication = self.native_publication.lock().await;
+            let source_head = source.head(source_branch).await?;
+            let (mapped, mut sync) = source
+                .replay_native_history_to(self, &[source_head], true)
+                .await?;
+            let repaired_head = *mapped.get(&source_head).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::MissingClosure,
+                    "native repair did not return a mapped head",
+                )
+            })?;
+            let loaded = self.load_ref(source_branch).await?;
+            if loaded.value.target != current {
+                return Err(Error::new(
+                    ErrorCode::PreconditionFailed,
+                    "destination branch moved during native repair",
+                ));
+            }
+            let movement = self
+                .move_ref_inner(
+                    source_branch,
+                    loaded,
+                    repaired_head,
+                    "repair native bindings from qualified source",
+                )
+                .await?;
+            sync.source_head = Some(repaired_head);
+            sync.ref_move = Some(movement);
+            let fsck = self.fsck_commit(repaired_head).await?;
+            return Ok(RepairReport { sync, fsck });
+        }
         let head = source.head(source_branch).await?;
         let mut sync = source
             .copy_commit_closure_to(self.plane.clone(), &self.options.repository_prefix, head)
@@ -8132,6 +9035,48 @@ impl<P: ObjectPlane> Repository<P> {
             )
             .retry(RetryAdvice::ReconcileOperation)
             .operation(operation.to_string())),
+        }
+    }
+
+    async fn reconcile_native_delete(
+        &self,
+        path: &ObjectPath,
+    ) -> Result<Option<crate::NativeObjectBindingV1>> {
+        let mut continuation = None;
+        let mut matches = Vec::new();
+        loop {
+            let page = self
+                .plane
+                .list(ListRequest {
+                    prefix: path.as_str().to_string(),
+                    continuation,
+                    limit: 1_000,
+                    include_versions: true,
+                })
+                .await?;
+            for entry in page.entries {
+                if entry.path != *path || !entry.metadata.delete_marker || !entry.is_latest {
+                    continue;
+                }
+                if let Some(version_id) = entry.metadata.token.version_id {
+                    matches.push(version_id);
+                }
+            }
+            continuation = page.continuation;
+            if continuation.is_none() {
+                break;
+            }
+        }
+        match matches.as_slice() {
+            [] => Ok(None),
+            [version_id] => Ok(Some(crate::NativeObjectBindingV1::DeleteMarker {
+                version_id: version_id.clone(),
+            })),
+            _ => Err(Error::new(
+                ErrorCode::OutcomeUnknown,
+                "native delete reconciliation found multiple current delete markers",
+            )
+            .retry(RetryAdvice::ReconcileOperation)),
         }
     }
 

--- a/extensions/s3/core/src/store.rs
+++ b/extensions/s3/core/src/store.rs
@@ -1,17 +1,38 @@
-use std::sync::Arc;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::{Arc, RwLock},
+};
 
-use prolly::{AsyncStore, BatchOp};
+use prolly::{AsyncStore, BatchOp, Cid};
 
 use crate::{
-    codec::sha256, DeleteOutcome, Error, ErrorCode, GetRequest, ImmutablePut, ObjectPath,
-    ObjectPlane, PhysicalVersion, Result,
+    codec::sha256, DeleteOutcome, Error, ErrorCode, GetRequest, ImmutablePut, ListRequest,
+    NodeIndexEntryV1, NodePackAttachmentKindV1, NodePackAttachmentV1, NodePackEntryV1, NodePackId,
+    NodePackRefV1, NodePackV1, ObjectPath, ObjectPlane, PhysicalVersion, Result, TreeFormatDigest,
 };
+
+#[derive(Clone)]
+struct PackedNodeLocation {
+    pack: NodePackId,
+    absolute_offset: u64,
+    len: u32,
+    sha256: [u8; 32],
+}
+
+#[derive(Default)]
+struct PackedNodeState {
+    pending: RwLock<BTreeMap<Cid, Vec<u8>>>,
+    locations: RwLock<BTreeMap<Cid, PackedNodeLocation>>,
+    packs: RwLock<BTreeMap<NodePackId, Arc<NodePackV1>>>,
+    indexed_packs: RwLock<BTreeSet<NodePackId>>,
+}
 
 /// Prolly node store backed by immutable objects in an [`ObjectPlane`].
 pub struct ProllyObjectStore<P> {
     plane: Arc<P>,
     repository_prefix: String,
     protection: Option<Arc<dyn crate::ProtectionSink>>,
+    packed: Option<Arc<PackedNodeState>>,
 }
 
 impl<P> Clone for ProllyObjectStore<P> {
@@ -20,6 +41,7 @@ impl<P> Clone for ProllyObjectStore<P> {
             plane: self.plane.clone(),
             repository_prefix: self.repository_prefix.clone(),
             protection: self.protection.clone(),
+            packed: self.packed.clone(),
         }
     }
 }
@@ -30,6 +52,16 @@ impl<P> ProllyObjectStore<P> {
             plane,
             repository_prefix: repository_prefix.into(),
             protection: None,
+            packed: None,
+        }
+    }
+
+    pub fn new_packed(plane: Arc<P>, repository_prefix: impl Into<String>) -> Self {
+        Self {
+            plane,
+            repository_prefix: repository_prefix.into(),
+            protection: None,
+            packed: Some(Arc::new(PackedNodeState::default())),
         }
     }
 
@@ -54,12 +86,400 @@ impl<P> ProllyObjectStore<P> {
             encoded
         ))
     }
+
+    fn node_pack_path(&self, id: NodePackId) -> Result<ObjectPath> {
+        let encoded = hex::encode(id.as_bytes());
+        ObjectPath::new(format!(
+            "{}/node-packs/sha256/{}/{}/{}.pack",
+            self.repository_prefix,
+            &encoded[..2],
+            &encoded[2..4],
+            encoded
+        ))
+    }
+}
+
+impl<P: ObjectPlane> ProllyObjectStore<P> {
+    pub fn is_packed(&self) -> bool {
+        self.packed.is_some()
+    }
+
+    pub fn export_node_index(&self) -> Result<Vec<NodeIndexEntryV1>> {
+        let Some(state) = &self.packed else {
+            return Ok(Vec::new());
+        };
+        let locations = state
+            .locations
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?;
+        Ok(locations
+            .iter()
+            .map(|(cid, location)| NodeIndexEntryV1 {
+                cid: cid.clone(),
+                pack: location.pack,
+                absolute_offset: location.absolute_offset,
+                len: location.len,
+                sha256: location.sha256,
+            })
+            .collect())
+    }
+
+    pub fn import_node_index(&self, entries: &[NodeIndexEntryV1]) -> Result<()> {
+        let Some(state) = &self.packed else {
+            if entries.is_empty() {
+                return Ok(());
+            }
+            return Err(Error::new(
+                ErrorCode::InternalInvariant,
+                "cannot import a packed-node index into the direct node store",
+            ));
+        };
+        let mut locations = state
+            .locations
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?;
+        for entry in entries {
+            if entry.len == 0 || entry.cid.as_bytes() != entry.sha256 {
+                return Err(Error::new(
+                    ErrorCode::CorruptNode,
+                    "node-index checkpoint entry is invalid",
+                ));
+            }
+            locations.insert(
+                entry.cid.clone(),
+                PackedNodeLocation {
+                    pack: entry.pack,
+                    absolute_offset: entry.absolute_offset,
+                    len: entry.len,
+                    sha256: entry.sha256,
+                },
+            );
+        }
+        Ok(())
+    }
+
+    pub async fn rebuild_node_index(&self) -> Result<()> {
+        if self.packed.is_some() {
+            self.scan_node_packs().await?;
+        }
+        Ok(())
+    }
+
+    pub async fn flush_node_pack(
+        &self,
+        format_digest: TreeFormatDigest,
+        attachments: Vec<(NodePackAttachmentKindV1, Vec<u8>)>,
+    ) -> Result<Option<NodePackRefV1>> {
+        let Some(state) = &self.packed else {
+            return Ok(None);
+        };
+        let pending = state
+            .pending
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?
+            .clone();
+        if pending.is_empty() && attachments.is_empty() {
+            return Ok(None);
+        }
+        let mut payload = Vec::new();
+        let mut entries = Vec::with_capacity(pending.len());
+        for (cid, bytes) in &pending {
+            let offset = payload.len() as u64;
+            payload.extend_from_slice(bytes);
+            entries.push(NodePackEntryV1 {
+                cid: cid.clone(),
+                offset,
+                len: u32::try_from(bytes.len()).map_err(|_| {
+                    Error::new(ErrorCode::InvalidLimit, "packed node exceeds u32 length")
+                })?,
+                sha256: sha256(bytes),
+            });
+        }
+        let mut packed_attachments = Vec::with_capacity(attachments.len());
+        for (kind, bytes) in attachments {
+            let offset = payload.len() as u64;
+            payload.extend_from_slice(&bytes);
+            packed_attachments.push(NodePackAttachmentV1 {
+                kind,
+                digest: sha256(&bytes),
+                offset,
+                len: u32::try_from(bytes.len()).map_err(|_| {
+                    Error::new(
+                        ErrorCode::InvalidLimit,
+                        "node-pack attachment exceeds u32 length",
+                    )
+                })?,
+            });
+        }
+        let pack = NodePackV1 {
+            format_digest,
+            entries,
+            attachments: packed_attachments,
+            payload,
+        };
+        pack.validate()?;
+        let reference = pack.reference()?;
+        let encoded = pack.encode_object()?;
+        let payload_offset = NodePackV1::object_payload_offset(&encoded[..12])?;
+        self.plane
+            .put_immutable(ImmutablePut {
+                path: self.node_pack_path(reference.id)?,
+                expected_sha256: sha256(&encoded),
+                bytes: encoded,
+            })
+            .await?;
+        {
+            let mut locations = state.locations.write().map_err(|_| {
+                Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned")
+            })?;
+            for entry in &pack.entries {
+                locations.insert(
+                    entry.cid.clone(),
+                    PackedNodeLocation {
+                        pack: reference.id,
+                        absolute_offset: payload_offset + entry.offset,
+                        len: entry.len,
+                        sha256: entry.sha256,
+                    },
+                );
+            }
+        }
+        state
+            .packs
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?
+            .insert(reference.id, Arc::new(pack));
+        state
+            .indexed_packs
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?
+            .insert(reference.id);
+        let mut live_pending = state
+            .pending
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?;
+        for (cid, bytes) in pending {
+            if live_pending.get(&cid) == Some(&bytes) {
+                live_pending.remove(&cid);
+            }
+        }
+        Ok(Some(reference))
+    }
+
+    async fn get_packed(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        if key.len() != 32 {
+            return Err(Error::new(
+                ErrorCode::CorruptNode,
+                format!("Prolly node key has {} bytes, expected 32", key.len()),
+            ));
+        }
+        let cid = Cid(key.try_into().expect("length checked"));
+        let state = self.packed.as_ref().ok_or_else(|| {
+            Error::new(ErrorCode::InternalInvariant, "packed node state is absent")
+        })?;
+        if let Some(bytes) = state
+            .pending
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?
+            .get(&cid)
+            .cloned()
+        {
+            return Ok(Some(bytes));
+        }
+        if let Some(bytes) = self.cached_packed_node(&cid)? {
+            return Ok(Some(bytes));
+        }
+        if let Some(bytes) = self.ranged_packed_node(&cid).await? {
+            return Ok(Some(bytes));
+        }
+        self.scan_node_packs().await?;
+        if let Some(bytes) = self.cached_packed_node(&cid)? {
+            return Ok(Some(bytes));
+        }
+        self.ranged_packed_node(&cid).await
+    }
+
+    fn cached_packed_node(&self, cid: &Cid) -> Result<Option<Vec<u8>>> {
+        let state = self.packed.as_ref().ok_or_else(|| {
+            Error::new(ErrorCode::InternalInvariant, "packed node state is absent")
+        })?;
+        let location = state
+            .locations
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?
+            .get(cid)
+            .cloned();
+        let Some(location) = location else {
+            return Ok(None);
+        };
+        let packs = state
+            .packs
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?;
+        let Some(pack) = packs.get(&location.pack) else {
+            return Ok(None);
+        };
+        Ok(pack.node(cid)?.map(ToOwned::to_owned))
+    }
+
+    async fn ranged_packed_node(&self, cid: &Cid) -> Result<Option<Vec<u8>>> {
+        let state = self.packed.as_ref().ok_or_else(|| {
+            Error::new(ErrorCode::InternalInvariant, "packed node state is absent")
+        })?;
+        let location = state
+            .locations
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?
+            .get(cid)
+            .cloned();
+        let Some(location) = location else {
+            return Ok(None);
+        };
+        if location.len == 0 {
+            return Err(Error::new(
+                ErrorCode::CorruptNode,
+                "packed node has zero length",
+            ));
+        }
+        let end = location
+            .absolute_offset
+            .checked_add(u64::from(location.len) - 1)
+            .ok_or_else(|| Error::new(ErrorCode::CorruptNode, "packed-node range overflow"))?;
+        let object = self
+            .plane
+            .get(GetRequest {
+                path: self.node_pack_path(location.pack)?,
+                range: Some(location.absolute_offset..=end),
+                physical_version: None,
+            })
+            .await?
+            .ok_or_else(|| Error::new(ErrorCode::MissingClosure, "node pack is missing"))?;
+        if object.bytes.len() != location.len as usize
+            || sha256(&object.bytes) != location.sha256
+            || cid.as_bytes() != location.sha256
+        {
+            return Err(Error::new(
+                ErrorCode::CorruptNode,
+                "ranged node-pack read failed CID verification",
+            ));
+        }
+        Ok(Some(object.bytes))
+    }
+
+    async fn scan_node_packs(&self) -> Result<()> {
+        let state = self.packed.as_ref().ok_or_else(|| {
+            Error::new(ErrorCode::InternalInvariant, "packed node state is absent")
+        })?;
+        let prefix = format!("{}/node-packs/sha256/", self.repository_prefix);
+        let mut continuation = None;
+        loop {
+            let page = self
+                .plane
+                .list(ListRequest {
+                    prefix: prefix.clone(),
+                    continuation,
+                    limit: 1_000,
+                    include_versions: false,
+                })
+                .await?;
+            for listed in page.entries {
+                let name = listed.path.as_str().rsplit('/').next().unwrap_or_default();
+                let encoded = name.strip_suffix(".pack").ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::CorruptNode,
+                        "node-pack path has an invalid suffix",
+                    )
+                })?;
+                let raw = hex::decode(encoded).map_err(|_| {
+                    Error::new(ErrorCode::CorruptNode, "node-pack path has an invalid ID")
+                })?;
+                let id = NodePackId::from_hash(raw.try_into().map_err(|_| {
+                    Error::new(ErrorCode::CorruptNode, "node-pack ID has the wrong length")
+                })?);
+                if state
+                    .indexed_packs
+                    .read()
+                    .map_err(|_| {
+                        Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned")
+                    })?
+                    .contains(&id)
+                {
+                    continue;
+                }
+                let prefix = self
+                    .plane
+                    .get(GetRequest {
+                        path: listed.path.clone(),
+                        range: Some(0..=11),
+                        physical_version: None,
+                    })
+                    .await?
+                    .ok_or_else(|| {
+                        Error::new(ErrorCode::MissingClosure, "listed node pack disappeared")
+                    })?;
+                let payload_offset = NodePackV1::object_payload_offset(&prefix.bytes)?;
+                if payload_offset < 13 || payload_offset > listed.metadata.len {
+                    return Err(Error::new(
+                        ErrorCode::CorruptNode,
+                        "node-pack table-of-contents offset is invalid",
+                    ));
+                }
+                let header = self
+                    .plane
+                    .get(GetRequest {
+                        path: listed.path,
+                        range: Some(12..=payload_offset - 1),
+                        physical_version: None,
+                    })
+                    .await?
+                    .ok_or_else(|| {
+                        Error::new(ErrorCode::MissingClosure, "listed node pack disappeared")
+                    })?;
+                let toc = NodePackV1::decode_toc(&header.bytes)?;
+                if payload_offset + toc.payload_len != listed.metadata.len {
+                    return Err(Error::new(
+                        ErrorCode::CorruptNode,
+                        "node-pack object length disagrees with its table of contents",
+                    ));
+                }
+                {
+                    let mut locations = state.locations.write().map_err(|_| {
+                        Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned")
+                    })?;
+                    for entry in &toc.entries {
+                        locations
+                            .entry(entry.cid.clone())
+                            .or_insert_with(|| PackedNodeLocation {
+                                pack: id,
+                                absolute_offset: payload_offset + entry.offset,
+                                len: entry.len,
+                                sha256: entry.sha256,
+                            });
+                    }
+                }
+                state
+                    .indexed_packs
+                    .write()
+                    .map_err(|_| {
+                        Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned")
+                    })?
+                    .insert(id);
+            }
+            continuation = page.continuation;
+            if continuation.is_none() {
+                return Ok(());
+            }
+        }
+    }
 }
 
 impl<P: ObjectPlane> AsyncStore for ProllyObjectStore<P> {
     type Error = Error;
 
     async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        if self.packed.is_some() {
+            return self.get_packed(key).await;
+        }
         let path = self.path_for_key(key)?;
         let Some(object) = self
             .plane
@@ -88,6 +508,14 @@ impl<P: ObjectPlane> AsyncStore for ProllyObjectStore<P> {
                 "attempted Prolly node write under the wrong CID",
             ));
         }
+        if let Some(state) = &self.packed {
+            state
+                .pending
+                .write()
+                .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?
+                .insert(Cid(key.try_into().expect("length checked")), value.to_vec());
+            return Ok(());
+        }
         let path = self.path_for_key(key)?;
         self.plane
             .put_immutable(ImmutablePut {
@@ -103,6 +531,20 @@ impl<P: ObjectPlane> AsyncStore for ProllyObjectStore<P> {
     }
 
     async fn delete(&self, key: &[u8]) -> Result<()> {
+        if let Some(state) = &self.packed {
+            if key.len() != 32 {
+                return Err(Error::new(
+                    ErrorCode::CorruptNode,
+                    format!("Prolly node key has {} bytes, expected 32", key.len()),
+                ));
+            }
+            state
+                .pending
+                .write()
+                .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?
+                .remove(&Cid(key.try_into().expect("length checked")));
+            return Ok(());
+        }
         let path = self.path_for_key(key)?;
         let Some(metadata) = self.plane.head(&path).await? else {
             return Ok(());

--- a/extensions/s3/core/tests/canonical_fixtures.rs
+++ b/extensions/s3/core/tests/canonical_fixtures.rs
@@ -43,8 +43,8 @@ fn canonical_v1_fixture_is_stable() {
         state_tree_format: TreeFormat::default(),
         content_index_format: TreeFormat::default(),
         canonical_limits: CanonicalLimits::default(),
-        min_reader_version: RepositoryFormatV1::CURRENT_READER_VERSION,
-        min_writer_version: RepositoryFormatV1::CURRENT_WRITER_VERSION,
+        min_reader_version: RepositoryFormatV1::DISTRIBUTED_PROTOCOL_VERSION,
+        min_writer_version: RepositoryFormatV1::DISTRIBUTED_PROTOCOL_VERSION,
         created_at_millis,
         required_capability_profile: RepositoryFormatV1::DISTRIBUTED_S3_CAPABILITY_PROFILE,
     };
@@ -68,6 +68,7 @@ fn canonical_v1_fixture_is_stable() {
         message: Some("initialize versioned S3 repository".to_string()),
         created_at_millis,
         metadata: BTreeMap::new(),
+        native: None,
     };
     let initial_commit_id = initial_commit.id().unwrap();
     let initial_reflog = ReflogEntryV1 {
@@ -89,6 +90,7 @@ fn canonical_v1_fixture_is_stable() {
         writer: "fixture-writer".to_string(),
         updated_at_millis: created_at_millis,
         tombstone: false,
+        native: None,
     };
     let actual = json!({
         "schema": "prolly-s3-canonical-fixtures/v1",

--- a/extensions/s3/core/tests/native_versioned_profile.rs
+++ b/extensions/s3/core/tests/native_versioned_profile.rs
@@ -1,0 +1,828 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use prolly::{Cid, TreeFormat};
+use prolly_s3_core::{
+    tree_format_digest, Checksums, CommitGeneration, ContentRef, ErrorCode,
+    LogicalObjectVersionKindV2, MemoryObjectPlane, MergePolicy, NativeBatchMutationV1,
+    NativeObjectBindingV1, NativePut, NodePackEntryV1, NodePackV1, ObjectHeaders, ObjectPath,
+    ObjectPlane, ObjectVersionBodyV1, ObjectVersionKindV1, ObjectVersionOrder, ObjectVersionV1,
+    OperationId, PhysicalVersion, PhysicalVersioning, ProviderCapabilities, Repository,
+    RepositoryId, RepositoryOptions, RepositoryStorageProfile,
+};
+
+fn native_options(prefix: &str) -> RepositoryOptions {
+    RepositoryOptions {
+        repository_prefix: prefix.to_string(),
+        storage_profile: RepositoryStorageProfile::NativeVersionedV1,
+        writer: "native-writer".to_string(),
+        ..RepositoryOptions::default()
+    }
+}
+
+#[tokio::test]
+async fn unfinished_native_protocols_fail_closed() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        native_options(".prolly/native-versioned/fail-closed"),
+    )
+    .await
+    .unwrap();
+
+    let multipart = repository
+        .create_multipart_upload(
+            "main",
+            b"large.bin".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(multipart.code, ErrorCode::MissingCapability);
+
+    let clone = repository
+        .clone_to(plane, ".prolly/native-versioned/clone")
+        .await
+        .unwrap_err();
+    assert_eq!(clone.code, ErrorCode::MissingCapability);
+}
+
+#[tokio::test]
+async fn two_object_native_batch_is_exactly_five_calls() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        native_options(".prolly/native-versioned/batch-budget"),
+    )
+    .await
+    .unwrap();
+    repository
+        .put_bytes(
+            "main",
+            b"warmup.bin".to_vec(),
+            b"warm".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let batch = repository
+        .begin_native_batch("main", "two objects", 60_000)
+        .await
+        .unwrap();
+    plane.reset_request_counts();
+    let receipt = repository
+        .publish_native_batch(
+            batch,
+            vec![
+                NativeBatchMutationV1::Put {
+                    key: b"batch/a.bin".to_vec(),
+                    bytes: b"a".to_vec(),
+                    headers: ObjectHeaders::default(),
+                    user_metadata: BTreeMap::new(),
+                },
+                NativeBatchMutationV1::Put {
+                    key: b"batch/b.bin".to_vec(),
+                    bytes: b"b".to_vec(),
+                    headers: ObjectHeaders::default(),
+                    user_metadata: BTreeMap::new(),
+                },
+            ],
+        )
+        .await
+        .unwrap();
+    assert_eq!(receipt.changed_keys, 2);
+    let requests = plane.request_snapshot();
+    assert_eq!(requests.native_put, 2);
+    assert_eq!(requests.immutable_put, 2);
+    assert_eq!(requests.compare_exchange, 1);
+    assert_eq!(requests.total(), 5, "unexpected calls: {requests:?}");
+}
+
+#[tokio::test]
+async fn warm_native_merge_reuses_bindings_in_three_calls() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        native_options(".prolly/native-versioned/merge-budget"),
+    )
+    .await
+    .unwrap();
+    let base = repository
+        .put_bytes(
+            "main",
+            b"base.bin".to_vec(),
+            b"base".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    repository.create_branch("feature", base.id).await.unwrap();
+    let feature = repository
+        .put_bytes(
+            "feature",
+            b"feature.bin".to_vec(),
+            b"feature".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    repository
+        .put_bytes(
+            "main",
+            b"main.bin".to_vec(),
+            b"main".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    plane.reset_request_counts();
+    repository
+        .merge(
+            "main",
+            feature.id,
+            Some(base.id),
+            MergePolicy::Fail,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let requests = plane.request_snapshot();
+    assert_eq!(requests.immutable_put, 2);
+    assert_eq!(requests.compare_exchange, 1);
+    assert_eq!(requests.total(), 3, "unexpected calls: {requests:?}");
+    assert_eq!(
+        repository
+            .get_current("main", b"feature.bin")
+            .await
+            .unwrap()
+            .bytes,
+        b"feature"
+    );
+}
+
+#[tokio::test]
+async fn warm_native_restore_reuses_live_binding_in_three_calls() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        native_options(".prolly/native-versioned/restore-budget"),
+    )
+    .await
+    .unwrap();
+    let source = repository
+        .put_bytes(
+            "main",
+            b"restore.bin".to_vec(),
+            b"source".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let current = repository
+        .put_bytes(
+            "main",
+            b"restore.bin".to_vec(),
+            b"newer".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    plane.reset_request_counts();
+    repository
+        .restore("main", source.id, current.id, None, None)
+        .await
+        .unwrap();
+    let requests = plane.request_snapshot();
+    assert_eq!(requests.immutable_put, 2);
+    assert_eq!(requests.compare_exchange, 1);
+    assert_eq!(requests.total(), 3, "unexpected calls: {requests:?}");
+    assert_eq!(
+        repository
+            .get_current("main", b"restore.bin")
+            .await
+            .unwrap()
+            .bytes,
+        b"source"
+    );
+}
+
+#[tokio::test]
+async fn lost_native_payload_response_is_reconciled_without_duplicate_upload() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        native_options(".prolly/native-versioned/lost-payload"),
+    )
+    .await
+    .unwrap();
+    plane.lose_next_native_put_response();
+    repository
+        .put_bytes(
+            "main",
+            b"lost.bin".to_vec(),
+            b"accepted-before-timeout".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        repository
+            .get_current("main", b"lost.bin")
+            .await
+            .unwrap()
+            .bytes,
+        b"accepted-before-timeout"
+    );
+    let versions = plane
+        .list(prolly_s3_core::ListRequest {
+            prefix: "lost.bin".to_string(),
+            continuation: None,
+            limit: 100,
+            include_versions: true,
+        })
+        .await
+        .unwrap();
+    assert_eq!(versions.entries.len(), 1);
+}
+
+#[tokio::test]
+async fn native_idempotent_replay_does_not_upload_again() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        native_options(".prolly/native-versioned/idempotency"),
+    )
+    .await
+    .unwrap();
+    let operation = OperationId::new();
+    let first = repository
+        .put_bytes(
+            "main",
+            b"idempotent.bin".to_vec(),
+            b"once".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            Some(operation),
+        )
+        .await
+        .unwrap();
+    plane.reset_request_counts();
+    let replay = repository
+        .put_bytes(
+            "main",
+            b"idempotent.bin".to_vec(),
+            b"once".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            Some(operation),
+        )
+        .await
+        .unwrap();
+    assert_eq!(replay.id, first.id);
+    assert!(replay.idempotent_replay);
+    assert_eq!(plane.request_snapshot().total(), 0);
+}
+
+fn native_live_body(bytes: &[u8]) -> ObjectVersionBodyV1 {
+    let sha256 = Cid::from_bytes(bytes).0;
+    ObjectVersionBodyV1 {
+        order: ObjectVersionOrder {
+            commit_generation: CommitGeneration(1),
+            mutation_ordinal: 0,
+        },
+        created_at_millis: 7,
+        kind: ObjectVersionKindV1::Live {
+            content: ContentRef::Empty,
+            size: bytes.len() as u64,
+            logical_etag: "\"logical\"".to_string(),
+            headers: ObjectHeaders::default(),
+            checksums: Checksums {
+                md5: None,
+                sha256: Some(sha256),
+                algorithm_values: BTreeMap::new(),
+            },
+            user_metadata: BTreeMap::new(),
+            tags: BTreeMap::new(),
+        },
+    }
+}
+
+#[test]
+fn native_object_identity_excludes_provider_binding() {
+    let bytes = b"whole object";
+    let repository = RepositoryId::from_hash([3; 32]);
+    let operation = OperationId::new();
+    let body = native_live_body(bytes);
+    let checksum_sha256 = Cid::from_bytes(bytes).0;
+    let first = ObjectVersionV1::derive_native(
+        repository,
+        b"asset.bin",
+        operation,
+        body.clone(),
+        NativeObjectBindingV1::Live {
+            version_id: "version-a".to_string(),
+            provider_etag: "etag-a".to_string(),
+            checksum_sha256,
+        },
+    )
+    .unwrap();
+    let second = ObjectVersionV1::derive_native(
+        repository,
+        b"asset.bin",
+        operation,
+        body,
+        NativeObjectBindingV1::Live {
+            version_id: "version-b".to_string(),
+            provider_etag: "etag-b".to_string(),
+            checksum_sha256,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(first.id, second.id);
+    assert_ne!(first.native_binding, second.native_binding);
+    first.validate_native().unwrap();
+    second.validate_native().unwrap();
+}
+
+#[test]
+fn native_binding_rejects_kind_and_checksum_mismatch() {
+    let error = ObjectVersionV1::derive_native(
+        RepositoryId::from_hash([4; 32]),
+        b"asset.bin",
+        OperationId::new(),
+        native_live_body(b"expected"),
+        NativeObjectBindingV1::DeleteMarker {
+            version_id: "delete-version".to_string(),
+        },
+    )
+    .err()
+    .unwrap();
+    assert_eq!(error.code, ErrorCode::CorruptCommit);
+
+    let logical = LogicalObjectVersionKindV2::DeleteMarker;
+    assert!(matches!(logical, LogicalObjectVersionKindV2::DeleteMarker));
+}
+
+#[test]
+fn node_pack_verifies_cids_ranges_and_corruption() {
+    let first_bytes = b"node-a".to_vec();
+    let second_bytes = b"node-b".to_vec();
+    let first = Cid::from_bytes(&first_bytes);
+    let second = Cid::from_bytes(&second_bytes);
+    let mut nodes = [(first.clone(), first_bytes), (second, second_bytes)];
+    nodes.sort_by_key(|(cid, _)| cid.clone());
+    let mut payload = Vec::new();
+    let mut entries = Vec::new();
+    for (cid, bytes) in nodes {
+        let offset = payload.len() as u64;
+        payload.extend_from_slice(&bytes);
+        let checksum = cid.0;
+        entries.push(NodePackEntryV1 {
+            cid,
+            offset,
+            len: bytes.len() as u32,
+            sha256: checksum,
+        });
+    }
+    let pack = NodePackV1 {
+        format_digest: tree_format_digest(&TreeFormat::default()).unwrap(),
+        entries,
+        attachments: Vec::new(),
+        payload,
+    };
+    pack.validate().unwrap();
+    assert_eq!(pack.node(&first).unwrap().unwrap(), b"node-a");
+    assert_eq!(pack.reference().unwrap().node_count, 2);
+
+    let mut corrupt = pack;
+    corrupt.payload[0] ^= 1;
+    assert_eq!(corrupt.validate().unwrap_err().code, ErrorCode::CorruptNode);
+}
+
+#[test]
+fn provider_native_profile_requires_enabled_versioning() {
+    let mut capabilities = ProviderCapabilities {
+        conditional_create: true,
+        conditional_update: true,
+        strong_get_after_put: true,
+        strong_list_after_put: true,
+        strong_list_after_delete: true,
+        ranged_get: true,
+        paged_list: true,
+        list_physical_versions: true,
+        exact_version_delete: true,
+        physical_versioning: PhysicalVersioning::Suspended,
+        conflicting_lifecycle_rule: false,
+        default_object_lock_retention: false,
+        max_object_bytes: 5 * 1024 * 1024,
+        max_single_put_bytes: 5 * 1024 * 1024,
+    };
+    assert_eq!(
+        capabilities.validate_native_versioned().unwrap_err().code,
+        ErrorCode::ProviderNotQualified
+    );
+    capabilities.physical_versioning = PhysicalVersioning::Enabled;
+    capabilities.validate_native_versioned().unwrap();
+}
+
+#[tokio::test]
+async fn native_repository_round_trips_exact_physical_versions() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let options = native_options(".prolly/native-versioned/test");
+    let repository = Repository::initialize(plane.clone(), options.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        repository.storage_profile(),
+        RepositoryStorageProfile::NativeVersionedV1
+    );
+
+    let first = repository
+        .put_bytes(
+            "main",
+            b"notes/file.txt".to_vec(),
+            b"first".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let first_version = first.object_versions[0];
+    repository
+        .put_bytes(
+            "main",
+            b"notes/file.txt".to_vec(),
+            b"second".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        repository
+            .get_version("main", b"notes/file.txt", first_version)
+            .await
+            .unwrap()
+            .bytes,
+        b"first"
+    );
+    assert_eq!(
+        repository
+            .get_current("main", b"notes/file.txt")
+            .await
+            .unwrap()
+            .bytes,
+        b"second"
+    );
+
+    repository
+        .copy_object(
+            "main",
+            b"notes/file.txt",
+            Some(first_version),
+            b"notes/copied.txt".to_vec(),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        repository
+            .get_current("main", b"notes/copied.txt")
+            .await
+            .unwrap()
+            .bytes,
+        b"first"
+    );
+
+    let deleted = repository
+        .delete_object("main", b"notes/file.txt".to_vec(), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        repository
+            .get_current("main", b"notes/file.txt")
+            .await
+            .unwrap_err()
+            .code,
+        ErrorCode::NoSuchKey
+    );
+    let marker = repository
+        .head_version("main", b"notes/file.txt", deleted.object_versions[0])
+        .await
+        .unwrap()
+        .1;
+    assert!(matches!(
+        marker.version.native_binding,
+        Some(NativeObjectBindingV1::DeleteMarker { .. })
+    ));
+
+    let reserved = repository
+        .put_bytes(
+            "main",
+            b".prolly/native-versioned/test/internal".to_vec(),
+            vec![1],
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(reserved.code, ErrorCode::InvalidKey);
+
+    let mismatch = Repository::open(
+        plane,
+        RepositoryOptions {
+            repository_prefix: options.repository_prefix,
+            ..RepositoryOptions::default()
+        },
+    )
+    .await
+    .err()
+    .unwrap();
+    assert_eq!(mismatch.code, ErrorCode::RepositoryFormatConflict);
+}
+
+#[tokio::test]
+async fn warm_native_put_is_exactly_four_foreground_calls() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        native_options(".prolly/native-versioned/call-budget"),
+    )
+    .await
+    .unwrap();
+    repository
+        .put_bytes(
+            "main",
+            b"warmup.bin".to_vec(),
+            vec![1; 64 * 1024],
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    plane.reset_request_counts();
+    repository
+        .put_bytes(
+            "main",
+            b"measured.bin".to_vec(),
+            vec![2; 64 * 1024],
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let requests = plane.request_snapshot();
+    assert_eq!(requests.native_put, 1);
+    assert_eq!(requests.immutable_put, 2);
+    assert_eq!(requests.compare_exchange, 1);
+    assert_eq!(requests.total(), 4, "unexpected calls: {requests:?}");
+}
+
+#[tokio::test]
+async fn native_writer_queue_preserves_four_calls_at_1_8_and_32_callers() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        native_options(".prolly/native-versioned/concurrent-budget"),
+    )
+    .await
+    .unwrap();
+    repository
+        .put_bytes(
+            "main",
+            b"warmup.bin".to_vec(),
+            vec![0; 64 * 1024],
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    for writers in [1usize, 8, 32] {
+        plane.reset_request_counts();
+        let writes = (0..writers).map(|index| {
+            repository.put_bytes(
+                "main",
+                format!("tier-{writers}/object-{index}.bin").into_bytes(),
+                vec![index as u8; 64 * 1024],
+                ObjectHeaders::default(),
+                BTreeMap::new(),
+                None,
+            )
+        });
+        for result in futures_util::future::join_all(writes).await {
+            result.unwrap();
+        }
+        let requests = plane.request_snapshot();
+        assert_eq!(
+            requests.total(),
+            (writers * 4) as u64,
+            "{writers}-writer tier made unexpected calls: {requests:?}"
+        );
+        assert_eq!(requests.native_put, writers as u64);
+        assert_eq!(requests.immutable_put, (writers * 2) as u64);
+        assert_eq!(requests.compare_exchange, writers as u64);
+    }
+}
+
+#[tokio::test]
+async fn native_gc_deletes_only_unreachable_exact_versions() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository =
+        Repository::initialize(plane.clone(), native_options(".prolly/native-versioned/gc"))
+            .await
+            .unwrap();
+    repository
+        .put_bytes(
+            "main",
+            b"retained.bin".to_vec(),
+            b"retained".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let orphan = plane
+        .put_native(NativePut {
+            path: ObjectPath::new("orphan.bin").unwrap(),
+            bytes: b"orphan".to_vec(),
+            headers: ObjectHeaders::default(),
+            user_metadata: BTreeMap::new(),
+            repository: repository.repository_id(),
+            operation: OperationId::new(),
+            writer_fence_generation: 1,
+        })
+        .await
+        .unwrap();
+    let NativeObjectBindingV1::Live { version_id, .. } = orphan.binding else {
+        unreachable!()
+    };
+
+    let plan = repository.plan_gc(120_000, 10).await.unwrap();
+    assert_eq!(plan.plan.body.candidates.len(), 1);
+    assert_eq!(plan.plan.body.candidates[0].path.as_str(), "orphan.bin");
+    repository.sweep_gc(plan.plan.id).await.unwrap();
+    assert!(plane
+        .get(prolly_s3_core::GetRequest {
+            path: ObjectPath::new("orphan.bin").unwrap(),
+            range: None,
+            physical_version: Some(PhysicalVersion::Versioned { version_id }),
+        })
+        .await
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        repository
+            .get_current("main", b"retained.bin")
+            .await
+            .unwrap()
+            .bytes,
+        b"retained"
+    );
+}
+
+#[tokio::test]
+async fn checkpointed_reopen_uses_ranged_nodes_without_pack_listing() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let options = native_options(".prolly/native-versioned/checkpoint");
+    let repository = Repository::initialize(plane.clone(), options.clone())
+        .await
+        .unwrap();
+    for index in 0..8 {
+        repository
+            .put_bytes(
+                "main",
+                format!("objects/{index}.bin").into_bytes(),
+                vec![index; 4096],
+                ObjectHeaders::default(),
+                BTreeMap::new(),
+                None,
+            )
+            .await
+            .unwrap();
+    }
+    let checkpoint = repository
+        .create_node_index_checkpoint("main")
+        .await
+        .unwrap();
+    assert!(!checkpoint.entries.is_empty());
+
+    let reopened = Repository::open(
+        plane.clone(),
+        RepositoryOptions {
+            read_only: true,
+            ..options
+        },
+    )
+    .await
+    .unwrap();
+    plane.reset_request_counts();
+    assert_eq!(
+        reopened
+            .get_current("main", b"objects/7.bin")
+            .await
+            .unwrap()
+            .bytes,
+        vec![7; 4096]
+    );
+    let requests = plane.request_snapshot();
+    assert_eq!(
+        requests.list, 0,
+        "point read rebuilt by listing: {requests:?}"
+    );
+    assert!(requests.get >= 4, "cold read accounting was incomplete");
+}
+
+#[tokio::test]
+async fn explicit_takeover_barrier_fences_the_old_writer() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let options = native_options(".prolly/native-versioned/takeover");
+    let old_writer = Repository::initialize(plane.clone(), options.clone())
+        .await
+        .unwrap();
+    old_writer
+        .put_bytes(
+            "main",
+            b"before.bin".to_vec(),
+            b"before".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let mut new_writer = Repository::open(
+        plane,
+        RepositoryOptions {
+            writer: "replacement-writer".to_string(),
+            read_only: true,
+            ..options
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        new_writer
+            .takeover_native_writer(
+                "native-writer",
+                1,
+                "old credentials revoked and process stopped",
+            )
+            .await
+            .unwrap(),
+        2
+    );
+    new_writer
+        .put_bytes(
+            "main",
+            b"after.bin".to_vec(),
+            b"after".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let stale = old_writer
+        .put_bytes(
+            "main",
+            b"stale.bin".to_vec(),
+            b"stale".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(stale.code, ErrorCode::PreconditionFailed);
+}

--- a/extensions/s3/core/tests/native_versioned_profile.rs
+++ b/extensions/s3/core/tests/native_versioned_profile.rs
@@ -1,14 +1,16 @@
 use std::{collections::BTreeMap, sync::Arc};
 
+use md5::Md5;
 use prolly::{Cid, TreeFormat};
 use prolly_s3_core::{
     tree_format_digest, Checksums, CommitGeneration, ContentRef, ErrorCode,
     LogicalObjectVersionKindV2, MemoryObjectPlane, MergePolicy, NativeBatchMutationV1,
-    NativeObjectBindingV1, NativePut, NodePackEntryV1, NodePackV1, ObjectHeaders, ObjectPath,
-    ObjectPlane, ObjectVersionBodyV1, ObjectVersionKindV1, ObjectVersionOrder, ObjectVersionV1,
-    OperationId, PhysicalVersion, PhysicalVersioning, ProviderCapabilities, Repository,
-    RepositoryId, RepositoryOptions, RepositoryStorageProfile,
+    NativeMultipartCompletedPart, NativeObjectBindingV1, NativePut, NodePackEntryV1, NodePackV1,
+    ObjectHeaders, ObjectPath, ObjectPlane, ObjectVersionBodyV1, ObjectVersionKindV1,
+    ObjectVersionOrder, ObjectVersionV1, OperationId, PhysicalVersion, PhysicalVersioning,
+    ProviderCapabilities, Repository, RepositoryId, RepositoryOptions, RepositoryStorageProfile,
 };
+use sha2::{Digest as _, Sha256};
 
 fn native_options(prefix: &str) -> RepositoryOptions {
     RepositoryOptions {
@@ -45,6 +47,107 @@ async fn unfinished_native_protocols_fail_closed() {
         .await
         .unwrap_err();
     assert_eq!(clone.code, ErrorCode::MissingCapability);
+}
+
+#[tokio::test]
+async fn native_multipart_uses_n_plus_five_calls_and_replays_without_io() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        native_options(".prolly/native-versioned/multipart-budget"),
+    )
+    .await
+    .unwrap();
+    repository
+        .put_bytes(
+            "main",
+            b"warmup.bin".to_vec(),
+            b"warm".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let first_bytes = vec![7; 5 * 1024 * 1024];
+    let second_bytes = vec![9; 1024];
+    let mut whole = first_bytes.clone();
+    whole.extend_from_slice(&second_bytes);
+    let checksum_sha256: [u8; 32] = Sha256::digest(&whole).into();
+    let checksum_md5: [u8; 16] = Md5::digest(&whole).into();
+
+    plane.reset_request_counts();
+    let session = repository
+        .create_native_multipart_upload(
+            "main",
+            b"multipart.bin".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let first = repository
+        .upload_native_multipart_part(&session, 1, first_bytes)
+        .await
+        .unwrap();
+    let second = repository
+        .upload_native_multipart_part(&session, 2, second_bytes)
+        .await
+        .unwrap();
+    let parts = [&first, &second]
+        .into_iter()
+        .map(|part| NativeMultipartCompletedPart {
+            part_number: part.part_number,
+            etag: part.etag.clone(),
+            checksum_sha256: part.checksum_sha256.unwrap(),
+            size: part.size,
+        })
+        .collect::<Vec<_>>();
+    let receipt = repository
+        .complete_native_multipart_upload(
+            session.clone(),
+            parts.clone(),
+            checksum_sha256,
+            checksum_md5,
+            whole.len() as u64,
+            Some(session.operation),
+        )
+        .await
+        .unwrap();
+    assert_eq!(receipt.changed_keys, 1);
+    let requests = plane.request_snapshot();
+    assert_eq!(requests.native_multipart_create, 1);
+    assert_eq!(requests.native_multipart_upload_part, 2);
+    assert_eq!(requests.native_multipart_complete, 1);
+    assert_eq!(requests.immutable_put, 2);
+    assert_eq!(requests.compare_exchange, 1);
+    assert_eq!(requests.total(), 7, "unexpected calls: {requests:?}");
+    assert_eq!(
+        repository
+            .get_current("main", b"multipart.bin")
+            .await
+            .unwrap()
+            .bytes,
+        whole
+    );
+
+    plane.reset_request_counts();
+    let replay = repository
+        .complete_native_multipart_upload(
+            session.clone(),
+            parts,
+            checksum_sha256,
+            checksum_md5,
+            first.size + second.size,
+            Some(session.operation),
+        )
+        .await
+        .unwrap();
+    assert_eq!(replay.id, receipt.id);
+    assert!(replay.idempotent_replay);
+    assert_eq!(plane.request_snapshot().total(), 0);
 }
 
 #[tokio::test]

--- a/extensions/s3/core/tests/native_versioned_profile.rs
+++ b/extensions/s3/core/tests/native_versioned_profile.rs
@@ -22,7 +22,7 @@ fn native_options(prefix: &str) -> RepositoryOptions {
 }
 
 #[tokio::test]
-async fn unfinished_native_protocols_fail_closed() {
+async fn legacy_native_multipart_protocol_fails_closed() {
     let plane = Arc::new(MemoryObjectPlane::new(true));
     let repository = Repository::initialize(
         plane.clone(),
@@ -41,12 +41,319 @@ async fn unfinished_native_protocols_fail_closed() {
         .await
         .unwrap_err();
     assert_eq!(multipart.code, ErrorCode::MissingCapability);
+}
 
-    let clone = repository
-        .clone_to(plane, ".prolly/native-versioned/clone")
+#[tokio::test]
+async fn native_clone_replays_history_and_rebinds_physical_versions() {
+    let source_plane = Arc::new(MemoryObjectPlane::new(true));
+    let source = Repository::initialize(
+        source_plane,
+        native_options(".prolly/native-versioned/clone-source"),
+    )
+    .await
+    .unwrap();
+    let first = source
+        .put_bytes(
+            "main",
+            b"history.txt".to_vec(),
+            b"first".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
         .await
-        .unwrap_err();
-    assert_eq!(clone.code, ErrorCode::MissingCapability);
+        .unwrap();
+    source
+        .put_bytes(
+            "main",
+            b"history.txt".to_vec(),
+            b"second".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let destination_plane = Arc::new(MemoryObjectPlane::new(true));
+    let report = source
+        .clone_to(
+            destination_plane.clone(),
+            ".prolly/native-versioned/clone-destination",
+        )
+        .await
+        .unwrap();
+    assert!(report.immutable_objects >= 7);
+    assert_eq!(report.refs, 1);
+    let resumed = source
+        .clone_to(
+            destination_plane.clone(),
+            ".prolly/native-versioned/clone-destination",
+        )
+        .await
+        .unwrap();
+    assert_eq!(resumed.immutable_objects, 0);
+    assert_eq!(resumed.immutable_bytes, 0);
+    assert_eq!(resumed.refs, 1);
+
+    let destination = Repository::open(
+        destination_plane,
+        native_options(".prolly/native-versioned/clone-destination"),
+    )
+    .await
+    .unwrap();
+    assert_eq!(destination.repository_id(), source.repository_id());
+    assert_eq!(
+        destination
+            .get_current("main", b"history.txt")
+            .await
+            .unwrap()
+            .bytes,
+        b"second"
+    );
+    assert_eq!(
+        destination
+            .get_version("main", b"history.txt", first.object_versions[0])
+            .await
+            .unwrap()
+            .bytes,
+        b"first"
+    );
+    let source_version = source
+        .head_version("main", b"history.txt", first.object_versions[0])
+        .await
+        .unwrap()
+        .1
+        .version;
+    let destination_version = destination
+        .head_version("main", b"history.txt", first.object_versions[0])
+        .await
+        .unwrap()
+        .1
+        .version;
+    assert_eq!(source_version.id, destination_version.id);
+    assert_ne!(
+        source_version.native_binding,
+        destination_version.native_binding
+    );
+}
+
+#[tokio::test]
+async fn native_push_replays_only_new_history_and_moves_destination_ref() {
+    let source_plane = Arc::new(MemoryObjectPlane::new(true));
+    let source = Repository::initialize(
+        source_plane,
+        native_options(".prolly/native-versioned/push-source"),
+    )
+    .await
+    .unwrap();
+    source
+        .put_bytes(
+            "main",
+            b"sync.txt".to_vec(),
+            b"base".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let destination_plane = Arc::new(MemoryObjectPlane::new(true));
+    source
+        .clone_to(
+            destination_plane.clone(),
+            ".prolly/native-versioned/push-destination",
+        )
+        .await
+        .unwrap();
+    let destination = Repository::open(
+        destination_plane,
+        native_options(".prolly/native-versioned/push-destination"),
+    )
+    .await
+    .unwrap();
+    let expected_destination = destination.head("main").await.unwrap();
+    let next = source
+        .put_bytes(
+            "main",
+            b"sync.txt".to_vec(),
+            b"incremental".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let report = source
+        .push_to(
+            &destination,
+            "main",
+            "main",
+            expected_destination,
+            "incremental native push",
+        )
+        .await
+        .unwrap();
+    assert_eq!(report.copied_objects, 3);
+    assert_eq!(report.copied_bytes, b"incremental".len() as u64);
+    assert_eq!(
+        destination
+            .get_current("main", b"sync.txt")
+            .await
+            .unwrap()
+            .bytes,
+        b"incremental"
+    );
+    assert_eq!(
+        destination
+            .head_current("main", b"sync.txt")
+            .await
+            .unwrap()
+            .version
+            .id,
+        next.object_versions[0]
+    );
+}
+
+#[tokio::test]
+async fn native_repair_rebinds_a_missing_destination_payload() {
+    let source_plane = Arc::new(MemoryObjectPlane::new(true));
+    let source = Repository::initialize(
+        source_plane,
+        native_options(".prolly/native-versioned/repair-source"),
+    )
+    .await
+    .unwrap();
+    source
+        .put_bytes(
+            "main",
+            b"repair.txt".to_vec(),
+            b"recoverable".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let destination_plane = Arc::new(MemoryObjectPlane::new(true));
+    source
+        .clone_to(
+            destination_plane.clone(),
+            ".prolly/native-versioned/repair-destination",
+        )
+        .await
+        .unwrap();
+    let destination = Repository::open(
+        destination_plane.clone(),
+        native_options(".prolly/native-versioned/repair-destination"),
+    )
+    .await
+    .unwrap();
+    let damaged = destination
+        .head_current("main", b"repair.txt")
+        .await
+        .unwrap()
+        .version;
+    let NativeObjectBindingV1::Live { version_id, .. } = damaged.native_binding.clone().unwrap()
+    else {
+        panic!("expected live native binding")
+    };
+    destination_plane
+        .delete_exact(
+            &ObjectPath::new("repair.txt").unwrap(),
+            PhysicalVersion::Versioned { version_id },
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        destination
+            .get_current("main", b"repair.txt")
+            .await
+            .unwrap_err()
+            .code,
+        ErrorCode::MissingClosure
+    );
+
+    let repaired = destination
+        .repair_missing_from(&source, "main")
+        .await
+        .unwrap();
+    assert!(repaired.sync.ref_move.is_some());
+    assert_eq!(
+        destination
+            .get_current("main", b"repair.txt")
+            .await
+            .unwrap()
+            .bytes,
+        b"recoverable"
+    );
+}
+
+#[tokio::test]
+async fn native_fetch_returns_a_destination_local_mapped_head() {
+    let source_plane = Arc::new(MemoryObjectPlane::new(true));
+    let source = Repository::initialize(
+        source_plane,
+        native_options(".prolly/native-versioned/fetch-source"),
+    )
+    .await
+    .unwrap();
+    source
+        .put_bytes(
+            "main",
+            b"base.txt".to_vec(),
+            b"base".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let destination_plane = Arc::new(MemoryObjectPlane::new(true));
+    source
+        .clone_to(
+            destination_plane.clone(),
+            ".prolly/native-versioned/fetch-destination",
+        )
+        .await
+        .unwrap();
+    let destination = Repository::open(
+        destination_plane,
+        native_options(".prolly/native-versioned/fetch-destination"),
+    )
+    .await
+    .unwrap();
+    let source_base = source.head("main").await.unwrap();
+    source.create_branch("feature", source_base).await.unwrap();
+    source
+        .put_bytes(
+            "feature",
+            b"feature.txt".to_vec(),
+            b"feature".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let fetched = destination.fetch_from(&source, "feature").await.unwrap();
+    let mapped_head = fetched.source_head.unwrap();
+    assert_ne!(mapped_head, source.head("feature").await.unwrap());
+    destination.fsck_commit(mapped_head).await.unwrap();
+    destination
+        .create_branch("imported", mapped_head)
+        .await
+        .unwrap();
+    assert_eq!(
+        destination
+            .get_current("imported", b"feature.txt")
+            .await
+            .unwrap()
+            .bytes,
+        b"feature"
+    );
 }
 
 #[tokio::test]
@@ -363,6 +670,102 @@ async fn lost_native_payload_response_is_reconciled_without_duplicate_upload() {
         .await
         .unwrap();
     assert_eq!(versions.entries.len(), 1);
+}
+
+#[tokio::test]
+async fn lost_native_copy_response_is_reconciled_without_duplicate_upload() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        native_options(".prolly/native-versioned/lost-copy"),
+    )
+    .await
+    .unwrap();
+    repository
+        .put_bytes(
+            "main",
+            b"source.txt".to_vec(),
+            b"copy me".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let operation = OperationId::new();
+    plane.lose_next_native_put_response();
+    let copied = repository
+        .copy_object(
+            "main",
+            b"source.txt",
+            None,
+            b"destination.txt".to_vec(),
+            Some(operation),
+        )
+        .await
+        .unwrap();
+    assert_eq!(copied.operation, operation);
+    assert_eq!(
+        repository
+            .get_current("main", b"destination.txt")
+            .await
+            .unwrap()
+            .bytes,
+        b"copy me"
+    );
+    let replay = repository
+        .copy_object(
+            "main",
+            b"source.txt",
+            None,
+            b"destination.txt".to_vec(),
+            Some(operation),
+        )
+        .await
+        .unwrap();
+    assert!(replay.idempotent_replay);
+}
+
+#[tokio::test]
+async fn lost_native_delete_response_is_reconciled_to_the_current_marker() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        native_options(".prolly/native-versioned/lost-delete"),
+    )
+    .await
+    .unwrap();
+    repository
+        .put_bytes(
+            "main",
+            b"deleted.txt".to_vec(),
+            b"delete me".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let operation = OperationId::new();
+    plane.lose_next_native_delete_response();
+    let deleted = repository
+        .delete_object("main", b"deleted.txt".to_vec(), Some(operation))
+        .await
+        .unwrap();
+    assert_eq!(deleted.operation, operation);
+    assert_eq!(
+        repository
+            .get_current("main", b"deleted.txt")
+            .await
+            .unwrap_err()
+            .code,
+        ErrorCode::NoSuchKey
+    );
+    let replay = repository
+        .delete_object("main", b"deleted.txt".to_vec(), Some(operation))
+        .await
+        .unwrap();
+    assert!(replay.idempotent_replay);
 }
 
 #[tokio::test]
@@ -865,6 +1268,77 @@ async fn checkpointed_reopen_uses_ranged_nodes_without_pack_listing() {
 }
 
 #[tokio::test]
+async fn corrupt_checkpoint_falls_back_to_canonical_pack_rebuild() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let options = native_options(".prolly/native-versioned/checkpoint-corrupt");
+    let repository = Repository::initialize(plane.clone(), options.clone())
+        .await
+        .unwrap();
+    repository
+        .put_bytes(
+            "main",
+            b"rebuild.bin".to_vec(),
+            b"canonical".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    repository
+        .create_node_index_checkpoint("main")
+        .await
+        .unwrap();
+    let listed = plane
+        .list(prolly_s3_core::ListRequest {
+            prefix: format!("{}/node-index/checkpoints/", options.repository_prefix),
+            continuation: None,
+            limit: 10,
+            include_versions: false,
+        })
+        .await
+        .unwrap();
+    let checkpoint = listed.entries.into_iter().next().unwrap();
+    plane
+        .delete_exact(
+            &checkpoint.path,
+            PhysicalVersion::Versioned {
+                version_id: checkpoint.metadata.token.version_id.clone().unwrap(),
+            },
+        )
+        .await
+        .unwrap();
+    plane
+        .put_immutable(prolly_s3_core::ImmutablePut {
+            path: checkpoint.path,
+            bytes: b"not canonical cbor".to_vec(),
+            expected_sha256: Sha256::digest(b"not canonical cbor").into(),
+        })
+        .await
+        .unwrap();
+
+    let reopened = Repository::open(
+        plane.clone(),
+        RepositoryOptions {
+            read_only: true,
+            ..options
+        },
+    )
+    .await
+    .unwrap();
+    plane.reset_request_counts();
+    assert_eq!(
+        reopened
+            .get_current("main", b"rebuild.bin")
+            .await
+            .unwrap()
+            .bytes,
+        b"canonical"
+    );
+    assert!(plane.request_snapshot().list > 0);
+}
+
+#[tokio::test]
 async fn explicit_takeover_barrier_fences_the_old_writer() {
     let plane = Arc::new(MemoryObjectPlane::new(true));
     let options = native_options(".prolly/native-versioned/takeover");
@@ -884,7 +1358,7 @@ async fn explicit_takeover_barrier_fences_the_old_writer() {
         .unwrap();
 
     let mut new_writer = Repository::open(
-        plane,
+        plane.clone(),
         RepositoryOptions {
             writer: "replacement-writer".to_string(),
             read_only: true,
@@ -916,6 +1390,12 @@ async fn explicit_takeover_barrier_fences_the_old_writer() {
         .await
         .unwrap();
 
+    assert_eq!(
+        old_writer.renew_writer_lease().await.unwrap_err().code,
+        ErrorCode::PreconditionFailed
+    );
+    plane.reset_request_counts();
+
     let stale = old_writer
         .put_bytes(
             "main",
@@ -928,4 +1408,5 @@ async fn explicit_takeover_barrier_fences_the_old_writer() {
         .await
         .unwrap_err();
     assert_eq!(stale.code, ErrorCode::PreconditionFailed);
+    assert_eq!(plane.request_snapshot().native_put, 0);
 }

--- a/extensions/s3/core/tests/repository_contract.rs
+++ b/extensions/s3/core/tests/repository_contract.rs
@@ -1400,7 +1400,23 @@ async fn future_reader_or_writer_requirement_fails_before_any_open_write() {
         .unwrap();
     let format_path = ObjectPath::new("repo-rolling-version/format/v1.cbor").unwrap();
 
-    for (reader, writer, capability_profile) in [(2, 1, 1), (1, 2, 1), (1, 1, 2)] {
+    for (reader, writer, capability_profile) in [
+        (
+            RepositoryFormatV1::CURRENT_READER_VERSION + 1,
+            RepositoryFormatV1::DISTRIBUTED_PROTOCOL_VERSION,
+            RepositoryFormatV1::DISTRIBUTED_S3_CAPABILITY_PROFILE,
+        ),
+        (
+            RepositoryFormatV1::DISTRIBUTED_PROTOCOL_VERSION,
+            RepositoryFormatV1::CURRENT_WRITER_VERSION + 1,
+            RepositoryFormatV1::DISTRIBUTED_S3_CAPABILITY_PROFILE,
+        ),
+        (
+            RepositoryFormatV1::DISTRIBUTED_PROTOCOL_VERSION,
+            RepositoryFormatV1::DISTRIBUTED_PROTOCOL_VERSION,
+            RepositoryFormatV1::NATIVE_VERSIONED_S3_CAPABILITY_PROFILE + 1,
+        ),
+    ] {
         let current = plane.load_mutable(&format_path).await.unwrap().unwrap();
         let mut format: RepositoryFormatV1 = decode_canonical(&current.bytes).unwrap();
         format.min_reader_version = reader;


### PR DESCRIPTION
## Summary

- add the accepted native-versioned S3 architecture and persisted repository profile
- store each logical live object once at its original key and bind history to the exact provider `VersionId`
- pack commit-scoped Prolly nodes and collapse warm publication to payload + pack + commit + ref CAS
- add exclusive-writer leasing, fail-closed background renewal, fencing, takeover barriers, checkpoints, exact-version fsck, and GC
- add bounded disk-spooled whole-object upload, native multipart, and exact-version cross-bucket transfer
- implement logical clone, fetch, push, and repair with destination `VersionId` rebinding and destination-local commit IDs
- reconcile lost put, copy, delete, multipart completion, and ref-publication responses

## Request gates

- warm 64 KiB put: 4 calls
- 1/8/32 queued callers: 4 calls per write
- two-object atomic commit: 5 calls
- merge/restore: 3 calls
- native multipart with N parts: N + 5 calls
- idempotent replay: 0 calls

The pinned RustFS probes observed four SDK executions/wire transmissions for the warm write and seven for a two-part multipart upload, with no retry. Native clone preserved logical object-version IDs while rebinding physical VersionIds, and incremental push transferred one payload + one pack + one commit before the destination ref move.

## Verification

- `cargo fmt --manifest-path extensions/s3/Cargo.toml --all -- --check`
- `cargo check --manifest-path extensions/s3/Cargo.toml --workspace`
- `cargo clippy --manifest-path extensions/s3/Cargo.toml --workspace --all-targets -- -D warnings`
- ordinary workspace tests passed with only the unchanged ~18-minute 10,000-operation historical corpus skipped
- 24 native-profile deterministic tests passed
- 5 live pinned-RustFS native tests passed

## Production boundary

This remains experimental. Automatic checkpoint scheduling, the migration/bootstrap command surface, complete crash-boundary drills for the new transfer paths, AWS latency/cost/throttling qualification, and million-key/ten-million-version scale evidence remain explicit release gates. RustFS multipart compatibility deviations and the exact production limits are recorded in the design and qualification documents.

Development note: implemented and reviewed with OpenAI Codex.