### PR TITLE
Harden versioned S3 scale paths

### DIFF
--- a/extensions/s3/CACHE-AND-SCALE-DESIGN.md
+++ b/extensions/s3/CACHE-AND-SCALE-DESIGN.md
@@ -84,6 +84,14 @@ therefore fetches each distinct node at most once per process at a time; a warm
 lookup performs no metadata-node S3 reads. Fetching the file body remains one
 version-qualified S3 `GetObject`.
 
+After a branch CAS succeeds—or an ambiguous CAS is reconciled by operation
+ID—the writer admits every node in the committed pack to the configured cache.
+Foyer flushes those verified immutable nodes to disk on graceful close. A
+reader reopening the same cache directory can therefore traverse the writer's
+snapshot without re-fetching nodes. A new host can call
+`Client::prewarm_node_cache` for selected snapshots and prefixes before serving
+traffic.
+
 ### Cache keys
 
 Node bytes use this logical cache key:
@@ -235,11 +243,12 @@ Foreground publication remains:
 2. write one immutable commit/node envelope;
 3. conditionally publish the branch ref.
 
-New nodes are placed in the pending/L1 cache while the commit is built. After
-the commit envelope is durable, they are eligible for L2 admission. The
+New nodes remain pending while the commit is built. Only after successful or
+reconciled ref publication are they admitted concurrently to L1/L2. The
 background indexer consumes commit-envelope summaries, creates new index pages,
-and advances the node-index head. Cache warming and index compaction add no
-foreground S3 requests.
+and advances the node-index head. Cache write-through adds local I/O but no
+foreground S3 request; explicit prewarming performs the traversal reads needed
+to populate a new host.
 
 The fenced writer serializes only publication for a single branch. Scale-out
 uses independent branches or repository partitions; a branch with one mutable
@@ -334,7 +343,10 @@ negotiated capability; readers never reinterpret v1 bytes as v2.
 4. Done: paged derived ref catalog with explicit freshness.
 5. Done: epoch-based GC v2 with persisted work/candidate partitions and shared
    node-container safety.
-6. Pending: execute and publish the Tier A/B/C AWS qualification matrix.
+6. Done locally: publication write-through, Foyer close/reopen persistence,
+   and bounded snapshot prewarming. A 10K-file RustFS reopen listed the full
+   snapshot with one commit GET and zero node-range GETs.
+7. Pending: execute and publish the Tier A/B/C AWS qualification matrix.
 
 Foyer is pinned to `0.22.3` with Tokio runtime only. `cargo-deny` contains a
 narrow, reason-bearing exception for RUSTSEC-2024-0436: Foyer's transitive

--- a/extensions/s3/OPERATIONS.md
+++ b/extensions/s3/OPERATIONS.md
@@ -41,6 +41,7 @@ Track separately:
 - unreachable physical versions and commit envelopes;
 - GC candidate bytes, exact-version deletes, and failures;
 - node-index checkpoint age and rebuild fallbacks.
+- branch-ref physical version count and compaction failures.
 
 The three-call write budget counts SDK operations, not internal HTTP retry
 attempts. Alert on either dimension independently.
@@ -50,6 +51,27 @@ request-rate budget. Bound in-process metadata with `max_cached_commits`,
 `max_cached_branches`, and `max_cached_node_pack_bytes`; do not disable these
 bounds in a long-running writer. Alert when publication wait consumes a
 material part of end-to-end latency or max queue depth grows continuously.
+
+## Bulk ingestion and cache warm-up
+
+Use `Client::ingest_objects` as the default path for imports and backfills. It
+publishes at most 100 whole files per commit and also obeys
+`max_staged_batch_bytes`. Tune the count downward when file sizes or commit
+latency require it; use multipart for one file larger than the staged bound.
+
+Configure a Foyer node cache on writers and traversal-heavy readers. Successful
+publications write committed immutable nodes through to the cache. Reopen the
+same cache directory after a restart, with only one process owning that
+directory. On a new or empty host, call `prewarm_node_cache` for the production
+snapshot and required prefixes before accepting list, diff, or history traffic.
+
+The writer automatically compacts a branch ref every 5,000 generations and
+retains 100 physical ref versions by default. This deletes only obsolete
+physical CAS-object versions; immutable commits, object versions, and logical
+history are unchanged. Keep `s3:ListBucketVersions` and version-qualified
+`s3:DeleteObject`/`s3:DeleteObjects` permissions available. Tune
+`branch_ref_compaction_interval` below a provider's per-object version limit,
+or invoke `compact_branch_ref_versions` during controlled maintenance.
 
 ## Conflict and outage handling
 

--- a/extensions/s3/QUALIFICATION.md
+++ b/extensions/s3/QUALIFICATION.md
@@ -20,6 +20,8 @@ Core tests verify:
 - bounded legacy node-location fallback after in-memory eviction;
 - corrupt v2 node/ref/graph indexes failing open and rebuilding from authority;
 - idempotent replay and lost put/copy/delete response reconciliation;
+- applied-then-conflicted CAS reconciliation by operation ID for puts and
+  atomic batches;
 - exclusive writer takeover fencing;
 - clone, fetch, push, repair, and provider-ID rebinding;
 - exact-version GC and corrupt-checkpoint recovery.
