### PR TITLE
Enable concurrent branch publication

### DIFF
--- a/extensions/s3/CACHE-AND-SCALE-DESIGN.md
+++ b/extensions/s3/CACHE-AND-SCALE-DESIGN.md
@@ -250,9 +250,10 @@ and advances the node-index head. Cache write-through adds local I/O but no
 foreground S3 request; explicit prewarming performs the traversal reads needed
 to populate a new host.
 
-The fenced writer serializes only publication for a single branch. Scale-out
-uses independent branches or repository partitions; a branch with one mutable
-head has a finite maximum commit rate.
+The fenced writer uses one publication lane per branch. Different branch refs
+can publish concurrently; repository-wide maintenance takes an exclusive
+barrier across those lanes. Scale-out uses independent branches or repository
+partitions; a branch with one mutable head has a finite maximum commit rate.
 
 ## Garbage collection at billion scale
 

--- a/extensions/s3/PROLLY-S3-DESIGN.md
+++ b/extensions/s3/PROLLY-S3-DESIGN.md
@@ -10,7 +10,8 @@ The S3 extension has one storage architecture:
 - Prolly commits are authoritative for current state and history;
 - each logical version records the exact provider-issued `VersionId`;
 - the Prolly wrapper is the exclusive writer for managed keys;
-- one fenced writer service serializes mutation publication;
+- one fenced writer service serializes publication per branch while allowing
+  independent branches to publish concurrently;
 - repository metadata uses format v1 under `.prolly/v1/`.
 
 The repository-chunked profile, profile selector, mixed-mode codec, durable
@@ -160,8 +161,11 @@ SHA-256 values, sizes, and whole-object checksums.
 
 The architecture intentionally does not use optimistic multi-writer retry
 loops. A repository-scoped lease grants one process mutation authority.
-Concurrent callers inside that process upload payloads before a short
-publication mutex; batch payload mutations use configurable bounded
+Concurrent callers inside that process upload payloads before entering a
+branch-keyed publication lane. Callers on one branch remain ordered, while
+independent branches can construct commits and CAS their refs concurrently.
+Repository-wide maintenance, including GC and repair, takes an exclusive
+barrier across all lanes. Batch payload mutations use configurable bounded
 parallelism. This keeps each completed warm write at three calls under 1, 8,
 or 32 callers without serializing network upload time.
 

--- a/extensions/s3/README.md
+++ b/extensions/s3/README.md
@@ -35,7 +35,8 @@ path and publishes up to 100 whole files per commit by default.
 - The bucket must have physical versioning enabled.
 - The wrapper must be the exclusive writer for managed object keys.
 - One fenced writer service owns mutations. Concurrent payload requests run in
-  parallel; only commit construction and ref publication are serialized.
+  parallel; commit construction and ref publication are serialized per branch,
+  and independent branches publish concurrently.
 - Reads always use the exact S3 `VersionId` recorded by the selected Prolly
   commit. A raw `GetObject` without `version_id` is not a canonical read.
 - Bucket lifecycle rules must not expire versions managed by the repository.

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -277,8 +277,9 @@ assert_eq!(result.commit.as_ref().unwrap().operation, operation);
 ```
 
 The client does not retry logical branch conflicts. Local payload uploads may
-run concurrently, while the short metadata-publication phase is serialized; a
-stale expected head fails explicitly.
+run concurrently. The short metadata-publication phase is serialized per
+branch, while independent branches can publish concurrently; a stale expected
+head fails explicitly.
 
 ## Add a persistent node cache
 

--- a/extensions/s3/core/src/object_plane.rs
+++ b/extensions/s3/core/src/object_plane.rs
@@ -531,6 +531,9 @@ pub struct MemoryObjectPlane {
     physical_put_delay_millis: Arc<AtomicU64>,
     physical_put_in_flight: Arc<AtomicU64>,
     physical_put_max_in_flight: Arc<AtomicU64>,
+    compare_exchange_delay_millis: Arc<AtomicU64>,
+    compare_exchange_in_flight: Arc<AtomicU64>,
+    compare_exchange_max_in_flight: Arc<AtomicU64>,
 }
 
 struct InFlightGuard(Arc<AtomicU64>);
@@ -634,6 +637,9 @@ impl MemoryObjectPlane {
             physical_put_delay_millis: Arc::new(AtomicU64::new(0)),
             physical_put_in_flight: Arc::new(AtomicU64::new(0)),
             physical_put_max_in_flight: Arc::new(AtomicU64::new(0)),
+            compare_exchange_delay_millis: Arc::new(AtomicU64::new(0)),
+            compare_exchange_in_flight: Arc::new(AtomicU64::new(0)),
+            compare_exchange_max_in_flight: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -650,6 +656,21 @@ impl MemoryObjectPlane {
 
     pub fn reset_physical_put_concurrency(&self) {
         self.physical_put_max_in_flight.store(0, Ordering::Relaxed);
+    }
+
+    /// Test hook for proving independent mutable-object publications overlap.
+    pub fn set_compare_exchange_delay_millis(&self, delay_millis: u64) {
+        self.compare_exchange_delay_millis
+            .store(delay_millis, Ordering::Relaxed);
+    }
+
+    pub fn max_compare_exchanges_in_flight(&self) -> u64 {
+        self.compare_exchange_max_in_flight.load(Ordering::Relaxed)
+    }
+
+    pub fn reset_compare_exchange_concurrency(&self) {
+        self.compare_exchange_max_in_flight
+            .store(0, Ordering::Relaxed);
     }
 
     pub fn lose_next_physical_put_response(&self) {
@@ -860,6 +881,17 @@ impl ObjectPlane for MemoryObjectPlane {
         self.requests
             .compare_exchange
             .fetch_add(1, Ordering::Relaxed);
+        let in_flight = self
+            .compare_exchange_in_flight
+            .fetch_add(1, Ordering::Relaxed)
+            + 1;
+        self.compare_exchange_max_in_flight
+            .fetch_max(in_flight, Ordering::Relaxed);
+        let _in_flight = InFlightGuard(self.compare_exchange_in_flight.clone());
+        let delay = self.compare_exchange_delay_millis.load(Ordering::Relaxed);
+        if delay > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+        }
         let mut state = self
             .inner
             .write()

--- a/extensions/s3/core/src/repository.rs
+++ b/extensions/s3/core/src/repository.rs
@@ -657,6 +657,11 @@ pub struct NodeIndexMaintenance {
     task: tokio::task::JoinHandle<()>,
 }
 
+struct PublicationLaneGuard<'a> {
+    _barrier: tokio::sync::RwLockReadGuard<'a, ()>,
+    _lane: tokio::sync::OwnedMutexGuard<()>,
+}
+
 impl Drop for NodeIndexMaintenance {
     fn drop(&mut self) {
         self.task.abort();
@@ -676,7 +681,8 @@ pub struct Repository<P: ObjectPlane> {
     writer_lease: Arc<RwLock<Option<HeldWriterLease>>>,
     warm_branches: Arc<RwLock<BoundedCache<String, WarmBranchState>>>,
     commit_cache: Arc<RwLock<BoundedCache<CommitId, BucketCommitV1>>>,
-    physical_publication: Arc<tokio::sync::Mutex<()>>,
+    publication_barrier: Arc<tokio::sync::RwLock<()>>,
+    publication_lanes: Arc<std::sync::Mutex<BTreeMap<String, Weak<tokio::sync::Mutex<()>>>>>,
     payload_writes: Arc<tokio::sync::Semaphore>,
     operation_locks: Arc<std::sync::Mutex<BTreeMap<OperationId, Weak<tokio::sync::Mutex<()>>>>>,
     lease_renewal: Arc<tokio::sync::Mutex<()>>,
@@ -946,7 +952,8 @@ impl<P: ObjectPlane> Repository<P> {
             writer_lease: Arc::new(RwLock::new(None)),
             warm_branches: Arc::new(RwLock::new(BoundedCache::new(max_cached_branches))),
             commit_cache: Arc::new(RwLock::new(BoundedCache::new(max_cached_commits))),
-            physical_publication: Arc::new(tokio::sync::Mutex::new(())),
+            publication_barrier: Arc::new(tokio::sync::RwLock::new(())),
+            publication_lanes: Arc::new(std::sync::Mutex::new(BTreeMap::new())),
             payload_writes: Arc::new(tokio::sync::Semaphore::new(max_parallel_payload_writes)),
             operation_locks: Arc::new(std::sync::Mutex::new(BTreeMap::new())),
             lease_renewal: Arc::new(tokio::sync::Mutex::new(())),
@@ -997,7 +1004,7 @@ impl<P: ObjectPlane> Repository<P> {
         }
     }
 
-    async fn lock_publication(&self) -> tokio::sync::MutexGuard<'_, ()> {
+    fn begin_publication_wait(&self) -> std::time::Instant {
         let depth = self
             .performance
             .publication_queue_depth
@@ -1006,8 +1013,10 @@ impl<P: ObjectPlane> Repository<P> {
         self.performance
             .publication_max_queue_depth
             .fetch_max(depth, Ordering::Relaxed);
-        let started = std::time::Instant::now();
-        let guard = self.physical_publication.lock().await;
+        std::time::Instant::now()
+    }
+
+    fn finish_publication_wait(&self, started: std::time::Instant) {
         self.performance
             .publication_queue_depth
             .fetch_sub(1, Ordering::Relaxed);
@@ -1018,7 +1027,54 @@ impl<P: ObjectPlane> Repository<P> {
             u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX),
             Ordering::Relaxed,
         );
-        guard
+    }
+
+    fn publication_lane(&self, scope: &str) -> Arc<tokio::sync::Mutex<()>> {
+        let mut lanes = self
+            .publication_lanes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        lanes.retain(|_, lane| lane.strong_count() > 0);
+        if let Some(lane) = lanes.get(scope).and_then(Weak::upgrade) {
+            return lane;
+        }
+        let lane = Arc::new(tokio::sync::Mutex::new(()));
+        lanes.insert(scope.to_string(), Arc::downgrade(&lane));
+        lane
+    }
+
+    async fn lock_publication_lane(&self, scope: &str) -> PublicationLaneGuard<'_> {
+        let started = self.begin_publication_wait();
+        // Take the keyed lane first. Otherwise multiple waiters for one branch
+        // could hold read locks and unnecessarily starve global maintenance.
+        let lane = self.publication_lane(scope).lock_owned().await;
+        let barrier = self.publication_barrier.read().await;
+        self.finish_publication_wait(started);
+        PublicationLaneGuard {
+            _barrier: barrier,
+            _lane: lane,
+        }
+    }
+
+    async fn lock_branch_publication(&self, branch: &str) -> PublicationLaneGuard<'_> {
+        self.lock_publication_lane(&format!("branch:{branch}"))
+            .await
+    }
+
+    async fn lock_named_publication(
+        &self,
+        namespace: &str,
+        name: &str,
+    ) -> PublicationLaneGuard<'_> {
+        self.lock_publication_lane(&format!("{namespace}:{name}"))
+            .await
+    }
+
+    async fn lock_global_publication(&self) -> tokio::sync::RwLockWriteGuard<'_, ()> {
+        let started = self.begin_publication_wait();
+        let barrier = self.publication_barrier.write().await;
+        self.finish_publication_wait(started);
+        barrier
     }
 
     /// Serialize requests that reuse an idempotency key before they touch the
@@ -2232,7 +2288,7 @@ impl<P: ObjectPlane> Repository<P> {
     ) -> Result<RefVersionCompactionReport> {
         validate_branch(branch)?;
         self.physical_writer_generation_for_mutation().await?;
-        let _publication = self.lock_publication().await;
+        let _publication = self.lock_branch_publication(branch).await;
         let loaded = self.load_ref_including_tombstone(branch).await?;
         self.compact_branch_ref_versions_inner(branch, &loaded)
             .await
@@ -2937,6 +2993,14 @@ impl<P: ObjectPlane> Repository<P> {
             }
         }
         let writer_fence_generation = target.physical_writer_generation_for_mutation().await?;
+        let target_write_store = target.node_store.isolated_write_session();
+        let target_engine = AsyncProlly::new(
+            target_write_store.clone(),
+            Config {
+                format: target.format.state_tree_format.clone(),
+                runtime: RuntimeConfig::default(),
+            },
+        );
         let mut binding_map: BTreeMap<(Vec<u8>, ObjectVersionId), crate::PhysicalObjectBindingV1> =
             BTreeMap::new();
         for (source_id, source_commit) in source_ordered {
@@ -2956,7 +3020,7 @@ impl<P: ObjectPlane> Repository<P> {
                 Some(parent) => Some(target.load_commit(*parent).await?),
                 None => None,
             };
-            let empty = target.engine.create();
+            let empty = target_engine.create();
             let mut objects = match &base {
                 Some(commit) => target
                     .tree_from_root(&commit.state.objects, &target.format.state_tree_format)?,
@@ -3039,8 +3103,7 @@ impl<P: ObjectPlane> Repository<P> {
                 binding_map.insert(binding_key, binding.clone());
                 version.binding = binding;
                 version.validate()?;
-                versions = target
-                    .engine
+                versions = target_engine
                     .put(
                         &versions,
                         version_tree_key(&transition.key, version.body.order, version.id),
@@ -3048,10 +3111,9 @@ impl<P: ObjectPlane> Repository<P> {
                     )
                     .await?;
                 objects = if transition.delete_marker {
-                    target.engine.delete(&objects, &transition.key).await?
+                    target_engine.delete(&objects, &transition.key).await?
                 } else {
-                    target
-                        .engine
+                    target_engine
                         .put(
                             &objects,
                             transition.key.clone(),
@@ -3073,8 +3135,7 @@ impl<P: ObjectPlane> Repository<P> {
                             "physical transfer delta names a missing operation",
                         )
                     })?;
-                operations = target
-                    .engine
+                operations = target_engine
                     .put(&operations, operation.as_bytes().to_vec(), record)
                     .await?;
             }
@@ -3089,7 +3150,7 @@ impl<P: ObjectPlane> Repository<P> {
                     "physical transfer replay did not reproduce the logical operation state",
                 ));
             }
-            let prepared = target.node_store.prepare_node_pack(
+            let prepared = target_write_store.prepare_node_pack(
                 tree_format_digest(&target.format.state_tree_format)?,
                 Vec::new(),
             )?;
@@ -3123,7 +3184,7 @@ impl<P: ObjectPlane> Repository<P> {
         source_branch: &str,
     ) -> Result<SyncReport> {
         self.validate_sync_identity(source)?;
-        let _publication = self.lock_publication().await;
+        let _publication = self.lock_global_publication().await;
         let source_head = source.head(source_branch).await?;
         let (mapped, mut report) = source
             .replay_physical_history_to(self, &[source_head], false)
@@ -3147,7 +3208,9 @@ impl<P: ObjectPlane> Repository<P> {
     ) -> Result<SyncReport> {
         self.validate_sync_identity(destination)?;
         let source_head = self.head(source_branch).await?;
-        let _publication = destination.lock_publication().await;
+        let _publication = destination
+            .lock_branch_publication(destination_branch)
+            .await;
         let (mapped, mut report) = self
             .replay_physical_history_to(destination, &[source_head], false)
             .await?;
@@ -3196,7 +3259,7 @@ impl<P: ObjectPlane> Repository<P> {
         validate_branch(name)?;
         let commit = self.load_commit(from).await?;
         let operation = self.new_operation();
-        let _physical_publication = self.lock_publication().await;
+        let _physical_publication = self.lock_branch_publication(name).await;
         let writer_fence_generation = self.physical_writer_generation_for_mutation().await?;
         let created_at_millis = self.now_millis()?;
         let reflog = ReflogEntryV1 {
@@ -3265,7 +3328,7 @@ impl<P: ObjectPlane> Repository<P> {
     }
 
     pub async fn delete_branch(&self, name: &str, expected: CommitId) -> Result<()> {
-        let _physical_publication = self.lock_publication().await;
+        let _physical_publication = self.lock_branch_publication(name).await;
         let writer_fence_generation = self.physical_writer_generation_for_mutation().await?;
         let loaded = self.load_ref(name).await?;
         if loaded.value.target != expected {
@@ -3488,7 +3551,7 @@ impl<P: ObjectPlane> Repository<P> {
         target: CommitId,
         reason: &str,
     ) -> Result<RefMoveReceipt> {
-        let _physical_publication = self.lock_publication().await;
+        let _physical_publication = self.lock_branch_publication(branch).await;
         self.move_ref_inner(branch, loaded, target, reason).await
     }
 
@@ -3733,7 +3796,7 @@ impl<P: ObjectPlane> Repository<P> {
     pub async fn create_tag(&self, name: &str, target: CommitId) -> Result<Tag> {
         validate_branch(name)?;
         self.load_commit(target).await?;
-        let _publication = self.lock_publication().await;
+        let _publication = self.lock_named_publication("tag", name).await;
         self.physical_writer_generation_for_mutation().await?;
         let operation = self.new_operation();
         let created_at_millis = self.now_millis()?;
@@ -3947,6 +4010,7 @@ impl<P: ObjectPlane> Repository<P> {
     }
 
     pub async fn delete_tag(&self, name: &str, expected: CommitId) -> Result<()> {
+        let _publication = self.lock_named_publication("tag", name).await;
         let path = tag_path(&self.options.repository_prefix, name)?;
         let stored = self
             .plane
@@ -4037,7 +4101,7 @@ impl<P: ObjectPlane> Repository<P> {
             ));
         }
         self.load_commit(target).await?;
-        let _publication = self.lock_publication().await;
+        let _publication = self.lock_named_publication("pin", name).await;
         self.physical_writer_generation_for_mutation().await?;
         let path = retention_pin_path(&self.options.repository_prefix, name)?;
         let current = self.plane.load_mutable(&path).await?;
@@ -4095,6 +4159,7 @@ impl<P: ObjectPlane> Repository<P> {
     }
 
     pub async fn delete_retention_pin(&self, name: &str, expected: CommitId) -> Result<()> {
+        let _publication = self.lock_named_publication("pin", name).await;
         let path = retention_pin_path(&self.options.repository_prefix, name)?;
         let stored =
             self.plane.load_mutable(&path).await?.ok_or_else(|| {
@@ -4188,6 +4253,7 @@ impl<P: ObjectPlane> Repository<P> {
                 "tag recovery requires a non-empty reason",
             ));
         }
+        let _publication = self.lock_named_publication("tag", tag).await;
         let entry = self.tag_reflog(tag, reflog).await?;
         let target = entry.old_target.ok_or_else(|| {
             Error::new(
@@ -4567,7 +4633,7 @@ impl<P: ObjectPlane> Repository<P> {
                 "physical provider result disagrees with the uploaded object identity",
             ));
         }
-        let _publication = self.lock_publication().await;
+        let _publication = self.lock_branch_publication(branch).await;
         self.commit_one(
             branch,
             key,
@@ -4678,7 +4744,7 @@ impl<P: ObjectPlane> Repository<P> {
                 "physical provider result disagrees with the uploaded object identity",
             ));
         }
-        let _publication = self.lock_publication().await;
+        let _publication = self.lock_branch_publication(branch).await;
         self.commit_one(
             branch,
             key,
@@ -5096,7 +5162,7 @@ impl<P: ObjectPlane> Repository<P> {
                 "physical multipart result disagrees with its declared object identity",
             ));
         }
-        let _publication = self.lock_publication().await;
+        let _publication = self.lock_branch_publication(&session.branch).await;
         self.commit_one(
             &session.branch,
             session.key,
@@ -5212,7 +5278,7 @@ impl<P: ObjectPlane> Repository<P> {
             let (key, mutation) = result?;
             prepared.insert(key, mutation);
         }
-        let _publication = self.lock_publication().await;
+        let _publication = self.lock_branch_publication(&batch.branch).await;
         self.commit_batch(&batch, &prepared, request_digest).await
     }
 
@@ -5333,7 +5399,7 @@ impl<P: ObjectPlane> Repository<P> {
             },
         };
         drop(_payload_permit);
-        let _publication = self.lock_publication().await;
+        let _publication = self.lock_branch_publication(branch).await;
         self.commit_one(
             branch,
             key,
@@ -5438,15 +5504,16 @@ impl<P: ObjectPlane> Repository<P> {
             bindings.insert(key, binding);
         }
 
-        let _publication = self.lock_publication().await;
+        let _publication = self.lock_branch_publication(branch).await;
         let warm = self.warm_branch_state(branch).await?;
         let loaded_ref = LoadedRef {
             value: warm.reference,
             token: warm.token,
         };
         let base = warm.commit;
+        let write_store = self.node_store.isolated_write_session();
         let engine = AsyncProlly::new(
-            self.node_store.clone(),
+            write_store.clone(),
             Config {
                 format: self.format.state_tree_format.clone(),
                 runtime: RuntimeConfig::default(),
@@ -5547,7 +5614,7 @@ impl<P: ObjectPlane> Repository<P> {
             operation_ids: vec![operation],
             changes: transitions,
         };
-        let prepared = self.node_store.prepare_node_pack(
+        let prepared = write_store.prepare_node_pack(
             tree_format_digest(&self.format.state_tree_format)?,
             Vec::new(),
         )?;
@@ -5756,7 +5823,7 @@ impl<P: ObjectPlane> Repository<P> {
             },
         };
         drop(_payload_permit);
-        let _publication = self.lock_publication().await;
+        let _publication = self.lock_branch_publication(branch).await;
         self.commit_one(
             branch,
             destination_key,
@@ -5787,8 +5854,9 @@ impl<P: ObjectPlane> Repository<P> {
         validate_branch(branch)?;
         let created_at_millis = self.now_millis()?;
         let writer_fence_generation = self.physical_writer_generation_for_mutation().await?;
+        let write_store = self.node_store.isolated_write_session();
         let engine = AsyncProlly::new(
-            self.node_store.clone(),
+            write_store.clone(),
             Config {
                 format: self.format.state_tree_format.clone(),
                 runtime: RuntimeConfig::default(),
@@ -5925,7 +5993,7 @@ impl<P: ObjectPlane> Repository<P> {
                 ),
             }],
         };
-        let prepared = self.node_store.prepare_node_pack(
+        let prepared = write_store.prepare_node_pack(
             tree_format_digest(&self.format.state_tree_format)?,
             Vec::new(),
         )?;
@@ -6058,8 +6126,9 @@ impl<P: ObjectPlane> Repository<P> {
             ));
         }
         let writer_fence_generation = self.physical_writer_generation_for_mutation().await?;
+        let write_store = self.node_store.isolated_write_session();
         let engine = AsyncProlly::new(
-            self.node_store.clone(),
+            write_store.clone(),
             Config {
                 format: self.format.state_tree_format.clone(),
                 runtime: RuntimeConfig::default(),
@@ -6173,7 +6242,7 @@ impl<P: ObjectPlane> Repository<P> {
             operation_ids: vec![batch.operation],
             changes: transitions,
         };
-        let prepared = self.node_store.prepare_node_pack(
+        let prepared = write_store.prepare_node_pack(
             tree_format_digest(&self.format.state_tree_format)?,
             Vec::new(),
         )?;
@@ -7101,10 +7170,11 @@ impl<P: ObjectPlane> Repository<P> {
             base.as_bytes(),
             &[policy_byte],
         ]);
-        let _physical_publication = self.lock_publication().await;
+        let _physical_publication = self.lock_branch_publication(target).await;
         let writer_fence_generation = self.physical_writer_generation_for_mutation().await?;
+        let write_store = self.node_store.isolated_write_session();
         let engine = AsyncProlly::new(
-            self.node_store.clone(),
+            write_store.clone(),
             Config {
                 format: self.format.state_tree_format.clone(),
                 runtime: RuntimeConfig::default(),
@@ -7271,7 +7341,7 @@ impl<P: ObjectPlane> Repository<P> {
             operation_ids: vec![operation],
             changes: transitions,
         };
-        let prepared = self.node_store.prepare_node_pack(
+        let prepared = write_store.prepare_node_pack(
             tree_format_digest(&self.format.state_tree_format)?,
             Vec::new(),
         )?;
@@ -7352,10 +7422,11 @@ impl<P: ObjectPlane> Repository<P> {
             .into_iter()
             .filter(|key| ours_map.get(key) != source_map.get(key))
             .collect();
-        let _physical_publication = self.lock_publication().await;
+        let _physical_publication = self.lock_branch_publication(branch).await;
         let writer_fence_generation = self.physical_writer_generation_for_mutation().await?;
+        let write_store = self.node_store.isolated_write_session();
         let engine = AsyncProlly::new(
-            self.node_store.clone(),
+            write_store.clone(),
             Config {
                 format: self.format.state_tree_format.clone(),
                 runtime: RuntimeConfig::default(),
@@ -7504,7 +7575,7 @@ impl<P: ObjectPlane> Repository<P> {
             operation_ids: vec![operation],
             changes: transitions,
         };
-        let prepared = self.node_store.prepare_node_pack(
+        let prepared = write_store.prepare_node_pack(
             tree_format_digest(&self.format.state_tree_format)?,
             Vec::new(),
         )?;
@@ -7770,7 +7841,7 @@ impl<P: ObjectPlane> Repository<P> {
                 fsck,
             });
         }
-        let _publication = self.lock_publication().await;
+        let _publication = self.lock_global_publication().await;
         let source_head = source.head(source_branch).await?;
         let (mapped, mut sync) = source
             .replay_physical_history_to(self, &[source_head], true)
@@ -8118,7 +8189,7 @@ impl<P: ObjectPlane> Repository<P> {
     pub async fn start_gc_epoch_v2(&self, grace_millis: u64) -> Result<GcEpochV2> {
         self.validate_gc_plan_limits(grace_millis, 1)?;
         self.physical_writer_generation_for_mutation().await?;
-        let _publication = self.lock_publication().await;
+        let _publication = self.lock_global_publication().await;
         let planned_at_millis = self.now_millis()?;
         let cutoff_millis = planned_at_millis
             .checked_sub(grace_millis)
@@ -8187,7 +8258,7 @@ impl<P: ObjectPlane> Repository<P> {
             ));
         }
         self.physical_writer_generation_for_mutation().await?;
-        let _publication = self.lock_publication().await;
+        let _publication = self.lock_global_publication().await;
         let acquisition = self
             .performance
             .publication_acquisitions
@@ -8751,7 +8822,7 @@ impl<P: ObjectPlane> Repository<P> {
             ));
         }
         self.physical_writer_generation_for_mutation().await?;
-        let _publication = self.lock_publication().await;
+        let _publication = self.lock_global_publication().await;
         let acquisition = self
             .performance
             .publication_acquisitions

--- a/extensions/s3/core/src/store.rs
+++ b/extensions/s3/core/src/store.rs
@@ -25,8 +25,9 @@ struct PackedNodeLocation {
     sha256: [u8; 32],
 }
 
+type PackedPendingNodes = Arc<RwLock<BTreeMap<Cid, Vec<u8>>>>;
+
 struct PackedNodeState {
-    pending: RwLock<BTreeMap<Cid, Vec<u8>>>,
     locations: RwLock<BoundedNodeLocations>,
     packs: RwLock<PackedNodeCache>,
     node_cache: Option<Arc<dyn NodeCache>>,
@@ -172,6 +173,7 @@ pub struct ProllyObjectStore<P> {
     plane: Arc<P>,
     repository_prefix: String,
     packed: Option<Arc<PackedNodeState>>,
+    packed_pending: Option<PackedPendingNodes>,
     direct: Option<Arc<DirectNodeState>>,
 }
 
@@ -181,6 +183,7 @@ impl<P> Clone for ProllyObjectStore<P> {
             plane: self.plane.clone(),
             repository_prefix: self.repository_prefix.clone(),
             packed: self.packed.clone(),
+            packed_pending: self.packed_pending.clone(),
             direct: self.direct.clone(),
         }
     }
@@ -192,6 +195,7 @@ impl<P> ProllyObjectStore<P> {
             plane,
             repository_prefix: repository_prefix.into(),
             packed: None,
+            packed_pending: None,
             direct: None,
         }
     }
@@ -218,7 +222,6 @@ impl<P> ProllyObjectStore<P> {
             plane,
             repository_prefix: repository_prefix.into(),
             packed: Some(Arc::new(PackedNodeState {
-                pending: RwLock::new(BTreeMap::new()),
                 locations: RwLock::new(BoundedNodeLocations::new(max_cached_locations)),
                 packs: RwLock::new(PackedNodeCache::new(max_cached_pack_bytes)),
                 node_cache: None,
@@ -233,6 +236,7 @@ impl<P> ProllyObjectStore<P> {
                 ranged_fetches: AtomicU64::new(0),
                 locator: RwLock::new(None),
             })),
+            packed_pending: Some(Arc::new(RwLock::new(BTreeMap::new()))),
             direct: None,
         }
     }
@@ -249,6 +253,7 @@ impl<P> ProllyObjectStore<P> {
             plane,
             repository_prefix: repository_prefix.into(),
             packed: None,
+            packed_pending: None,
             direct: Some(Arc::new(DirectNodeState {
                 node_cache,
                 cache_namespace: NodeCacheNamespace {
@@ -321,6 +326,16 @@ impl<P> ProllyObjectStore<P> {
 impl<P: ObjectPlane> ProllyObjectStore<P> {
     pub fn is_packed(&self) -> bool {
         self.packed.is_some()
+    }
+
+    /// Share immutable node locations and caches while isolating newly built
+    /// nodes to one commit construction session.
+    pub(crate) fn isolated_write_session(&self) -> Self {
+        let mut session = self.clone();
+        if self.packed.is_some() {
+            session.packed_pending = Some(Arc::new(RwLock::new(BTreeMap::new())));
+        }
+        session
     }
 
     pub fn node_cache_snapshot(&self) -> NodeCacheSnapshot {
@@ -511,17 +526,27 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
         format_digest: TreeFormatDigest,
         attachments: Vec<(NodePackAttachmentKindV1, Vec<u8>)>,
     ) -> Result<Option<PreparedNodePack>> {
-        let Some(state) = &self.packed else {
-            return Ok(None);
-        };
-        let pending = state
-            .pending
-            .read()
-            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?
-            .clone();
-        if pending.is_empty() && attachments.is_empty() {
+        if self.packed.is_none() {
             return Ok(None);
         }
+        let mut pending_guard = self
+            .packed_pending
+            .as_ref()
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InternalInvariant,
+                    "packed pending-node session is absent",
+                )
+            })?
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?;
+        if pending_guard.is_empty() && attachments.is_empty() {
+            return Ok(None);
+        }
+        // A write session owns its pending set. Drain it into the prepared pack
+        // so a long-running replay can safely prepare more than one commit.
+        let pending = std::mem::take(&mut *pending_guard);
+        drop(pending_guard);
         let mut payload = Vec::new();
         let mut entries = Vec::with_capacity(pending.len());
         for (cid, bytes) in &pending {
@@ -610,16 +635,6 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
                 Arc::new(pack),
                 usize::try_from(reference.object_len).unwrap_or(usize::MAX),
             );
-        {
-            let mut live_pending = state.pending.write().map_err(|_| {
-                Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned")
-            })?;
-            for (cid, bytes) in &pending {
-                if live_pending.get(cid) == Some(bytes) {
-                    live_pending.remove(cid);
-                }
-            }
-        }
         futures_util::stream::iter(pending)
             .for_each_concurrent(Some(16), |(cid, bytes)| async move {
                 self.admit_node(cid, bytes).await;
@@ -687,8 +702,13 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
         let state = self.packed.as_ref().ok_or_else(|| {
             Error::new(ErrorCode::InternalInvariant, "packed node state is absent")
         })?;
-        if let Some(bytes) = state
-            .pending
+        let pending = self.packed_pending.as_ref().ok_or_else(|| {
+            Error::new(
+                ErrorCode::InternalInvariant,
+                "packed pending-node session is absent",
+            )
+        })?;
+        if let Some(bytes) = pending
             .read()
             .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?
             .get(&cid)
@@ -722,8 +742,7 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
 
         // Another request may have populated any tier while this request was
         // waiting for the CID-scoped fetch lock.
-        if let Some(bytes) = state
-            .pending
+        if let Some(bytes) = pending
             .read()
             .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?
             .get(&cid)
@@ -1113,9 +1132,15 @@ impl<P: ObjectPlane> AsyncStore for ProllyObjectStore<P> {
                 "attempted Prolly node write under the wrong CID",
             ));
         }
-        if let Some(state) = &self.packed {
-            state
-                .pending
+        if self.packed.is_some() {
+            self.packed_pending
+                .as_ref()
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "packed pending-node session is absent",
+                    )
+                })?
                 .write()
                 .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?
                 .insert(Cid(key.try_into().expect("length checked")), value.to_vec());
@@ -1137,15 +1162,21 @@ impl<P: ObjectPlane> AsyncStore for ProllyObjectStore<P> {
     }
 
     async fn delete(&self, key: &[u8]) -> Result<()> {
-        if let Some(state) = &self.packed {
+        if self.packed.is_some() {
             if key.len() != 32 {
                 return Err(Error::new(
                     ErrorCode::CorruptNode,
                     format!("Prolly node key has {} bytes, expected 32", key.len()),
                 ));
             }
-            state
-                .pending
+            self.packed_pending
+                .as_ref()
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "packed pending-node session is absent",
+                    )
+                })?
                 .write()
                 .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?
                 .remove(&Cid(key.try_into().expect("length checked")));

--- a/extensions/s3/core/tests/prolly_s3_profile.rs
+++ b/extensions/s3/core/tests/prolly_s3_profile.rs
@@ -784,6 +784,51 @@ async fn physical_batch_payload_uploads_are_bounded_and_parallel() {
     assert_eq!(plane.max_physical_puts_in_flight(), 3);
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn independent_branches_publish_their_refs_concurrently() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        physical_options(".prolly/prolly-s3/independent-branch-lanes"),
+    )
+    .await
+    .unwrap();
+    let root = repository.head("main").await.unwrap();
+    repository.create_branch("alpha", root).await.unwrap();
+    repository.create_branch("beta", root).await.unwrap();
+
+    plane.set_compare_exchange_delay_millis(50);
+    plane.reset_compare_exchange_concurrency();
+    let (alpha, beta) = tokio::join!(
+        repository.put_bytes(
+            "alpha",
+            b"alpha.bin".to_vec(),
+            b"alpha".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        ),
+        repository.put_bytes(
+            "beta",
+            b"beta.bin".to_vec(),
+            b"beta".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        ),
+    );
+    let alpha = alpha.unwrap();
+    let beta = beta.unwrap();
+
+    assert_eq!(
+        plane.max_compare_exchanges_in_flight(),
+        2,
+        "independent branch refs were serialized"
+    );
+    repository.fsck_commit(alpha.id).await.unwrap();
+    repository.fsck_commit(beta.id).await.unwrap();
+}
+
 #[tokio::test]
 async fn warm_physical_merge_reuses_bindings_in_two_calls() {
     let plane = Arc::new(MemoryObjectPlane::new(true));
@@ -1479,6 +1524,8 @@ async fn concurrent_writers_upload_payloads_before_serial_publication() {
     let repository = Repository::initialize(plane.clone(), options)
         .await
         .unwrap();
+    plane.set_compare_exchange_delay_millis(20);
+    plane.reset_compare_exchange_concurrency();
     plane.reset_physical_put_concurrency();
     let writes = (0..8).map(|index| {
         repository.put_bytes(
@@ -1495,6 +1542,7 @@ async fn concurrent_writers_upload_payloads_before_serial_publication() {
     }
     assert!(plane.max_physical_puts_in_flight() > 1);
     assert_eq!(plane.max_physical_puts_in_flight(), 3);
+    assert_eq!(plane.max_compare_exchanges_in_flight(), 1);
     let performance = repository.performance_snapshot();
     assert_eq!(performance.publication_acquisitions, 8);
     assert!(performance.publication_max_queue_depth >= 1);


### PR DESCRIPTION
## What changed

- replace the repository-wide publication mutex with branch-keyed publication lanes
- allow independent branch refs to construct commits and CAS concurrently
- retain a repository-wide read/write barrier for GC, repair, fetch, and other global maintenance
- isolate packed-node pending state per commit construction session
- serialize tag and retention-pin changes by object name
- update the architecture and client documentation

## Why

The repository-wide mutex serialized metadata publication even when writers targeted unrelated branch refs. It also meant simply removing the mutex would be unsafe because concurrent Prolly commit construction shared one mutable pending-node map.

The new locking model preserves ordering and CAS correctness on a hot branch while allowing independent branches to progress in parallel. Global maintenance still excludes every publication lane.

## Impact

One writer process can now publish independent branches concurrently. Same-branch writes remain ordered, and the repository-scoped writer lease remains the cross-process fencing boundary.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p prolly-s3-core --test prolly_s3_profile`
- `cargo test -p prolly-s3-core --test gc_retention`

The new deterministic regression delays mutable-object CAS calls and proves two independent branch publications overlap (`max in flight = 2`). The existing concurrent hot-branch test now also proves same-branch CAS remains serialized (`max in flight = 1`), and both concurrent commit closures pass fsck.