@@ -43,6 +45,51 @@ PROLLY_S3_RUSTFS=1 \
   cargo test --manifest-path extensions/s3/Cargo.toml \
   -p prolly-s3-client --test rustfs_repository -- --nocapture
 ```
+
+Run the reproducible 10K concurrent-commit regression gate separately. It is
+ignored by default because it is intentionally sustained and writes a unique
+development repository prefix:
+
+```bash
+PROLLY_S3_RUSTFS=1 \
+PROLLY_S3_RUSTFS_10K=1 \
+PROLLY_RUSTFS_10K_CONCURRENCY=32 \
+PROLLY_RUSTFS_10K_OBJECT_BYTES=65536 \
+cargo test --release --manifest-path extensions/s3/Cargo.toml \
+  -p prolly-s3-client --test rustfs_repository \
+  rustfs_10k_concurrent_commits_are_reconciled_and_complete \
+  -- --ignored --exact --nocapture
+```
+
+The gate runs cumulative 1K, 5K, and 10K tiers against one hot branch. It
+reports throughput and p50/p95/p99 latency, bounds SDK calls per write, checks
+the final ref generation, pages through exactly 10K logical objects, and
+requires an empty publication queue.
+
+On 2026-08-11, the pinned local RustFS gate passed all 10K commits in 469.81 s.
+The final 5K tier sustained 19.63 writes/s with p50/p95/p99 of
+1,462/2,760/3,285 ms and 3.005 SDK calls/write. The additional 24 calls were
+amortized branch-ref version compaction. RustFS beta.10 hardcodes a 10,000
+physical-version limit per object; automatic compaction at generation 5,000
+retained 100 ref versions while preserving the complete logical commit DAG.
+
+Run the batched-ingest and persisted-cache gate with the Foyer feature:
+
+```bash
+PROLLY_S3_RUSTFS=1 \
+PROLLY_S3_RUSTFS_BATCH_10K=1 \
+cargo test --release --manifest-path extensions/s3/Cargo.toml \
+  -p prolly-s3-client --features foyer-cache --test rustfs_repository \
+  rustfs_10k_batched_ingest_has_bounded_bytes_and_persisted_cache \
+  -- --ignored --exact --nocapture
+```
+
+On 2026-08-11, 100 commits ingested 10K × 64 KiB files in 78.89 s
+(126.76 files/s) at 1.020 calls/file. Upload amplification was 1.083×, down
+from the pre-fix 2.70×; all node packs totaled 49.73 MiB and the largest was
+965.65 KiB. After a graceful Foyer close/reopen, listing all 10K files took
+285 ms, one commit GET, and zero node-range GETs, down from 421+ S3 calls in the
+uncached baseline.
 
 ## Not yet qualified
 

--- a/extensions/s3/README.md
+++ b/extensions/s3/README.md
@@ -25,7 +25,8 @@ A warm single-object write uses three foreground S3 operations:
 No content chunks, content manifests, publication leases, durable staging
 workspaces, or post-CAS readback are created. A two-object atomic commit uses
 four calls: two parallelizable payload writes, one commit envelope, and one
-branch-ref CAS.
+branch-ref CAS. For bulk ingestion, `Client::ingest_objects` is the recommended
+path and publishes up to 100 whole files per commit by default.
 
 ## Authority model
 
@@ -79,11 +80,17 @@ The integration tests enforce these warm-path budgets:
 | Merge or restore | 2 |
 | Multipart with `N` parts | `N + 4` |
 | Warm current or historical read | 1 |
+| Bulk ingest with 100 files/commit | 1.02 per file |
 
 The core contract also exercises 1, 8, and 32 concurrent callers and requires
-three calls per completed whole-object write. The RustFS load probe also runs
-32 concurrent 64 KiB writes, checks 96 total calls, and reports latency and
-throughput.
+three calls per completed whole-object write. The RustFS probes include 32
+concurrent 64 KiB writes and an ignored-by-default 10K hot-branch regression
+gate that validates the complete logical key set and operation-ID
+reconciliation.
+
+The local 10K batch gate also enforces less than 1.5× uploaded-byte
+amplification and verifies that a closed/reopened Foyer cache lists all 10K
+files with zero node-range reads.
 
 ## Current limits
 

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -78,7 +78,41 @@ against your key count and memory budget. Export `performance_snapshot()` for
 publication queue/wait telemetry and `s3_operation_metrics()` for SDK request
 counts.
 
-## Put and read a file
+## Ingest files in batches (recommended)
+
+Use `ingest_objects` when loading more than one file. It publishes up to 100
+whole files per commit by default, reducing commit-envelope and branch-CAS
+traffic from two calls per file to two calls per batch.
+
+```rust
+use prolly_s3_client::IngestObject;
+
+let files = (0..1_000).map(|index| {
+    IngestObject::new(
+        format!("imports/file-{index:04}.json"),
+        format!(r#"{{"index":{index}}}"#).into_bytes(),
+    )
+    .content_type("application/json")
+    .metadata("source", "initial-import")
+});
+
+let report = client.ingest_objects(files).await?;
+assert_eq!(report.object_count, 1_000);
+assert_eq!(report.commits.len(), 10);
+```
+
+The default is bounded by both 100 files and the configured
+`max_staged_batch_bytes`. Use `ingest_objects_with_limit` to choose a smaller
+commit size. Use multipart upload for any single file larger than the staged
+byte limit.
+
+The checked-in RustFS gate measured 10K × 64 KiB files at 1.020 SDK calls/file
+and 1.083× uploaded-byte amplification. Treat those as local regression
+budgets, not AWS latency or durability claims.
+
+For interactive or independent writes, use the single-file API below.
+
+## Put and read one file
 
 The builders intentionally resemble the AWS Rust SDK:
 
@@ -149,7 +183,7 @@ let old_bytes = old.output.body.collect().await?.into_bytes();
 assert_eq!(old_bytes.as_ref(), b"mode = 'safe'\n");
 ```
 
-## Publish several changes atomically
+## Publish a custom atomic change set
 
 Staged changes are invisible until `publish`. The session is intentionally
 in-memory; it is not resumable after process loss.
@@ -184,8 +218,9 @@ println!("published commit: {}", receipt.id);
 ```
 
 For `N` staged keys, publication uses `N + 2` foreground S3 calls. Payload
-mutations are bounded and parallel; one commit envelope and one branch CAS make
-the batch visible.
+mutations are bounded and parallel. One commit envelope and one branch CAS make
+the entire batch visible. Prefer `ingest_objects` for homogeneous bulk puts;
+use a commit session when you need mixed puts and deletes or a custom message.
 
 ## List, branch, and diff
 
@@ -248,8 +283,9 @@ stale expected head fails explicitly.
 ## Add a persistent node cache
 
 Foyer keeps verified immutable Prolly nodes in bounded memory and local disk.
-Cache hits are checked against the CID; corruption and cache I/O errors fail
-open to a verified S3 read.
+Successful commits write their new nodes through to this cache. Cache hits are
+checked against the CID; corruption and cache I/O errors fail open to a
+verified S3 read.
 
 ```rust
 use std::{path::PathBuf, sync::Arc, time::Duration};
@@ -286,10 +322,19 @@ let client = Client::builder()
     .node_index_maintenance(Duration::from_secs(60), 1_000)
     .open()
     .await?;
+
+// On a cold host, populate the cache before serving traversal-heavy reads.
+let snapshot = client.head_commit().await?;
+let warmed = client
+    .prewarm_node_cache(snapshot, b"", 1_000)
+    .await?;
+println!("warmed {} objects in {} pages", warmed.object_count, warmed.pages);
 ```
 
 Use one filesystem owner per cache directory. Drop clients before calling
-`node_cache.close().await?` during graceful shutdown.
+`node_cache.close().await?` during graceful shutdown. Reopen the same directory
+after restart to reuse persisted immutable nodes. A new host should run
+`prewarm_node_cache` before taking traversal-heavy traffic.
 
 ## Page through large histories and ref sets
 

--- a/extensions/s3/client/src/aws_object.rs
+++ b/extensions/s3/client/src/aws_object.rs
@@ -8,7 +8,11 @@ use std::{
     },
 };
 
-use aws_sdk_s3::{primitives::ByteStream, types::MetadataDirective, Client};
+use aws_sdk_s3::{
+    primitives::ByteStream,
+    types::{Delete, MetadataDirective, ObjectIdentifier},
+    Client,
+};
 use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use aws_smithy_types::DateTime;
 use aws_types::request_id::RequestId;
@@ -39,6 +43,7 @@ pub struct S3OperationMetrics {
     pub list_objects_v2: u64,
     pub list_object_versions: u64,
     pub delete_object: u64,
+    pub delete_objects: u64,
     pub create_multipart_upload: u64,
     pub upload_part: u64,
     pub upload_part_copy: u64,
@@ -59,6 +64,7 @@ impl S3OperationMetrics {
             + self.list_objects_v2
             + self.list_object_versions
             + self.delete_object
+            + self.delete_objects
             + self.create_multipart_upload
             + self.upload_part
             + self.upload_part_copy
@@ -78,6 +84,7 @@ struct AtomicS3OperationMetrics {
     list_objects_v2: AtomicU64,
     list_object_versions: AtomicU64,
     delete_object: AtomicU64,
+    delete_objects: AtomicU64,
     create_multipart_upload: AtomicU64,
     upload_part: AtomicU64,
     upload_part_copy: AtomicU64,
@@ -99,6 +106,7 @@ impl AtomicS3OperationMetrics {
             list_objects_v2: self.list_objects_v2.load(Ordering::Relaxed),
             list_object_versions: self.list_object_versions.load(Ordering::Relaxed),
             delete_object: self.delete_object.load(Ordering::Relaxed),
+            delete_objects: self.delete_objects.load(Ordering::Relaxed),
             create_multipart_upload: self.create_multipart_upload.load(Ordering::Relaxed),
             upload_part: self.upload_part.load(Ordering::Relaxed),
             upload_part_copy: self.upload_part_copy.load(Ordering::Relaxed),
@@ -120,6 +128,7 @@ impl AtomicS3OperationMetrics {
             list_objects_v2: self.list_objects_v2.swap(0, Ordering::Relaxed),
             list_object_versions: self.list_object_versions.swap(0, Ordering::Relaxed),
             delete_object: self.delete_object.swap(0, Ordering::Relaxed),
+            delete_objects: self.delete_objects.swap(0, Ordering::Relaxed),
             create_multipart_upload: self.create_multipart_upload.swap(0, Ordering::Relaxed),
             upload_part: self.upload_part.swap(0, Ordering::Relaxed),
             upload_part_copy: self.upload_part_copy.swap(0, Ordering::Relaxed),
@@ -453,6 +462,89 @@ impl ObjectPlane for AwsS3ObjectPlane {
             Err(error) if is_precondition_failed(&error) => Ok(DeleteOutcome::TokenMismatch),
             Err(error) => Err(map_sdk_error("DeleteObject", error)),
         }
+    }
+
+    async fn delete_exact_batch(
+        &self,
+        objects: Vec<(ObjectPath, PhysicalVersion)>,
+    ) -> Result<Vec<DeleteOutcome>> {
+        if objects.len() > 1_000 {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "exact delete batch cannot exceed 1,000 versions",
+            ));
+        }
+        if objects.is_empty() {
+            return Ok(Vec::new());
+        }
+        if objects
+            .iter()
+            .any(|(_, version)| !matches!(version, PhysicalVersion::Versioned { .. }))
+        {
+            let mut outcomes = Vec::with_capacity(objects.len());
+            for (path, version) in objects {
+                outcomes.push(self.delete_exact(&path, version).await?);
+            }
+            return Ok(outcomes);
+        }
+
+        let identifiers = objects
+            .iter()
+            .map(|(path, version)| {
+                let PhysicalVersion::Versioned { version_id } = version else {
+                    unreachable!("unversioned objects were handled above");
+                };
+                ObjectIdentifier::builder()
+                    .key(path.as_str())
+                    .version_id(version_id)
+                    .build()
+                    .map_err(|error| {
+                        Error::new(
+                            ErrorCode::InvalidRequest,
+                            format!("invalid exact delete identifier: {error}"),
+                        )
+                    })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let delete = Delete::builder()
+            .set_objects(Some(identifiers))
+            .quiet(true)
+            .build()
+            .map_err(|error| {
+                Error::new(
+                    ErrorCode::InvalidRequest,
+                    format!("invalid exact delete batch: {error}"),
+                )
+            })?;
+        self.metrics.delete_objects.fetch_add(1, Ordering::Relaxed);
+        let output = self
+            .client
+            .delete_objects()
+            .bucket(&self.bucket)
+            .delete(delete)
+            .send()
+            .await
+            .map_err(|error| map_sdk_error("DeleteObjects exact versions", error))?;
+        if let Some(error) = output.errors().first() {
+            return Err(Error::new(
+                ErrorCode::Transport,
+                format!(
+                    "DeleteObjects exact versions failed for key {:?}, version {:?}: {}: {}",
+                    error.key(),
+                    error.version_id(),
+                    error.code().unwrap_or("Unknown"),
+                    error
+                        .message()
+                        .unwrap_or("provider omitted an error message")
+                ),
+            )
+            .provider_metadata(
+                error.code().map(ToString::to_string),
+                error.message().map(ToString::to_string),
+            )
+            .retry(RetryAdvice::Safe));
+        }
+        Ok(vec![DeleteOutcome::Deleted; objects.len()])
     }
 
     async fn put_physical(&self, request: PhysicalPut) -> Result<PhysicalObjectWriteResult> {

--- a/extensions/s3/client/src/client.rs
+++ b/extensions/s3/client/src/client.rs
@@ -59,6 +59,52 @@ pub struct Versioned<T> {
     pub commit: Option<CommitReceipt>,
 }
 
+/// Default number of whole-file puts published in one bulk-ingest commit.
+pub const DEFAULT_INGEST_FILES_PER_COMMIT: usize = 100;
+
+/// One in-memory whole file for [`Client::ingest_objects`].
+#[derive(Clone, Debug)]
+pub struct IngestObject {
+    pub key: String,
+    pub bytes: Vec<u8>,
+    pub headers: ObjectHeaders,
+    pub metadata: BTreeMap<String, String>,
+}
+
+impl IngestObject {
+    pub fn new(key: impl Into<String>, bytes: impl Into<Vec<u8>>) -> Self {
+        Self {
+            key: key.into(),
+            bytes: bytes.into(),
+            headers: ObjectHeaders::default(),
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    pub fn content_type(mut self, value: impl Into<String>) -> Self {
+        self.headers.content_type = Some(value.into());
+        self
+    }
+
+    pub fn metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct IngestReport {
+    pub object_count: usize,
+    pub commits: Vec<CommitReceipt>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NodeCachePrewarmReport {
+    pub snapshot: CommitId,
+    pub object_count: usize,
+    pub pages: usize,
+}
+
 pub fn supported_input_fields(operation: &str) -> Option<&'static [&'static str]> {
     match operation {
         "put_object" => Some(&[
@@ -512,6 +558,8 @@ pub struct ClientBuilder {
     max_cached_node_locations: Option<usize>,
     max_cached_node_bytes: Option<usize>,
     node_cache: Option<Arc<dyn prolly_s3_core::NodeCache>>,
+    branch_ref_compaction_interval: Option<u64>,
+    branch_ref_versions_to_retain: Option<usize>,
     node_index_maintenance_interval: Option<Duration>,
     node_index_maintenance_batch: Option<usize>,
     max_staged_batch_bytes: Option<usize>,
@@ -564,6 +612,17 @@ impl Client {
     /// Returns hot-branch publication queue and wait counters.
     pub fn performance_snapshot(&self) -> prolly_s3_core::RepositoryPerformanceSnapshot {
         self.repository.performance_snapshot()
+    }
+
+    /// Compact obsolete physical versions of the selected branch-ref object.
+    /// Logical commits, history, and object versions are not removed.
+    pub async fn compact_branch_ref_versions(
+        &self,
+    ) -> Result<prolly_s3_core::RefVersionCompactionReport> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .compact_branch_ref_versions(&self.branch)
+            .await
     }
 
     /// Run one bounded node-index maintenance step immediately. Normal
@@ -800,6 +859,133 @@ impl Client {
             message: "atomic bucket commit".to_string(),
             expires_after: Duration::from_secs(60 * 60),
         }
+    }
+
+    /// Publish whole files in bounded atomic commits instead of creating one
+    /// hot-branch CAS and commit envelope per file.
+    pub async fn ingest_objects<I>(&self, objects: I) -> Result<IngestReport>
+    where
+        I: IntoIterator<Item = IngestObject>,
+    {
+        self.ingest_objects_with_limit(objects, DEFAULT_INGEST_FILES_PER_COMMIT)
+            .await
+    }
+
+    pub async fn ingest_objects_with_limit<I>(
+        &self,
+        objects: I,
+        max_files_per_commit: usize,
+    ) -> Result<IngestReport>
+    where
+        I: IntoIterator<Item = IngestObject>,
+    {
+        self.ensure_provider_qualified()?;
+        if max_files_per_commit == 0
+            || max_files_per_commit
+                > self
+                    .repository
+                    .format()
+                    .canonical_limits
+                    .max_mutations_per_commit as usize
+        {
+            return Err(invalid(
+                "max_files_per_commit must fit the repository mutation limit",
+            ));
+        }
+
+        let mut report = IngestReport::default();
+        let mut chunk = Vec::with_capacity(max_files_per_commit);
+        let mut chunk_bytes = 0usize;
+        for object in objects {
+            if object.bytes.len() > self.max_staged_batch_bytes {
+                return Err(Error::new(
+                    ErrorCode::EntityTooLarge,
+                    "one ingest object exceeds the configured staged-byte limit; use multipart",
+                ));
+            }
+            let next_bytes = chunk_bytes
+                .checked_add(object.bytes.len())
+                .ok_or_else(|| invalid("ingest byte accounting overflow"))?;
+            if !chunk.is_empty()
+                && (chunk.len() == max_files_per_commit || next_bytes > self.max_staged_batch_bytes)
+            {
+                report.commits.push(self.publish_ingest_chunk(chunk).await?);
+                chunk = Vec::with_capacity(max_files_per_commit);
+                chunk_bytes = 0;
+            }
+            chunk_bytes = chunk_bytes
+                .checked_add(object.bytes.len())
+                .ok_or_else(|| invalid("ingest byte accounting overflow"))?;
+            report.object_count = report
+                .object_count
+                .checked_add(1)
+                .ok_or_else(|| invalid("ingest object count overflow"))?;
+            chunk.push(object);
+        }
+        if !chunk.is_empty() {
+            report.commits.push(self.publish_ingest_chunk(chunk).await?);
+        }
+        Ok(report)
+    }
+
+    async fn publish_ingest_chunk(&self, objects: Vec<IngestObject>) -> Result<CommitReceipt> {
+        let batch = self
+            .repository
+            .begin_physical_batch(&self.branch, "bulk ingest", 60 * 60 * 1_000)
+            .await?;
+        let mutations = objects
+            .into_iter()
+            .map(|object| prolly_s3_core::PhysicalBatchMutationV1::Put {
+                key: object.key.into_bytes(),
+                bytes: object.bytes,
+                headers: object.headers,
+                user_metadata: object.metadata,
+            })
+            .collect();
+        let receipt = self
+            .repository
+            .publish_physical_batch(batch, mutations)
+            .await?;
+        self.record_advisory(&receipt).await;
+        Ok(receipt)
+    }
+
+    /// Traverse one immutable object snapshot and populate the configured
+    /// verified node cache without downloading object payloads.
+    pub async fn prewarm_node_cache(
+        &self,
+        snapshot: CommitId,
+        prefix: &[u8],
+        page_size: usize,
+    ) -> Result<NodeCachePrewarmReport> {
+        self.ensure_provider_qualified()?;
+        if page_size == 0 {
+            return Err(invalid("prewarm page_size must be greater than zero"));
+        }
+        let mut after = None;
+        let mut object_count = 0usize;
+        let mut pages = 0usize;
+        loop {
+            let (objects, truncated) = self
+                .repository
+                .list_objects_at(snapshot, prefix, after.as_deref(), page_size)
+                .await?;
+            pages = pages
+                .checked_add(1)
+                .ok_or_else(|| invalid("prewarm page count overflow"))?;
+            object_count = object_count
+                .checked_add(objects.len())
+                .ok_or_else(|| invalid("prewarm object count overflow"))?;
+            after = objects.last().map(|object| object.key.clone());
+            if !truncated {
+                break;
+            }
+        }
+        Ok(NodeCachePrewarmReport {
+            snapshot,
+            object_count,
+            pages,
+        })
     }
     pub async fn at(&self, commit: CommitId) -> Result<Snapshot> {
         self.ensure_provider_qualified()?;
@@ -1615,6 +1801,11 @@ impl ClientBuilder {
         self.node_cache = Some(cache);
         self
     }
+    pub fn branch_ref_compaction(mut self, interval: u64, versions_to_retain: usize) -> Self {
+        self.branch_ref_compaction_interval = Some(interval);
+        self.branch_ref_versions_to_retain = Some(versions_to_retain);
+        self
+    }
     pub fn node_index_maintenance(mut self, interval: Duration, batch: usize) -> Self {
         self.node_index_maintenance_interval = Some(interval);
         self.node_index_maintenance_batch = Some(batch);
@@ -1761,6 +1952,12 @@ impl ClientBuilder {
             options.max_cached_node_bytes = value;
         }
         options.node_cache = self.node_cache;
+        if let Some(value) = self.branch_ref_compaction_interval {
+            options.branch_ref_compaction_interval = value;
+        }
+        if let Some(value) = self.branch_ref_versions_to_retain {
+            options.branch_ref_versions_to_retain = value;
+        }
         if let Some(value) = self.gc_delete_rate_limit_per_second {
             options.gc_delete_rate_limit_per_second = value;
         }

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -10,7 +10,10 @@ use aws_sdk_s3::{
     config::Region,
     types::{BucketVersioningStatus, VersioningConfiguration},
 };
+use futures_util::StreamExt;
 use md5::{Digest as _, Md5};
+#[cfg(feature = "foyer-cache")]
+use prolly_s3_client::{core::PhysicalBatchMutationV1, FoyerNodeCache, FoyerNodeCacheConfig};
 use prolly_s3_client::{
     core::{ObjectHeaders, PhysicalMultipartCompletedPart, Repository, RepositoryOptions},
     AwsS3ObjectPlane,
@@ -348,4 +351,258 @@ async fn rustfs_32_writer_load_preserves_the_three_call_budget() {
         percentile(99).as_millis(),
         32.0 / wall.as_secs_f64(),
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[ignore = "operator-run 10K hot-branch release gate"]
+async fn rustfs_10k_concurrent_commits_are_reconciled_and_complete() {
+    if !rustfs_enabled() || std::env::var("PROLLY_S3_RUSTFS_10K").as_deref() != Ok("1") {
+        eprintln!("set PROLLY_S3_RUSTFS=1 and PROLLY_S3_RUSTFS_10K=1");
+        return;
+    }
+
+    let concurrency = std::env::var("PROLLY_RUSTFS_10K_CONCURRENCY")
+        .map(|value| value.parse::<usize>().expect("numeric concurrency"))
+        .unwrap_or(32);
+    let object_bytes = std::env::var("PROLLY_RUSTFS_10K_OBJECT_BYTES")
+        .map(|value| value.parse::<usize>().expect("numeric object size"))
+        .unwrap_or(64 * 1024);
+    let (aws, bucket) = rustfs_client().await;
+    let plane = Arc::new(AwsS3ObjectPlane::new(aws, &bucket));
+    let object_prefix = unique_name("ten-thousand-objects");
+    let repository = Repository::initialize(
+        plane.clone(),
+        RepositoryOptions {
+            repository_prefix: unique_name("ten-thousand-repository"),
+            writer: "rustfs-10k-writer".to_string(),
+            writer_lease_millis: 60 * 60 * 1_000,
+            max_parallel_payload_writes: concurrency,
+            ..RepositoryOptions::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let mut previous = 0;
+    for target in [1_000, 5_000, 10_000] {
+        plane.reset_metrics();
+        let started = Instant::now();
+        let writes = futures_util::stream::iter(previous..target)
+            .map(|index| {
+                let repository = &repository;
+                let object_prefix = &object_prefix;
+                async move {
+                    let operation_started = Instant::now();
+                    repository
+                        .put_bytes(
+                            "main",
+                            format!("{object_prefix}/{index:05}.bin").into_bytes(),
+                            vec![index as u8; object_bytes],
+                            ObjectHeaders::default(),
+                            BTreeMap::new(),
+                            None,
+                        )
+                        .await
+                        .map(|receipt| (operation_started.elapsed(), receipt.idempotent_replay))
+                }
+            })
+            .buffer_unordered(concurrency)
+            .collect::<Vec<_>>()
+            .await;
+        let wall = started.elapsed();
+        let mut latencies = writes
+            .into_iter()
+            .map(|result| result.expect("10K commit"))
+            .collect::<Vec<_>>();
+        let reconciled = latencies.iter().filter(|(_, replay)| *replay).count();
+        latencies.sort_unstable_by_key(|(latency, _)| *latency);
+        let percentile = |percent: usize| {
+            latencies[(latencies.len() * percent).div_ceil(100) - 1]
+                .0
+                .as_millis()
+        };
+        let metrics = plane.reset_metrics();
+        let tier_writes = target - previous;
+        assert!(
+            metrics.total_calls() <= (tier_writes as u64 * 301).div_ceil(100),
+            "request budget exceeded: {metrics:?}"
+        );
+        eprintln!(
+            "rustfs_10k live_files={target} tier_writes={tier_writes} wall_ms={} writes_per_second={:.2} p50_ms={} p95_ms={} p99_ms={} reconciled={reconciled} s3_calls={} calls_per_write={:.3}",
+            wall.as_millis(),
+            tier_writes as f64 / wall.as_secs_f64(),
+            percentile(50),
+            percentile(95),
+            percentile(99),
+            metrics.total_calls(),
+            metrics.total_calls() as f64 / tier_writes as f64,
+        );
+        previous = target;
+    }
+
+    let head = repository.head("main").await.unwrap();
+    assert_eq!(repository.commit(head).await.unwrap().generation.0, 10_000);
+    let mut after = None;
+    let mut listed = 0;
+    loop {
+        let (objects, truncated) = repository
+            .list_objects_at(head, object_prefix.as_bytes(), after.as_deref(), 1_000)
+            .await
+            .unwrap();
+        listed += objects.len();
+        after = objects.last().map(|object| object.key.clone());
+        if !truncated {
+            break;
+        }
+    }
+    assert_eq!(listed, 10_000);
+    assert_eq!(repository.performance_snapshot().publication_queue_depth, 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[cfg(feature = "foyer-cache")]
+#[ignore = "operator-run 10K batched-ingest and persisted-cache release gate"]
+async fn rustfs_10k_batched_ingest_has_bounded_bytes_and_persisted_cache() {
+    if !rustfs_enabled() || std::env::var("PROLLY_S3_RUSTFS_BATCH_10K").as_deref() != Ok("1") {
+        eprintln!("set PROLLY_S3_RUSTFS=1 and PROLLY_S3_RUSTFS_BATCH_10K=1");
+        return;
+    }
+
+    let (aws, bucket) = rustfs_client().await;
+    let plane = Arc::new(AwsS3ObjectPlane::new(aws, &bucket));
+    let repository_prefix = unique_name("ten-thousand-batched-repository");
+    let object_prefix = unique_name("ten-thousand-batched-objects");
+    let cache_directory = tempfile::tempdir().unwrap();
+    let cache_config = FoyerNodeCacheConfig {
+        directory: cache_directory.path().to_path_buf(),
+        memory_capacity_bytes: 64 * 1024 * 1024,
+        disk_capacity_bytes: 512 * 1024 * 1024,
+        disk_block_size_bytes: 8 * 1024 * 1024,
+        memory_shards: 16,
+    };
+    let writer_cache = FoyerNodeCache::open(cache_config.clone()).await.unwrap();
+    let options = RepositoryOptions {
+        repository_prefix,
+        writer: "rustfs-batched-10k-writer".to_string(),
+        writer_lease_millis: 60 * 60 * 1_000,
+        max_parallel_payload_writes: 32,
+        max_cached_node_pack_bytes: 1,
+        node_cache: Some(writer_cache.clone()),
+        ..RepositoryOptions::default()
+    };
+    let repository = Repository::initialize(plane.clone(), options.clone())
+        .await
+        .unwrap();
+    plane.reset_metrics();
+    let started = Instant::now();
+    let mut packed_bytes = 0_u64;
+    let mut max_pack_bytes = 0_u64;
+    for batch_index in 0..100 {
+        let batch = repository
+            .begin_physical_batch("main", "100-file bulk ingest", 60 * 60 * 1_000)
+            .await
+            .unwrap();
+        let mutations = (0..100)
+            .map(|offset| {
+                let index = batch_index * 100 + offset;
+                PhysicalBatchMutationV1::Put {
+                    key: format!("{object_prefix}/{index:05}.bin").into_bytes(),
+                    bytes: vec![index as u8; 64 * 1024],
+                    headers: ObjectHeaders::default(),
+                    user_metadata: BTreeMap::new(),
+                }
+            })
+            .collect();
+        let receipt = repository
+            .publish_physical_batch(batch, mutations)
+            .await
+            .unwrap();
+        let pack_bytes = repository
+            .commit(receipt.id)
+            .await
+            .unwrap()
+            .node_pack
+            .expect("batch node pack")
+            .object_len;
+        packed_bytes += pack_bytes;
+        max_pack_bytes = max_pack_bytes.max(pack_bytes);
+    }
+    let ingest_wall = started.elapsed();
+    let ingest_metrics = plane.reset_metrics();
+    let logical_payload_bytes = 10_000_u64 * 64 * 1024;
+    let upload_ratio = ingest_metrics.uploaded_body_bytes as f64 / logical_payload_bytes as f64;
+    assert_eq!(ingest_metrics.total_calls(), 10_200);
+    assert!(
+        upload_ratio < 1.5,
+        "batch upload byte amplification is {upload_ratio:.3}x: {ingest_metrics:?}"
+    );
+    assert!(
+        max_pack_bytes < 2 * 1024 * 1024,
+        "one 100-file batch packed {max_pack_bytes} transient bytes"
+    );
+    let head = repository.head("main").await.unwrap();
+    eprintln!(
+        "rustfs_batch_10k files=10000 commits=100 wall_ms={} files_per_second={:.2} s3_calls={} calls_per_file={:.3} uploaded_mib={:.2} upload_ratio={:.3} packed_mib={:.2} max_pack_kib={:.2}",
+        ingest_wall.as_millis(),
+        10_000.0 / ingest_wall.as_secs_f64(),
+        ingest_metrics.total_calls(),
+        ingest_metrics.total_calls() as f64 / 10_000.0,
+        ingest_metrics.uploaded_body_bytes as f64 / (1024.0 * 1024.0),
+        upload_ratio,
+        packed_bytes as f64 / (1024.0 * 1024.0),
+        max_pack_bytes as f64 / 1024.0,
+    );
+
+    drop(repository);
+    writer_cache.close().await.unwrap();
+    drop(writer_cache);
+    let reader_cache = FoyerNodeCache::open(cache_config).await.unwrap();
+    let reader = Repository::open(
+        plane.clone(),
+        RepositoryOptions {
+            read_only: true,
+            node_cache: Some(reader_cache.clone()),
+            ..options
+        },
+    )
+    .await
+    .unwrap();
+    plane.reset_metrics();
+    let before = reader.performance_snapshot();
+    let list_started = Instant::now();
+    let mut after = None;
+    let mut listed = 0;
+    loop {
+        let (objects, truncated) = reader
+            .list_objects_at(head, object_prefix.as_bytes(), after.as_deref(), 1_000)
+            .await
+            .unwrap();
+        listed += objects.len();
+        after = objects.last().map(|object| object.key.clone());
+        if !truncated {
+            break;
+        }
+    }
+    let list_wall = list_started.elapsed();
+    let after_snapshot = reader.performance_snapshot();
+    let list_metrics = plane.reset_metrics();
+    let ranged_fetches = after_snapshot
+        .node_ranged_fetches
+        .saturating_sub(before.node_ranged_fetches);
+    let cache_hits = after_snapshot
+        .node_cache_hits
+        .saturating_sub(before.node_cache_hits);
+    assert_eq!(listed, 10_000);
+    assert_eq!(ranged_fetches, 0, "persisted cache missed immutable nodes");
+    assert!(
+        list_metrics.total_calls() <= 1,
+        "persisted-cache list issued unexpected S3 calls: {list_metrics:?}"
+    );
+    eprintln!(
+        "rustfs_persisted_cache files=10000 list_ms={} s3_calls={} ranged_fetches={ranged_fetches} cache_hits={cache_hits}",
+        list_wall.as_millis(),
+        list_metrics.total_calls(),
+    );
+    drop(reader);
+    reader_cache.close().await.unwrap();
 }

--- a/extensions/s3/core/src/lib.rs
+++ b/extensions/s3/core/src/lib.rs
@@ -21,8 +21,9 @@ pub use repository::{
     FsckReport, GcDryRun, GcEpochStepReport, GcSweepReport, HistoryCursor, IndexFreshness,
     MergeConflict, MergePlan, MergePolicy, NodeIndexAdvanceReport, NodeIndexMaintenance,
     ObjectDiff, ObjectDiffCursor, ObjectDiffPage, ObjectSummary, RefCatalogAdvanceReport,
-    RefMoveReceipt, RepairReport, Repository, RepositoryOptions, RepositoryPerformanceSnapshot,
-    SyncReport, Tag, TagPage, TraversalBudget, VersionSummary, WriterLeaseMaintenance,
+    RefMoveReceipt, RefVersionCompactionReport, RepairReport, Repository, RepositoryOptions,
+    RepositoryPerformanceSnapshot, SyncReport, Tag, TagPage, TraversalBudget, VersionSummary,
+    WriterLeaseMaintenance,
 };
 pub use runtime::*;
 pub use store::{NodeCacheSnapshot, ProllyObjectStore};

--- a/extensions/s3/core/src/object_plane.rs
+++ b/extensions/s3/core/src/object_plane.rs
@@ -329,6 +329,26 @@ pub trait ObjectPlane: Send + Sync + 'static {
         version: PhysicalVersion,
     ) -> Result<DeleteOutcome>;
 
+    /// Delete at most 1,000 exact physical versions. Providers with a bulk
+    /// delete API should override this; the default preserves correctness for
+    /// simpler object planes.
+    async fn delete_exact_batch(
+        &self,
+        objects: Vec<(ObjectPath, PhysicalVersion)>,
+    ) -> Result<Vec<DeleteOutcome>> {
+        if objects.len() > 1_000 {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "exact delete batch cannot exceed 1,000 versions",
+            ));
+        }
+        let mut outcomes = Vec::with_capacity(objects.len());
+        for (path, version) in objects {
+            outcomes.push(self.delete_exact(&path, version).await?);
+        }
+        Ok(outcomes)
+    }
+
     async fn put_physical(&self, _request: PhysicalPut) -> Result<PhysicalObjectWriteResult> {
         Err(Error::new(
             ErrorCode::MissingCapability,
@@ -505,6 +525,7 @@ pub struct MemoryObjectPlane {
     inner: Arc<RwLock<MemoryState>>,
     versioned: bool,
     requests: Arc<MemoryRequestCounters>,
+    conflict_after_next_compare_exchange: Arc<AtomicBool>,
     lose_next_physical_put_response: Arc<AtomicBool>,
     lose_next_physical_delete_response: Arc<AtomicBool>,
     physical_put_delay_millis: Arc<AtomicU64>,
@@ -607,6 +628,7 @@ impl MemoryObjectPlane {
             inner: Arc::new(RwLock::new(MemoryState::default())),
             versioned,
             requests: Arc::new(MemoryRequestCounters::default()),
+            conflict_after_next_compare_exchange: Arc::new(AtomicBool::new(false)),
             lose_next_physical_put_response: Arc::new(AtomicBool::new(false)),
             lose_next_physical_delete_response: Arc::new(AtomicBool::new(false)),
             physical_put_delay_millis: Arc::new(AtomicU64::new(0)),
@@ -632,6 +654,14 @@ impl MemoryObjectPlane {
 
     pub fn lose_next_physical_put_response(&self) {
         self.lose_next_physical_put_response
+            .store(true, Ordering::Relaxed);
+    }
+
+    /// Test hook that applies the next successful CAS, then reports a
+    /// conflict containing the applied value. This models a provider or SDK
+    /// retry whose first wire attempt committed but whose response was lost.
+    pub fn conflict_after_next_compare_exchange(&self) {
+        self.conflict_after_next_compare_exchange
             .store(true, Ordering::Relaxed);
     }
 
@@ -858,9 +888,18 @@ impl ObjectPlane for MemoryObjectPlane {
             versions.clear();
         }
         versions.push(MemoryVersion {
-            bytes: Some(request.bytes),
+            bytes: Some(request.bytes.clone()),
             metadata: metadata.clone(),
         });
+        if self
+            .conflict_after_next_compare_exchange
+            .swap(false, Ordering::Relaxed)
+        {
+            return Ok(CompareExchangeOutcome::Conflict(Some(StoredObject {
+                bytes: request.bytes,
+                metadata,
+            })));
+        }
         Ok(CompareExchangeOutcome::Applied(metadata))
     }
 

--- a/extensions/s3/core/src/repository.rs
+++ b/extensions/s3/core/src/repository.rs
@@ -66,6 +66,12 @@ pub struct RepositoryOptions {
     /// Optional shared memory/disk cache. Cache failures are fail-open and all
     /// returned bytes are verified by CID before use.
     pub node_cache: Option<Arc<dyn NodeCache>>,
+    /// Compact obsolete physical versions of a hot branch ref at this
+    /// generation interval. Zero disables automatic compaction.
+    pub branch_ref_compaction_interval: u64,
+    /// Number of physical ref versions retained during compaction. Logical
+    /// history remains in immutable commits and is unaffected.
+    pub branch_ref_versions_to_retain: usize,
     /// Maximum exact physical deletions per second during GC. Zero disables
     /// pacing. The physical format accepts 1..=1,000 when configured.
     pub gc_delete_rate_limit_per_second: u32,
@@ -92,6 +98,8 @@ impl Default for RepositoryOptions {
             max_cached_node_locations: 65_536,
             max_cached_node_bytes: 64 * 1024 * 1024,
             node_cache: None,
+            branch_ref_compaction_interval: 5_000,
+            branch_ref_versions_to_retain: 100,
             gc_delete_rate_limit_per_second: 0,
             clock: Arc::new(SystemClock),
             ids: Arc::new(RandomIdSource),
@@ -180,6 +188,14 @@ pub struct RefMoveReceipt {
     pub new_target: CommitId,
     pub operation: OperationId,
     pub generation: RefGeneration,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RefVersionCompactionReport {
+    pub scanned: usize,
+    pub retained: usize,
+    pub deleted: usize,
+    pub already_missing: usize,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -745,7 +761,7 @@ impl<P: ObjectPlane> Repository<P> {
         };
         let stored = repository.store_commit(&commit, None).await?;
         let commit_id = stored.id;
-        repository.finalize_stored_commit(stored)?;
+        repository.finalize_stored_commit(stored).await?;
 
         let reflog = ReflogEntryV1 {
             branch: options.default_branch.clone(),
@@ -2199,6 +2215,147 @@ impl<P: ObjectPlane> Repository<P> {
         Ok(())
     }
 
+    fn invalidate_branch_cache(&self, branch: &str) -> Result<()> {
+        self.warm_branches
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "branch-cache lock poisoned"))?
+            .remove(&branch.to_string());
+        Ok(())
+    }
+
+    /// Delete obsolete physical versions of one branch-ref object while
+    /// retaining the current CAS token. Immutable commits remain the logical
+    /// history and are never removed by this maintenance operation.
+    pub async fn compact_branch_ref_versions(
+        &self,
+        branch: &str,
+    ) -> Result<RefVersionCompactionReport> {
+        validate_branch(branch)?;
+        self.physical_writer_generation_for_mutation().await?;
+        let _publication = self.lock_publication().await;
+        let loaded = self.load_ref_including_tombstone(branch).await?;
+        self.compact_branch_ref_versions_inner(branch, &loaded)
+            .await
+    }
+
+    async fn maybe_compact_branch_ref_versions(
+        &self,
+        branch: &str,
+        loaded: &LoadedRef,
+    ) -> Result<()> {
+        let interval = self.options.branch_ref_compaction_interval;
+        if interval != 0
+            && loaded.value.generation.0 != 0
+            && loaded.value.generation.0.is_multiple_of(interval)
+        {
+            self.compact_branch_ref_versions_inner(branch, loaded)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn compact_branch_ref_versions_inner(
+        &self,
+        branch: &str,
+        loaded: &LoadedRef,
+    ) -> Result<RefVersionCompactionReport> {
+        let path = branch_path(&self.options.repository_prefix, branch)?;
+        let current_version = loaded.token.version_id.as_deref().ok_or_else(|| {
+            Error::new(
+                ErrorCode::ProviderNotQualified,
+                "branch-ref compaction requires a versioned physical CAS object",
+            )
+        })?;
+        let mut continuation = None;
+        let mut versions = Vec::new();
+        loop {
+            let page = self
+                .plane
+                .list(ListRequest {
+                    prefix: path.as_str().to_string(),
+                    continuation,
+                    limit: 1_000,
+                    include_versions: true,
+                })
+                .await?;
+            versions.extend(
+                page.entries
+                    .into_iter()
+                    .filter(|entry| entry.path == path && !entry.metadata.delete_marker),
+            );
+            continuation = page.continuation;
+            if continuation.is_none() {
+                break;
+            }
+        }
+
+        if !versions.iter().any(|entry| {
+            entry.metadata.token.version_id.as_deref() == Some(current_version) && entry.is_latest
+        }) {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "current branch-ref version was absent from the version listing",
+            ));
+        }
+        versions.sort_by(|left, right| {
+            right
+                .is_latest
+                .cmp(&left.is_latest)
+                .then_with(|| {
+                    right
+                        .metadata
+                        .last_modified_millis
+                        .cmp(&left.metadata.last_modified_millis)
+                })
+                .then_with(|| {
+                    right
+                        .metadata
+                        .token
+                        .version_id
+                        .cmp(&left.metadata.token.version_id)
+                })
+        });
+        let scanned = versions.len();
+        let mut retained_versions = BTreeSet::new();
+        retained_versions.insert(current_version.to_string());
+        for entry in &versions {
+            if retained_versions.len() >= self.options.branch_ref_versions_to_retain {
+                break;
+            }
+            if let Some(version_id) = entry.metadata.token.version_id.as_ref() {
+                retained_versions.insert(version_id.clone());
+            }
+        }
+        let candidates = versions
+            .into_iter()
+            .filter_map(|entry| {
+                let version_id = entry.metadata.token.version_id?;
+                (!retained_versions.contains(&version_id))
+                    .then_some((entry.path, PhysicalVersion::Versioned { version_id }))
+            })
+            .collect::<Vec<_>>();
+        let mut report = RefVersionCompactionReport {
+            scanned,
+            retained: retained_versions.len(),
+            ..RefVersionCompactionReport::default()
+        };
+        for batch in candidates.chunks(1_000) {
+            for outcome in self.plane.delete_exact_batch(batch.to_vec()).await? {
+                match outcome {
+                    DeleteOutcome::Deleted => report.deleted += 1,
+                    DeleteOutcome::NotFound => report.already_missing += 1,
+                    DeleteOutcome::TokenMismatch => {
+                        return Err(Error::new(
+                            ErrorCode::PreconditionFailed,
+                            "branch-ref version changed during exact compaction",
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(report)
+    }
+
     async fn warm_branch_state(&self, branch: &str) -> Result<WarmBranchState> {
         if let Some(cached) = self
             .warm_branches
@@ -2951,7 +3108,7 @@ impl<P: ObjectPlane> Repository<P> {
             };
             let stored = target.store_commit(&destination_commit, prepared).await?;
             let destination_id = stored.id;
-            target.finalize_stored_commit(stored)?;
+            target.finalize_stored_commit(stored).await?;
             report.copied_objects += 1;
             commit_map.insert(source_id, destination_id);
         }
@@ -5320,6 +5477,8 @@ impl<P: ObjectPlane> Repository<P> {
                 idempotent_replay: true,
             });
         }
+        self.maybe_compact_branch_ref_versions(branch, &loaded_ref)
+            .await?;
         let created_at_millis = self.now_millis()?;
         let generation = CommitGeneration(base.generation.0.checked_add(1).ok_or_else(|| {
             Error::new(ErrorCode::InternalInvariant, "commit generation overflow")
@@ -5440,17 +5599,17 @@ impl<P: ObjectPlane> Repository<P> {
                 "physical writer fence changed during multi-delete publication",
             ));
         }
-        match self
+        let publication = self
             .plane
             .compare_exchange(CompareExchange {
                 path: branch_path(&self.options.repository_prefix, branch)?,
                 expected: Some(loaded_ref.token),
                 bytes: encode_canonical(&next_ref)?,
             })
-            .await?
-        {
-            CompareExchangeOutcome::Applied(metadata) => {
-                self.finalize_stored_commit(stored)?;
+            .await;
+        match publication {
+            Ok(CompareExchangeOutcome::Applied(metadata)) => {
+                self.finalize_stored_commit(stored).await?;
                 self.cache_branch(branch, next_ref, metadata.token, commit.clone())?;
                 Ok(CommitReceipt {
                     id: commit_id,
@@ -5462,10 +5621,38 @@ impl<P: ObjectPlane> Repository<P> {
                     idempotent_replay: false,
                 })
             }
-            CompareExchangeOutcome::Conflict(_) => Err(Error::new(
-                ErrorCode::PreconditionFailed,
-                "physical branch CAS conflicted; writer is fenced and must reopen",
-            )),
+            Ok(CompareExchangeOutcome::Conflict(_)) => {
+                self.invalidate_branch_cache(branch)?;
+                if let Some(receipt) = self
+                    .reconcile_operation(branch, operation, input_digest)
+                    .await?
+                {
+                    self.finalize_stored_commit(stored).await?;
+                    return Ok(receipt);
+                }
+                Err(Error::new(
+                    ErrorCode::PreconditionFailed,
+                    "physical branch CAS conflicted; writer is fenced and must reopen",
+                )
+                .retry(RetryAdvice::ReloadHead)
+                .operation(operation.to_string()))
+            }
+            Err(error) => {
+                self.invalidate_branch_cache(branch)?;
+                if let Some(receipt) = self
+                    .reconcile_operation(branch, operation, input_digest)
+                    .await?
+                {
+                    self.finalize_stored_commit(stored).await?;
+                    return Ok(receipt);
+                }
+                Err(Error::new(
+                    ErrorCode::OutcomeUnknown,
+                    format!("branch publication outcome is unknown: {error}"),
+                )
+                .retry(RetryAdvice::ReconcileOperation)
+                .operation(operation.to_string()))
+            }
         }
     }
 
@@ -5648,6 +5835,9 @@ impl<P: ObjectPlane> Repository<P> {
             return Ok(receipt);
         }
 
+        self.maybe_compact_branch_ref_versions(branch, &loaded_ref)
+            .await?;
+
         let generation = CommitGeneration(base.generation.0.checked_add(1).ok_or_else(|| {
             Error::new(ErrorCode::InternalInvariant, "commit generation overflow")
         })?);
@@ -5795,7 +5985,7 @@ impl<P: ObjectPlane> Repository<P> {
             .await;
         match publication {
             Ok(CompareExchangeOutcome::Applied(metadata)) => {
-                self.finalize_stored_commit(stored)?;
+                self.finalize_stored_commit(stored).await?;
                 let receipt = CommitReceipt {
                     id: commit_id,
                     operation,
@@ -5809,23 +5999,28 @@ impl<P: ObjectPlane> Repository<P> {
                 Ok(receipt)
             }
             Ok(CompareExchangeOutcome::Conflict(_)) => {
-                self.warm_branches
-                    .write()
-                    .map_err(|_| {
-                        Error::new(ErrorCode::InternalInvariant, "branch-cache lock poisoned")
-                    })?
-                    .remove(&branch.to_string());
-                Err(Error::new(
-                    ErrorCode::PreconditionFailed,
-                    "physical branch CAS conflicted; writer is fenced and must reopen",
-                ))
-            }
-            Err(error) => {
+                self.invalidate_branch_cache(branch)?;
                 if let Some(receipt) = self
                     .reconcile_operation(branch, operation, input_digest)
                     .await?
                 {
-                    self.finalize_stored_commit(stored)?;
+                    self.finalize_stored_commit(stored).await?;
+                    return Ok(receipt);
+                }
+                Err(Error::new(
+                    ErrorCode::PreconditionFailed,
+                    "physical branch CAS conflicted; writer is fenced and must reopen",
+                )
+                .retry(RetryAdvice::ReloadHead)
+                .operation(operation.to_string()))
+            }
+            Err(error) => {
+                self.invalidate_branch_cache(branch)?;
+                if let Some(receipt) = self
+                    .reconcile_operation(branch, operation, input_digest)
+                    .await?
+                {
+                    self.finalize_stored_commit(stored).await?;
                     return Ok(receipt);
                 }
                 Err(Error::new(
@@ -5870,10 +6065,8 @@ impl<P: ObjectPlane> Repository<P> {
                 runtime: RuntimeConfig::default(),
             },
         );
-        let mut objects =
-            self.tree_from_root(&base.state.objects, &self.format.state_tree_format)?;
-        let mut versions =
-            self.tree_from_root(&base.state.versions, &self.format.state_tree_format)?;
+        let objects = self.tree_from_root(&base.state.objects, &self.format.state_tree_format)?;
+        let versions = self.tree_from_root(&base.state.versions, &self.format.state_tree_format)?;
         let operations =
             self.tree_from_root(&base.state.operations, &self.format.state_tree_format)?;
         let generation = CommitGeneration(base.generation.0.checked_add(1).ok_or_else(|| {
@@ -5882,6 +6075,8 @@ impl<P: ObjectPlane> Repository<P> {
         let now = self.now_millis()?;
         let mut transitions = Vec::with_capacity(mutations.len());
         let mut version_ids = Vec::with_capacity(mutations.len());
+        let mut object_mutations = Vec::with_capacity(mutations.len());
+        let mut version_mutations = Vec::with_capacity(mutations.len());
         for (ordinal, mutation) in mutations.values().enumerate() {
             let key = mutation.key();
             let previous = engine
@@ -5931,37 +6126,32 @@ impl<P: ObjectPlane> Repository<P> {
                 body,
                 binding,
             )?;
-            objects = if matches!(version.body.kind, LogicalObjectVersionKindV1::DeleteMarker) {
-                engine.delete(&objects, key).await?
+            let delete_marker =
+                matches!(version.body.kind, LogicalObjectVersionKindV1::DeleteMarker);
+            if delete_marker {
+                object_mutations.push(Mutation::Delete { key: key.to_vec() });
             } else {
-                engine
-                    .put(
-                        &objects,
-                        key.to_vec(),
-                        encode_canonical(&CurrentObjectV1 {
-                            version: version.clone(),
-                        })?,
-                    )
-                    .await?
-            };
-            versions = engine
-                .put(
-                    &versions,
-                    version_tree_key(key, version.body.order, version.id),
-                    encode_canonical(&version)?,
-                )
-                .await?;
+                object_mutations.push(Mutation::Upsert {
+                    key: key.to_vec(),
+                    val: encode_canonical(&CurrentObjectV1 {
+                        version: version.clone(),
+                    })?,
+                });
+            }
+            version_mutations.push(Mutation::Upsert {
+                key: version_tree_key(key, version.body.order, version.id),
+                val: encode_canonical(&version)?,
+            });
             transitions.push(ObjectTransition {
                 key: key.to_vec(),
                 previous,
                 next: version.id,
-                delete_marker: matches!(
-                    version.body.kind,
-                    LogicalObjectVersionKindV1::DeleteMarker
-                ),
+                delete_marker,
             });
             version_ids.push(version.id);
         }
+        let objects = engine.batch(&objects, object_mutations).await?;
+        let versions = engine.batch(&versions, version_mutations).await?;
         let result = CanonicalOperationResult {
             kind: OperationKind::CommitSession,
             object_versions: version_ids.clone(),
@@ -6008,6 +6198,7 @@ impl<P: ObjectPlane> Repository<P> {
             &batch.branch,
             loaded_ref,
             batch.operation,
+            input_digest,
             commit,
             prepared,
             result,
@@ -7105,6 +7296,7 @@ impl<P: ObjectPlane> Repository<P> {
             target,
             loaded_ref,
             operation,
+            input_digest,
             commit,
             prepared,
             operation_result,
@@ -7337,6 +7529,7 @@ impl<P: ObjectPlane> Repository<P> {
             branch,
             loaded_ref,
             operation,
+            input_digest,
             commit,
             prepared,
             operation_result,
@@ -7434,6 +7627,7 @@ impl<P: ObjectPlane> Repository<P> {
         branch: &str,
         loaded_ref: LoadedRef,
         operation: OperationId,
+        input_digest: [u8; 32],
         commit: BucketCommitV1,
         prepared: Option<PreparedNodePack>,
         operation_result: CanonicalOperationResult,
@@ -7446,6 +7640,8 @@ impl<P: ObjectPlane> Repository<P> {
                 "prepared commit has a zero writer fence generation",
             ));
         }
+        self.maybe_compact_branch_ref_versions(branch, &loaded_ref)
+            .await?;
         let stored = self.store_commit(&commit, prepared).await?;
         let commit_id = stored.id;
         let reflog = ReflogEntryV1 {
@@ -7488,7 +7684,7 @@ impl<P: ObjectPlane> Repository<P> {
             .await;
         match publication {
             Ok(CompareExchangeOutcome::Applied(metadata)) => {
-                self.finalize_stored_commit(stored)?;
+                self.finalize_stored_commit(stored).await?;
                 let receipt = CommitReceipt {
                     id: commit_id,
                     operation,
@@ -7501,15 +7697,29 @@ impl<P: ObjectPlane> Repository<P> {
                 self.cache_branch(branch, next_ref, metadata.token, commit)?;
                 Ok(receipt)
             }
-            Ok(CompareExchangeOutcome::Conflict(_)) => Err(Error::new(
-                ErrorCode::PreconditionFailed,
-                "physical branch CAS conflicted; writer is fenced and must reopen",
-            )
-            .retry(RetryAdvice::ReloadHead)
-            .operation(operation.to_string())),
+            Ok(CompareExchangeOutcome::Conflict(_)) => {
+                self.invalidate_branch_cache(branch)?;
+                if let Some(receipt) = self
+                    .reconcile_operation(branch, operation, input_digest)
+                    .await?
+                {
+                    self.finalize_stored_commit(stored).await?;
+                    return Ok(receipt);
+                }
+                Err(Error::new(
+                    ErrorCode::PreconditionFailed,
+                    "physical branch CAS conflicted; writer is fenced and must reopen",
+                )
+                .retry(RetryAdvice::ReloadHead)
+                .operation(operation.to_string()))
+            }
             Err(error) => {
-                if let Some(receipt) = self.lookup_operation(branch, operation).await? {
-                    self.finalize_stored_commit(stored)?;
+                self.invalidate_branch_cache(branch)?;
+                if let Some(receipt) = self
+                    .reconcile_operation(branch, operation, input_digest)
+                    .await?
+                {
+                    self.finalize_stored_commit(stored).await?;
                     return Ok(receipt);
                 }
                 Err(Error::new(
@@ -9621,10 +9831,11 @@ impl<P: ObjectPlane> Repository<P> {
         Ok(StoredCommit { id, pending_pack })
     }
 
-    fn finalize_stored_commit(&self, stored: StoredCommit) -> Result<()> {
+    async fn finalize_stored_commit(&self, stored: StoredCommit) -> Result<()> {
         if let Some((prepared, payload_offset)) = stored.pending_pack {
             self.node_store
-                .commit_node_pack(stored.id, prepared, payload_offset)?;
+                .commit_node_pack(stored.id, prepared, payload_offset)
+                .await?;
         }
         Ok(())
     }
@@ -9760,6 +9971,17 @@ fn validate_options(options: &RepositoryOptions) -> Result<()> {
         return Err(Error::new(
             ErrorCode::InvalidLimit,
             "metadata and node-pack cache bounds must be greater than zero",
+        ));
+    }
+    if options.branch_ref_compaction_interval != 0
+        && (options.branch_ref_compaction_interval < 100
+            || options.branch_ref_versions_to_retain == 0
+            || options.branch_ref_versions_to_retain as u64
+                >= options.branch_ref_compaction_interval)
+    {
+        return Err(Error::new(
+            ErrorCode::InvalidLimit,
+            "branch-ref compaction requires an interval of at least 100 and a smaller nonzero retention count",
         ));
     }
     if options.gc_delete_rate_limit_per_second > 1_000 {

--- a/extensions/s3/core/src/store.rs
+++ b/extensions/s3/core/src/store.rs
@@ -6,6 +6,7 @@ use std::{
     },
 };
 
+use futures_util::StreamExt;
 use prolly::{AsyncStore, BatchOp, Cid};
 
 use crate::{
@@ -566,7 +567,7 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
         }))
     }
 
-    pub(crate) fn commit_node_pack(
+    pub(crate) async fn commit_node_pack(
         &self,
         container: CommitId,
         prepared: PreparedNodePack,
@@ -609,15 +610,21 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
                 Arc::new(pack),
                 usize::try_from(reference.object_len).unwrap_or(usize::MAX),
             );
-        let mut live_pending = state
-            .pending
-            .write()
-            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?;
-        for (cid, bytes) in pending {
-            if live_pending.get(&cid) == Some(&bytes) {
-                live_pending.remove(&cid);
+        {
+            let mut live_pending = state.pending.write().map_err(|_| {
+                Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned")
+            })?;
+            for (cid, bytes) in &pending {
+                if live_pending.get(cid) == Some(bytes) {
+                    live_pending.remove(cid);
+                }
             }
         }
+        futures_util::stream::iter(pending)
+            .for_each_concurrent(Some(16), |(cid, bytes)| async move {
+                self.admit_node(cid, bytes).await;
+            })
+            .await;
         Ok(())
     }
 

--- a/extensions/s3/core/tests/prolly_s3_profile.rs
+++ b/extensions/s3/core/tests/prolly_s3_profile.rs
@@ -537,6 +537,183 @@ async fn two_object_physical_batch_is_exactly_four_calls() {
 }
 
 #[tokio::test]
+async fn applied_put_cas_conflict_is_reconciled_by_operation_id() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        physical_options(".prolly/prolly-s3/reconcile-applied-put"),
+    )
+    .await
+    .unwrap();
+
+    plane.conflict_after_next_compare_exchange();
+    let receipt = repository
+        .put_bytes(
+            "main",
+            b"reconciled.bin".to_vec(),
+            b"published".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(receipt.idempotent_replay);
+    assert_eq!(repository.head("main").await.unwrap(), receipt.id);
+    assert_eq!(
+        repository
+            .get_current("main", b"reconciled.bin")
+            .await
+            .unwrap()
+            .bytes,
+        b"published"
+    );
+}
+
+#[tokio::test]
+async fn applied_batch_cas_conflict_is_reconciled_by_operation_id() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        physical_options(".prolly/prolly-s3/reconcile-applied-batch"),
+    )
+    .await
+    .unwrap();
+    let batch = repository
+        .begin_physical_batch("main", "reconciled batch", 60_000)
+        .await
+        .unwrap();
+
+    plane.conflict_after_next_compare_exchange();
+    let receipt = repository
+        .publish_physical_batch(
+            batch,
+            vec![PhysicalBatchMutationV1::Put {
+                key: b"reconciled-batch.bin".to_vec(),
+                bytes: b"published".to_vec(),
+                headers: ObjectHeaders::default(),
+                user_metadata: BTreeMap::new(),
+            }],
+        )
+        .await
+        .unwrap();
+
+    assert!(receipt.idempotent_replay);
+    assert_eq!(repository.head("main").await.unwrap(), receipt.id);
+}
+
+#[tokio::test]
+async fn applied_multi_delete_cas_conflict_is_reconciled_by_operation_id() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        physical_options(".prolly/prolly-s3/reconcile-applied-multi-delete"),
+    )
+    .await
+    .unwrap();
+    repository
+        .put_bytes(
+            "main",
+            b"delete-me.bin".to_vec(),
+            b"published".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    plane.conflict_after_next_compare_exchange();
+    let receipt = repository
+        .delete_objects("main", vec![b"delete-me.bin".to_vec()], None)
+        .await
+        .unwrap();
+
+    assert!(receipt.idempotent_replay);
+    assert_eq!(repository.head("main").await.unwrap(), receipt.id);
+    assert!(repository
+        .get_current("main", b"delete-me.bin")
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn hot_branch_ref_versions_are_compacted_without_losing_history() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let mut options = physical_options(".prolly/prolly-s3/ref-version-compaction");
+    options.branch_ref_compaction_interval = 100;
+    options.branch_ref_versions_to_retain = 5;
+    let repository = Repository::initialize(plane, options).await.unwrap();
+    for index in 0..101 {
+        repository
+            .put_bytes(
+                "main",
+                format!("objects/{index:04}.bin").into_bytes(),
+                vec![index as u8; 32],
+                ObjectHeaders::default(),
+                BTreeMap::new(),
+                None,
+            )
+            .await
+            .unwrap();
+    }
+
+    let report = repository
+        .compact_branch_ref_versions("main")
+        .await
+        .unwrap();
+    assert_eq!(report.scanned, 6, "automatic compaction did not run");
+    assert_eq!(report.retained, 5);
+    assert_eq!(report.deleted, 1);
+    assert_eq!(repository.list_reflog("main").await.unwrap().len(), 101);
+    assert_eq!(
+        repository
+            .get_current("main", b"objects/0000.bin")
+            .await
+            .unwrap()
+            .bytes,
+        vec![0; 32]
+    );
+}
+
+#[tokio::test]
+async fn hundred_object_batch_packs_only_final_reachable_nodes() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane,
+        physical_options(".prolly/prolly-s3/final-batch-nodes"),
+    )
+    .await
+    .unwrap();
+    let batch = repository
+        .begin_physical_batch("main", "one hundred objects", 60_000)
+        .await
+        .unwrap();
+    let receipt = repository
+        .publish_physical_batch(
+            batch,
+            (0..100)
+                .map(|index| PhysicalBatchMutationV1::Put {
+                    key: format!("objects/{index:04}.bin").into_bytes(),
+                    bytes: vec![index as u8; 1024],
+                    headers: ObjectHeaders::default(),
+                    user_metadata: BTreeMap::new(),
+                })
+                .collect(),
+        )
+        .await
+        .unwrap();
+    let commit = repository.commit(receipt.id).await.unwrap();
+    let packed_bytes = commit.node_pack.expect("batch node pack").object_len;
+
+    assert!(
+        packed_bytes < 2 * 1024 * 1024,
+        "100-object commit packed {packed_bytes} bytes of transient nodes"
+    );
+}
+
+#[tokio::test]
 async fn two_object_physical_multi_delete_is_exactly_four_calls() {
     let plane = Arc::new(MemoryObjectPlane::new(true));
     let repository = Repository::initialize(
@@ -1621,6 +1798,56 @@ async fn sharded_node_index_opens_lazily_and_node_cache_eliminates_repeat_ranges
     assert!(shared_warm.node_cache_hits > 0);
     assert_eq!(shared_warm.node_ranged_fetches, 0);
     assert_eq!(plane.request_snapshot().list, 0);
+}
+
+#[tokio::test]
+async fn writer_populates_shared_node_cache_for_a_zero_range_reopen() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let shared_node_cache = Arc::new(MemoryNodeCache::new(64 * 1024 * 1024));
+    let options = RepositoryOptions {
+        max_cached_node_pack_bytes: 1,
+        node_cache: Some(shared_node_cache.clone()),
+        ..physical_options(".prolly/prolly-s3/write-through-node-cache")
+    };
+    let repository = Repository::initialize(plane.clone(), options.clone())
+        .await
+        .unwrap();
+    for index in 0..128 {
+        repository
+            .put_bytes(
+                "main",
+                format!("objects/{index:04}.bin").into_bytes(),
+                vec![index as u8; 1024],
+                ObjectHeaders::default(),
+                BTreeMap::new(),
+                None,
+            )
+            .await
+            .unwrap();
+    }
+    let head = repository.head("main").await.unwrap();
+    drop(repository);
+
+    let reader = Repository::open(
+        plane.clone(),
+        RepositoryOptions {
+            read_only: true,
+            node_cache: Some(shared_node_cache),
+            ..options
+        },
+    )
+    .await
+    .unwrap();
+    plane.reset_request_counts();
+    let (objects, truncated) = reader
+        .list_objects_at(head, b"objects/", None, 1_000)
+        .await
+        .unwrap();
+
+    assert_eq!(objects.len(), 128);
+    assert!(!truncated);
+    assert_eq!(reader.performance_snapshot().node_ranged_fetches, 0);
+    assert!(plane.request_snapshot().get <= 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What changed

- reconcile ambiguous branch CAS conflicts by stable operation ID before returning a fenced-writer error
- add deterministic applied-then-conflicted tests for put, atomic batch, and multi-delete
- add an ignored, reproducible 10K concurrent-commit RustFS regression gate
- compact obsolete physical branch-ref versions every 5,000 generations using bulk exact-version deletes
- add `Client::ingest_objects`, with 100 whole files per commit as the recommended default bulk path
- build batch Prolly trees with one `batch` mutation pass so transient intermediate nodes are not packed
- write committed nodes through to the configured cache only after successful or reconciled publication
- add bounded node-cache prewarming and verify Foyer close/reopen persistence
- document the APIs, production limits, maintenance controls, and measured local evidence

## Why

The previous sustained hot-branch probe could fail an ambiguous CAS without checking whether the operation had actually committed. Batch construction also packed transient nodes, causing 2.70x uploaded-byte amplification. Cold 10K traversal required 421+ S3 calls because committed nodes were not persisted into Foyer.

The first new 10K run also exposed RustFS beta.10's hardcoded 10,000-version limit per physical object. A branch ref is one hot CAS object, so automatic exact-version compaction is required for a reproducible 10K gate and for providers with finite per-object version limits. Compaction removes only obsolete physical ref-object versions; immutable commits and logical history remain authoritative.

## Impact

- Single whole-file writes remain three foreground S3 calls outside the amortized maintenance boundary.
- Bulk ingestion defaults to 100 files per commit and measured 1.020 calls/file locally.
- The final 10K independent-commit tier measured 3.005 calls/write, including 24 amortized compaction calls.
- A persisted Foyer cache reduces the measured 10K snapshot listing from 421+ S3 calls to one commit GET and zero node-range GETs.

## RustFS evidence

- 10K concurrent commits, 32 callers, 64 KiB/file: passed in 469.81 s; final tier 19.63 writes/s, p50/p95/p99 1,462/2,760/3,285 ms; final generation and all 10K logical keys verified
- 10K batched files, 100 files/commit: passed in 78.89 s at 126.76 files/s and 1.020 calls/file
- uploaded-byte amplification: 1.083x, down from 2.70x
- node packs: 49.73 MiB total; 965.65 KiB maximum per 100-file commit
- Foyer close/reopen full listing: 285 ms, one S3 call, zero ranged node fetches

These are local regression results, not AWS durability, availability, latency, or cost claims.

## Validation

- `cargo fmt --manifest-path extensions/s3/Cargo.toml --all -- --check`
- `cargo test --manifest-path extensions/s3/Cargo.toml --workspace --all-features`
- `cargo clippy --manifest-path extensions/s3/Cargo.toml --workspace --all-features --all-targets -- -D warnings`
- `extensions/s3/scripts/check_clean_downstream.sh`
- `extensions/s3/scripts/check_dependency_security.sh`
- normal RustFS integration suite
- ignored 10K concurrent-commit RustFS gate
- ignored 10K batched-ingest and persisted-Foyer RustFS gate
