### PR TITLE
Add native protocol-v2 S3 production path

### DIFF
--- a/.github/workflows/versioned-s3-client-required.yml
+++ b/.github/workflows/versioned-s3-client-required.yml
@@ -49,8 +49,10 @@ jobs:
           cargo +"$CLIENT_TOOLCHAIN" test --locked
           --manifest-path extensions/s3/Cargo.toml --workspace --all-features
           -- --skip seeded_histories_are_identical_across_stores_and_restart
-      - name: Independent canonical-format verifier
-        run: python3 extensions/s3/spec/prolly-s3/v1/conformance/verify.py
+      - name: Independent protocol structure verifiers
+        run: |
+          python3 extensions/s3/spec/prolly-s3/v1/conformance/verify.py
+          python3 extensions/s3/spec/prolly-s3/v2/conformance/verify.py
       - name: AWS qualification gate fails closed without operator inputs
         run: |
           if PROLLY_S3_AWS_PERF=0 cargo +"$CLIENT_TOOLCHAIN" test --locked \

--- a/extensions/s3/API.md
+++ b/extensions/s3/API.md
@@ -27,7 +27,7 @@ branches, diffs, conditional publication, and idempotency.
 | Partitioned GC | `start_gc_epoch`, `advance_gc_epoch`, `sweep_gc_epoch` |
 | Merge/restore | `merge`, `restore` |
 | Verify repository | `fsck` |
-| Explicit writer handoff | `takeover_writer` |
+| Explicit branch-writer handoff | `takeover_branch_writer` |
 | SDK request counters | `s3_operation_metrics` |
 | Publication queue/wait counters | `performance_snapshot` |
 

--- a/extensions/s3/API.md
+++ b/extensions/s3/API.md
@@ -31,6 +31,27 @@ branches, diffs, conditional publication, and idempotency.
 | SDK request counters | `s3_operation_metrics` |
 | Publication queue/wait counters | `performance_snapshot` |
 
+## Native protocol-v2 entry points
+
+New repositories that need immutable payload keys, resumable ingestion,
+event-driven ref catalogs, and scale-safe merge use `ClientV2`. V1 and v2 use
+separate format markers and are never dual-written.
+
+| Goal | API |
+|---|---|
+| Create or open native v2 | `ClientV2::builder().initialize()`, `open()` |
+| Select a branch | `for_branch` |
+| Stream a durable atomic commit | `begin_commit`, `put_stream`, `checkpoint`, `resume_commit`, `publish` |
+| Create/delete branches and tags | `create_branch`, `delete_branch`, `create_tag`, `delete_tag` |
+| Page ref catalogs | `list_branch_catalog_page`, `list_tag_catalog_page` |
+| Repair a catalog gap | `repair_branch_catalog_page`, `repair_tag_catalog_page` |
+| Start or advance merge | `start_merge`, `advance_merge` |
+| Select a criss-cross base | `merge_bases_page`, `select_merge_base` |
+| Inspect merge output | `merge_changes_page`, `merge_conflicts_page` |
+| Publish or discard merge | `publish_merge`, `cleanup_merge` |
+| Observe/rebuild branch indexes | `branch_index_health`, `start_branch_index_rebuild`, `advance_branch_index_rebuild` |
+| Explicit branch-writer handoff | `takeover_branch_writer` |
+
 ## Semantics to remember
 
 - `Versioned<T>::snapshot` is the Prolly commit used by the response.
@@ -49,3 +70,6 @@ branches, diffs, conditional publication, and idempotency.
   authoritative object before mutation.
 - Whole-result compatibility APIs retain finite limits. Use bounded history,
   structural diff, catalog, and GC APIs for growing repositories.
+- A native-v2 merge cursor is process-independent only when the caller saves
+  the exact cursor returned by each successful step. Publication rejects a
+  moved target branch and never rebases a completed plan.

--- a/extensions/s3/CACHE-AND-SCALE-DESIGN.md
+++ b/extensions/s3/CACHE-AND-SCALE-DESIGN.md
@@ -212,14 +212,25 @@ instead of treating repository size as an error. `diff_page_bounded` uses the
 engine's structural checkpoint, preserving CID-subtree pruning across pages.
 Legacy `log_at`, `diff_at`, `merge_bases`, merge planning, and whole-repository
 `fsck` remain compatibility APIs with finite traversal/memory limits; they are
-not the interfaces to use for unbounded jobs.
+not the interfaces to use for unbounded jobs. Native-v2 merge instead persists
+its graph frontier, seen set, candidate bases, changes, and conflicts in a
+job-scoped Prolly tree. Its canonical cursor remains constant-size and every
+advance has an explicit record budget.
 
 Background workers build a separate immutable commit-graph Prolly tree with
 generation numbers and binary-lifting ancestor pointers. A commit can reference
 ancestors at distances 1, 2, 4, 8, and so on, allowing bounded first-parent
 walks to skip history. Missing segments fall back to bounded graph walking,
-preserving correctness. Merge-base discovery remains a finite compatibility
-API until it gains its own resumable graph frontier.
+preserving correctness. Native-v2 merge uses those generation and skip-pointer
+entries for a fast first-parent ancestry path and a generation-priority,
+bidirectional paint-down frontier for general and criss-cross histories.
+
+Planning structurally diffs `base → ours` and `base → theirs`. Equal CIDs prune
+unchanged subtrees, and each page retains at most one pending record per input
+stream. Selected changes and conflicts are independently pageable. Output
+object, version, and external-delta roots are built in bounded pages and stored
+at deterministic CID paths so a different process can resume before a final
+commit envelope exists.
 
 ## Refs
 
@@ -227,11 +238,11 @@ Each ref retains its deterministic S3 object and independent CAS token. Exact
 lookup and publication therefore remain O(1) in ref count, and unrelated refs
 do not contend on a global head.
 
-Listing millions or billions of refs uses a derived Prolly catalog keyed by
-normalized ref name. The catalog is partitioned by tenant and prefix and is
-updated asynchronously by bounded, repeated authoritative namespace scans.
-List responses are paged and disclose catalog generation, scan epoch, and
-update time. A later scan repairs missed or stale entries.
+Listing millions or billions of native-v2 refs uses a 16-shard derived Prolly
+catalog keyed by normalized ref name. Immutable lifecycle events update only
+the selected shard during steady-state create, move, and delete operations.
+Bounded authoritative namespace scans are repair-only. Catalog pages are
+stable by shard and name and expose canonical continuation cursors.
 
 The catalog must never authorize writes. A caller that selects a catalog result
 still loads the authoritative ref object before mutation. Ref creation and

--- a/extensions/s3/OPERATIONS.md
+++ b/extensions/s3/OPERATIONS.md
@@ -118,6 +118,15 @@ v1's older `advance_node_index_v2`, `advance_commit_graph_v2`, and
 `advance_ref_catalog_v2` scan epochs remain compatibility/rebuild tools; do not
 use them as protocol-v2 steady-state maintenance.
 
+Native protocol v2 enumerates branches and tags through 16 event-driven
+catalog shards. Branch index maintenance records the latest authoritative ref
+generation after advancing its journal indexes. Branch/tag create and delete
+also update the catalog before returning. Catalog reads perform point GETs and
+must not call `ListObjectsV2`; monitor any ref-namespace LIST as repair or
+administrative traffic. If a crash leaves a published ref absent from the
+catalog, page `repair_branch_catalog_page` or `repair_tag_catalog_page` with a
+bounded limit and persist the returned continuation between invocations.
+
 ```rust
 use prolly::TreeFormat;
 use prolly_s3_core::JournalDerivedIndexesV2;

--- a/extensions/s3/OPERATIONS.md
+++ b/extensions/s3/OPERATIONS.md
@@ -154,7 +154,7 @@ are exact-deleted in restartable batches. Only one GC epoch may be active.
   the application decide whether to retry or merge.
 - Never automatically rebase an atomic commit.
 - Reuse a stable `OperationId` after an ambiguous response.
-- Stop writes when lease renewal is ambiguous or the fence is lost.
+- Stop writes when authority renewal is ambiguous or the fence is lost.
 - Perform takeover only after establishing that the previous writer cannot
   continue publishing.
 
@@ -209,8 +209,9 @@ For a portable backup, use `clone_to` to create a complete logical repository
 in a versioned archive bucket. Restore by opening that archive read-only and
 cloning it to the destination; both hops replay history and bind every logical
 version to the destination provider's exact ID. Open the result read-only, run
-`fsck`, and only then call `takeover_writer` with the previous writer ID, lease
-generation, and auditable credential/process-isolation evidence.
+`fsck`, and only then call `takeover_branch_writer` for each branch that the
+restored service will own, using the previous writer ID, authority generation,
+and auditable credential/process-isolation evidence.
 
 A provider-native physical snapshot is usable in place only when the restore
 mechanism explicitly guarantees preservation of every opaque `VersionId` and

--- a/extensions/s3/OPERATIONS.md
+++ b/extensions/s3/OPERATIONS.md
@@ -156,6 +156,36 @@ println!(
 );
 ```
 
+## Native-v2 merge jobs
+
+Treat `MergeCursorV2` as workflow state. Canonically persist the exact cursor
+returned by `start_merge`, `select_merge_base`, or every successful
+`advance_merge` call before scheduling the next page. The cursor is
+constant-size; its job-scoped Prolly root owns the potentially unbounded graph
+frontier, changes, and conflicts.
+
+Use a bounded `max_steps` appropriate for the worker deadline. A page may
+perform graph work without emitting changes, so completion is determined only
+by `MergePhaseV2`, not by an empty result vector. `AwaitingBase` requires the
+operator or application to page the best bases and select one. `Conflicted`
+under the `Fail` policy cannot be published; page conflicts for reporting and
+then clean up the plan or start a new merge with an explicit resolution policy.
+
+`publish_merge` is safe to retry with the same cursor. It reconciles the
+operation ID before fencing on an ambiguous ref CAS. A target branch that moved
+after planning returns `RefConflict`; do not edit the cursor or rebase the plan.
+Start a new merge against the new target head.
+
+After successful publication, or when abandoning any incomplete/conflicted
+job, call `cleanup_merge` until its continuation is absent. Cleanup deletes
+only `administration/v2/merge/<job>/plan`; it never deletes output nodes
+referenced by a published commit. Alert on old merge-job prefixes because the
+repository cannot infer whether an externally persisted cursor is still live.
+
+Output state and delta nodes are immutable and addressed by CID. Keep the
+verified node cache enabled on merge workers and readers; a cold reader can
+recover them through deterministic point GETs without a namespace scan.
+
 Partitioned GC no longer holds the repository publication barrier while it
 discovers roots, marks commits/nodes/versions, scans candidates, or consumes
 dirty roots. Starting an epoch activates one durable coordinator. Each live

--- a/extensions/s3/OPERATIONS.md
+++ b/extensions/s3/OPERATIONS.md
@@ -127,6 +127,14 @@ administrative traffic. If a crash leaves a published ref absent from the
 catalog, page `repair_branch_catalog_page` or `repair_tag_catalog_page` with a
 bounded limit and persist the returned continuation between invocations.
 
+For v1-to-native-v2 migration, initialize a separate v2 prefix and migrate into
+a new branch. Persist the canonical migration cursor after every bounded page.
+The workflow holds a non-expiring v1 retention pin until the destination ref
+and its complete node/commit-graph closure are durable; alert on old
+`v1-to-v2-*` pins because they indicate abandoned jobs. After completion, run
+bounded migration cleanup until it reports complete. Never delete the source
+repository or run an unpinned source GC while a migration is active.
+
 ```rust
 use prolly::TreeFormat;
 use prolly_s3_core::JournalDerivedIndexesV2;

--- a/extensions/s3/PROLLY-S3-DESIGN.md
+++ b/extensions/s3/PROLLY-S3-DESIGN.md
@@ -220,7 +220,7 @@ reachability checks.
 ## Request budgets
 
 These budgets exclude provider retries, cold open, provider qualification,
-lease renewal, checkpointing, GC, and cross-bucket payload transfer:
+authority renewal, checkpointing, GC, and cross-bucket payload transfer:
 
 | Warm logical operation | S3 calls |
 |---|---:|
@@ -247,7 +247,7 @@ Required release evidence includes:
 - AWS general-purpose bucket validation in target regions;
 - latency and request-price measurements for expected traffic mixes;
 - throttling and retry behavior at sustained and burst load;
-- hot-branch queue latency and lease renewal under load;
+- hot-branch queue latency and authority renewal under load;
 - one million live keys and at least ten million retained versions;
 - crash tests around every physical mutation and ref CAS;
 - backup/restore and exact-version GC drills with lifecycle guardrails;

--- a/extensions/s3/PROLLY-S3-DESIGN.md
+++ b/extensions/s3/PROLLY-S3-DESIGN.md
@@ -104,6 +104,54 @@ photos/launch.jpg                          # S3 version v1, v2, ...
 There are no payload chunks, content manifests, delta side objects,
 workspaces, publication leases, or repository multipart-part objects.
 
+## Native protocol-v2 additions
+
+Native v2 uses a separate repository prefix and format marker. Payload bytes
+move to immutable repository-scoped SHA-256 keys, while branch refs,
+publication journals, operation indexes, and node/graph indexes are sharded by
+branch.
+
+```text
+P/
+├── format/v2.cbor
+├── payloads/v2/<repository>/sha256/<2>/<2>/<digest>
+├── commits/v2/sha256/<2>/<2>/<commit>
+├── refs/v2/heads/<encoded-branch>
+├── publications/v2/sha256/<2>/<2>/<event>
+├── journal-index/v2/heads/<encoded-branch>.cbor
+├── operation-index/v2/heads/<encoded-branch>.cbor
+├── administration/v2/merge/<job>/plan/nodes/sha256/...
+└── nodes/sha256/<2>/<2>/<cid>
+```
+
+The last path stores immutable nodes produced by restartable administrative
+builders before a final commit envelope exists. Reads first consult the
+branch-local node locator and verified cache, then use this deterministic CID
+point lookup. Native-v2 reads never recover a missing node by scanning a
+namespace.
+
+### Resumable native-v2 merge
+
+`start_merge` pins the observed target and source commit IDs. A generation
+priority frontier finds best common ancestors and persists its queue, seen
+flags, candidate bases, and results in the job plan. First-parent ancestry uses
+the commit graph's binary-lifting pointers. Criss-cross histories expose every
+best base and require an explicit selection.
+
+Planning structurally diffs `base → target` and `base → source`, pruning equal
+CID subtrees. Each advance processes a bounded record page and batches that
+page into one new plan root. Conflicts and selected changes use separate key
+prefixes so both can be paged without loading the complete plan.
+
+The builder unions immutable version trees and applies selected object changes
+in bounded pages. A large commit delta is a Prolly root plus exact record count
+rather than an inline vector. The final commit has parents `[target, source]`
+and generation `max(parent generations) + 1`. Publication revalidates the
+target ref, reconciles the operation ID after an ambiguous CAS, and never
+silently rebases. Job-plan nodes require explicit bounded cleanup after success
+or abandonment; state, version, and delta nodes referenced by the commit are
+not part of that cleanup.
+
 ## Single-object publication
 
 ![Write protocol](diagram/prolly-s3-write-path.svg)

--- a/extensions/s3/QUALIFICATION.md
+++ b/extensions/s3/QUALIFICATION.md
@@ -120,7 +120,7 @@ The following are release blockers for a production claim:
 | Request cost | Measured traffic mix using current AWS request prices |
 | Latency | p50/p95/p99 for writes, reads, batches, multipart, merge, restore |
 | Throttling | Sustained and burst load including transport retry attempts |
-| Hot branch | Queue latency, timeout policy, and lease renewal under peak load |
+| Hot branch | Queue latency, timeout policy, and authority renewal under peak load |
 | Scale | 1M live keys and 10M retained versions with reopen, list, diff, fsck, GC |
 | Transfer scale | Interrupted clone/push/repair at 10M commits with bounded RSS, zero commit-namespace LISTs, and stale-mapping rebuild |
 | Administrative scale | Restart deep fsck in every phase at 1M keys/10M versions; assert bounded RSS, cursor size, and provider requests per page |

--- a/extensions/s3/QUALIFICATION.md
+++ b/extensions/s3/QUALIFICATION.md
@@ -35,6 +35,10 @@ Core tests verify:
   bounded work/output, paged pins/reflogs, and bounded exact cleanup;
 - raw cross-bucket restore rejection plus portable archive clone/rebind,
   read-only `fsck`, explicit writer takeover, post-restore write, and cleanup.
+- native-v2 merge with a durable generation-priority merge-base frontier,
+  structural three-way diff, paged changes/conflicts, restart after every
+  two-record page, cursor-tamper rejection, source deletion, target-ref
+  movement, CAS reconciliation, and bounded plan cleanup;
 
 RustFS integration tests verify a 64 KiB whole-object write at four S3 calls,
 one-call warm current and historical reads, historical content after overwrite,
@@ -53,6 +57,44 @@ PROLLY_S3_RUSTFS=1 \
   cargo test --manifest-path extensions/s3/Cargo.toml \
   -p prolly-s3-client --test rustfs_repository -- --nocapture
 ```
+
+Run the native-v2 merge scale gates separately. The first builds a 10K-object
+snapshot, changes one key per branch, and requires structural pruning to keep
+logical merge work below 32 records. The second builds 4,096 first-parent
+commits and requires skip-pointer ancestry detection without entering the
+general frontier.
+
+```bash
+cargo test --release --manifest-path extensions/s3/Cargo.toml \
+  -p prolly-s3-core --test merge_v2 \
+  native_v2_sparse_merge_prunes_unchanged_10k_snapshot \
+  -- --ignored --exact --nocapture
+
+cargo test --release --manifest-path extensions/s3/Cargo.toml \
+  -p prolly-s3-core --test merge_v2 \
+  native_v2_merge_base_skips_deep_first_parent_history \
+  -- --ignored --exact --nocapture
+```
+
+On 2026-08-12, both release gates passed locally. The 10K sparse test body
+completed in 1.60 s after compilation. The 4,096-commit history gate completed
+in 200.88 s; almost all of that time constructs the sequential history, while
+the final assertion requires zero general-frontier visits.
+
+The RustFS merge regression drops and reopens `ClientV2` between every bounded
+page, round-trips the canonical cursor, publishes through the real conditional
+S3 adapter, and verifies both selected object bodies:
+
+```bash
+PROLLY_S3_RUSTFS=1 \
+  cargo test --manifest-path extensions/s3/Cargo.toml \
+  -p prolly-s3-client --test rustfs_repository \
+  rustfs_native_v2_merge_resumes_and_publishes_structural_plan \
+  -- --exact --nocapture
+```
+
+On 2026-08-12, the RustFS merge regression completed in 2.30 s. These timings
+are development-machine regression evidence, not AWS latency SLOs.
 
 Run the reproducible 10K concurrent-commit regression gate separately. It is
 ignored by default because it is intentionally sustained and writes a unique

--- a/extensions/s3/client/Cargo.toml
+++ b/extensions/s3/client/Cargo.toml
@@ -33,13 +33,13 @@ serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 sha2 = "0.10"
 slatedb = { version = "0.14.0", default-features = false, features = ["aws"], optional = true }
+tempfile = "3.23"
 thiserror = "2.0"
 tokio = { version = "1.45", features = ["io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]
 aws-config = { version = "1.8", features = ["behavior-version-latest"] }
 serde_json = "1.0"
-tempfile = "3.23"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -205,6 +205,38 @@ Maintenance is branch-local and checks only branches registered in that
 process. `background_index_maintenance(false)` is available for isolated
 request-shape probes; production clients should keep the default enabled.
 
+If health reports that lag exceeded the incremental window, run the resumable
+rebuild workflow. Persist the canonical cursor after every step in your job
+store before scheduling the next step:
+
+```rust
+let mut cursor = client.start_branch_index_rebuild().await?;
+
+loop {
+    let step = client
+        .advance_branch_index_rebuild(&cursor, 256)
+        .await?;
+
+    cursor = step.cursor;
+    let encoded_cursor = prolly_s3_client::core::encode_canonical(&cursor)?;
+    std::fs::write("journal-index-rebuild.cbor", encoded_cursor)?;
+
+    if step.complete {
+        break;
+    }
+}
+
+while !client
+    .cleanup_branch_index_rebuild(&cursor, 1_000)
+    .await?
+    .complete
+{}
+```
+
+Discovery and application are independently paged. Rebuild state consists of
+immutable linked chunks and fresh Prolly roots, so restart does not rediscover
+already scanned history.
+
 ## Ingest files in batches (recommended)
 
 Use `ingest_objects` when loading more than one file. It publishes up to 100

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -189,6 +189,92 @@ client.delete_tag("release-2026-08", release.target).await?;
 client.delete_branch("feature", committed.id).await?;
 ```
 
+### Merge branches with bounded, restartable work
+
+Native-v2 merge never materializes complete snapshots or ancestor sets. The
+cursor stays constant-size while the graph frontier, changes, conflicts, and
+partially built output roots live in a job-scoped Prolly tree.
+
+```rust
+use prolly_s3_client::core::{
+    decode_canonical, encode_canonical, MergeCursorV2, MergePhaseV2,
+    MergePolicyV2,
+};
+
+let mut cursor = client
+    .start_merge(
+        "feature",
+        None,
+        MergePolicyV2::Theirs,
+        "merge reviewed feature",
+    )
+    .await?;
+std::fs::write("merge.cbor", encode_canonical(&cursor)?)?;
+
+loop {
+    if cursor.phase == MergePhaseV2::AwaitingBase {
+        let page = client.merge_bases_page(&cursor, None, 100).await?;
+        let base = page
+            .bases
+            .first()
+            .copied()
+            .ok_or_else(|| std::io::Error::other("merge reported no best base"))?;
+        cursor = client.select_merge_base(&cursor, base).await?;
+        std::fs::write("merge.cbor", encode_canonical(&cursor)?)?;
+    }
+
+    if matches!(
+        cursor.phase,
+        MergePhaseV2::ReadyToPublish | MergePhaseV2::Conflicted
+    ) {
+        break;
+    }
+
+    let page = client.advance_merge(&cursor, 512).await?;
+    cursor = page.cursor;
+
+    // Save only the returned cursor. An older saved cursor is safe to replay,
+    // but may repeat already completed bounded work.
+    std::fs::write("merge.cbor", encode_canonical(&cursor)?)?;
+}
+
+// Another process can reopen ClientV2 and resume from the canonical cursor.
+let saved: MergeCursorV2 = decode_canonical(&std::fs::read("merge.cbor")?)?;
+cursor = saved;
+
+let mut after = None;
+loop {
+    let page = client.merge_changes_page(&cursor, after.as_ref(), 500).await?;
+    for change in &page.changes {
+        println!("change: {}", String::from_utf8_lossy(&change.key));
+    }
+    after = page.continuation;
+    if after.is_none() {
+        break;
+    }
+}
+
+let receipt = client.publish_merge(&cursor).await?;
+println!("published merge {}", receipt.id);
+
+let mut cleanup = None;
+loop {
+    let page = client.cleanup_merge(&cursor, cleanup.as_ref(), 1_000).await?;
+    cleanup = page.continuation;
+    if cleanup.is_none() {
+        break;
+    }
+}
+```
+
+`MergePolicyV2::Fail` stops in `Conflicted`; page conflicts with
+`merge_conflicts_page`, then clean up the abandoned plan or start a new plan
+with an explicit `Ours` or `Theirs` policy. A criss-cross history can produce
+several best bases and stops in `AwaitingBase` until the caller selects one.
+Publication revalidates the target branch head and uses operation-ID
+reconciliation after an ambiguous CAS. A target move is returned as
+`RefConflict`; merge never silently rebases the completed plan.
+
 ### Page the native ref catalog
 
 The catalog is split into 16 independent shards. Listing uses point reads of
@@ -796,15 +882,17 @@ For a large repository, call `advance_node_index` until its report says
   distinct branch authority. A branch still has exactly one active writer, and
   direct S3 mutations outside this client remain unsupported.
 - No repository-level deduplication, chunking, or partial-file updates.
-- Commit sessions buffer bodies in memory and fail closed at the configured
-  aggregate byte limit; use physical multipart for large individual files.
+- Legacy `Client` commit sessions buffer bodies in memory and fail closed at
+  the configured aggregate byte limit. Native-v2 durable sessions spool
+  streams to disk and retain only verified immutable bindings.
 - Multipart restart requires the caller to persist the upload handle, each
   part's ETag/SHA-256/size, and whole-object checksums.
 - Provider-native version IDs cannot be preserved across buckets.
 - Raw S3 listing shows physical state, not a branch or historical snapshot.
-- Whole-result compatibility methods such as `list_branches`, `merge_bases`,
-  merge planning, and repository-wide `fsck` are not billion-scale APIs. Use
-  paged catalog/history/diff calls and partition operational work.
+- Legacy whole-result methods such as `list_branches`, `merge_bases`, and
+  repository-wide `fsck` are not billion-scale APIs. Native-v2 merge uses a
+  durable frontier and paged changes/conflicts; other repository-wide work
+  still requires bounded administrative APIs.
 - Production AWS scale and throttling qualification is still pending.
 
 The complete RustFS example is

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -180,6 +180,31 @@ loop {
 }
 ```
 
+### Observe cold-start index readiness
+
+`ClientV2` starts branch-local index maintenance and waits for the default
+branch to become readable during open. Foreground reads never replay a journal
+tail. A newly selected branch instead fails quickly with `MissingClosure` and
+retry advice until background catch-up completes.
+
+```rust
+let health = client.branch_index_health().await?;
+println!(
+    "ready={} lag={} last_error={:?}",
+    health.ready,
+    health.lag_generations,
+    health.last_error,
+);
+
+client
+    .wait_for_branch_indexes(std::time::Duration::from_secs(30))
+    .await?;
+```
+
+Maintenance is branch-local and checks only branches registered in that
+process. `background_index_maintenance(false)` is available for isolated
+request-shape probes; production clients should keep the default enabled.
+
 ## Ingest files in batches (recommended)
 
 Use `ingest_objects` when loading more than one file. It publishes up to 100

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -79,6 +79,107 @@ against your key count and memory budget. Export `performance_snapshot()` for
 publication queue/wait telemetry and `s3_operation_metrics()` for SDK request
 counts.
 
+## Use the native v2 client for new repositories
+
+`ClientV2` stores payloads under immutable SHA-256-derived keys. Repeated
+writes to one logical filename therefore do not consume provider versions at
+that filename. V2 is a separate repository format and does not dual-write v1.
+
+```rust
+use std::sync::Arc;
+
+use prolly_s3_client::{
+    ClientV2, HmacAttestationSigner, ProviderIdentity,
+    core::ProviderPerKeyVersionLimitV2,
+};
+
+async fn create_v2(
+    aws: aws_sdk_s3::Client,
+    bucket: &str,
+) -> Result<ClientV2, prolly_s3_client::Error> {
+    ClientV2::builder()
+        .aws_client(aws)
+        .bucket(bucket)
+        .repository_prefix(".prolly/native-v2")
+        .writer("ingestion-service")
+        .provider_identity(ProviderIdentity::aws_region("us-west-2"))
+        .attestation_signer(Arc::new(HmacAttestationSigner::single(
+            "provider-key-2026-01",
+            vec![0x41; 32],
+        )?))
+        .provider_per_key_version_limit(
+            ProviderPerKeyVersionLimitV2::Finite(10_000),
+        )
+        .initialize()
+        .await
+}
+```
+
+### Stream and resume a durable batch
+
+Durable commit sessions are the default. Each body is spooled with bounded
+memory, hashed once, and uploaded to its immutable payload key. Checkpoints
+store bindings and operation IDs, never body bytes.
+
+```rust
+use aws_sdk_s3::primitives::ByteStream;
+
+let mut commit = client
+    .begin_commit()
+    .message("daily document import")
+    .checkpoint_every(256)
+    .start()
+    .await?;
+
+let session_id = commit.id();
+
+commit
+    .put_stream(
+        "documents/report.pdf",
+        ByteStream::from_path("report.pdf").await?,
+    )
+    .await?;
+
+commit.delete_object("documents/obsolete.pdf")?;
+commit.checkpoint().await?;
+
+// After a process restart, construct/open ClientV2 again and resume by ID.
+let resumed = client.resume_commit(session_id).await?;
+let receipt = resumed.publish().await?;
+println!("published {}", receipt.id);
+```
+
+Resume reuses verified payloads. It fails if the branch moved, the session
+expired, or another writer took ownership. Publication reconciles an ambiguous
+ref CAS by operation ID before fencing the branch.
+
+Durability adds one checkpoint PUT at session creation, one per configured
+checkpoint interval, and a final checkpoint when needed. The payload and
+atomic publication path remains `N + 3` PUTs. For a latency-sensitive batch
+that does not require restart recovery, opt out explicitly:
+
+```rust
+let commit = client.begin_commit().ephemeral().start().await?;
+```
+
+### Clean expired checkpoints
+
+Cleanup is bounded and resumable. Run it periodically from repository
+maintenance:
+
+```rust
+let mut cursor = None;
+loop {
+    let page = client
+        .cleanup_expired_commit_sessions(cursor, 1_000)
+        .await?;
+    cursor = page.continuation;
+    if cursor.is_none() {
+        break;
+    }
+}
+```
+
 ## Ingest files in batches (recommended)
 
 Use `ingest_objects` when loading more than one file. It publishes up to 100

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -226,8 +226,23 @@ loop {
     }
 }
 
+// The operation-ID index replays the same linked chunks after the node and
+// graph roots are complete. Persist this cursor after every bounded step too.
+let mut operation = client.start_operation_index_rebuild(&cursor).await?;
+loop {
+    let step = client
+        .advance_operation_index_rebuild(&operation, 256)
+        .await?;
+    operation = step.cursor;
+    let encoded_cursor = prolly_s3_client::core::encode_canonical(&operation)?;
+    std::fs::write("operation-index-rebuild.cbor", encoded_cursor)?;
+    if step.complete {
+        break;
+    }
+}
+
 while !client
-    .cleanup_branch_index_rebuild(&cursor, 1_000)
+    .cleanup_branch_index_rebuild(&cursor, &operation, 1_000)
     .await?
     .complete
 {}
@@ -235,7 +250,8 @@ while !client
 
 Discovery and application are independently paged. Rebuild state consists of
 immutable linked chunks and fresh Prolly roots, so restart does not rediscover
-already scanned history.
+already scanned history. Do not clean up the shared chunks until both the
+node/graph and operation-index cursors are complete.
 
 ## Ingest files in batches (recommended)
 

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -231,6 +231,78 @@ loop {
 Repair is intentionally the only native-v2 path that lists the authoritative
 ref namespace. It should not run in foreground request handling.
 
+### Migrate a v1 branch without dual writes
+
+Migration copies one immutable v1 branch snapshot into a new native-v2 branch
+while preserving its complete commit DAG, merge parents, commit metadata,
+object history, and delete markers. The source and destination repositories
+must use different prefixes; the destination branch must not exist.
+
+```rust
+let mut cursor = v1_client
+    .start_v2_migration(&v2_client, "imported-main")
+    .await?;
+
+loop {
+    let page = v1_client
+        .advance_v2_migration(&v2_client, &cursor, 4_096, 256)
+        .await?;
+
+    cursor = page.cursor;
+    let checkpoint = prolly_s3_client::core::encode_canonical(&cursor)?;
+    std::fs::write("v1-to-v2-migration.cbor", checkpoint)?;
+
+    if page.complete {
+        break;
+    }
+}
+
+let imported = v2_client.for_branch("imported-main")?;
+println!("native-v2 head: {}", imported.head().await?);
+```
+
+The cursor is constant-size. Its traversal stack, source-to-destination commit
+mappings, and imported node/commit-graph roots live in immutable Prolly nodes.
+Restart either process, reopen both clients with the same writer identities,
+decode the last persisted cursor, and continue. Replaying an older cursor is
+safe: payload and commit writes are content-addressed and reconcile exactly.
+
+Migration creates a non-expiring source retention pin before traversal and
+removes it only after the destination ref and complete cold-read indexes are
+durable. Clean the now-unreferenced traversal nodes afterward:
+
+```rust
+loop {
+    let cleanup = v1_client.cleanup_v2_migration(&cursor, 1_000).await?;
+    if cleanup.complete {
+        break;
+    }
+}
+```
+
+To abandon an incomplete job, call `abort_v2_migration` in bounded cleanup
+pages. It releases the source pin, unregisters the target's transient imported
+index root, and deletes traversal state. Unreachable immutable payloads and
+commits remain safe for native-v2 GC.
+
+Run one migration per source branch that must remain independently named. The
+native importer uses one target system-authority scope, so shared commits have
+stable destination identities within the same authority epoch. Before cleanup,
+resolve any source tag target and create its native tag explicitly:
+
+```rust
+for source_tag in v1_client.list_tags().await? {
+    if let Some(native_target) = v1_client
+        .v2_migration_mapping(&cursor, source_tag.target)
+        .await?
+    {
+        v2_client.create_tag(&source_tag.name, native_target).await?;
+    }
+}
+```
+
+Do not mutate both formats as a migration strategy.
+
 ### Clean expired checkpoints
 
 Cleanup is bounded and resumable. Run it periodically from repository

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -162,6 +162,75 @@ that does not require restart recovery, opt out explicitly:
 let commit = client.begin_commit().ephemeral().start().await?;
 ```
 
+### Create branches and immutable tags
+
+Branches are independent publication lanes. Creating a branch points it at an
+existing durable commit; it does not copy payloads or Prolly nodes.
+
+```rust
+let main = client.head().await?;
+let feature_head = client.create_branch("feature", Some(main)).await?;
+
+let feature = client.for_branch("feature")?;
+let committed = feature
+    .put_object("docs/feature.txt", b"ready for review".to_vec())
+    .await?;
+
+let release = client.create_tag("release-2026-08", committed.id).await?;
+assert_eq!(client.tag("release-2026-08").await?, release);
+assert_eq!(feature_head.target, main);
+```
+
+Delete operations require the target you observed. A concurrent branch move
+or tag replacement therefore fails instead of deleting newer state.
+
+```rust
+client.delete_tag("release-2026-08", release.target).await?;
+client.delete_branch("feature", committed.id).await?;
+```
+
+### Page the native ref catalog
+
+The catalog is split into 16 independent shards. Listing uses point reads of
+the shard heads and nodes; it does not scan the S3 ref prefix. Ordering is
+stable by shard and then name, so persist the opaque cursor rather than
+constructing one.
+
+```rust
+let mut cursor = None;
+loop {
+    let page = client.list_branch_catalog_page(cursor, 500).await?;
+    for branch in page.branches {
+        println!("{} -> {}", branch.name, branch.target);
+    }
+    cursor = page.continuation;
+    if cursor.is_none() {
+        break;
+    }
+}
+```
+
+The catalog is derived discovery state. Resolve a chosen branch with
+`client.for_branch(name)?.head().await?` or a tag with `client.tag(name).await?`
+before acting on it. If a process crashes after publishing a ref but before
+updating its shard, run the bounded repair API from an administrative job:
+
+```rust
+let mut continuation = None;
+loop {
+    let page = client
+        .repair_branch_catalog_page(continuation, 500)
+        .await?;
+    continuation = page.continuation;
+    if continuation.is_none() {
+        break;
+    }
+}
+```
+
+Repair is intentionally the only native-v2 path that lists the authoritative
+ref namespace. It should not run in foreground request handling.
+
 ### Clean expired checkpoints
 
 Cleanup is bounded and resumable. Run it periodically from repository

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -284,6 +284,40 @@ run concurrently. The short metadata-publication phase is serialized per
 branch, while independent branches can publish concurrently; a stale expected
 head fails explicitly.
 
+## Hand off one branch writer
+
+Writer authority is branch-scoped. Open the replacement client read-only, make
+the previous process and credentials unable to publish, then perform an
+explicit generation-checked takeover:
+
+```rust
+let mut replacement = Client::builder()
+    .aws_client(aws)
+    .bucket(bucket)
+    .writer("repository-service-b")
+    .read_only(true)
+    .provider_identity(ProviderIdentity::aws_region("us-west-2"))
+    .attestation_signer(attestation_signer)
+    .open()
+    .await?;
+
+let generation = replacement
+    .takeover_branch_writer(
+        "main",
+        "repository-service-a",
+        7,
+        "old credentials revoked and process isolated",
+    )
+    .await?;
+
+assert_eq!(generation, 8);
+```
+
+The no-target-change branch-ref CAS is the fencing barrier. After it succeeds,
+the old writer fails its authority validation before uploading payload bytes.
+Take over additional branches independently; do not use one branch handoff as
+evidence that another branch changed owner.
+
 ## Add a persistent node cache
 
 Foyer keeps verified immutable Prolly nodes in bounded memory and local disk.
@@ -443,7 +477,9 @@ For a large repository, call `advance_node_index` until its report says
 
 ## Limitations
 
-- No unmanaged or multi-process concurrent writers.
+- Managed writers may run in multiple processes when each process owns a
+  distinct branch authority. A branch still has exactly one active writer, and
+  direct S3 mutations outside this client remain unsupported.
 - No repository-level deduplication, chunking, or partial-file updates.
 - Commit sessions buffer bodies in memory and fail closed at the configured
   aggregate byte limit; use physical multipart for large individual files.

--- a/extensions/s3/client/src/aws_object.rs
+++ b/extensions/s3/client/src/aws_object.rs
@@ -20,14 +20,15 @@ use base64::{engine::general_purpose::STANDARD, Engine as _};
 use md5::Md5;
 use prolly_s3_core::{
     Checksums, CompareExchange, CompareExchangeOutcome, DeleteOutcome, Error, ErrorCode,
-    GetRequest, ImmutablePut, ImmutablePutOutcome, ListRequest, ObjectPath, ObjectPlane,
-    PhysicalCopy, PhysicalDelete, PhysicalFileGet, PhysicalFileGetResult, PhysicalFilePut,
-    PhysicalListEntry, PhysicalListPage, PhysicalMultipartAbort, PhysicalMultipartComplete,
-    PhysicalMultipartCreate, PhysicalMultipartFilePart, PhysicalMultipartListParts,
-    PhysicalMultipartListPartsPage, PhysicalMultipartListUploads, PhysicalMultipartListUploadsPage,
-    PhysicalMultipartPartResult, PhysicalMultipartUploadEntry, PhysicalMultipartUploadPart,
-    PhysicalMultipartUploadPartCopy, PhysicalObjectBindingV1, PhysicalObjectWriteResult,
-    PhysicalPut, PhysicalVersion, Result, RetryAdvice, StorageToken, StoredMetadata, StoredObject,
+    GetRequest, ImmutableFilePut, ImmutablePut, ImmutablePutOutcome, ListRequest, ObjectPath,
+    ObjectPlane, PhysicalCopy, PhysicalDelete, PhysicalFileGet, PhysicalFileGetResult,
+    PhysicalFilePut, PhysicalListEntry, PhysicalListPage, PhysicalMultipartAbort,
+    PhysicalMultipartComplete, PhysicalMultipartCreate, PhysicalMultipartFilePart,
+    PhysicalMultipartListParts, PhysicalMultipartListPartsPage, PhysicalMultipartListUploads,
+    PhysicalMultipartListUploadsPage, PhysicalMultipartPartResult, PhysicalMultipartUploadEntry,
+    PhysicalMultipartUploadPart, PhysicalMultipartUploadPartCopy, PhysicalObjectBindingV1,
+    PhysicalObjectWriteResult, PhysicalPut, PhysicalVersion, Result, RetryAdvice, StorageToken,
+    StoredMetadata, StoredObject,
 };
 use sha2::{Digest, Sha256};
 
@@ -338,6 +339,72 @@ impl ObjectPlane for AwsS3ObjectPlane {
                 Ok(ImmutablePutOutcome::AlreadyPresent(existing.metadata))
             }
             Err(error) => Err(map_sdk_error("PutObject immutable", error)),
+        }
+    }
+
+    async fn put_immutable_file(&self, request: ImmutableFilePut) -> Result<ImmutablePutOutcome> {
+        let file_size = std::fs::metadata(&request.body_path)
+            .map_err(|error| transport_error("immutable spool metadata", error))?
+            .len();
+        if file_size != request.size {
+            return Err(Error::new(
+                ErrorCode::ChecksumMismatch,
+                "immutable spool size changed before upload",
+            ));
+        }
+        self.metrics.put_object.fetch_add(1, Ordering::Relaxed);
+        self.metrics
+            .uploaded_body_bytes
+            .fetch_add(request.size, Ordering::Relaxed);
+        let body = ByteStream::from_path(&request.body_path)
+            .await
+            .map_err(|error| transport_error("immutable spool open", error))?;
+        let result = self
+            .client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(request.path.as_str())
+            .if_none_match("*")
+            .metadata("prolly-sha256", hex::encode(request.expected_sha256))
+            .body(body)
+            .send()
+            .await;
+        match result {
+            Ok(output) => Ok(ImmutablePutOutcome::Created(StoredMetadata {
+                token: StorageToken {
+                    etag: output.e_tag().unwrap_or_default().to_string(),
+                    version_id: output.version_id().map(ToString::to_string),
+                },
+                len: request.size,
+                sha256: request.expected_sha256,
+                last_modified_millis: 0,
+                delete_marker: false,
+                user_metadata: BTreeMap::from([(
+                    "prolly-sha256".to_string(),
+                    hex::encode(request.expected_sha256),
+                )]),
+            })),
+            Err(error) => {
+                let precondition_failed = is_precondition_failed(&error);
+                let original = map_sdk_error("PutObject immutable spool", error);
+                match self.head(&request.path).await {
+                    Ok(Some(existing))
+                        if existing.len == request.size
+                            && existing.sha256 == request.expected_sha256 =>
+                    {
+                        Ok(ImmutablePutOutcome::AlreadyPresent(existing))
+                    }
+                    Ok(Some(_)) => Err(Error::new(
+                        ErrorCode::CorruptContent,
+                        format!("different bytes exist at {}", request.path),
+                    )),
+                    Ok(None) if precondition_failed => Err(Error::new(
+                        ErrorCode::OutcomeUnknown,
+                        "immutable create conflicted but the winner is not readable",
+                    )),
+                    Ok(None) | Err(_) => Err(original),
+                }
+            }
         }
     }
 

--- a/extensions/s3/client/src/client.rs
+++ b/extensions/s3/client/src/client.rs
@@ -45,6 +45,7 @@ use prolly_s3_core::{
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 
+use crate::client_v2::ClientV2;
 use crate::{
     ensure_attestation_current, load_valid_attestation, qualify_and_store,
     validate_provider_bucket, AdvisoryIndex, AttestationSigner, AwsS3ObjectPlane, ProviderIdentity,
@@ -855,6 +856,80 @@ impl Client {
     pub async fn head_commit(&self) -> Result<CommitId> {
         self.ensure_provider_qualified()?;
         self.repository.head(&self.branch).await
+    }
+
+    /// Start a history-preserving migration of this v1 branch into a new
+    /// branch in a physically separate native-v2 repository.
+    pub async fn start_v2_migration(
+        &self,
+        target: &ClientV2,
+        destination_branch: impl AsRef<str>,
+    ) -> Result<prolly_s3_core::V1ToV2MigrationCursor> {
+        self.ensure_provider_qualified()?;
+        target.ensure_provider_qualified()?;
+        self.repository
+            .start_v1_to_v2_migration(
+                target.repository_handle().as_ref(),
+                &self.branch,
+                destination_branch.as_ref(),
+            )
+            .await
+    }
+
+    /// Advance one bounded migration page. Persist the returned cursor before
+    /// scheduling the next call so another process can resume it.
+    pub async fn advance_v2_migration(
+        &self,
+        target: &ClientV2,
+        cursor: &prolly_s3_core::V1ToV2MigrationCursor,
+        max_steps: usize,
+        max_commits: usize,
+    ) -> Result<prolly_s3_core::V1ToV2MigrationPage> {
+        self.ensure_provider_qualified()?;
+        target.ensure_provider_qualified()?;
+        self.repository
+            .v1_to_v2_migration_page(
+                target.repository_handle().as_ref(),
+                cursor,
+                max_steps,
+                max_commits,
+            )
+            .await
+    }
+
+    pub async fn cleanup_v2_migration(
+        &self,
+        cursor: &prolly_s3_core::V1ToV2MigrationCursor,
+        limit: usize,
+    ) -> Result<prolly_s3_core::CommitClosureCleanupReport> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .cleanup_v1_to_v2_migration(cursor, limit)
+            .await
+    }
+
+    pub async fn abort_v2_migration(
+        &self,
+        target: &ClientV2,
+        cursor: &prolly_s3_core::V1ToV2MigrationCursor,
+        limit: usize,
+    ) -> Result<prolly_s3_core::CommitClosureCleanupReport> {
+        self.ensure_provider_qualified()?;
+        target.ensure_provider_qualified()?;
+        self.repository
+            .abort_v1_to_v2_migration(target.repository_handle().as_ref(), cursor, limit)
+            .await
+    }
+
+    pub async fn v2_migration_mapping(
+        &self,
+        cursor: &prolly_s3_core::V1ToV2MigrationCursor,
+        source: CommitId,
+    ) -> Result<Option<prolly_s3_core::CommitIdV2>> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .v1_to_v2_migration_mapping(cursor, source)
+            .await
     }
     pub async fn log(
         &self,

--- a/extensions/s3/client/src/client.rs
+++ b/extensions/s3/client/src/client.rs
@@ -40,7 +40,7 @@ use prolly_s3_core::{
     ObjectVersionId, ObjectWriteConditionV1, OperationId, PhysicalBatchV1,
     PhysicalMultipartCompletedPart, PhysicalMultipartPartResult, PhysicalMultipartSessionV1,
     PhysicalVersion, PhysicalVersioning, ProviderAttestationV1, ProviderProfileId, RefValueV1,
-    Repository, RepositoryOptions, Result, RetryAdvice, VersionSummary, WriterLeaseMaintenance,
+    Repository, RepositoryOptions, Result, RetryAdvice, ShardAuthorityMaintenance, VersionSummary,
 };
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -653,7 +653,7 @@ pub struct Client {
     provider_attestation: Arc<RwLock<ProviderAttestationV1>>,
     physical_multipart_parts: Arc<RwLock<BTreeMap<(String, u32), PhysicalMultipartPartResult>>>,
     physical_multipart_sessions: Arc<RwLock<BTreeMap<String, PhysicalMultipartSessionV1>>>,
-    writer_lease_maintenance: Option<Arc<WriterLeaseMaintenance>>,
+    shard_authority_maintenance: Option<Arc<ShardAuthorityMaintenance>>,
     node_index_maintenance: Option<Arc<prolly_s3_core::NodeIndexMaintenance>>,
     max_staged_batch_bytes: usize,
 }
@@ -665,7 +665,7 @@ pub struct ClientBuilder {
     repository_prefix: Option<String>,
     default_branch: Option<String>,
     writer: Option<String>,
-    writer_lease_duration: Option<Duration>,
+    shard_authority_lease_duration: Option<Duration>,
     read_only: bool,
     max_parallel_payload_writes: Option<usize>,
     max_cached_commits: Option<usize>,
@@ -770,32 +770,64 @@ impl Client {
         Ok((nodes, refs, graph))
     }
 
-    /// Perform an operator-authorized writer handoff after the previous
-    /// process and credentials have been independently stopped or revoked.
+    /// Take over one branch authority after the previous process and
+    /// credentials have been independently stopped or revoked.
+    ///
     /// Open this client read-only and ensure no derived branch/snapshot clients
-    /// are alive before calling.
+    /// are alive before calling. The branch-ref CAS is the fencing barrier;
+    /// unrelated branches and their writers are unaffected.
+    pub async fn takeover_branch_writer(
+        &mut self,
+        branch: impl AsRef<str>,
+        expected_writer: &str,
+        expected_generation: u64,
+        handoff_evidence: &str,
+    ) -> Result<u64> {
+        self.ensure_provider_qualified()?;
+        let branch = branch.as_ref();
+        validate_branch_name(branch)?;
+        let generation = {
+            let repository = Arc::get_mut(&mut self.repository).ok_or_else(|| {
+                invalid("branch writer takeover requires an unshared read-only client handle")
+            })?;
+            repository
+                .takeover_branch_writer(
+                    branch,
+                    expected_writer,
+                    expected_generation,
+                    handoff_evidence,
+                )
+                .await?
+        };
+        self.shard_authority_maintenance = Some(Arc::new(
+            self.repository.start_shard_authority_maintenance()?,
+        ));
+        self.node_index_maintenance = Some(Arc::new(
+            self.repository
+                .start_node_index_maintenance(Duration::from_secs(60), 1_000)?,
+        ));
+        Ok(generation)
+    }
+
+    /// Compatibility shorthand that takes over this client's selected branch.
+    #[deprecated(
+        since = "0.1.0",
+        note = "use takeover_branch_writer to make the authority scope explicit"
+    )]
     pub async fn takeover_writer(
         &mut self,
         expected_writer: &str,
         expected_generation: u64,
         handoff_evidence: &str,
     ) -> Result<u64> {
-        self.ensure_provider_qualified()?;
-        let generation = {
-            let repository = Arc::get_mut(&mut self.repository).ok_or_else(|| {
-                invalid("writer takeover requires an unshared read-only client handle")
-            })?;
-            repository
-                .takeover_physical_writer(expected_writer, expected_generation, handoff_evidence)
-                .await?
-        };
-        self.writer_lease_maintenance =
-            Some(Arc::new(self.repository.start_writer_lease_maintenance()?));
-        self.node_index_maintenance = Some(Arc::new(
-            self.repository
-                .start_node_index_maintenance(Duration::from_secs(60), 1_000)?,
-        ));
-        Ok(generation)
+        let branch = self.branch.clone();
+        self.takeover_branch_writer(
+            branch,
+            expected_writer,
+            expected_generation,
+            handoff_evidence,
+        )
+        .await
     }
 
     pub fn on_branch(&self, branch: impl Into<String>) -> Result<Self> {
@@ -814,7 +846,7 @@ impl Client {
             provider_attestation: self.provider_attestation.clone(),
             physical_multipart_parts: self.physical_multipart_parts.clone(),
             physical_multipart_sessions: self.physical_multipart_sessions.clone(),
-            writer_lease_maintenance: self.writer_lease_maintenance.clone(),
+            shard_authority_maintenance: self.shard_authority_maintenance.clone(),
             node_index_maintenance: self.node_index_maintenance.clone(),
             max_staged_batch_bytes: self.max_staged_batch_bytes,
         })
@@ -1877,9 +1909,17 @@ impl ClientBuilder {
         self.writer = Some(writer.into());
         self
     }
-    pub fn writer_lease_duration(mut self, duration: Duration) -> Self {
-        self.writer_lease_duration = Some(duration);
+    pub fn shard_authority_lease_duration(mut self, duration: Duration) -> Self {
+        self.shard_authority_lease_duration = Some(duration);
         self
+    }
+
+    #[deprecated(
+        since = "0.1.0",
+        note = "use shard_authority_lease_duration; authority is scoped per branch/system namespace"
+    )]
+    pub fn writer_lease_duration(self, duration: Duration) -> Self {
+        self.shard_authority_lease_duration(duration)
     }
     pub fn read_only(mut self, value: bool) -> Self {
         self.read_only = value;
@@ -2044,9 +2084,9 @@ impl ClientBuilder {
         if let Some(value) = self.writer {
             options.writer = value;
         }
-        if let Some(value) = self.writer_lease_duration {
+        if let Some(value) = self.shard_authority_lease_duration {
             options.writer_lease_millis = u64::try_from(value.as_millis())
-                .map_err(|_| invalid("writer lease duration exceeds u64 milliseconds"))?;
+                .map_err(|_| invalid("shard-authority lease duration exceeds u64 milliseconds"))?;
         }
         options.read_only = self.read_only;
         if let Some(value) = self.max_parallel_payload_writes {
@@ -2080,7 +2120,7 @@ impl ClientBuilder {
         if let Some(value) = self.gc_delete_rate_limit_per_second {
             options.gc_delete_rate_limit_per_second = value;
         }
-        let maintain_physical_writer = !options.read_only;
+        let maintain_shard_authority = !options.read_only;
         let branch = options.default_branch.clone();
         let plane = Arc::new(AwsS3ObjectPlane::new(aws, bucket.clone()));
         let provider_identity = self
@@ -2132,11 +2172,11 @@ impl ClientBuilder {
             (repository, attestation)
         };
         let repository = Arc::new(repository);
-        let writer_lease_maintenance = maintain_physical_writer
-            .then(|| repository.start_writer_lease_maintenance())
+        let shard_authority_maintenance = maintain_shard_authority
+            .then(|| repository.start_shard_authority_maintenance())
             .transpose()?
             .map(Arc::new);
-        let node_index_maintenance = maintain_physical_writer
+        let node_index_maintenance = maintain_shard_authority
             .then(|| {
                 repository.start_node_index_maintenance(
                     self.node_index_maintenance_interval
@@ -2159,7 +2199,7 @@ impl ClientBuilder {
             provider_attestation: Arc::new(RwLock::new(attestation)),
             physical_multipart_parts: Arc::new(RwLock::new(BTreeMap::new())),
             physical_multipart_sessions: Arc::new(RwLock::new(BTreeMap::new())),
-            writer_lease_maintenance,
+            shard_authority_maintenance,
             node_index_maintenance,
             max_staged_batch_bytes,
         })

--- a/extensions/s3/client/src/client_v2.rs
+++ b/extensions/s3/client/src/client_v2.rs
@@ -8,10 +8,10 @@ use std::{
 use aws_sdk_s3::primitives::ByteStream;
 use md5::Md5;
 use prolly_s3_core::{
-    BranchIndexAdvanceReportV2, CommitIdV2, CommitReceiptV2, Error, ErrorCode, ObjectDataV2,
-    ObjectHeaders, ObjectSummaryV2, ObjectVersionV2, PhysicalBatchV2, ProviderAttestationV1,
-    ProviderPerKeyVersionLimitV2, ProviderProfileId, RepositoryV2, RepositoryV2Options, Result,
-    StagedMutationV2, VersionSummaryV2,
+    BatchId, BranchIndexAdvanceReportV2, CommitIdV2, CommitReceiptV2, Error, ErrorCode,
+    ObjectDataV2, ObjectHeaders, ObjectSummaryV2, ObjectVersionV2, PhysicalBatchV2,
+    ProviderAttestationV1, ProviderPerKeyVersionLimitV2, ProviderProfileId, RepositoryV2,
+    RepositoryV2Options, Result, StagedMutationV2, VersionSummaryV2,
 };
 use sha2::{Digest as _, Sha256};
 
@@ -141,7 +141,29 @@ impl ClientV2 {
             client: self.clone(),
             message: "atomic protocol-v2 commit".to_string(),
             expires_after: Duration::from_secs(60 * 60),
+            durable: true,
+            checkpoint_every: 256,
         }
+    }
+
+    /// Resume the latest canonical remote checkpoint for a session. Verified
+    /// immutable payload bindings are reused; bodies are not uploaded again.
+    pub async fn resume_commit(&self, batch: BatchId) -> Result<CommitSessionV2> {
+        self.ensure_provider_qualified()?;
+        let checkpoint = self.repository.resume_commit_session(batch).await?;
+        Ok(CommitSessionV2 {
+            client: self.clone(),
+            manifest: checkpoint.session,
+            staged: checkpoint
+                .mutations
+                .into_iter()
+                .map(|mutation| (mutation.key().to_vec(), mutation))
+                .collect(),
+            durable: true,
+            checkpoint_every: 256,
+            checkpoint_sequence: checkpoint.sequence,
+            dirty_mutations: 0,
+        })
     }
 
     pub async fn list_objects(
@@ -247,6 +269,17 @@ impl ClientV2 {
         self.repository.advance_branch_indexes(&self.branch).await
     }
 
+    pub async fn cleanup_expired_commit_sessions(
+        &self,
+        continuation: Option<String>,
+        limit: usize,
+    ) -> Result<prolly_s3_core::CommitSessionCleanupReportV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .cleanup_expired_commit_sessions(continuation, limit)
+            .await
+    }
+
     pub fn s3_operation_metrics(&self) -> S3OperationMetrics {
         self.repository.plane().metrics()
     }
@@ -283,6 +316,8 @@ pub struct CommitSessionV2Builder {
     client: ClientV2,
     message: String,
     expires_after: Duration,
+    durable: bool,
+    checkpoint_every: usize,
 }
 
 impl CommitSessionV2Builder {
@@ -296,19 +331,55 @@ impl CommitSessionV2Builder {
         self
     }
 
+    /// Disable remote checkpoints for the minimum N + 3 S3 PUT shape. The
+    /// session cannot then be resumed after process loss.
+    pub fn ephemeral(mut self) -> Self {
+        self.durable = false;
+        self
+    }
+
+    /// Checkpoint after this many staged mutations. The final state is always
+    /// checkpointed before publication for durable sessions.
+    pub fn checkpoint_every(mut self, mutations: usize) -> Self {
+        self.checkpoint_every = mutations;
+        self
+    }
+
     pub async fn start(self) -> Result<CommitSessionV2> {
         self.client.ensure_provider_qualified()?;
         let expires_after_millis = u64::try_from(self.expires_after.as_millis())
             .map_err(|_| invalid("v2 commit-session expiry exceeds u64 milliseconds"))?;
-        let manifest = self
-            .client
-            .repository
-            .begin_commit_session(&self.client.branch, self.message, expires_after_millis)
-            .await?;
+        if self.durable && self.checkpoint_every == 0 {
+            return Err(invalid("v2 checkpoint interval must be positive"));
+        }
+        let (manifest, checkpoint_sequence) = if self.durable {
+            let checkpoint = self
+                .client
+                .repository
+                .begin_durable_commit_session(
+                    &self.client.branch,
+                    self.message,
+                    expires_after_millis,
+                )
+                .await?;
+            (checkpoint.session, checkpoint.sequence)
+        } else {
+            (
+                self.client
+                    .repository
+                    .begin_commit_session(&self.client.branch, self.message, expires_after_millis)
+                    .await?,
+                0,
+            )
+        };
         Ok(CommitSessionV2 {
             client: self.client,
             manifest,
             staged: BTreeMap::new(),
+            durable: self.durable,
+            checkpoint_every: self.checkpoint_every,
+            checkpoint_sequence,
+            dirty_mutations: 0,
         })
     }
 }
@@ -317,6 +388,10 @@ pub struct CommitSessionV2 {
     client: ClientV2,
     manifest: PhysicalBatchV2,
     staged: BTreeMap<Vec<u8>, StagedMutationV2>,
+    durable: bool,
+    checkpoint_every: usize,
+    checkpoint_sequence: u64,
+    dirty_mutations: usize,
 }
 
 impl CommitSessionV2 {
@@ -334,6 +409,10 @@ impl CommitSessionV2 {
 
     pub fn staged_objects(&self) -> usize {
         self.staged.len()
+    }
+
+    pub fn is_durable(&self) -> bool {
+        self.durable
     }
 
     pub async fn put_object(&mut self, key: impl Into<String>, bytes: Vec<u8>) -> Result<()> {
@@ -361,6 +440,7 @@ impl CommitSessionV2 {
             )
             .await?;
         self.staged.insert(staged.key().to_vec(), staged);
+        self.mark_staged_and_checkpoint_if_due().await?;
         Ok(())
     }
 
@@ -439,6 +519,7 @@ impl CommitSessionV2 {
             )
             .await?;
         self.staged.insert(staged.key().to_vec(), staged);
+        self.mark_staged_and_checkpoint_if_due().await?;
         Ok(())
     }
 
@@ -449,20 +530,65 @@ impl CommitSessionV2 {
         }
         self.staged
             .insert(key.clone(), StagedMutationV2::delete(key));
+        self.dirty_mutations = self.dirty_mutations.saturating_add(1);
         Ok(())
     }
 
-    pub async fn publish(self) -> Result<CommitReceiptV2> {
+    pub async fn checkpoint(&mut self) -> Result<()> {
+        if !self.durable || self.dirty_mutations == 0 {
+            return Ok(());
+        }
+        let sequence = self
+            .checkpoint_sequence
+            .checked_add(1)
+            .ok_or_else(|| invalid("v2 commit-session checkpoint sequence overflow"))?;
+        let checkpoint = self
+            .client
+            .repository
+            .checkpoint_commit_session(
+                &self.manifest,
+                self.staged.values().cloned().collect(),
+                sequence,
+            )
+            .await?;
+        self.manifest = checkpoint.session;
+        self.checkpoint_sequence = checkpoint.sequence;
+        self.dirty_mutations = 0;
+        Ok(())
+    }
+
+    pub async fn publish(mut self) -> Result<CommitReceiptV2> {
         self.client.ensure_provider_qualified()?;
+        self.checkpoint().await?;
         self.client
             .repository
             .publish_commit_session(self.manifest, self.staged.into_values().collect())
             .await
     }
 
-    /// Aborting leaves only content-addressed payload candidates. A bounded v2
-    /// staging/GC workflow will reclaim payloads that no commit references.
-    pub fn abort(self) {}
+    /// Mark a durable session aborted. Immutable payload candidates remain
+    /// deduplicated and bounded staging cleanup removes expired checkpoints.
+    pub async fn abort(self) -> Result<()> {
+        if !self.durable {
+            return Ok(());
+        }
+        let sequence = self
+            .checkpoint_sequence
+            .checked_add(1)
+            .ok_or_else(|| invalid("v2 commit-session checkpoint sequence overflow"))?;
+        self.client
+            .repository
+            .abort_commit_session(self.manifest, self.staged.into_values().collect(), sequence)
+            .await
+    }
+
+    async fn mark_staged_and_checkpoint_if_due(&mut self) -> Result<()> {
+        self.dirty_mutations = self.dirty_mutations.saturating_add(1);
+        if self.durable && self.dirty_mutations >= self.checkpoint_every {
+            self.checkpoint().await?;
+        }
+        Ok(())
+    }
 }
 
 impl ClientV2Builder {

--- a/extensions/s3/client/src/client_v2.rs
+++ b/extensions/s3/client/src/client_v2.rs
@@ -9,9 +9,10 @@ use aws_sdk_s3::primitives::ByteStream;
 use md5::Md5;
 use prolly_s3_core::{
     BatchId, BranchIndexAdvanceReportV2, BranchIndexHealthV2, CommitIdV2, CommitReceiptV2, Error,
-    ErrorCode, ObjectDataV2, ObjectHeaders, ObjectSummaryV2, ObjectVersionV2, PhysicalBatchV2,
-    ProviderAttestationV1, ProviderPerKeyVersionLimitV2, ProviderProfileId, RepositoryV2,
-    RepositoryV2Options, Result, StagedMutationV2, VersionSummaryV2,
+    ErrorCode, JournalIndexRebuildCleanupV2, JournalIndexRebuildCursorV2,
+    JournalIndexRebuildStepV2, ObjectDataV2, ObjectHeaders, ObjectSummaryV2, ObjectVersionV2,
+    PhysicalBatchV2, ProviderAttestationV1, ProviderPerKeyVersionLimitV2, ProviderProfileId,
+    RepositoryV2, RepositoryV2Options, Result, StagedMutationV2, VersionSummaryV2,
 };
 use sha2::{Digest as _, Sha256};
 
@@ -49,6 +50,7 @@ pub struct ClientV2Builder {
     max_cached_node_bytes: Option<usize>,
     node_cache: Option<Arc<dyn prolly_s3_core::NodeCache>>,
     mutable_control_versions_to_retain: Option<usize>,
+    journal_index_max_unindexed_events: Option<usize>,
     provider_identity: Option<ProviderIdentity>,
     attestation_signer: Option<Arc<dyn AttestationSigner>>,
     provider_attestation: Option<ProviderProfileId>,
@@ -274,6 +276,35 @@ impl ClientV2 {
     pub async fn branch_index_health(&self) -> Result<BranchIndexHealthV2> {
         self.ensure_provider_qualified()?;
         self.repository.branch_index_health(&self.branch).await
+    }
+
+    pub async fn start_branch_index_rebuild(&self) -> Result<JournalIndexRebuildCursorV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .start_branch_index_rebuild(&self.branch)
+            .await
+    }
+
+    pub async fn advance_branch_index_rebuild(
+        &self,
+        cursor: &JournalIndexRebuildCursorV2,
+        max_events: usize,
+    ) -> Result<JournalIndexRebuildStepV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .advance_branch_index_rebuild(cursor, max_events)
+            .await
+    }
+
+    pub async fn cleanup_branch_index_rebuild(
+        &self,
+        cursor: &JournalIndexRebuildCursorV2,
+        limit: usize,
+    ) -> Result<JournalIndexRebuildCleanupV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .cleanup_branch_index_rebuild(cursor, limit)
+            .await
     }
 
     pub async fn wait_for_branch_indexes(&self, timeout: Duration) -> Result<BranchIndexHealthV2> {
@@ -634,6 +665,11 @@ impl ClientV2Builder {
         self
     }
 
+    pub fn journal_index_max_unindexed_events(mut self, events: usize) -> Self {
+        self.journal_index_max_unindexed_events = Some(events);
+        self
+    }
+
     pub fn bucket(mut self, bucket: impl Into<String>) -> Self {
         self.bucket = Some(bucket.into());
         self
@@ -815,6 +851,9 @@ impl ClientV2Builder {
         }
         if let Some(versions) = self.mutable_control_versions_to_retain {
             options.mutable_control_versions_to_retain = versions;
+        }
+        if let Some(events) = self.journal_index_max_unindexed_events {
+            options.journal_index_max_unindexed_events = events;
         }
         options.node_cache = self.node_cache;
         let branch = options.default_branch.clone();

--- a/extensions/s3/client/src/client_v2.rs
+++ b/extensions/s3/client/src/client_v2.rs
@@ -1,15 +1,19 @@
 use std::{
     collections::BTreeMap,
+    io::Write as _,
     sync::{Arc, Mutex},
     time::Duration,
 };
 
+use aws_sdk_s3::primitives::ByteStream;
+use md5::Md5;
 use prolly_s3_core::{
     BranchIndexAdvanceReportV2, CommitIdV2, CommitReceiptV2, Error, ErrorCode, ObjectDataV2,
     ObjectHeaders, ObjectSummaryV2, ObjectVersionV2, PhysicalBatchV2, ProviderAttestationV1,
     ProviderPerKeyVersionLimitV2, ProviderProfileId, RepositoryV2, RepositoryV2Options, Result,
     StagedMutationV2, VersionSummaryV2,
 };
+use sha2::{Digest as _, Sha256};
 
 use crate::{
     ensure_attestation_current, load_valid_attestation, qualify_and_store,
@@ -352,6 +356,84 @@ impl CommitSessionV2 {
                 &self.manifest,
                 key.into().into_bytes(),
                 bytes,
+                headers,
+                metadata,
+            )
+            .await?;
+        self.staged.insert(staged.key().to_vec(), staged);
+        Ok(())
+    }
+
+    /// Stage a streamed object through a bounded-memory disk spool. The spool
+    /// is removed after its immutable content-addressed upload completes.
+    pub async fn put_stream(&mut self, key: impl Into<String>, body: ByteStream) -> Result<()> {
+        self.put_stream_with_metadata(key, body, ObjectHeaders::default(), BTreeMap::new())
+            .await
+    }
+
+    pub async fn put_stream_with_metadata(
+        &mut self,
+        key: impl Into<String>,
+        mut body: ByteStream,
+        headers: ObjectHeaders,
+        metadata: BTreeMap<String, String>,
+    ) -> Result<()> {
+        self.client.ensure_provider_qualified()?;
+        let key = key.into().into_bytes();
+        if key.is_empty() {
+            return Err(invalid("v2 commit-session put key is empty"));
+        }
+        let mut spool = tempfile::NamedTempFile::new().map_err(|error| {
+            Error::new(
+                ErrorCode::Transport,
+                format!("could not create v2 upload spool: {error}"),
+            )
+        })?;
+        let max_object_bytes = self.client.repository.max_object_bytes();
+        let mut size = 0_u64;
+        let mut sha256 = Sha256::new();
+        let mut md5 = Md5::new();
+        while let Some(next) = body.next().await {
+            let next = next.map_err(|error| {
+                Error::new(
+                    ErrorCode::Transport,
+                    format!("v2 object input stream failed: {error}"),
+                )
+            })?;
+            size = size.checked_add(next.len() as u64).ok_or_else(|| {
+                Error::new(ErrorCode::EntityTooLarge, "v2 object length overflow")
+            })?;
+            if size > max_object_bytes {
+                return Err(Error::new(
+                    ErrorCode::EntityTooLarge,
+                    "v2 object exceeds the repository object-size limit",
+                ));
+            }
+            spool.write_all(&next).map_err(|error| {
+                Error::new(
+                    ErrorCode::Transport,
+                    format!("v2 upload spool write failed: {error}"),
+                )
+            })?;
+            sha256.update(&next);
+            md5.update(&next);
+        }
+        spool.flush().map_err(|error| {
+            Error::new(
+                ErrorCode::Transport,
+                format!("v2 upload spool flush failed: {error}"),
+            )
+        })?;
+        let staged = self
+            .client
+            .repository
+            .stage_commit_session_file(
+                &self.manifest,
+                key,
+                spool.path().to_path_buf(),
+                size,
+                sha256.finalize().into(),
+                md5.finalize().into(),
                 headers,
                 metadata,
             )

--- a/extensions/s3/client/src/client_v2.rs
+++ b/extensions/s3/client/src/client_v2.rs
@@ -8,8 +8,8 @@ use std::{
 use aws_sdk_s3::primitives::ByteStream;
 use md5::Md5;
 use prolly_s3_core::{
-    BatchId, BranchIndexAdvanceReportV2, CommitIdV2, CommitReceiptV2, Error, ErrorCode,
-    ObjectDataV2, ObjectHeaders, ObjectSummaryV2, ObjectVersionV2, PhysicalBatchV2,
+    BatchId, BranchIndexAdvanceReportV2, BranchIndexHealthV2, CommitIdV2, CommitReceiptV2, Error,
+    ErrorCode, ObjectDataV2, ObjectHeaders, ObjectSummaryV2, ObjectVersionV2, PhysicalBatchV2,
     ProviderAttestationV1, ProviderPerKeyVersionLimitV2, ProviderProfileId, RepositoryV2,
     RepositoryV2Options, Result, StagedMutationV2, VersionSummaryV2,
 };
@@ -32,6 +32,7 @@ pub struct ClientV2 {
     branch: String,
     provider_attestation: ProviderAttestationV1,
     shard_authority_maintenance: Arc<Mutex<Option<prolly_s3_core::ShardAuthorityMaintenance>>>,
+    _branch_index_maintenance: Arc<Mutex<Option<prolly_s3_core::BranchIndexMaintenance>>>,
 }
 
 #[derive(Default)]
@@ -53,6 +54,7 @@ pub struct ClientV2Builder {
     provider_attestation: Option<ProviderProfileId>,
     qualification_options: Option<ProviderQualificationOptions>,
     provider_per_key_version_limit: Option<ProviderPerKeyVersionLimitV2>,
+    background_index_maintenance: Option<bool>,
 }
 
 impl ClientV2 {
@@ -267,6 +269,34 @@ impl ClientV2 {
     pub async fn advance_branch_indexes(&self) -> Result<BranchIndexAdvanceReportV2> {
         self.ensure_provider_qualified()?;
         self.repository.advance_branch_indexes(&self.branch).await
+    }
+
+    pub async fn branch_index_health(&self) -> Result<BranchIndexHealthV2> {
+        self.ensure_provider_qualified()?;
+        self.repository.branch_index_health(&self.branch).await
+    }
+
+    pub async fn wait_for_branch_indexes(&self, timeout: Duration) -> Result<BranchIndexHealthV2> {
+        self.ensure_provider_qualified()?;
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let health = self.repository.branch_index_health(&self.branch).await?;
+            if health.ready {
+                return Ok(health);
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(Error::new(
+                    ErrorCode::MissingClosure,
+                    health.last_error.unwrap_or_else(|| {
+                        format!(
+                            "protocol-v2 branch indexes remain {} generation(s) behind",
+                            health.lag_generations
+                        )
+                    }),
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
     }
 
     pub async fn cleanup_expired_commit_sessions(
@@ -597,6 +627,13 @@ impl ClientV2Builder {
         self
     }
 
+    /// Enable or disable automatic branch-index catch-up. It is enabled by
+    /// default; disabling it is intended for isolated request-shape probes.
+    pub fn background_index_maintenance(mut self, enabled: bool) -> Self {
+        self.background_index_maintenance = Some(enabled);
+        self
+    }
+
     pub fn bucket(mut self, bucket: impl Into<String>) -> Self {
         self.bucket = Some(bucket.into());
         self
@@ -693,6 +730,7 @@ impl ClientV2Builder {
                 "native v2 initialization requires a writable client",
             ));
         }
+        let background_index_maintenance = self.background_index_maintenance.unwrap_or(true);
         let aws = self
             .aws_client
             .ok_or_else(|| invalid("aws_client is required"))?;
@@ -791,13 +829,25 @@ impl ClientV2Builder {
         } else {
             Some(repository.start_shard_authority_maintenance()?)
         };
-        Ok(ClientV2 {
+        let branch_index_maintenance = if background_index_maintenance {
+            Some(repository.start_branch_index_maintenance(Duration::from_secs(5))?)
+        } else {
+            None
+        };
+        let client = ClientV2 {
             repository,
             bucket,
             branch,
             provider_attestation: attestation,
             shard_authority_maintenance: Arc::new(Mutex::new(shard_authority_maintenance)),
-        })
+            _branch_index_maintenance: Arc::new(Mutex::new(branch_index_maintenance)),
+        };
+        if background_index_maintenance {
+            client
+                .wait_for_branch_indexes(Duration::from_secs(30))
+                .await?;
+        }
+        Ok(client)
     }
 }
 

--- a/extensions/s3/client/src/client_v2.rs
+++ b/extensions/s3/client/src/client_v2.rs
@@ -11,8 +11,9 @@ use prolly_s3_core::{
     BatchId, BranchIndexAdvanceReportV2, BranchIndexHealthV2, CommitIdV2, CommitReceiptV2, Error,
     ErrorCode, JournalIndexRebuildCleanupV2, JournalIndexRebuildCursorV2,
     JournalIndexRebuildStepV2, ObjectDataV2, ObjectHeaders, ObjectSummaryV2, ObjectVersionV2,
-    PhysicalBatchV2, ProviderAttestationV1, ProviderPerKeyVersionLimitV2, ProviderProfileId,
-    RepositoryV2, RepositoryV2Options, Result, StagedMutationV2, VersionSummaryV2,
+    OperationId, OperationIndexRebuildCursorV2, OperationIndexRebuildStepV2, PhysicalBatchV2,
+    ProviderAttestationV1, ProviderPerKeyVersionLimitV2, ProviderProfileId, RepositoryV2,
+    RepositoryV2Options, Result, StagedMutationV2, VersionSummaryV2,
 };
 use sha2::{Digest as _, Sha256};
 
@@ -51,6 +52,9 @@ pub struct ClientV2Builder {
     node_cache: Option<Arc<dyn prolly_s3_core::NodeCache>>,
     mutable_control_versions_to_retain: Option<usize>,
     journal_index_max_unindexed_events: Option<usize>,
+    operation_index_leaf_entries: Option<usize>,
+    operation_index_merge_fanout: Option<usize>,
+    operation_index_max_unindexed_events: Option<usize>,
     provider_identity: Option<ProviderIdentity>,
     attestation_signer: Option<Arc<dyn AttestationSigner>>,
     provider_attestation: Option<ProviderProfileId>,
@@ -108,6 +112,28 @@ impl ClientV2 {
                 bytes,
                 headers,
                 metadata,
+            )
+            .await
+    }
+
+    /// Put one object with a caller-stable operation ID. Reuse the same ID and
+    /// exact input after an ambiguous response to reconcile the committed
+    /// result without uploading the payload again.
+    pub async fn put_object_with_operation(
+        &self,
+        key: impl Into<String>,
+        bytes: Vec<u8>,
+        operation: OperationId,
+    ) -> Result<CommitReceiptV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .put_object_with_operation(
+                &self.branch,
+                key.into().into_bytes(),
+                bytes,
+                ObjectHeaders::default(),
+                BTreeMap::new(),
+                operation,
             )
             .await
     }
@@ -298,12 +324,32 @@ impl ClientV2 {
 
     pub async fn cleanup_branch_index_rebuild(
         &self,
-        cursor: &JournalIndexRebuildCursorV2,
+        journal: &JournalIndexRebuildCursorV2,
+        operations: &OperationIndexRebuildCursorV2,
         limit: usize,
     ) -> Result<JournalIndexRebuildCleanupV2> {
         self.ensure_provider_qualified()?;
         self.repository
-            .cleanup_branch_index_rebuild(cursor, limit)
+            .cleanup_branch_index_rebuild(journal, operations, limit)
+            .await
+    }
+
+    pub async fn start_operation_index_rebuild(
+        &self,
+        journal: &JournalIndexRebuildCursorV2,
+    ) -> Result<OperationIndexRebuildCursorV2> {
+        self.ensure_provider_qualified()?;
+        self.repository.start_operation_index_rebuild(journal).await
+    }
+
+    pub async fn advance_operation_index_rebuild(
+        &self,
+        cursor: &OperationIndexRebuildCursorV2,
+        max_events: usize,
+    ) -> Result<OperationIndexRebuildStepV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .advance_operation_index_rebuild(cursor, max_events)
             .await
     }
 
@@ -670,6 +716,21 @@ impl ClientV2Builder {
         self
     }
 
+    /// Configure the bounded operation-index shape. Production deployments
+    /// normally use the defaults; smaller limits are useful for deterministic
+    /// recovery qualification.
+    pub fn operation_index_limits(
+        mut self,
+        leaf_entries: usize,
+        merge_fanout: usize,
+        max_unindexed_events: usize,
+    ) -> Self {
+        self.operation_index_leaf_entries = Some(leaf_entries);
+        self.operation_index_merge_fanout = Some(merge_fanout);
+        self.operation_index_max_unindexed_events = Some(max_unindexed_events);
+        self
+    }
+
     pub fn bucket(mut self, bucket: impl Into<String>) -> Self {
         self.bucket = Some(bucket.into());
         self
@@ -854,6 +915,15 @@ impl ClientV2Builder {
         }
         if let Some(events) = self.journal_index_max_unindexed_events {
             options.journal_index_max_unindexed_events = events;
+        }
+        if let Some(entries) = self.operation_index_leaf_entries {
+            options.operation_index_leaf_entries = entries;
+        }
+        if let Some(fanout) = self.operation_index_merge_fanout {
+            options.operation_index_merge_fanout = fanout;
+        }
+        if let Some(events) = self.operation_index_max_unindexed_events {
+            options.operation_index_max_unindexed_events = events;
         }
         options.node_cache = self.node_cache;
         let branch = options.default_branch.clone();

--- a/extensions/s3/client/src/client_v2.rs
+++ b/extensions/s3/client/src/client_v2.rs
@@ -1,9 +1,10 @@
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use prolly_s3_core::{
-    BranchIndexAdvanceReportV2, CommitReceiptV2, Error, ErrorCode, ObjectDataV2, ObjectHeaders,
-    ProviderAttestationV1, ProviderPerKeyVersionLimitV2, ProviderProfileId, RepositoryV2,
-    RepositoryV2Options, Result,
+    BranchIndexAdvanceReportV2, CommitIdV2, CommitReceiptV2, Error, ErrorCode, ObjectDataV2,
+    ObjectHeaders, ObjectSummaryV2, ObjectVersionV2, ProviderAttestationV1,
+    ProviderPerKeyVersionLimitV2, ProviderProfileId, RepositoryV2, RepositoryV2Options, Result,
+    VersionSummaryV2,
 };
 
 use crate::{
@@ -102,6 +103,101 @@ impl ClientV2 {
         self.ensure_provider_qualified()?;
         self.repository
             .get_object(&self.branch, key.as_ref().as_bytes())
+            .await
+    }
+
+    pub async fn get_object_at(
+        &self,
+        snapshot: CommitIdV2,
+        key: impl AsRef<str>,
+    ) -> Result<Option<ObjectDataV2>> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .get_object_at(&self.branch, snapshot, key.as_ref().as_bytes())
+            .await
+    }
+
+    pub async fn delete_object(&self, key: impl Into<String>) -> Result<CommitReceiptV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .delete_object(&self.branch, key.into().into_bytes())
+            .await
+    }
+
+    pub async fn list_objects(
+        &self,
+        prefix: impl AsRef<str>,
+        after: Option<&str>,
+        limit: usize,
+    ) -> Result<(CommitIdV2, Vec<ObjectSummaryV2>, bool)> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .list_objects(
+                &self.branch,
+                prefix.as_ref().as_bytes(),
+                after.map(str::as_bytes),
+                limit,
+            )
+            .await
+    }
+
+    pub async fn list_objects_at(
+        &self,
+        snapshot: CommitIdV2,
+        prefix: impl AsRef<str>,
+        after: Option<&str>,
+        limit: usize,
+    ) -> Result<(Vec<ObjectSummaryV2>, bool)> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .list_objects_at(
+                &self.branch,
+                snapshot,
+                prefix.as_ref().as_bytes(),
+                after.map(str::as_bytes),
+                limit,
+            )
+            .await
+    }
+
+    pub async fn list_object_versions(
+        &self,
+        key: impl AsRef<str>,
+        limit: usize,
+    ) -> Result<(CommitIdV2, Vec<ObjectVersionV2>)> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .list_object_versions(&self.branch, key.as_ref().as_bytes(), limit)
+            .await
+    }
+
+    pub async fn list_versions_prefix(
+        &self,
+        prefix: impl AsRef<str>,
+        limit: usize,
+    ) -> Result<(CommitIdV2, Vec<VersionSummaryV2>)> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .list_versions_prefix(&self.branch, prefix.as_ref().as_bytes(), limit)
+            .await
+    }
+
+    pub async fn list_versions_at(
+        &self,
+        snapshot: CommitIdV2,
+        prefix: impl AsRef<str>,
+        after: Option<&[u8]>,
+        limit: usize,
+    ) -> Result<(Vec<VersionSummaryV2>, bool)> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .list_versions_at(
+                &self.branch,
+                snapshot,
+                prefix.as_ref().as_bytes(),
+                after,
+                limit,
+            )
             .await
     }
 

--- a/extensions/s3/client/src/client_v2.rs
+++ b/extensions/s3/client/src/client_v2.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use prolly_s3_core::{
     BranchIndexAdvanceReportV2, CommitIdV2, CommitReceiptV2, Error, ErrorCode, ObjectDataV2,
@@ -23,6 +27,7 @@ pub struct ClientV2 {
     bucket: String,
     branch: String,
     provider_attestation: ProviderAttestationV1,
+    shard_authority_maintenance: Arc<Mutex<Option<prolly_s3_core::ShardAuthorityMaintenance>>>,
 }
 
 #[derive(Default)]
@@ -209,14 +214,17 @@ impl ClientV2 {
         handoff_evidence: &str,
     ) -> Result<u64> {
         self.ensure_provider_qualified()?;
-        self.repository
+        let generation = self
+            .repository
             .takeover_branch_writer(
                 branch.as_ref(),
                 expected_writer,
                 expected_generation,
                 handoff_evidence,
             )
-            .await
+            .await?;
+        self.ensure_shard_authority_maintenance()?;
+        Ok(generation)
     }
 
     pub async fn advance_branch_indexes(&self) -> Result<BranchIndexAdvanceReportV2> {
@@ -232,12 +240,27 @@ impl ClientV2 {
         self.repository.plane().reset_metrics()
     }
 
+    pub fn fenced_branches(&self) -> Result<Vec<String>> {
+        self.repository.fenced_branches()
+    }
+
     fn ensure_provider_qualified(&self) -> Result<()> {
         ensure_attestation_current(&self.provider_attestation)?;
         self.provider_attestation
             .body
             .capabilities
             .validate_prolly_s3()
+    }
+
+    fn ensure_shard_authority_maintenance(&self) -> Result<()> {
+        let mut maintenance = self
+            .shard_authority_maintenance
+            .lock()
+            .map_err(|_| invalid("shard-authority maintenance lock is poisoned"))?;
+        if maintenance.is_none() {
+            *maintenance = Some(self.repository.start_shard_authority_maintenance()?);
+        }
+        Ok(())
     }
 }
 
@@ -435,11 +458,18 @@ impl ClientV2Builder {
         } else {
             RepositoryV2::open(plane, options).await?
         };
+        let repository = Arc::new(repository);
+        let shard_authority_maintenance = if self.read_only {
+            None
+        } else {
+            Some(repository.start_shard_authority_maintenance()?)
+        };
         Ok(ClientV2 {
-            repository: Arc::new(repository),
+            repository,
             bucket,
             branch,
             provider_attestation: attestation,
+            shard_authority_maintenance: Arc::new(Mutex::new(shard_authority_maintenance)),
         })
     }
 }

--- a/extensions/s3/client/src/client_v2.rs
+++ b/extensions/s3/client/src/client_v2.rs
@@ -10,12 +10,14 @@ use md5::Md5;
 use prolly_s3_core::{
     BatchId, BranchCatalogPageV2, BranchHeadV2, BranchIndexAdvanceReportV2, BranchIndexHealthV2,
     CommitIdV2, CommitReceiptV2, Error, ErrorCode, JournalIndexRebuildCleanupV2,
-    JournalIndexRebuildCursorV2, JournalIndexRebuildStepV2, ObjectDataV2, ObjectHeaders,
-    ObjectSummaryV2, ObjectVersionV2, OperationId, OperationIndexRebuildCursorV2,
-    OperationIndexRebuildStepV2, PhysicalBatchV2, ProviderAttestationV1,
-    ProviderPerKeyVersionLimitV2, ProviderProfileId, RefCatalogCursorV2, RefCatalogRepairPageV2,
-    RefKindV2, RepositoryV2, RepositoryV2Options, Result, StagedMutationV2, TagCatalogPageV2,
-    TagV2, VersionSummaryV2,
+    JournalIndexRebuildCursorV2, JournalIndexRebuildStepV2, MergeAdvancePageV2, MergeBaseCursorV2,
+    MergeBasePageV2, MergeChangeCursorV2, MergeChangePageV2, MergeCleanupCursorV2,
+    MergeCleanupPageV2, MergeConflictCursorV2, MergeConflictPageV2, MergeCursorV2, MergePolicyV2,
+    MergeReceiptV2, ObjectDataV2, ObjectHeaders, ObjectSummaryV2, ObjectVersionV2, OperationId,
+    OperationIndexRebuildCursorV2, OperationIndexRebuildStepV2, PhysicalBatchV2,
+    ProviderAttestationV1, ProviderPerKeyVersionLimitV2, ProviderProfileId, RefCatalogCursorV2,
+    RefCatalogRepairPageV2, RefKindV2, RepositoryV2, RepositoryV2Options, Result, StagedMutationV2,
+    TagCatalogPageV2, TagV2, VersionSummaryV2,
 };
 use sha2::{Digest as _, Sha256};
 
@@ -126,6 +128,98 @@ impl ClientV2 {
     pub async fn delete_tag(&self, name: impl AsRef<str>, expected: CommitIdV2) -> Result<()> {
         self.ensure_provider_qualified()?;
         self.repository.delete_tag(name.as_ref(), expected).await
+    }
+
+    /// Start a restartable structural merge from `source_branch` into this
+    /// client's selected branch.
+    pub async fn start_merge(
+        &self,
+        source_branch: impl AsRef<str>,
+        selected_base: Option<CommitIdV2>,
+        policy: MergePolicyV2,
+        message: impl Into<String>,
+    ) -> Result<MergeCursorV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .start_merge(
+                &self.branch,
+                source_branch.as_ref(),
+                selected_base,
+                policy,
+                message,
+            )
+            .await
+    }
+
+    pub async fn advance_merge(
+        &self,
+        cursor: &MergeCursorV2,
+        max_steps: usize,
+    ) -> Result<MergeAdvancePageV2> {
+        self.ensure_provider_qualified()?;
+        self.repository.advance_merge(cursor, max_steps).await
+    }
+
+    pub async fn select_merge_base(
+        &self,
+        cursor: &MergeCursorV2,
+        base: CommitIdV2,
+    ) -> Result<MergeCursorV2> {
+        self.ensure_provider_qualified()?;
+        self.repository.select_merge_base(cursor, base).await
+    }
+
+    pub async fn merge_bases_page(
+        &self,
+        cursor: &MergeCursorV2,
+        continuation: Option<&MergeBaseCursorV2>,
+        limit: usize,
+    ) -> Result<MergeBasePageV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .merge_bases_page(cursor, continuation, limit)
+            .await
+    }
+
+    pub async fn merge_changes_page(
+        &self,
+        cursor: &MergeCursorV2,
+        continuation: Option<&MergeChangeCursorV2>,
+        limit: usize,
+    ) -> Result<MergeChangePageV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .merge_changes_page(cursor, continuation, limit)
+            .await
+    }
+
+    pub async fn merge_conflicts_page(
+        &self,
+        cursor: &MergeCursorV2,
+        continuation: Option<&MergeConflictCursorV2>,
+        limit: usize,
+    ) -> Result<MergeConflictPageV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .merge_conflicts_page(cursor, continuation, limit)
+            .await
+    }
+
+    pub async fn publish_merge(&self, cursor: &MergeCursorV2) -> Result<MergeReceiptV2> {
+        self.ensure_provider_qualified()?;
+        self.repository.publish_merge(cursor).await
+    }
+
+    pub async fn cleanup_merge(
+        &self,
+        cursor: &MergeCursorV2,
+        continuation: Option<&MergeCleanupCursorV2>,
+        limit: usize,
+    ) -> Result<MergeCleanupPageV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .cleanup_merge(cursor, continuation, limit)
+            .await
     }
 
     pub async fn list_branch_catalog_page(

--- a/extensions/s3/client/src/client_v2.rs
+++ b/extensions/s3/client/src/client_v2.rs
@@ -8,12 +8,14 @@ use std::{
 use aws_sdk_s3::primitives::ByteStream;
 use md5::Md5;
 use prolly_s3_core::{
-    BatchId, BranchIndexAdvanceReportV2, BranchIndexHealthV2, CommitIdV2, CommitReceiptV2, Error,
-    ErrorCode, JournalIndexRebuildCleanupV2, JournalIndexRebuildCursorV2,
-    JournalIndexRebuildStepV2, ObjectDataV2, ObjectHeaders, ObjectSummaryV2, ObjectVersionV2,
-    OperationId, OperationIndexRebuildCursorV2, OperationIndexRebuildStepV2, PhysicalBatchV2,
-    ProviderAttestationV1, ProviderPerKeyVersionLimitV2, ProviderProfileId, RepositoryV2,
-    RepositoryV2Options, Result, StagedMutationV2, VersionSummaryV2,
+    BatchId, BranchCatalogPageV2, BranchHeadV2, BranchIndexAdvanceReportV2, BranchIndexHealthV2,
+    CommitIdV2, CommitReceiptV2, Error, ErrorCode, JournalIndexRebuildCleanupV2,
+    JournalIndexRebuildCursorV2, JournalIndexRebuildStepV2, ObjectDataV2, ObjectHeaders,
+    ObjectSummaryV2, ObjectVersionV2, OperationId, OperationIndexRebuildCursorV2,
+    OperationIndexRebuildStepV2, PhysicalBatchV2, ProviderAttestationV1,
+    ProviderPerKeyVersionLimitV2, ProviderProfileId, RefCatalogCursorV2, RefCatalogRepairPageV2,
+    RefKindV2, RepositoryV2, RepositoryV2Options, Result, StagedMutationV2, TagCatalogPageV2,
+    TagV2, VersionSummaryV2,
 };
 use sha2::{Digest as _, Sha256};
 
@@ -86,6 +88,86 @@ impl ClientV2 {
         let mut client = self.clone();
         client.branch = branch;
         Ok(client)
+    }
+
+    pub async fn head(&self) -> Result<CommitIdV2> {
+        self.ensure_provider_qualified()?;
+        self.repository.head(&self.branch).await
+    }
+
+    pub async fn create_branch(
+        &self,
+        name: impl AsRef<str>,
+        from: Option<CommitIdV2>,
+    ) -> Result<BranchHeadV2> {
+        self.ensure_provider_qualified()?;
+        let from = match from {
+            Some(from) => from,
+            None => self.repository.head(&self.branch).await?,
+        };
+        self.repository.create_branch(name.as_ref(), from).await
+    }
+
+    pub async fn delete_branch(&self, name: impl AsRef<str>, expected: CommitIdV2) -> Result<()> {
+        self.ensure_provider_qualified()?;
+        self.repository.delete_branch(name.as_ref(), expected).await
+    }
+
+    pub async fn create_tag(&self, name: impl AsRef<str>, target: CommitIdV2) -> Result<TagV2> {
+        self.ensure_provider_qualified()?;
+        self.repository.create_tag(name.as_ref(), target).await
+    }
+
+    pub async fn tag(&self, name: impl AsRef<str>) -> Result<TagV2> {
+        self.ensure_provider_qualified()?;
+        self.repository.tag(name.as_ref()).await
+    }
+
+    pub async fn delete_tag(&self, name: impl AsRef<str>, expected: CommitIdV2) -> Result<()> {
+        self.ensure_provider_qualified()?;
+        self.repository.delete_tag(name.as_ref(), expected).await
+    }
+
+    pub async fn list_branch_catalog_page(
+        &self,
+        cursor: Option<RefCatalogCursorV2>,
+        limit: usize,
+    ) -> Result<BranchCatalogPageV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .list_branch_catalog_page(cursor, limit)
+            .await
+    }
+
+    pub async fn list_tag_catalog_page(
+        &self,
+        cursor: Option<RefCatalogCursorV2>,
+        limit: usize,
+    ) -> Result<TagCatalogPageV2> {
+        self.ensure_provider_qualified()?;
+        self.repository.list_tag_catalog_page(cursor, limit).await
+    }
+
+    pub async fn repair_branch_catalog_page(
+        &self,
+        continuation: Option<String>,
+        limit: usize,
+    ) -> Result<RefCatalogRepairPageV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .repair_ref_catalog_page(RefKindV2::Branch, continuation, limit)
+            .await
+    }
+
+    pub async fn repair_tag_catalog_page(
+        &self,
+        continuation: Option<String>,
+        limit: usize,
+    ) -> Result<RefCatalogRepairPageV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .repair_ref_catalog_page(RefKindV2::Tag, continuation, limit)
+            .await
     }
 
     pub async fn put_object(

--- a/extensions/s3/client/src/client_v2.rs
+++ b/extensions/s3/client/src/client_v2.rs
@@ -6,9 +6,9 @@ use std::{
 
 use prolly_s3_core::{
     BranchIndexAdvanceReportV2, CommitIdV2, CommitReceiptV2, Error, ErrorCode, ObjectDataV2,
-    ObjectHeaders, ObjectSummaryV2, ObjectVersionV2, ProviderAttestationV1,
+    ObjectHeaders, ObjectSummaryV2, ObjectVersionV2, PhysicalBatchV2, ProviderAttestationV1,
     ProviderPerKeyVersionLimitV2, ProviderProfileId, RepositoryV2, RepositoryV2Options, Result,
-    VersionSummaryV2,
+    StagedMutationV2, VersionSummaryV2,
 };
 
 use crate::{
@@ -127,6 +127,17 @@ impl ClientV2 {
         self.repository
             .delete_object(&self.branch, key.into().into_bytes())
             .await
+    }
+
+    /// Begin an atomic protocol-v2 commit session. Payloads are uploaded as
+    /// they are staged, so the session retains metadata rather than complete
+    /// object bodies in process memory.
+    pub fn begin_commit(&self) -> CommitSessionV2Builder {
+        CommitSessionV2Builder {
+            client: self.clone(),
+            message: "atomic protocol-v2 commit".to_string(),
+            expires_after: Duration::from_secs(60 * 60),
+        }
     }
 
     pub async fn list_objects(
@@ -262,6 +273,114 @@ impl ClientV2 {
         }
         Ok(())
     }
+}
+
+pub struct CommitSessionV2Builder {
+    client: ClientV2,
+    message: String,
+    expires_after: Duration,
+}
+
+impl CommitSessionV2Builder {
+    pub fn message(mut self, message: impl Into<String>) -> Self {
+        self.message = message.into();
+        self
+    }
+
+    pub fn expires_after(mut self, expires_after: Duration) -> Self {
+        self.expires_after = expires_after;
+        self
+    }
+
+    pub async fn start(self) -> Result<CommitSessionV2> {
+        self.client.ensure_provider_qualified()?;
+        let expires_after_millis = u64::try_from(self.expires_after.as_millis())
+            .map_err(|_| invalid("v2 commit-session expiry exceeds u64 milliseconds"))?;
+        let manifest = self
+            .client
+            .repository
+            .begin_commit_session(&self.client.branch, self.message, expires_after_millis)
+            .await?;
+        Ok(CommitSessionV2 {
+            client: self.client,
+            manifest,
+            staged: BTreeMap::new(),
+        })
+    }
+}
+
+pub struct CommitSessionV2 {
+    client: ClientV2,
+    manifest: PhysicalBatchV2,
+    staged: BTreeMap<Vec<u8>, StagedMutationV2>,
+}
+
+impl CommitSessionV2 {
+    pub fn id(&self) -> prolly_s3_core::BatchId {
+        self.manifest.id
+    }
+
+    pub fn operation(&self) -> prolly_s3_core::OperationId {
+        self.manifest.identity.operation
+    }
+
+    pub fn base_commit(&self) -> CommitIdV2 {
+        self.manifest.base_commit
+    }
+
+    pub fn staged_objects(&self) -> usize {
+        self.staged.len()
+    }
+
+    pub async fn put_object(&mut self, key: impl Into<String>, bytes: Vec<u8>) -> Result<()> {
+        self.put_object_with_metadata(key, bytes, ObjectHeaders::default(), BTreeMap::new())
+            .await
+    }
+
+    pub async fn put_object_with_metadata(
+        &mut self,
+        key: impl Into<String>,
+        bytes: Vec<u8>,
+        headers: ObjectHeaders,
+        metadata: BTreeMap<String, String>,
+    ) -> Result<()> {
+        self.client.ensure_provider_qualified()?;
+        let staged = self
+            .client
+            .repository
+            .stage_commit_session_put(
+                &self.manifest,
+                key.into().into_bytes(),
+                bytes,
+                headers,
+                metadata,
+            )
+            .await?;
+        self.staged.insert(staged.key().to_vec(), staged);
+        Ok(())
+    }
+
+    pub fn delete_object(&mut self, key: impl Into<String>) -> Result<()> {
+        let key = key.into().into_bytes();
+        if key.is_empty() {
+            return Err(invalid("v2 commit-session delete key is empty"));
+        }
+        self.staged
+            .insert(key.clone(), StagedMutationV2::delete(key));
+        Ok(())
+    }
+
+    pub async fn publish(self) -> Result<CommitReceiptV2> {
+        self.client.ensure_provider_qualified()?;
+        self.client
+            .repository
+            .publish_commit_session(self.manifest, self.staged.into_values().collect())
+            .await
+    }
+
+    /// Aborting leaves only content-addressed payload candidates. A bounded v2
+    /// staging/GC workflow will reclaim payloads that no commit references.
+    pub fn abort(self) {}
 }
 
 impl ClientV2Builder {

--- a/extensions/s3/client/src/client_v2.rs
+++ b/extensions/s3/client/src/client_v2.rs
@@ -481,7 +481,11 @@ impl ClientV2 {
         self.repository.fenced_branches()
     }
 
-    fn ensure_provider_qualified(&self) -> Result<()> {
+    pub(crate) fn repository_handle(&self) -> Arc<RepositoryV2<AwsS3ObjectPlane>> {
+        self.repository.clone()
+    }
+
+    pub(crate) fn ensure_provider_qualified(&self) -> Result<()> {
         ensure_attestation_current(&self.provider_attestation)?;
         self.provider_attestation
             .body

--- a/extensions/s3/client/src/client_v2.rs
+++ b/extensions/s3/client/src/client_v2.rs
@@ -1,0 +1,353 @@
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+use prolly_s3_core::{
+    BranchIndexAdvanceReportV2, CommitReceiptV2, Error, ErrorCode, ObjectDataV2, ObjectHeaders,
+    ProviderAttestationV1, ProviderPerKeyVersionLimitV2, ProviderProfileId, RepositoryV2,
+    RepositoryV2Options, Result,
+};
+
+use crate::{
+    ensure_attestation_current, load_valid_attestation, qualify_and_store,
+    validate_provider_bucket, AttestationSigner, AwsS3ObjectPlane, ProviderIdentity,
+    ProviderQualificationOptions, S3OperationMetrics,
+};
+
+/// Application-facing native protocol-v2 client.
+///
+/// V2 repositories are physically and logically separate from legacy v1
+/// repositories. This client never dual-writes v1 state.
+#[derive(Clone)]
+pub struct ClientV2 {
+    repository: Arc<RepositoryV2<AwsS3ObjectPlane>>,
+    bucket: String,
+    branch: String,
+    provider_attestation: ProviderAttestationV1,
+}
+
+#[derive(Default)]
+pub struct ClientV2Builder {
+    aws_client: Option<aws_sdk_s3::Client>,
+    bucket: Option<String>,
+    repository_prefix: Option<String>,
+    default_branch: Option<String>,
+    writer: Option<String>,
+    authority_lease_duration: Option<Duration>,
+    read_only: bool,
+    max_cached_node_pack_bytes: Option<usize>,
+    max_cached_node_locations: Option<usize>,
+    max_cached_node_bytes: Option<usize>,
+    node_cache: Option<Arc<dyn prolly_s3_core::NodeCache>>,
+    mutable_control_versions_to_retain: Option<usize>,
+    provider_identity: Option<ProviderIdentity>,
+    attestation_signer: Option<Arc<dyn AttestationSigner>>,
+    provider_attestation: Option<ProviderProfileId>,
+    qualification_options: Option<ProviderQualificationOptions>,
+    provider_per_key_version_limit: Option<ProviderPerKeyVersionLimitV2>,
+}
+
+impl ClientV2 {
+    pub fn builder() -> ClientV2Builder {
+        ClientV2Builder::default()
+    }
+
+    pub fn bucket(&self) -> &str {
+        &self.bucket
+    }
+
+    pub fn branch(&self) -> &str {
+        &self.branch
+    }
+
+    pub fn repository_id(&self) -> prolly_s3_core::RepositoryId {
+        self.repository.repository_id()
+    }
+
+    pub fn for_branch(&self, branch: impl Into<String>) -> Result<Self> {
+        let branch = branch.into();
+        prolly_s3_core::validate_branch(&branch)?;
+        let mut client = self.clone();
+        client.branch = branch;
+        Ok(client)
+    }
+
+    pub async fn put_object(
+        &self,
+        key: impl Into<String>,
+        bytes: Vec<u8>,
+    ) -> Result<CommitReceiptV2> {
+        self.put_object_with_metadata(key, bytes, ObjectHeaders::default(), BTreeMap::new())
+            .await
+    }
+
+    pub async fn put_object_with_metadata(
+        &self,
+        key: impl Into<String>,
+        bytes: Vec<u8>,
+        headers: ObjectHeaders,
+        metadata: BTreeMap<String, String>,
+    ) -> Result<CommitReceiptV2> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .put_object(
+                &self.branch,
+                key.into().into_bytes(),
+                bytes,
+                headers,
+                metadata,
+            )
+            .await
+    }
+
+    pub async fn get_object(&self, key: impl AsRef<str>) -> Result<Option<ObjectDataV2>> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .get_object(&self.branch, key.as_ref().as_bytes())
+            .await
+    }
+
+    pub async fn takeover_branch_writer(
+        &self,
+        branch: impl AsRef<str>,
+        expected_writer: &str,
+        expected_generation: u64,
+        handoff_evidence: &str,
+    ) -> Result<u64> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .takeover_branch_writer(
+                branch.as_ref(),
+                expected_writer,
+                expected_generation,
+                handoff_evidence,
+            )
+            .await
+    }
+
+    pub async fn advance_branch_indexes(&self) -> Result<BranchIndexAdvanceReportV2> {
+        self.ensure_provider_qualified()?;
+        self.repository.advance_branch_indexes(&self.branch).await
+    }
+
+    pub fn s3_operation_metrics(&self) -> S3OperationMetrics {
+        self.repository.plane().metrics()
+    }
+
+    pub fn reset_s3_operation_metrics(&self) -> S3OperationMetrics {
+        self.repository.plane().reset_metrics()
+    }
+
+    fn ensure_provider_qualified(&self) -> Result<()> {
+        ensure_attestation_current(&self.provider_attestation)?;
+        self.provider_attestation
+            .body
+            .capabilities
+            .validate_prolly_s3()
+    }
+}
+
+impl ClientV2Builder {
+    pub fn aws_client(mut self, client: aws_sdk_s3::Client) -> Self {
+        self.aws_client = Some(client);
+        self
+    }
+
+    pub fn bucket(mut self, bucket: impl Into<String>) -> Self {
+        self.bucket = Some(bucket.into());
+        self
+    }
+
+    pub fn repository_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.repository_prefix = Some(prefix.into());
+        self
+    }
+
+    pub fn default_branch(mut self, branch: impl Into<String>) -> Self {
+        self.default_branch = Some(branch.into());
+        self
+    }
+
+    pub fn writer(mut self, writer: impl Into<String>) -> Self {
+        self.writer = Some(writer.into());
+        self
+    }
+
+    pub fn authority_lease_duration(mut self, duration: Duration) -> Self {
+        self.authority_lease_duration = Some(duration);
+        self
+    }
+
+    pub fn read_only(mut self, read_only: bool) -> Self {
+        self.read_only = read_only;
+        self
+    }
+
+    pub fn node_cache(mut self, cache: Arc<dyn prolly_s3_core::NodeCache>) -> Self {
+        self.node_cache = Some(cache);
+        self
+    }
+
+    pub fn max_cached_node_pack_bytes(mut self, bytes: usize) -> Self {
+        self.max_cached_node_pack_bytes = Some(bytes);
+        self
+    }
+
+    pub fn max_cached_node_locations(mut self, locations: usize) -> Self {
+        self.max_cached_node_locations = Some(locations);
+        self
+    }
+
+    pub fn max_cached_node_bytes(mut self, bytes: usize) -> Self {
+        self.max_cached_node_bytes = Some(bytes);
+        self
+    }
+
+    pub fn mutable_control_version_retention(mut self, versions: usize) -> Self {
+        self.mutable_control_versions_to_retain = Some(versions);
+        self
+    }
+
+    /// Provider-attested maximum number of physical versions for one key.
+    /// Unknown limits fail closed for native v2 initialization and open.
+    pub fn provider_per_key_version_limit(mut self, limit: ProviderPerKeyVersionLimitV2) -> Self {
+        self.provider_per_key_version_limit = Some(limit);
+        self
+    }
+
+    pub fn provider_identity(mut self, identity: ProviderIdentity) -> Self {
+        self.provider_identity = Some(identity);
+        self
+    }
+
+    pub fn attestation_signer(mut self, signer: Arc<dyn AttestationSigner>) -> Self {
+        self.attestation_signer = Some(signer);
+        self
+    }
+
+    pub fn provider_attestation(mut self, id: ProviderProfileId) -> Self {
+        self.provider_attestation = Some(id);
+        self
+    }
+
+    pub fn provider_attestation_validity(mut self, validity: Duration) -> Self {
+        self.qualification_options = Some(ProviderQualificationOptions { validity });
+        self
+    }
+
+    pub async fn initialize(self) -> Result<ClientV2> {
+        self.finish(true).await
+    }
+
+    pub async fn open(self) -> Result<ClientV2> {
+        self.finish(false).await
+    }
+
+    async fn finish(self, initialize: bool) -> Result<ClientV2> {
+        if initialize && self.read_only {
+            return Err(invalid(
+                "native v2 initialization requires a writable client",
+            ));
+        }
+        let aws = self
+            .aws_client
+            .ok_or_else(|| invalid("aws_client is required"))?;
+        let bucket = self.bucket.ok_or_else(|| invalid("bucket is required"))?;
+        let identity = self
+            .provider_identity
+            .ok_or_else(|| invalid("provider_identity is required"))?;
+        validate_provider_bucket(&identity, &bucket)?;
+        let signer = self
+            .attestation_signer
+            .ok_or_else(|| invalid("attestation_signer is required"))?;
+        let provider_per_key_version_limit =
+            self.provider_per_key_version_limit.ok_or_else(|| {
+                Error::new(
+                    ErrorCode::ProviderNotQualified,
+                    "native v2 requires an explicit provider per-key version-limit attestation",
+                )
+            })?;
+        let prefix = self
+            .repository_prefix
+            .unwrap_or_else(|| RepositoryV2Options::default().repository_prefix);
+        let plane = Arc::new(AwsS3ObjectPlane::new(aws, bucket.clone()));
+        let attestation = if initialize {
+            match load_valid_attestation(
+                plane.clone(),
+                &prefix,
+                &identity,
+                signer.as_ref(),
+                self.provider_attestation,
+            )
+            .await
+            {
+                Ok(attestation) => attestation,
+                Err(error) if error.code == ErrorCode::ProviderNotQualified => {
+                    qualify_and_store(
+                        plane.clone(),
+                        &prefix,
+                        &identity,
+                        signer.as_ref(),
+                        &self.qualification_options.unwrap_or_default(),
+                    )
+                    .await?
+                }
+                Err(error) => return Err(error),
+            }
+        } else {
+            load_valid_attestation(
+                plane.clone(),
+                &prefix,
+                &identity,
+                signer.as_ref(),
+                self.provider_attestation,
+            )
+            .await?
+        };
+        attestation.body.capabilities.validate_prolly_s3()?;
+
+        let mut options = RepositoryV2Options {
+            repository_prefix: prefix,
+            read_only: self.read_only,
+            provider_per_key_version_limit,
+            ..RepositoryV2Options::default()
+        };
+        if let Some(branch) = self.default_branch {
+            options.default_branch = branch;
+        }
+        if let Some(writer) = self.writer {
+            options.writer = writer;
+        }
+        if let Some(duration) = self.authority_lease_duration {
+            options.authority_lease_millis = u64::try_from(duration.as_millis())
+                .map_err(|_| invalid("authority lease duration exceeds u64 milliseconds"))?;
+        }
+        if let Some(bytes) = self.max_cached_node_pack_bytes {
+            options.max_cached_node_pack_bytes = bytes;
+        }
+        if let Some(locations) = self.max_cached_node_locations {
+            options.max_cached_node_locations = locations;
+        }
+        if let Some(bytes) = self.max_cached_node_bytes {
+            options.max_cached_node_bytes = bytes;
+        }
+        if let Some(versions) = self.mutable_control_versions_to_retain {
+            options.mutable_control_versions_to_retain = versions;
+        }
+        options.node_cache = self.node_cache;
+        let branch = options.default_branch.clone();
+        let repository = if initialize {
+            RepositoryV2::initialize(plane, options).await?
+        } else {
+            RepositoryV2::open(plane, options).await?
+        };
+        Ok(ClientV2 {
+            repository: Arc::new(repository),
+            bucket,
+            branch,
+            provider_attestation: attestation,
+        })
+    }
+}
+
+fn invalid(message: impl Into<String>) -> Error {
+    Error::new(ErrorCode::InvalidRequest, message)
+}

--- a/extensions/s3/client/src/lib.rs
+++ b/extensions/s3/client/src/lib.rs
@@ -5,6 +5,7 @@ mod aws_object;
 #[cfg(feature = "foyer-cache")]
 mod cache;
 mod client;
+mod client_v2;
 mod provider;
 mod wire_metrics;
 
@@ -13,6 +14,7 @@ pub use aws_object::{AwsS3ObjectPlane, S3OperationMetrics};
 #[cfg(feature = "foyer-cache")]
 pub use cache::{FoyerNodeCache, FoyerNodeCacheConfig};
 pub use client::*;
+pub use client_v2::*;
 pub use prolly_s3_core as core;
 pub use prolly_s3_core::{Error, ErrorCode, Result};
 pub use provider::*;

--- a/extensions/s3/client/tests/rustfs_backup_restore.rs
+++ b/extensions/s3/client/tests/rustfs_backup_restore.rs
@@ -708,7 +708,8 @@ async fn rustfs_physical_backup_restore_process_helper() {
     assert!(!restored_ref_versions.is_empty());
     assert_eq!(
         restored
-            .takeover_writer(
+            .takeover_branch_writer(
+                "main",
                 "archive-reader",
                 1,
                 "archive reader is process-bound to a different bucket and cannot address restore",

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -15,8 +15,11 @@ use md5::{Digest as _, Md5};
 #[cfg(feature = "foyer-cache")]
 use prolly_s3_client::{core::PhysicalBatchMutationV1, FoyerNodeCache, FoyerNodeCacheConfig};
 use prolly_s3_client::{
-    core::{ObjectHeaders, PhysicalMultipartCompletedPart, Repository, RepositoryOptions},
-    AwsS3ObjectPlane, Client, HmacAttestationSigner, ProviderIdentity,
+    core::{
+        ObjectHeaders, PhysicalMultipartCompletedPart, ProviderPerKeyVersionLimitV2, Repository,
+        RepositoryOptions,
+    },
+    AwsS3ObjectPlane, Client, ClientV2, HmacAttestationSigner, ProviderIdentity,
 };
 use sha2::Sha256;
 
@@ -273,6 +276,87 @@ async fn rustfs_branch_takeover_fences_old_client_before_payload_upload() {
         .key(format!("{key_prefix}/after-takeover.bin"))
         .body(aws_sdk_s3::primitives::ByteStream::from_static(b"after"))
         .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rustfs_native_v2_client_uses_immutable_payloads_and_fences_takeover() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+
+    let (aws, bucket) = rustfs_client().await;
+    let repository_prefix = unique_name("native-v2-client-repository");
+    let old_writer = ClientV2::builder()
+        .aws_client(aws.clone())
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer("rustfs-native-v2-old-writer")
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .initialize()
+        .await
+        .unwrap();
+    old_writer
+        .put_object("docs/native-v2.txt", b"before takeover".to_vec())
+        .await
+        .unwrap();
+    let stored = old_writer
+        .get_object("docs/native-v2.txt")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.bytes, b"before takeover");
+    assert!(stored
+        .version
+        .binding
+        .unwrap()
+        .path
+        .as_str()
+        .contains("/payloads/v2/"));
+
+    let replacement = ClientV2::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer("rustfs-native-v2-new-writer")
+        .read_only(true)
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .open()
+        .await
+        .unwrap();
+    assert_eq!(
+        replacement
+            .takeover_branch_writer(
+                "main",
+                "rustfs-native-v2-old-writer",
+                1,
+                "old native-v2 test credentials revoked and process isolated",
+            )
+            .await
+            .unwrap(),
+        2
+    );
+
+    old_writer.reset_s3_operation_metrics();
+    let error = old_writer
+        .put_object("docs/stale-v2.txt", b"must not upload".to_vec())
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, prolly_s3_client::ErrorCode::PreconditionFailed);
+    let stale_calls = old_writer.reset_s3_operation_metrics();
+    assert_eq!(
+        stale_calls.put_object, 0,
+        "unexpected calls: {stale_calls:?}"
+    );
+
+    replacement
+        .put_object("docs/current-v2.txt", b"writer-b".to_vec())
         .await
         .unwrap();
 }

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -8,6 +8,7 @@ use aws_config::BehaviorVersion;
 use aws_credential_types::Credentials;
 use aws_sdk_s3::{
     config::Region,
+    primitives::ByteStream,
     types::{BucketVersioningStatus, VersioningConfiguration},
 };
 use futures_util::StreamExt;
@@ -491,7 +492,7 @@ async fn rustfs_native_v2_commit_session_preserves_n_plus_three_puts() {
         .await
         .unwrap();
     session
-        .put_object("batch/b.txt", b"second".to_vec())
+        .put_stream("batch/b.txt", ByteStream::from_static(b"second"))
         .await
         .unwrap();
     session.delete_object("batch/removed.txt").unwrap();
@@ -501,6 +502,10 @@ async fn rustfs_native_v2_commit_session_preserves_n_plus_three_puts() {
     assert_eq!(
         calls.put_object, 5,
         "two immutable payload PUTs plus commit/event/ref publication must preserve N + 3: {calls:?}"
+    );
+    assert_eq!(
+        calls.head_object, 0,
+        "the successful streaming path must not require reconciliation HEADs: {calls:?}"
     );
     assert_eq!(
         client

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -665,6 +665,78 @@ async fn rustfs_native_v2_cold_open_catches_indexes_before_serving_reads() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rustfs_native_v2_over_limit_index_rebuild_resumes_from_canonical_cursor() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+
+    let (aws, bucket) = rustfs_client().await;
+    let repository_prefix = unique_name("native-v2-index-rebuild");
+    let writer = ClientV2::builder()
+        .aws_client(aws.clone())
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer("rustfs-native-v2-rebuild-writer")
+        .journal_index_max_unindexed_events(2)
+        .background_index_maintenance(false)
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .initialize()
+        .await
+        .unwrap();
+    for index in 0..5 {
+        writer
+            .put_object(
+                format!("rebuild/{index}.txt"),
+                format!("value-{index}").into_bytes(),
+            )
+            .await
+            .unwrap();
+    }
+    drop(writer);
+
+    let reader = ClientV2::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .read_only(true)
+        .journal_index_max_unindexed_events(2)
+        .background_index_maintenance(false)
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .open()
+        .await
+        .unwrap();
+    assert!(!reader.branch_index_health().await.unwrap().ready);
+    let mut cursor = reader.start_branch_index_rebuild().await.unwrap();
+    loop {
+        let bytes = prolly_s3_client::core::encode_canonical(&cursor).unwrap();
+        cursor = prolly_s3_client::core::decode_canonical(&bytes).unwrap();
+        let step = reader
+            .advance_branch_index_rebuild(&cursor, 2)
+            .await
+            .unwrap();
+        cursor = step.cursor;
+        if step.complete {
+            break;
+        }
+    }
+    assert!(reader.branch_index_health().await.unwrap().ready);
+    assert_eq!(
+        reader
+            .get_object("rebuild/4.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"value-4"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn rustfs_two_part_multipart_write_uses_eight_s3_calls() {
     if !rustfs_enabled() {
         eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -462,6 +462,78 @@ async fn rustfs_native_v2_writable_reopen_resumes_the_same_writer() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rustfs_native_v2_ref_lifecycle_uses_catalog_shards_without_ref_scans() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+
+    let (aws, bucket) = rustfs_client().await;
+    let repository_prefix = unique_name("native-v2-ref-catalog");
+    let client = ClientV2::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer("rustfs-native-v2-ref-writer")
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .background_index_maintenance(false)
+        .initialize()
+        .await
+        .unwrap();
+    let main = client.head().await.unwrap();
+    client.create_branch("feature", Some(main)).await.unwrap();
+    let feature = client.for_branch("feature").unwrap();
+    let committed = feature
+        .put_object("docs/feature.txt", b"branch-local".to_vec())
+        .await
+        .unwrap();
+    feature.advance_branch_indexes().await.unwrap();
+    let tag = client.create_tag("release-1", committed.id).await.unwrap();
+
+    client.reset_s3_operation_metrics();
+    let branches = client.list_branch_catalog_page(None, 100).await.unwrap();
+    let mut names = branches
+        .branches
+        .into_iter()
+        .map(|branch| branch.name)
+        .collect::<Vec<_>>();
+    names.sort();
+    assert_eq!(names, vec!["feature", "main"]);
+    assert_eq!(
+        client.list_tag_catalog_page(None, 100).await.unwrap().tags,
+        vec![tag]
+    );
+    let metrics = client.reset_s3_operation_metrics();
+    assert_eq!(metrics.list_objects_v2, 0, "catalog listing scanned refs");
+    assert_eq!(
+        metrics.list_object_versions, 0,
+        "catalog listing scanned ref versions"
+    );
+
+    client.delete_tag("release-1", committed.id).await.unwrap();
+    client.delete_branch("feature", committed.id).await.unwrap();
+    assert!(client
+        .list_tag_catalog_page(None, 100)
+        .await
+        .unwrap()
+        .tags
+        .is_empty());
+    assert_eq!(
+        client
+            .list_branch_catalog_page(None, 100)
+            .await
+            .unwrap()
+            .branches
+            .into_iter()
+            .map(|branch| branch.name)
+            .collect::<Vec<_>>(),
+        vec!["main"]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn rustfs_native_v2_commit_session_preserves_n_plus_three_puts() {
     if !rustfs_enabled() {
         eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -474,6 +474,7 @@ async fn rustfs_native_v2_commit_session_preserves_n_plus_three_puts() {
         .bucket(&bucket)
         .repository_prefix(unique_name("native-v2-commit-session"))
         .writer("rustfs-native-v2-batch-writer")
+        .background_index_maintenance(false)
         .provider_identity(provider_identity())
         .attestation_signer(attestation_signer())
         .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
@@ -600,6 +601,66 @@ async fn rustfs_native_v2_durable_session_resumes_without_payload_reupload() {
             .unwrap()
             .bytes,
         payload
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rustfs_native_v2_cold_open_catches_indexes_before_serving_reads() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+
+    let (aws, bucket) = rustfs_client().await;
+    let repository_prefix = unique_name("native-v2-cold-index-catchup");
+    let writer = ClientV2::builder()
+        .aws_client(aws.clone())
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer("rustfs-native-v2-index-writer")
+        .background_index_maintenance(false)
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .initialize()
+        .await
+        .unwrap();
+    for index in 0..3 {
+        writer
+            .put_object(
+                format!("cold/{index}.txt"),
+                format!("value-{index}").into_bytes(),
+            )
+            .await
+            .unwrap();
+    }
+    drop(writer);
+
+    let reader = ClientV2::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .read_only(true)
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .open()
+        .await
+        .unwrap();
+    let health = reader.branch_index_health().await.unwrap();
+    assert!(
+        health.ready,
+        "cold open must await background catch-up: {health:?}"
+    );
+    assert_eq!(health.lag_generations, 0);
+    assert_eq!(
+        reader
+            .get_object("cold/2.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"value-2"
     );
 }
 

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -17,7 +17,8 @@ use md5::{Digest as _, Md5};
 use prolly_s3_client::{core::PhysicalBatchMutationV1, FoyerNodeCache, FoyerNodeCacheConfig};
 use prolly_s3_client::{
     core::{
-        LogicalObjectVersionKindV1, ObjectHeaders, PhysicalMultipartCompletedPart,
+        decode_canonical, encode_canonical, LogicalObjectVersionKindV1, MergeCursorV2,
+        MergePhaseV2, MergePolicyV2, ObjectHeaders, PhysicalMultipartCompletedPart,
         ProviderPerKeyVersionLimitV2, Repository, RepositoryOptions,
     },
     AwsS3ObjectPlane, Client, ClientV2, HmacAttestationSigner, ProviderIdentity,
@@ -706,6 +707,111 @@ async fn rustfs_native_v2_commit_session_preserves_n_plus_three_puts() {
         .await
         .unwrap()
         .is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rustfs_native_v2_merge_resumes_and_publishes_structural_plan() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+
+    let (aws, bucket) = rustfs_client().await;
+    let repository_prefix = unique_name("native-v2-merge");
+    let client = ClientV2::builder()
+        .aws_client(aws.clone())
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer("rustfs-native-v2-merge-writer")
+        .background_index_maintenance(false)
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .initialize()
+        .await
+        .unwrap();
+    client
+        .put_object("merge/conflict.txt", b"base".to_vec())
+        .await
+        .unwrap();
+    let base = client.head().await.unwrap();
+    client.create_branch("feature", Some(base)).await.unwrap();
+    client
+        .put_object("merge/conflict.txt", b"ours".to_vec())
+        .await
+        .unwrap();
+    let feature = client.for_branch("feature").unwrap();
+    feature
+        .put_object("merge/conflict.txt", b"theirs".to_vec())
+        .await
+        .unwrap();
+    feature
+        .put_object("merge/source-only.txt", b"source".to_vec())
+        .await
+        .unwrap();
+
+    let mut cursor = client
+        .start_merge(
+            "feature",
+            None,
+            MergePolicyV2::Theirs,
+            "merge feature through RustFS",
+        )
+        .await
+        .unwrap();
+    drop(feature);
+    drop(client);
+    while cursor.phase != MergePhaseV2::ReadyToPublish {
+        let reopened = ClientV2::builder()
+            .aws_client(aws.clone())
+            .bucket(&bucket)
+            .repository_prefix(&repository_prefix)
+            .writer("rustfs-native-v2-merge-writer")
+            .background_index_maintenance(false)
+            .provider_identity(provider_identity())
+            .attestation_signer(attestation_signer())
+            .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+            .open()
+            .await
+            .unwrap();
+        let encoded = encode_canonical(&cursor).unwrap();
+        let restored: MergeCursorV2 = decode_canonical(&encoded).unwrap();
+        cursor = reopened.advance_merge(&restored, 2).await.unwrap().cursor;
+        drop(reopened);
+    }
+    let publisher = ClientV2::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer("rustfs-native-v2-merge-writer")
+        .background_index_maintenance(false)
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .open()
+        .await
+        .unwrap();
+    let receipt = publisher.publish_merge(&cursor).await.unwrap();
+    assert_eq!(receipt.changed_keys, 2);
+    assert_eq!(receipt.conflicts, 1);
+    assert_eq!(
+        publisher
+            .get_object("merge/conflict.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"theirs"
+    );
+    assert_eq!(
+        publisher
+            .get_object("merge/source-only.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"source"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -679,6 +679,7 @@ async fn rustfs_native_v2_over_limit_index_rebuild_resumes_from_canonical_cursor
         .repository_prefix(&repository_prefix)
         .writer("rustfs-native-v2-rebuild-writer")
         .journal_index_max_unindexed_events(2)
+        .operation_index_limits(2, 2, 8)
         .background_index_maintenance(false)
         .provider_identity(provider_identity())
         .attestation_signer(attestation_signer())
@@ -686,23 +687,28 @@ async fn rustfs_native_v2_over_limit_index_rebuild_resumes_from_canonical_cursor
         .initialize()
         .await
         .unwrap();
+    let mut original = None;
     for index in 0..5 {
-        writer
+        let receipt = writer
             .put_object(
                 format!("rebuild/{index}.txt"),
                 format!("value-{index}").into_bytes(),
             )
             .await
             .unwrap();
+        if index == 4 {
+            original = Some(receipt);
+        }
     }
     drop(writer);
 
     let reader = ClientV2::builder()
-        .aws_client(aws)
+        .aws_client(aws.clone())
         .bucket(&bucket)
         .repository_prefix(&repository_prefix)
         .read_only(true)
         .journal_index_max_unindexed_events(2)
+        .operation_index_limits(2, 2, 2)
         .background_index_maintenance(false)
         .provider_identity(provider_identity())
         .attestation_signer(attestation_signer())
@@ -734,6 +740,54 @@ async fn rustfs_native_v2_over_limit_index_rebuild_resumes_from_canonical_cursor
             .bytes,
         b"value-4"
     );
+
+    let mut operation = reader.start_operation_index_rebuild(&cursor).await.unwrap();
+    loop {
+        let bytes = prolly_s3_client::core::encode_canonical(&operation).unwrap();
+        operation = prolly_s3_client::core::decode_canonical(&bytes).unwrap();
+        let step = reader
+            .advance_operation_index_rebuild(&operation, 2)
+            .await
+            .unwrap();
+        operation = step.cursor;
+        if step.complete {
+            break;
+        }
+    }
+
+    loop {
+        if reader
+            .cleanup_branch_index_rebuild(&cursor, &operation, 1)
+            .await
+            .unwrap()
+            .complete
+        {
+            break;
+        }
+    }
+    drop(reader);
+
+    let replay_writer = ClientV2::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer("rustfs-native-v2-rebuild-writer")
+        .journal_index_max_unindexed_events(2)
+        .operation_index_limits(2, 2, 2)
+        .background_index_maintenance(false)
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .open()
+        .await
+        .unwrap();
+    let original = original.unwrap();
+    let replay = replay_writer
+        .put_object_with_operation("rebuild/4.txt", b"value-4".to_vec(), original.operation)
+        .await
+        .unwrap();
+    assert!(replay.idempotent_replay);
+    assert_eq!(replay.id, original.id);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -294,6 +294,7 @@ async fn rustfs_native_v2_client_uses_immutable_payloads_and_fences_takeover() {
         .bucket(&bucket)
         .repository_prefix(&repository_prefix)
         .writer("rustfs-native-v2-old-writer")
+        .authority_lease_duration(Duration::from_secs(10))
         .provider_identity(provider_identity())
         .attestation_signer(attestation_signer())
         .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
@@ -364,6 +365,7 @@ async fn rustfs_native_v2_client_uses_immutable_payloads_and_fences_takeover() {
         .repository_prefix(&repository_prefix)
         .writer("rustfs-native-v2-new-writer")
         .read_only(true)
+        .authority_lease_duration(Duration::from_secs(10))
         .provider_identity(provider_identity())
         .attestation_signer(attestation_signer())
         .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
@@ -395,10 +397,67 @@ async fn rustfs_native_v2_client_uses_immutable_payloads_and_fences_takeover() {
         "unexpected calls: {stale_calls:?}"
     );
 
+    tokio::time::sleep(Duration::from_secs(11)).await;
     replacement
         .put_object("docs/current-v2.txt", b"writer-b".to_vec())
         .await
         .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rustfs_native_v2_writable_reopen_resumes_the_same_writer() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+
+    let (aws, bucket) = rustfs_client().await;
+    let repository_prefix = unique_name("native-v2-writable-reopen");
+    let original = ClientV2::builder()
+        .aws_client(aws.clone())
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer("rustfs-native-v2-restartable-writer")
+        .authority_lease_duration(Duration::from_secs(10))
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .initialize()
+        .await
+        .unwrap();
+    original
+        .put_object("docs/before-restart.txt", b"before".to_vec())
+        .await
+        .unwrap();
+    original.advance_branch_indexes().await.unwrap();
+    drop(original);
+
+    let reopened = ClientV2::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer("rustfs-native-v2-restartable-writer")
+        .authority_lease_duration(Duration::from_secs(10))
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .open()
+        .await
+        .unwrap();
+    reopened
+        .put_object("docs/after-restart.txt", b"after".to_vec())
+        .await
+        .unwrap();
+    assert_eq!(
+        reopened
+            .get_object("docs/after-restart.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"after"
+    );
+    assert!(reopened.fenced_branches().unwrap().is_empty());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -534,6 +534,108 @@ async fn rustfs_native_v2_ref_lifecycle_uses_catalog_shards_without_ref_scans() 
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rustfs_v1_history_migrates_to_native_v2_in_restartable_pages() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+
+    let (aws, bucket) = rustfs_client().await;
+    let key = format!("{}/history.txt", unique_name("v1-to-v2-object"));
+    let source = Client::builder()
+        .aws_client(aws.clone())
+        .bucket(&bucket)
+        .repository_prefix(unique_name("v1-to-v2-source"))
+        .writer("rustfs-v1-migration-source")
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .initialize()
+        .await
+        .unwrap();
+    for body in [b"first".as_slice(), b"second".as_slice()] {
+        source
+            .put_object()
+            .bucket(&bucket)
+            .key(&key)
+            .body(ByteStream::from(body.to_vec()))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let destination_prefix = unique_name("v1-to-v2-destination");
+    let destination = ClientV2::builder()
+        .aws_client(aws.clone())
+        .bucket(&bucket)
+        .repository_prefix(&destination_prefix)
+        .writer("rustfs-v2-migration-destination")
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .background_index_maintenance(false)
+        .initialize()
+        .await
+        .unwrap();
+    let mut cursor = source
+        .start_v2_migration(&destination, "imported-main")
+        .await
+        .unwrap();
+    loop {
+        cursor = prolly_s3_client::core::decode_canonical(
+            &prolly_s3_client::core::encode_canonical(&cursor).unwrap(),
+        )
+        .unwrap();
+        let page = source
+            .advance_v2_migration(&destination, &cursor, 100, 1)
+            .await
+            .unwrap();
+        cursor = page.cursor;
+        if page.complete {
+            break;
+        }
+    }
+    assert_eq!(cursor.migrated_commits, 3);
+    assert_eq!(cursor.migrated_payloads, 2);
+    let imported = destination.for_branch("imported-main").unwrap();
+    assert_eq!(
+        imported.get_object(&key).await.unwrap().unwrap().bytes,
+        b"second"
+    );
+    loop {
+        if source
+            .cleanup_v2_migration(&cursor, 1_000)
+            .await
+            .unwrap()
+            .complete
+        {
+            break;
+        }
+    }
+
+    drop(imported);
+    drop(destination);
+    let cold = ClientV2::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(destination_prefix)
+        .writer("rustfs-v2-migration-destination")
+        .read_only(true)
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .background_index_maintenance(false)
+        .open()
+        .await
+        .unwrap()
+        .for_branch("imported-main")
+        .unwrap();
+    assert_eq!(
+        cold.get_object(&key).await.unwrap().unwrap().bytes,
+        b"second"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn rustfs_native_v2_commit_session_preserves_n_plus_three_puts() {
     if !rustfs_enabled() {
         eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -461,6 +461,73 @@ async fn rustfs_native_v2_writable_reopen_resumes_the_same_writer() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rustfs_native_v2_commit_session_preserves_n_plus_three_puts() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+
+    let (aws, bucket) = rustfs_client().await;
+    let client = ClientV2::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(unique_name("native-v2-commit-session"))
+        .writer("rustfs-native-v2-batch-writer")
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .initialize()
+        .await
+        .unwrap();
+    let mut session = client
+        .begin_commit()
+        .message("two puts and one delete")
+        .start()
+        .await
+        .unwrap();
+    client.reset_s3_operation_metrics();
+    session
+        .put_object("batch/a.txt", b"first".to_vec())
+        .await
+        .unwrap();
+    session
+        .put_object("batch/b.txt", b"second".to_vec())
+        .await
+        .unwrap();
+    session.delete_object("batch/removed.txt").unwrap();
+    let receipt = session.publish().await.unwrap();
+    assert_eq!(receipt.changed_keys, 3);
+    let calls = client.reset_s3_operation_metrics();
+    assert_eq!(
+        calls.put_object, 5,
+        "two immutable payload PUTs plus commit/event/ref publication must preserve N + 3: {calls:?}"
+    );
+    assert_eq!(
+        client
+            .get_object("batch/a.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"first"
+    );
+    assert_eq!(
+        client
+            .get_object("batch/b.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"second"
+    );
+    assert!(client
+        .get_object("batch/removed.txt")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn rustfs_two_part_multipart_write_uses_eight_s3_calls() {
     if !rustfs_enabled() {
         eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -16,8 +16,8 @@ use md5::{Digest as _, Md5};
 use prolly_s3_client::{core::PhysicalBatchMutationV1, FoyerNodeCache, FoyerNodeCacheConfig};
 use prolly_s3_client::{
     core::{
-        ObjectHeaders, PhysicalMultipartCompletedPart, ProviderPerKeyVersionLimitV2, Repository,
-        RepositoryOptions,
+        LogicalObjectVersionKindV1, ObjectHeaders, PhysicalMultipartCompletedPart,
+        ProviderPerKeyVersionLimitV2, Repository, RepositoryOptions,
     },
     AwsS3ObjectPlane, Client, ClientV2, HmacAttestationSigner, ProviderIdentity,
 };
@@ -300,7 +300,7 @@ async fn rustfs_native_v2_client_uses_immutable_payloads_and_fences_takeover() {
         .initialize()
         .await
         .unwrap();
-    old_writer
+    let first = old_writer
         .put_object("docs/native-v2.txt", b"before takeover".to_vec())
         .await
         .unwrap();
@@ -317,6 +317,46 @@ async fn rustfs_native_v2_client_uses_immutable_payloads_and_fences_takeover() {
         .path
         .as_str()
         .contains("/payloads/v2/"));
+    old_writer
+        .put_object("docs/native-v2.txt", b"updated before takeover".to_vec())
+        .await
+        .unwrap();
+    assert_eq!(
+        old_writer
+            .get_object_at(first.id, "docs/native-v2.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"before takeover"
+    );
+    let (_, listed, truncated) = old_writer.list_objects("docs/", None, 10).await.unwrap();
+    assert!(!truncated);
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].key, b"docs/native-v2.txt");
+    let (_, versions) = old_writer
+        .list_object_versions("docs/native-v2.txt", 10)
+        .await
+        .unwrap();
+    assert_eq!(versions.len(), 2);
+    old_writer
+        .delete_object("docs/native-v2.txt")
+        .await
+        .unwrap();
+    assert!(old_writer
+        .get_object("docs/native-v2.txt")
+        .await
+        .unwrap()
+        .is_none());
+    let (_, versions) = old_writer
+        .list_object_versions("docs/native-v2.txt", 10)
+        .await
+        .unwrap();
+    assert_eq!(versions.len(), 3);
+    assert!(matches!(
+        versions[0].body.kind,
+        LogicalObjectVersionKindV1::DeleteMarker
+    ));
 
     let replacement = ClientV2::builder()
         .aws_client(aws)

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -16,7 +16,7 @@ use md5::{Digest as _, Md5};
 use prolly_s3_client::{core::PhysicalBatchMutationV1, FoyerNodeCache, FoyerNodeCacheConfig};
 use prolly_s3_client::{
     core::{ObjectHeaders, PhysicalMultipartCompletedPart, Repository, RepositoryOptions},
-    AwsS3ObjectPlane,
+    AwsS3ObjectPlane, Client, HmacAttestationSigner, ProviderIdentity,
 };
 use sha2::Sha256;
 
@@ -30,6 +30,18 @@ fn unique_name(label: &str) -> String {
         .expect("system clock")
         .as_nanos();
     format!("integration/{label}/{nanos}")
+}
+
+fn provider_identity() -> ProviderIdentity {
+    ProviderIdentity::s3_compatible(
+        std::env::var("PROLLY_RUSTFS_ENDPOINT")
+            .unwrap_or_else(|_| "http://127.0.0.1:9000".to_string()),
+        "us-east-1",
+    )
+}
+
+fn attestation_signer() -> Arc<HmacAttestationSigner> {
+    Arc::new(HmacAttestationSigner::single("rustfs-authority-test-v1", vec![0x31; 32]).unwrap())
 }
 
 async fn rustfs_client() -> (aws_sdk_s3::Client, String) {
@@ -180,6 +192,89 @@ async fn rustfs_whole_object_write_uses_four_s3_calls_and_preserves_history() {
         1,
         "unexpected warm historical-read calls: {calls:?}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rustfs_branch_takeover_fences_old_client_before_payload_upload() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+
+    let (aws, bucket) = rustfs_client().await;
+    let repository_prefix = unique_name("client-branch-takeover-repository");
+    let key_prefix = unique_name("client-branch-takeover-object");
+    let old_writer = Client::builder()
+        .aws_client(aws.clone())
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer("rustfs-old-branch-writer")
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .initialize()
+        .await
+        .unwrap();
+    old_writer
+        .put_object()
+        .bucket(&bucket)
+        .key(format!("{key_prefix}/before-takeover.bin"))
+        .body(aws_sdk_s3::primitives::ByteStream::from_static(b"before"))
+        .send()
+        .await
+        .unwrap();
+
+    let mut new_writer = Client::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer("rustfs-new-branch-writer")
+        .read_only(true)
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .open()
+        .await
+        .unwrap();
+    assert_eq!(
+        new_writer
+            .takeover_branch_writer(
+                "main",
+                "rustfs-old-branch-writer",
+                1,
+                "old test writer credentials revoked and process isolated",
+            )
+            .await
+            .unwrap(),
+        2
+    );
+
+    old_writer.reset_s3_operation_metrics();
+    let error = old_writer
+        .put_object()
+        .bucket(&bucket)
+        .key(format!("{key_prefix}/must-not-upload.bin"))
+        .body(aws_sdk_s3::primitives::ByteStream::from_static(b"stale"))
+        .send()
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, prolly_s3_client::ErrorCode::PreconditionFailed);
+    let stale_calls = old_writer.reset_s3_operation_metrics();
+    assert_eq!(
+        stale_calls.put_object, 0,
+        "stale client uploaded bytes after branch takeover: {stale_calls:?}"
+    );
+    assert_eq!(
+        stale_calls.get_object, 1,
+        "stale client must fail at the authority point read: {stale_calls:?}"
+    );
+
+    new_writer
+        .put_object()
+        .bucket(&bucket)
+        .key(format!("{key_prefix}/after-takeover.bin"))
+        .body(aws_sdk_s3::primitives::ByteStream::from_static(b"after"))
+        .send()
+        .await
+        .unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -482,6 +482,7 @@ async fn rustfs_native_v2_commit_session_preserves_n_plus_three_puts() {
         .unwrap();
     let mut session = client
         .begin_commit()
+        .ephemeral()
         .message("two puts and one delete")
         .start()
         .await
@@ -530,6 +531,76 @@ async fn rustfs_native_v2_commit_session_preserves_n_plus_three_puts() {
         .await
         .unwrap()
         .is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rustfs_native_v2_durable_session_resumes_without_payload_reupload() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+
+    let (aws, bucket) = rustfs_client().await;
+    let repository_prefix = unique_name("native-v2-durable-resume");
+    let client = ClientV2::builder()
+        .aws_client(aws.clone())
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer("rustfs-native-v2-resumable-writer")
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .initialize()
+        .await
+        .unwrap();
+    let payload = vec![0x5a; 1024 * 1024];
+    let mut session = client
+        .begin_commit()
+        .message("resume after process loss")
+        .start()
+        .await
+        .unwrap();
+    let batch = session.id();
+    let operation = session.operation();
+    session
+        .put_stream("resume/large.bin", ByteStream::from(payload.clone()))
+        .await
+        .unwrap();
+    session.checkpoint().await.unwrap();
+    drop(session);
+    drop(client);
+
+    let reopened = ClientV2::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(&repository_prefix)
+        .writer("rustfs-native-v2-resumable-writer")
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimitV2::Finite(10_000))
+        .open()
+        .await
+        .unwrap();
+    reopened.reset_s3_operation_metrics();
+    let resumed = reopened.resume_commit(batch).await.unwrap();
+    assert_eq!(resumed.operation(), operation);
+    assert_eq!(resumed.staged_objects(), 1);
+    let receipt = resumed.publish().await.unwrap();
+    assert_eq!(receipt.operation, operation);
+    let calls = reopened.reset_s3_operation_metrics();
+    assert!(
+        calls.uploaded_body_bytes < payload.len() as u64,
+        "resume must publish metadata without uploading the 1 MiB payload again: {calls:?}"
+    );
+    assert_eq!(
+        reopened
+            .get_object("resume/large.bin")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        payload
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/extensions/s3/core/src/commit_session_v2.rs
+++ b/extensions/s3/core/src/commit_session_v2.rs
@@ -1,0 +1,261 @@
+use std::sync::Arc;
+
+use crate::{
+    decode_canonical, encode_canonical, BatchId, CommitSessionCheckpointV2,
+    CommitSessionCleanupReportV2, DeleteOutcome, Error, ErrorCode, GetRequest, ImmutablePut,
+    ImmutablePutOutcome, ListRequest, ObjectPath, ObjectPlane, PhysicalVersion, RepositoryId,
+    Result,
+};
+
+/// Immutable checkpoint store for resumable protocol-v2 ingestion.
+///
+/// Checkpoints are append-only and sequence-addressed. Resume lists only one
+/// batch prefix; cleanup pages the staging namespace and deletes exact expired
+/// physical versions. No repository-wide mutable staging head is required.
+#[derive(Clone)]
+pub struct CommitSessionStoreV2<P: ObjectPlane> {
+    plane: Arc<P>,
+    prefix: String,
+    repository: RepositoryId,
+    max_mutations: usize,
+}
+
+impl<P: ObjectPlane> CommitSessionStoreV2<P> {
+    pub fn new(
+        plane: Arc<P>,
+        prefix: impl Into<String>,
+        repository: RepositoryId,
+        max_mutations: usize,
+    ) -> Result<Self> {
+        if max_mutations == 0 {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "v2 commit-session store requires a positive mutation limit",
+            ));
+        }
+        Ok(Self {
+            plane,
+            prefix: prefix.into(),
+            repository,
+            max_mutations,
+        })
+    }
+
+    pub async fn save(&self, checkpoint: &CommitSessionCheckpointV2) -> Result<()> {
+        checkpoint.validate(self.repository, self.max_mutations)?;
+        let bytes = encode_canonical(checkpoint)?;
+        let path = self.checkpoint_path(checkpoint.session.id, checkpoint.sequence)?;
+        let expected_sha256 = crate::codec::sha256(&bytes);
+        match self
+            .plane
+            .put_immutable(ImmutablePut {
+                path: path.clone(),
+                bytes: bytes.clone(),
+                expected_sha256,
+            })
+            .await
+        {
+            Ok(ImmutablePutOutcome::Created(_) | ImmutablePutOutcome::AlreadyPresent(_)) => Ok(()),
+            Err(original) => {
+                let stored = self
+                    .plane
+                    .get(GetRequest {
+                        path,
+                        range: None,
+                        physical_version: None,
+                    })
+                    .await;
+                match stored {
+                    Ok(Some(stored)) if stored.bytes == bytes => Ok(()),
+                    _ => Err(original),
+                }
+            }
+        }
+    }
+
+    pub async fn latest(&self, batch: BatchId) -> Result<Option<CommitSessionCheckpointV2>> {
+        let prefix = self.batch_prefix(batch);
+        let mut continuation = None;
+        let mut latest: Option<(u64, ObjectPath)> = None;
+        let mut scanned = 0_usize;
+        loop {
+            let page = self
+                .plane
+                .list(ListRequest {
+                    prefix: prefix.clone(),
+                    continuation,
+                    limit: 1_000,
+                    include_versions: false,
+                })
+                .await?;
+            for entry in page.entries {
+                scanned = scanned.checked_add(1).ok_or_else(|| {
+                    Error::new(ErrorCode::InvalidLimit, "v2 checkpoint scan overflow")
+                })?;
+                if scanned > self.max_mutations.saturating_add(2) {
+                    return Err(Error::new(
+                        ErrorCode::InvalidLimit,
+                        "v2 commit session has more checkpoints than its mutation limit",
+                    ));
+                }
+                let sequence = parse_checkpoint_sequence(&prefix, &entry.path)?;
+                if latest
+                    .as_ref()
+                    .is_none_or(|(current, _)| sequence > *current)
+                {
+                    latest = Some((sequence, entry.path));
+                }
+            }
+            continuation = page.continuation;
+            if continuation.is_none() {
+                break;
+            }
+        }
+        let Some((sequence, path)) = latest else {
+            return Ok(None);
+        };
+        let stored = self
+            .plane
+            .get(GetRequest {
+                path,
+                range: None,
+                physical_version: None,
+            })
+            .await?
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::OutcomeUnknown,
+                    "latest v2 commit-session checkpoint disappeared during resume",
+                )
+            })?;
+        let checkpoint: CommitSessionCheckpointV2 = decode_canonical(&stored.bytes)?;
+        checkpoint.validate(self.repository, self.max_mutations)?;
+        if checkpoint.session.id != batch {
+            return Err(Error::new(
+                ErrorCode::CorruptContent,
+                "v2 checkpoint path and embedded batch ID disagree",
+            ));
+        }
+        if checkpoint.sequence != sequence {
+            return Err(Error::new(
+                ErrorCode::CorruptContent,
+                "v2 checkpoint path and embedded sequence disagree",
+            ));
+        }
+        Ok(Some(checkpoint))
+    }
+
+    pub async fn cleanup_expired_page(
+        &self,
+        now_millis: u64,
+        continuation: Option<String>,
+        limit: usize,
+    ) -> Result<CommitSessionCleanupReportV2> {
+        if !(1..=1_000).contains(&limit) {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "v2 commit-session cleanup page must contain 1 to 1,000 versions",
+            ));
+        }
+        let page = self
+            .plane
+            .list(ListRequest {
+                prefix: self.staging_prefix(),
+                continuation,
+                limit,
+                include_versions: true,
+            })
+            .await?;
+        let mut report = CommitSessionCleanupReportV2 {
+            continuation: page.continuation,
+            ..CommitSessionCleanupReportV2::default()
+        };
+        for entry in page.entries {
+            report.scanned += 1;
+            if entry.metadata.delete_marker {
+                report.retained += 1;
+                continue;
+            }
+            let physical_version = entry.metadata.token.version_id.clone().map_or_else(
+                || PhysicalVersion::Unversioned {
+                    token: Some(entry.metadata.token.clone()),
+                },
+                |version_id| PhysicalVersion::Versioned { version_id },
+            );
+            let Some(stored) = self
+                .plane
+                .get(GetRequest {
+                    path: entry.path.clone(),
+                    range: None,
+                    physical_version: Some(physical_version.clone()),
+                })
+                .await?
+            else {
+                report.already_missing += 1;
+                continue;
+            };
+            let checkpoint: CommitSessionCheckpointV2 = decode_canonical(&stored.bytes)?;
+            checkpoint.validate(self.repository, self.max_mutations)?;
+            if checkpoint.session.expires_at_millis >= now_millis {
+                report.retained += 1;
+                continue;
+            }
+            match self
+                .plane
+                .delete_exact(&entry.path, physical_version)
+                .await?
+            {
+                DeleteOutcome::Deleted => report.deleted += 1,
+                DeleteOutcome::NotFound => report.already_missing += 1,
+                DeleteOutcome::TokenMismatch => {
+                    return Err(Error::new(
+                        ErrorCode::OutcomeUnknown,
+                        "v2 checkpoint changed during exact cleanup",
+                    ))
+                }
+            }
+        }
+        Ok(report)
+    }
+
+    fn staging_prefix(&self) -> String {
+        format!(
+            "{}/staging/v2/{}/",
+            self.prefix,
+            hex::encode(self.repository.as_bytes())
+        )
+    }
+
+    fn batch_prefix(&self, batch: BatchId) -> String {
+        format!("{}{batch}/checkpoints/", self.staging_prefix())
+    }
+
+    fn checkpoint_path(&self, batch: BatchId, sequence: u64) -> Result<ObjectPath> {
+        ObjectPath::new(format!("{}{sequence:020}.cbor", self.batch_prefix(batch)))
+    }
+}
+
+fn parse_checkpoint_sequence(prefix: &str, path: &ObjectPath) -> Result<u64> {
+    let suffix = path
+        .as_str()
+        .strip_prefix(prefix)
+        .and_then(|value| value.strip_suffix(".cbor"))
+        .ok_or_else(|| {
+            Error::new(
+                ErrorCode::CorruptContent,
+                "v2 checkpoint listing returned a path outside the batch namespace",
+            )
+        })?;
+    if suffix.len() != 20 || !suffix.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(Error::new(
+            ErrorCode::CorruptContent,
+            "v2 checkpoint path has a non-canonical sequence",
+        ));
+    }
+    suffix.parse().map_err(|_| {
+        Error::new(
+            ErrorCode::CorruptContent,
+            "v2 checkpoint sequence is out of range",
+        )
+    })
+}

--- a/extensions/s3/core/src/control_versions.rs
+++ b/extensions/s3/core/src/control_versions.rs
@@ -6,8 +6,8 @@ use std::{
 use crate::{
     decode_canonical, CommitGraphHeadV2, CompareExchange, CompareExchangeOutcome, DeleteOutcome,
     Error, ErrorCode, JournalDerivedIndexHeadV2, ListRequest, NodeIndexHeadV2, ObjectPath,
-    ObjectPlane, OperationIndexHeadV2, PhysicalVersion, RefCatalogHeadV2, RefValueV1, RefValueV2,
-    Result, StorageToken,
+    ObjectPlane, OperationIndexHeadV2, PhysicalVersion, RefCatalogHeadV2, RefCatalogShardHeadV2,
+    RefValueV1, RefValueV2, Result, StorageToken,
 };
 
 pub const DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN: usize = 100;
@@ -22,10 +22,12 @@ pub enum MutableControlKind {
     BranchRefV1,
     BranchRefV2,
     TagRefV1,
+    TagRefV2,
     RetentionPinV1,
     NodeIndexHeadV1,
     NodeIndexHeadV2,
     RefCatalogHeadV2,
+    RefCatalogShardHeadV2,
     CommitGraphHeadV2,
     OperationIndexHeadV2,
     GcMarkRunV1,
@@ -133,6 +135,10 @@ impl<P: ObjectPlane> MutableControlStore<P> {
                     let head: RefCatalogHeadV2 = decode_canonical(&request.bytes)?;
                     first_update || head.generation.is_multiple_of(ref_interval)
                 }
+                MutableControlKind::RefCatalogShardHeadV2 => {
+                    let head: RefCatalogShardHeadV2 = decode_canonical(&request.bytes)?;
+                    first_update || head.generation.is_multiple_of(ref_interval)
+                }
                 MutableControlKind::CommitGraphHeadV2 => {
                     let head: CommitGraphHeadV2 = decode_canonical(&request.bytes)?;
                     first_update || head.generation.is_multiple_of(ref_interval)
@@ -153,6 +159,7 @@ impl<P: ObjectPlane> MutableControlStore<P> {
                     | MutableControlKind::BranchRefV2
                     | MutableControlKind::NodeIndexHeadV2
                     | MutableControlKind::RefCatalogHeadV2
+                    | MutableControlKind::RefCatalogShardHeadV2
                     | MutableControlKind::CommitGraphHeadV2
                     | MutableControlKind::OperationIndexHeadV2
                     | MutableControlKind::JournalDerivedIndexHeadV2 => {
@@ -366,10 +373,14 @@ pub fn classify_mutable_control_path(
         ["refs", "heads", _] => Some(MutableControlKind::BranchRefV1),
         ["refs", "v2", "heads", _] => Some(MutableControlKind::BranchRefV2),
         ["refs", "tags", _] => Some(MutableControlKind::TagRefV1),
+        ["refs", "v2", "tags", _] => Some(MutableControlKind::TagRefV2),
         ["retention", "pins", _] => Some(MutableControlKind::RetentionPinV1),
         ["node-index", "latest.cbor"] => Some(MutableControlKind::NodeIndexHeadV1),
         ["node-index", "v2", "head.cbor"] => Some(MutableControlKind::NodeIndexHeadV2),
         ["ref-catalog", "v2", "head.cbor"] => Some(MutableControlKind::RefCatalogHeadV2),
+        ["ref-catalog", "v2", "shards", _, "head.cbor"] => {
+            Some(MutableControlKind::RefCatalogShardHeadV2)
+        }
         ["commit-graph", "v2", "head.cbor"] => Some(MutableControlKind::CommitGraphHeadV2),
         ["operation-index", "v2", "heads", _] => Some(MutableControlKind::OperationIndexHeadV2),
         ["gc", "mark-runs", _] => Some(MutableControlKind::GcMarkRunV1),

--- a/extensions/s3/core/src/journal_indexes_v2.rs
+++ b/extensions/s3/core/src/journal_indexes_v2.rs
@@ -1,14 +1,17 @@
 use std::sync::Arc;
 
 use prolly::{AsyncProlly, Config, Mutation, RuntimeConfig, Tree, TreeFormat};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     decode_canonical, encode_canonical, tree_format_digest, CommitIdV2, CommitObjectV2,
-    CompareExchange, CompareExchangeOutcome, Error, ErrorCode, JournalCommitGraphEntryV2,
-    JournalDerivedIndexHeadV2, JournalNodeIndexEntryV2, MemoryNodeCache, MutableControlStore,
-    NodeCache, ObjectPath, ObjectPlane, ProllyObjectStore, PublicationEventIdV2, RefGeneration,
-    RepositoryId, Result, RetryAdvice, ShardedBranchPublisherV2, StorageToken, TreeRootV1,
-    DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,
+    CompareExchange, CompareExchangeOutcome, DeleteOutcome, Error, ErrorCode, GetRequest,
+    ImmutablePut, ImmutablePutOutcome, JournalCommitGraphEntryV2, JournalDerivedIndexHeadV2,
+    JournalIndexRebuildChunkIdV2, JournalIndexRebuildChunkV2, JournalNodeIndexEntryV2, ListRequest,
+    MemoryNodeCache, MutableControlStore, NodeCache, ObjectPath, ObjectPlane, OperationId,
+    PhysicalVersion, ProllyObjectStore, PublicationEventIdV2, PublicationJournalCursorV2,
+    RefGeneration, RepositoryId, Result, RetryAdvice, ShardedBranchPublisherV2, StorageToken,
+    TreeRootV1, DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,
 };
 
 pub const DEFAULT_JOURNAL_INDEX_MAX_UNINDEXED_EVENTS: usize = 4_096;
@@ -21,6 +24,53 @@ pub struct JournalIndexAdvanceReportV2 {
     pub indexed_commits: usize,
     pub indexed_nodes: usize,
     pub initialized: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum JournalIndexRebuildPhaseV2 {
+    Discovering,
+    Applying,
+    Complete,
+}
+
+/// Constant-size process-independent cursor for rebuilding branch-local node
+/// and commit-graph indexes from an immutable publication-journal snapshot.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JournalIndexRebuildCursorV2 {
+    pub repository: RepositoryId,
+    pub branch: String,
+    pub job: OperationId,
+    pub snapshot: PublicationEventIdV2,
+    pub snapshot_generation: RefGeneration,
+    pub snapshot_target: CommitIdV2,
+    pub scan: Option<PublicationJournalCursorV2>,
+    pub oldest_chunk: Option<JournalIndexRebuildChunkIdV2>,
+    pub next_chunk: Option<JournalIndexRebuildChunkIdV2>,
+    pub next_chunk_sequence: u64,
+    pub node_root: TreeRootV1,
+    pub commit_graph_root: TreeRootV1,
+    pub discovered_publications: u64,
+    pub indexed_commits: u64,
+    pub indexed_nodes: u64,
+    pub baseline_checkpoint: Option<PublicationEventIdV2>,
+    pub baseline_generation: Option<u64>,
+    pub phase: JournalIndexRebuildPhaseV2,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct JournalIndexRebuildStepV2 {
+    pub cursor: JournalIndexRebuildCursorV2,
+    pub discovered_publications: usize,
+    pub indexed_publications: usize,
+    pub indexed_commits: usize,
+    pub indexed_nodes: usize,
+    pub complete: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct JournalIndexRebuildCleanupV2 {
+    pub deleted_objects: usize,
+    pub complete: bool,
 }
 
 struct LoadedHead {
@@ -341,6 +391,276 @@ impl<P: ObjectPlane> JournalDerivedIndexesV2<P> {
         })
     }
 
+    pub async fn start_rebuild(
+        &self,
+        publisher: &ShardedBranchPublisherV2<P>,
+        branch: &str,
+        job: OperationId,
+    ) -> Result<JournalIndexRebuildCursorV2> {
+        crate::repository::validate_branch(branch)?;
+        if job.is_nil() {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "journal-index rebuild requires a non-nil job ID",
+            ));
+        }
+        let scan = publisher.open_journal(branch).await?;
+        let snapshot_generation = scan.next_generation.ok_or_else(|| {
+            Error::new(
+                ErrorCode::CorruptCommit,
+                "journal-index rebuild snapshot has no generation",
+            )
+        })?;
+        let snapshot_target = scan.next_target.ok_or_else(|| {
+            Error::new(
+                ErrorCode::CorruptCommit,
+                "journal-index rebuild snapshot has no target",
+            )
+        })?;
+        let baseline = self.load_head(branch).await?;
+        let digest = tree_format_digest(&self.format)?;
+        Ok(JournalIndexRebuildCursorV2 {
+            repository: self.repository,
+            branch: branch.to_string(),
+            job,
+            snapshot: scan.snapshot_head,
+            snapshot_generation,
+            snapshot_target,
+            scan: Some(scan),
+            oldest_chunk: None,
+            next_chunk: None,
+            next_chunk_sequence: 0,
+            node_root: TreeRootV1 {
+                root: None,
+                format_digest: digest,
+            },
+            commit_graph_root: TreeRootV1 {
+                root: None,
+                format_digest: digest,
+            },
+            discovered_publications: 0,
+            indexed_commits: 0,
+            indexed_nodes: 0,
+            baseline_checkpoint: baseline.as_ref().map(|head| head.value.checkpoint),
+            baseline_generation: baseline.as_ref().map(|head| head.value.generation),
+            phase: JournalIndexRebuildPhaseV2::Discovering,
+        })
+    }
+
+    pub async fn advance_rebuild(
+        &self,
+        publisher: &ShardedBranchPublisherV2<P>,
+        cursor: &JournalIndexRebuildCursorV2,
+        max_events: usize,
+        now_millis: u64,
+    ) -> Result<JournalIndexRebuildStepV2> {
+        self.validate_rebuild_cursor(cursor)?;
+        if !(1..=1_000).contains(&max_events) {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "journal-index rebuild page must contain 1 to 1,000 events",
+            ));
+        }
+        if cursor.phase == JournalIndexRebuildPhaseV2::Complete {
+            return Ok(JournalIndexRebuildStepV2 {
+                cursor: cursor.clone(),
+                discovered_publications: 0,
+                indexed_publications: 0,
+                indexed_commits: 0,
+                indexed_nodes: 0,
+                complete: true,
+            });
+        }
+        if cursor.phase == JournalIndexRebuildPhaseV2::Discovering {
+            let scan = cursor.scan.as_ref().ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InvalidContinuationToken,
+                    "discovering journal-index rebuild has no scan cursor",
+                )
+            })?;
+            let page = publisher.read_journal_page(scan, max_events).await?;
+            if page.entries.is_empty() {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "journal-index rebuild discovery returned an empty page",
+                ));
+            }
+            let chunk = JournalIndexRebuildChunkV2 {
+                repository: self.repository,
+                branch: cursor.branch.clone(),
+                job: cursor.job,
+                sequence: cursor.next_chunk_sequence,
+                newer: cursor.oldest_chunk,
+                events: page.entries.into_iter().map(|entry| entry.event).collect(),
+            };
+            chunk.validate(self.repository, &cursor.branch)?;
+            let chunk_id = self.store_rebuild_chunk(&chunk).await?;
+            let discovered = chunk.events.len();
+            let mut next = cursor.clone();
+            next.scan = page.continuation;
+            next.oldest_chunk = Some(chunk_id);
+            next.next_chunk_sequence =
+                next.next_chunk_sequence.checked_add(1).ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::InvalidLimit,
+                        "journal rebuild chunk sequence overflow",
+                    )
+                })?;
+            next.discovered_publications = next
+                .discovered_publications
+                .checked_add(u64::try_from(discovered).map_err(|_| {
+                    Error::new(ErrorCode::InvalidLimit, "journal rebuild count overflow")
+                })?)
+                .ok_or_else(|| {
+                    Error::new(ErrorCode::InvalidLimit, "journal rebuild count overflow")
+                })?;
+            if next.scan.is_none() {
+                next.phase = JournalIndexRebuildPhaseV2::Applying;
+                next.next_chunk = next.oldest_chunk;
+            }
+            return Ok(JournalIndexRebuildStepV2 {
+                cursor: next,
+                discovered_publications: discovered,
+                indexed_publications: 0,
+                indexed_commits: 0,
+                indexed_nodes: 0,
+                complete: false,
+            });
+        }
+
+        let chunk_id = cursor.next_chunk.ok_or_else(|| {
+            Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "applying journal-index rebuild has no next chunk",
+            )
+        })?;
+        let chunk = self
+            .load_rebuild_chunk(&cursor.branch, cursor.job, chunk_id)
+            .await?;
+        if chunk.events.len() > max_events {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "journal-index rebuild apply limit is smaller than its persisted discovery chunk",
+            ));
+        }
+        let mut node_tree = self.tree_from_root(&cursor.node_root);
+        let mut graph_tree = self.tree_from_root(&cursor.commit_graph_root);
+        let mut indexed_commits = 0usize;
+        let mut indexed_nodes = 0usize;
+        for event in chunk.events.iter().rev() {
+            if self
+                .graph_engine
+                .get(&graph_tree, event.new_target.as_bytes())
+                .await?
+                .is_some()
+            {
+                continue;
+            }
+            let object = publisher.load_commit_object(event.new_target).await?;
+            self.index_node_pack(
+                &mut node_tree,
+                event.new_target,
+                &object,
+                &mut indexed_nodes,
+            )
+            .await?;
+            self.index_commit_graph(&mut graph_tree, event.new_target, object)
+                .await?;
+            indexed_commits += 1;
+        }
+        let mut next = cursor.clone();
+        next.node_root.root = node_tree.root;
+        next.commit_graph_root.root = graph_tree.root;
+        next.next_chunk = chunk.newer;
+        next.indexed_commits = next
+            .indexed_commits
+            .checked_add(u64::try_from(indexed_commits).map_err(|_| {
+                Error::new(
+                    ErrorCode::InvalidLimit,
+                    "journal rebuild commit count overflow",
+                )
+            })?)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InvalidLimit,
+                    "journal rebuild commit count overflow",
+                )
+            })?;
+        next.indexed_nodes = next
+            .indexed_nodes
+            .checked_add(u64::try_from(indexed_nodes).map_err(|_| {
+                Error::new(
+                    ErrorCode::InvalidLimit,
+                    "journal rebuild node count overflow",
+                )
+            })?)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InvalidLimit,
+                    "journal rebuild node count overflow",
+                )
+            })?;
+        if next.next_chunk.is_none() {
+            self.publish_rebuild(publisher, &next, now_millis).await?;
+            next.phase = JournalIndexRebuildPhaseV2::Complete;
+        }
+        Ok(JournalIndexRebuildStepV2 {
+            cursor: next.clone(),
+            discovered_publications: 0,
+            indexed_publications: chunk.events.len(),
+            indexed_commits,
+            indexed_nodes,
+            complete: next.phase == JournalIndexRebuildPhaseV2::Complete,
+        })
+    }
+
+    pub async fn cleanup_rebuild(
+        &self,
+        cursor: &JournalIndexRebuildCursorV2,
+        limit: usize,
+    ) -> Result<JournalIndexRebuildCleanupV2> {
+        self.validate_rebuild_cursor(cursor)?;
+        if !(1..=1_000).contains(&limit) {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "journal-index rebuild cleanup limit must be 1 to 1,000",
+            ));
+        }
+        let page = self
+            .plane
+            .list(ListRequest {
+                prefix: self.rebuild_chunk_prefix(&cursor.branch, cursor.job),
+                continuation: None,
+                limit,
+                include_versions: false,
+            })
+            .await?;
+        let mut targets = Vec::with_capacity(page.entries.len());
+        for entry in page.entries {
+            let token = entry.metadata.token;
+            let version = token.version_id.clone().map_or_else(
+                || PhysicalVersion::Unversioned {
+                    token: Some(token.clone()),
+                },
+                |version_id| PhysicalVersion::Versioned { version_id },
+            );
+            targets.push((entry.path, version));
+        }
+        let deleted_objects = targets.len();
+        for outcome in self.plane.delete_exact_batch(targets).await? {
+            if matches!(outcome, DeleteOutcome::TokenMismatch) {
+                return Err(Error::new(
+                    ErrorCode::PreconditionFailed,
+                    "journal-index rebuild state changed during cleanup",
+                ));
+            }
+        }
+        Ok(JournalIndexRebuildCleanupV2 {
+            deleted_objects,
+            complete: page.continuation.is_none(),
+        })
+    }
+
     pub async fn node_location(
         &self,
         branch: &str,
@@ -397,6 +717,237 @@ impl<P: ObjectPlane> JournalDerivedIndexesV2<P> {
 
     pub async fn head(&self, branch: &str) -> Result<Option<JournalDerivedIndexHeadV2>> {
         Ok(self.load_head(branch).await?.map(|head| head.value))
+    }
+
+    fn validate_rebuild_cursor(&self, cursor: &JournalIndexRebuildCursorV2) -> Result<()> {
+        crate::repository::validate_branch(&cursor.branch)?;
+        let digest = tree_format_digest(&self.format)?;
+        let phase_shape = match cursor.phase {
+            JournalIndexRebuildPhaseV2::Discovering => {
+                cursor.scan.is_some() && cursor.next_chunk.is_none()
+            }
+            JournalIndexRebuildPhaseV2::Applying => {
+                cursor.scan.is_none() && cursor.next_chunk.is_some()
+            }
+            JournalIndexRebuildPhaseV2::Complete => {
+                cursor.scan.is_none() && cursor.next_chunk.is_none()
+            }
+        };
+        if cursor.repository != self.repository
+            || cursor.job.is_nil()
+            || cursor.node_root.format_digest != digest
+            || cursor.commit_graph_root.format_digest != digest
+            || cursor.baseline_checkpoint.is_some() != cursor.baseline_generation.is_some()
+            || !phase_shape
+            || cursor.scan.as_ref().is_some_and(|scan| {
+                scan.repository != self.repository
+                    || scan.branch != cursor.branch
+                    || scan.snapshot_head != cursor.snapshot
+            })
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "journal-index rebuild cursor is malformed or belongs to another repository",
+            ));
+        }
+        Ok(())
+    }
+
+    async fn store_rebuild_chunk(
+        &self,
+        chunk: &JournalIndexRebuildChunkV2,
+    ) -> Result<JournalIndexRebuildChunkIdV2> {
+        chunk.validate(self.repository, &chunk.branch)?;
+        let id = chunk.id()?;
+        let bytes = encode_canonical(chunk)?;
+        let path = self.rebuild_chunk_path(&chunk.branch, chunk.job, id)?;
+        let expected_sha256 = crate::codec::sha256(&bytes);
+        match self
+            .plane
+            .put_immutable(ImmutablePut {
+                path: path.clone(),
+                bytes: bytes.clone(),
+                expected_sha256,
+            })
+            .await
+        {
+            Ok(ImmutablePutOutcome::Created(_) | ImmutablePutOutcome::AlreadyPresent(_)) => Ok(id),
+            Err(original) => match self
+                .plane
+                .get(GetRequest {
+                    path,
+                    range: None,
+                    physical_version: None,
+                })
+                .await
+            {
+                Ok(Some(stored)) if stored.bytes == bytes => Ok(id),
+                _ => Err(original),
+            },
+        }
+    }
+
+    async fn load_rebuild_chunk(
+        &self,
+        branch: &str,
+        job: OperationId,
+        id: JournalIndexRebuildChunkIdV2,
+    ) -> Result<JournalIndexRebuildChunkV2> {
+        let stored = self
+            .plane
+            .get(GetRequest {
+                path: self.rebuild_chunk_path(branch, job, id)?,
+                range: None,
+                physical_version: None,
+            })
+            .await?
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::MissingClosure,
+                    "journal-index rebuild chunk is missing",
+                )
+            })?;
+        let chunk: JournalIndexRebuildChunkV2 = decode_canonical(&stored.bytes)?;
+        chunk.validate(self.repository, branch)?;
+        if chunk.job != job || chunk.id()? != id {
+            return Err(Error::new(
+                ErrorCode::CorruptContent,
+                "journal-index rebuild chunk does not match its content address",
+            ));
+        }
+        Ok(chunk)
+    }
+
+    async fn publish_rebuild(
+        &self,
+        publisher: &ShardedBranchPublisherV2<P>,
+        cursor: &JournalIndexRebuildCursorV2,
+        now_millis: u64,
+    ) -> Result<()> {
+        let snapshot = publisher.load_publication(cursor.snapshot).await?;
+        let expected_publications =
+            cursor.snapshot_generation.0.checked_add(1).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InvalidLimit,
+                    "journal-index rebuild publication count overflow",
+                )
+            })?;
+        if snapshot.repository != self.repository
+            || snapshot.branch != cursor.branch
+            || snapshot.generation != cursor.snapshot_generation
+            || snapshot.new_target != cursor.snapshot_target
+            || cursor.discovered_publications != expected_publications
+        {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "journal-index rebuild cursor does not cover its complete snapshot",
+            ));
+        }
+        let loaded = self.load_head(&cursor.branch).await?;
+        let baseline_matches = match (
+            loaded.as_ref(),
+            cursor.baseline_checkpoint,
+            cursor.baseline_generation,
+        ) {
+            (None, None, None) => true,
+            (Some(head), Some(checkpoint), Some(generation)) => {
+                head.value.checkpoint == checkpoint && head.value.generation == generation
+            }
+            _ => false,
+        };
+        if !baseline_matches {
+            return Err(Error::new(
+                ErrorCode::RefConflict,
+                "journal index changed while its resumable rebuild was running",
+            )
+            .retry(RetryAdvice::ReloadHead));
+        }
+        let generation = loaded.as_ref().map_or(Ok(0), |head| {
+            head.value.generation.checked_add(1).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InternalInvariant,
+                    "journal-index rebuild head generation overflow",
+                )
+            })
+        })?;
+        let next = JournalDerivedIndexHeadV2 {
+            repository: self.repository,
+            branch: cursor.branch.clone(),
+            checkpoint: cursor.snapshot,
+            checkpoint_generation: cursor.snapshot_generation,
+            target: cursor.snapshot_target,
+            node_root: cursor.node_root.clone(),
+            commit_graph_root: cursor.commit_graph_root.clone(),
+            generation,
+            indexed_publications: cursor.discovered_publications,
+            indexed_commits: cursor.indexed_commits,
+            updated_at_millis: now_millis,
+        };
+        next.validate(
+            self.repository,
+            &cursor.branch,
+            tree_format_digest(&self.format)?,
+        )?;
+        let bytes = encode_canonical(&next)?;
+        let path = self.head_path(&cursor.branch)?;
+        match self
+            .controls
+            .compare_exchange(CompareExchange {
+                path: path.clone(),
+                expected: loaded.map(|head| head.token),
+                bytes: bytes.clone(),
+            })
+            .await
+        {
+            Ok(CompareExchangeOutcome::Applied(_)) => Ok(()),
+            Ok(CompareExchangeOutcome::Conflict(Some(current))) if current.bytes == bytes => Ok(()),
+            Ok(CompareExchangeOutcome::Conflict(_)) => Err(Error::new(
+                ErrorCode::RefConflict,
+                "journal-index rebuild head publication conflicted",
+            )
+            .retry(RetryAdvice::ReloadHead)),
+            Err(error) => {
+                if self
+                    .plane
+                    .load_mutable(&path)
+                    .await?
+                    .is_some_and(|current| current.bytes == bytes)
+                {
+                    Ok(())
+                } else {
+                    Err(Error::new(
+                        ErrorCode::OutcomeUnknown,
+                        format!("journal-index rebuild publication is unknown: {error}"),
+                    )
+                    .retry(RetryAdvice::ReconcileOperation))
+                }
+            }
+        }
+    }
+
+    fn rebuild_chunk_prefix(&self, branch: &str, job: OperationId) -> String {
+        format!(
+            "{}/administration/v2/index-rebuild/{}/{}/chunks/sha256/",
+            self.prefix,
+            hex::encode(branch.as_bytes()),
+            hex::encode(job.as_bytes())
+        )
+    }
+
+    fn rebuild_chunk_path(
+        &self,
+        branch: &str,
+        job: OperationId,
+        id: JournalIndexRebuildChunkIdV2,
+    ) -> Result<ObjectPath> {
+        let encoded = hex::encode(id.as_bytes());
+        ObjectPath::new(format!(
+            "{}{}/{}/{}",
+            self.rebuild_chunk_prefix(branch, job),
+            &encoded[..2],
+            &encoded[2..4],
+            encoded
+        ))
     }
 
     async fn index_node_pack(

--- a/extensions/s3/core/src/journal_indexes_v2.rs
+++ b/extensions/s3/core/src/journal_indexes_v2.rs
@@ -787,7 +787,7 @@ impl<P: ObjectPlane> JournalDerivedIndexesV2<P> {
         }
     }
 
-    async fn load_rebuild_chunk(
+    pub(crate) async fn load_rebuild_chunk(
         &self,
         branch: &str,
         job: OperationId,

--- a/extensions/s3/core/src/journal_indexes_v2.rs
+++ b/extensions/s3/core/src/journal_indexes_v2.rs
@@ -73,6 +73,19 @@ pub struct JournalIndexRebuildCleanupV2 {
     pub complete: bool,
 }
 
+/// Durable roots built while importing a parent-before-child commit closure.
+/// The roots live in the regular native-v2 index node namespaces, so this
+/// cursor remains constant-size and can be resumed by another process.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportedJournalIndexStateV2 {
+    pub repository: RepositoryId,
+    pub job: OperationId,
+    pub node_root: TreeRootV1,
+    pub commit_graph_root: TreeRootV1,
+    pub indexed_commits: u64,
+    pub indexed_nodes: u64,
+}
+
 struct LoadedHead {
     value: JournalDerivedIndexHeadV2,
     token: StorageToken,
@@ -686,6 +699,219 @@ impl<P: ObjectPlane> JournalDerivedIndexesV2<P> {
             ));
         }
         Ok(entry)
+    }
+
+    pub fn start_imported_closure(&self, job: OperationId) -> Result<ImportedJournalIndexStateV2> {
+        if job.is_nil() {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "imported journal-index closure requires a non-nil job ID",
+            ));
+        }
+        Ok(ImportedJournalIndexStateV2 {
+            repository: self.repository,
+            job,
+            node_root: TreeRootV1::from_tree(&self.node_engine.create())?,
+            commit_graph_root: TreeRootV1::from_tree(&self.graph_engine.create())?,
+            indexed_commits: 0,
+            indexed_nodes: 0,
+        })
+    }
+
+    /// Add one already durable native-v2 commit to an imported closure. The
+    /// caller supplies commits parent-before-child so first-parent skip links
+    /// can be constructed without an ancestor scan.
+    pub async fn index_imported_commit(
+        &self,
+        publisher: &ShardedBranchPublisherV2<P>,
+        state: &ImportedJournalIndexStateV2,
+        commit: CommitIdV2,
+    ) -> Result<ImportedJournalIndexStateV2> {
+        self.validate_imported_state(state)?;
+        let mut node_tree = self.tree_from_root(&state.node_root);
+        let mut graph_tree = self.tree_from_root(&state.commit_graph_root);
+        if self
+            .graph_engine
+            .get(&graph_tree, commit.as_bytes())
+            .await?
+            .is_some()
+        {
+            return Ok(state.clone());
+        }
+        let object = publisher.load_commit_object(commit).await?;
+        for parent in &object.commit.parents {
+            if self
+                .graph_engine
+                .get(&graph_tree, parent.as_bytes())
+                .await?
+                .is_none()
+            {
+                return Err(Error::new(
+                    ErrorCode::MissingClosure,
+                    "imported commit parent is not yet indexed",
+                ));
+            }
+        }
+        let mut indexed_nodes = 0usize;
+        self.index_node_pack(&mut node_tree, commit, &object, &mut indexed_nodes)
+            .await?;
+        self.index_commit_graph(&mut graph_tree, commit, object)
+            .await?;
+        Ok(ImportedJournalIndexStateV2 {
+            repository: state.repository,
+            job: state.job,
+            node_root: TreeRootV1::from_tree(&node_tree)?,
+            commit_graph_root: TreeRootV1::from_tree(&graph_tree)?,
+            indexed_commits: state.indexed_commits.checked_add(1).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InternalInvariant,
+                    "imported commit count overflow",
+                )
+            })?,
+            indexed_nodes: state
+                .indexed_nodes
+                .checked_add(u64::try_from(indexed_nodes).map_err(|_| {
+                    Error::new(ErrorCode::InvalidLimit, "imported node count exceeds u64")
+                })?)
+                .ok_or_else(|| {
+                    Error::new(ErrorCode::InternalInvariant, "imported node count overflow")
+                })?,
+        })
+    }
+
+    /// Resolve a packed node against roots held by an in-progress import.
+    /// This is what lets an interrupted migration continue without publishing
+    /// a partially imported user branch.
+    pub async fn imported_node_location(
+        &self,
+        state: &ImportedJournalIndexStateV2,
+        cid: &prolly::Cid,
+    ) -> Result<Option<JournalNodeIndexEntryV2>> {
+        self.validate_imported_state(state)?;
+        let tree = self.tree_from_root(&state.node_root);
+        let entry = self
+            .node_engine
+            .get(&tree, cid.as_bytes())
+            .await?
+            .map(|encoded| decode_canonical(&encoded))
+            .transpose()?;
+        if entry
+            .as_ref()
+            .is_some_and(|entry: &JournalNodeIndexEntryV2| entry.cid != *cid)
+        {
+            return Err(Error::new(
+                ErrorCode::CorruptNode,
+                "imported node-index value does not match its key",
+            ));
+        }
+        Ok(entry)
+    }
+
+    /// Atomically install a completed imported closure as the selected
+    /// branch's durable node/commit-graph checkpoint.
+    pub async fn publish_imported_closure(
+        &self,
+        publisher: &ShardedBranchPublisherV2<P>,
+        branch: &str,
+        state: &ImportedJournalIndexStateV2,
+        now_millis: u64,
+    ) -> Result<()> {
+        self.validate_imported_state(state)?;
+        let reference = publisher.load(branch).await?;
+        let graph_tree = self.tree_from_root(&state.commit_graph_root);
+        if self
+            .graph_engine
+            .get(&graph_tree, reference.value.target.as_bytes())
+            .await?
+            .is_none()
+        {
+            return Err(Error::new(
+                ErrorCode::MissingClosure,
+                "imported branch target is absent from its commit-graph closure",
+            ));
+        }
+        let path = self.head_path(branch)?;
+        let loaded = self.load_head(branch).await?;
+        if loaded.as_ref().is_some_and(|head| {
+            head.value.checkpoint == reference.value.publication
+                && head.value.checkpoint_generation == reference.value.generation
+                && head.value.target == reference.value.target
+                && head.value.node_root == state.node_root
+                && head.value.commit_graph_root == state.commit_graph_root
+        }) {
+            return Ok(());
+        }
+        let next = JournalDerivedIndexHeadV2 {
+            repository: self.repository,
+            branch: branch.to_string(),
+            checkpoint: reference.value.publication,
+            checkpoint_generation: reference.value.generation,
+            target: reference.value.target,
+            node_root: state.node_root.clone(),
+            commit_graph_root: state.commit_graph_root.clone(),
+            generation: loaded.as_ref().map_or(Ok(0), |head| {
+                head.value.generation.checked_add(1).ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "imported journal-index generation overflow",
+                    )
+                })
+            })?,
+            indexed_publications: 1,
+            indexed_commits: state.indexed_commits,
+            updated_at_millis: now_millis,
+        };
+        next.validate(self.repository, branch, tree_format_digest(&self.format)?)?;
+        let bytes = encode_canonical(&next)?;
+        let expected = loaded.map(|head| head.token);
+        match self
+            .controls
+            .compare_exchange(CompareExchange {
+                path: path.clone(),
+                expected,
+                bytes: bytes.clone(),
+            })
+            .await
+        {
+            Ok(CompareExchangeOutcome::Applied(_)) => Ok(()),
+            Ok(CompareExchangeOutcome::Conflict(Some(current))) if current.bytes == bytes => Ok(()),
+            Ok(CompareExchangeOutcome::Conflict(_)) => Err(Error::new(
+                ErrorCode::RefConflict,
+                "imported journal-index publication conflicted",
+            )
+            .retry(RetryAdvice::ReloadHead)),
+            Err(error) => {
+                if self
+                    .plane
+                    .load_mutable(&path)
+                    .await?
+                    .is_some_and(|current| current.bytes == bytes)
+                {
+                    Ok(())
+                } else {
+                    Err(Error::new(
+                        ErrorCode::OutcomeUnknown,
+                        format!("imported journal-index publication is unknown: {error}"),
+                    )
+                    .retry(RetryAdvice::ReconcileOperation))
+                }
+            }
+        }
+    }
+
+    fn validate_imported_state(&self, state: &ImportedJournalIndexStateV2) -> Result<()> {
+        let digest = tree_format_digest(&self.format)?;
+        if state.repository != self.repository
+            || state.job.is_nil()
+            || state.node_root.format_digest != digest
+            || state.commit_graph_root.format_digest != digest
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "imported journal-index state belongs to another repository or format",
+            ));
+        }
+        Ok(())
     }
 
     pub async fn commit_graph_entry(

--- a/extensions/s3/core/src/journal_indexes_v2.rs
+++ b/extensions/s3/core/src/journal_indexes_v2.rs
@@ -146,7 +146,7 @@ impl<P: ObjectPlane> JournalDerivedIndexesV2<P> {
             .is_some_and(|head| head.value.checkpoint == current.value.publication)
         {
             let head = &loaded.as_ref().expect("checked as present").value;
-            if head.checkpoint_generation != current.value.generation
+            if head.checkpoint_generation.0 > current.value.generation.0
                 || head.target != current.value.target
             {
                 return Err(Error::new(

--- a/extensions/s3/core/src/lib.rs
+++ b/extensions/s3/core/src/lib.rs
@@ -37,7 +37,8 @@ pub use journal_indexes_v2::{
 pub use model::*;
 pub use object_plane::*;
 pub use operation_index_v2::{
-    OperationIndexAdvanceReportV2, SegmentedOperationIndexV2, DEFAULT_OPERATION_INDEX_LEAF_ENTRIES,
+    OperationIndexAdvanceReportV2, OperationIndexRebuildCursorV2, OperationIndexRebuildStepV2,
+    SegmentedOperationIndexV2, DEFAULT_OPERATION_INDEX_LEAF_ENTRIES,
     DEFAULT_OPERATION_INDEX_MAX_UNINDEXED_EVENTS, DEFAULT_OPERATION_INDEX_MERGE_FANOUT,
 };
 pub use payload_v2::ImmutablePayloadStoreV2;

--- a/extensions/s3/core/src/lib.rs
+++ b/extensions/s3/core/src/lib.rs
@@ -59,8 +59,8 @@ pub use repository::{
     TagReflogPage, TraversalBudget, VersionSummary,
 };
 pub use repository_v2::{
-    BranchIndexAdvanceReportV2, CommitReceiptV2, ObjectDataV2, ObjectSummaryV2, RepositoryV2,
-    RepositoryV2Options, VersionSummaryV2,
+    BranchIndexAdvanceReportV2, BranchIndexHealthV2, BranchIndexMaintenance, CommitReceiptV2,
+    ObjectDataV2, ObjectSummaryV2, RepositoryV2, RepositoryV2Options, VersionSummaryV2,
 };
 #[deprecated(
     since = "0.1.0",

--- a/extensions/s3/core/src/lib.rs
+++ b/extensions/s3/core/src/lib.rs
@@ -44,8 +44,8 @@ pub use publication_v2::{
     PublicationJournalEntryV2, PublicationJournalPageV2, ShardedBranchPublisherV2,
 };
 pub use repository::{
-    version_cursor_after_key, BranchHead, BranchPage, BranchReflogCursor, BranchReflogPage,
-    CatalogBranchPage, CatalogTagPage, CloneReport, CommitClosureCleanupReport,
+    validate_branch, version_cursor_after_key, BranchHead, BranchPage, BranchReflogCursor,
+    BranchReflogPage, CatalogBranchPage, CatalogTagPage, CloneReport, CommitClosureCleanupReport,
     CommitClosureCursor, CommitClosurePage, CommitGraphAdvanceReport, CommitPage,
     FirstParentCursor, FirstParentPage, FsckReport, GcDryRun, GcEpochStepReport, GcSweepReport,
     HistoryCursor, IndexFreshness, InternalNodePrewarmReport, MergeConflict, MergePlan,

--- a/extensions/s3/core/src/lib.rs
+++ b/extensions/s3/core/src/lib.rs
@@ -7,6 +7,7 @@ mod commit_session_v2;
 mod control_versions;
 mod error;
 mod journal_indexes_v2;
+mod merge_v2;
 mod model;
 mod object_plane;
 mod operation_index_v2;
@@ -35,6 +36,12 @@ pub use journal_indexes_v2::{
     ImportedJournalIndexStateV2, JournalDerivedIndexesV2, JournalIndexAdvanceReportV2,
     JournalIndexRebuildCleanupV2, JournalIndexRebuildCursorV2, JournalIndexRebuildPhaseV2,
     JournalIndexRebuildStepV2, DEFAULT_JOURNAL_INDEX_MAX_UNINDEXED_EVENTS,
+};
+pub use merge_v2::{
+    MergeAdvancePageV2, MergeBaseCursorV2, MergeBasePageV2, MergeChangeCursorV2, MergeChangePageV2,
+    MergeChangeV2, MergeCleanupCursorV2, MergeCleanupPageV2, MergeConflictCursorV2,
+    MergeConflictPageV2, MergeConflictV2, MergeCursorV2, MergePhaseV2, MergePolicyV2,
+    MergeReceiptV2,
 };
 pub use model::*;
 pub use object_plane::*;

--- a/extensions/s3/core/src/lib.rs
+++ b/extensions/s3/core/src/lib.rs
@@ -3,6 +3,7 @@
 mod authority;
 mod cache;
 mod codec;
+mod commit_session_v2;
 mod control_versions;
 mod error;
 mod journal_indexes_v2;
@@ -22,6 +23,7 @@ pub use authority::{
 };
 pub use cache::{MemoryNodeCache, NodeCache, NodeCacheError, NodeCacheKey};
 pub use codec::{decode_canonical, encode_canonical};
+pub use commit_session_v2::CommitSessionStoreV2;
 pub use control_versions::{
     classify_mutable_control_path, ControlVersionCompactionReport, MutableControlKind,
     MutableControlObserver, MutableControlStore, DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,

--- a/extensions/s3/core/src/lib.rs
+++ b/extensions/s3/core/src/lib.rs
@@ -12,6 +12,7 @@ mod operation_index_v2;
 mod payload_v2;
 mod publication_v2;
 mod repository;
+mod repository_v2;
 mod runtime;
 mod store;
 
@@ -54,6 +55,9 @@ pub use repository::{
     RepositoryOptions, RepositoryPerformanceSnapshot, ResumableFsckCursor, ResumableFsckPage,
     ResumableFsckPhase, RetentionPinPage, ShardAuthorityMaintenance, SyncReport, Tag, TagPage,
     TagReflogPage, TraversalBudget, VersionSummary,
+};
+pub use repository_v2::{
+    BranchIndexAdvanceReportV2, CommitReceiptV2, ObjectDataV2, RepositoryV2, RepositoryV2Options,
 };
 #[deprecated(
     since = "0.1.0",

--- a/extensions/s3/core/src/lib.rs
+++ b/extensions/s3/core/src/lib.rs
@@ -57,7 +57,8 @@ pub use repository::{
     TagReflogPage, TraversalBudget, VersionSummary,
 };
 pub use repository_v2::{
-    BranchIndexAdvanceReportV2, CommitReceiptV2, ObjectDataV2, RepositoryV2, RepositoryV2Options,
+    BranchIndexAdvanceReportV2, CommitReceiptV2, ObjectDataV2, ObjectSummaryV2, RepositoryV2,
+    RepositoryV2Options, VersionSummaryV2,
 };
 #[deprecated(
     since = "0.1.0",

--- a/extensions/s3/core/src/lib.rs
+++ b/extensions/s3/core/src/lib.rs
@@ -30,7 +30,8 @@ pub use control_versions::{
 };
 pub use error::{Error, ErrorCode, Result, RetryAdvice};
 pub use journal_indexes_v2::{
-    JournalDerivedIndexesV2, JournalIndexAdvanceReportV2,
+    JournalDerivedIndexesV2, JournalIndexAdvanceReportV2, JournalIndexRebuildCleanupV2,
+    JournalIndexRebuildCursorV2, JournalIndexRebuildPhaseV2, JournalIndexRebuildStepV2,
     DEFAULT_JOURNAL_INDEX_MAX_UNINDEXED_EVENTS,
 };
 pub use model::*;

--- a/extensions/s3/core/src/lib.rs
+++ b/extensions/s3/core/src/lib.rs
@@ -52,8 +52,13 @@ pub use repository::{
     ObjectDiffPage, ObjectSummary, PhysicalTransferCursor, PhysicalTransferPage,
     RefCatalogAdvanceReport, RefMoveReceipt, RefVersionCompactionReport, RepairReport, Repository,
     RepositoryOptions, RepositoryPerformanceSnapshot, ResumableFsckCursor, ResumableFsckPage,
-    ResumableFsckPhase, RetentionPinPage, SyncReport, Tag, TagPage, TagReflogPage, TraversalBudget,
-    VersionSummary, WriterLeaseMaintenance,
+    ResumableFsckPhase, RetentionPinPage, ShardAuthorityMaintenance, SyncReport, Tag, TagPage,
+    TagReflogPage, TraversalBudget, VersionSummary,
 };
+#[deprecated(
+    since = "0.1.0",
+    note = "use ShardAuthorityMaintenance; repository writes use branch/system authority scopes"
+)]
+pub type WriterLeaseMaintenance = ShardAuthorityMaintenance;
 pub use runtime::*;
 pub use store::{NodeCacheSnapshot, ProllyObjectStore};

--- a/extensions/s3/core/src/lib.rs
+++ b/extensions/s3/core/src/lib.rs
@@ -12,10 +12,12 @@ mod object_plane;
 mod operation_index_v2;
 mod payload_v2;
 mod publication_v2;
+mod ref_catalog_v2;
 mod repository;
 mod repository_v2;
 mod runtime;
 mod store;
+mod tag_v2;
 
 pub use authority::{
     AuthorityLeaseStateV2, AuthorityLeaseV2, AuthorityPermitV2, AuthorityScopeV2, AuthorityStampV2,
@@ -47,6 +49,10 @@ pub use publication_v2::{
     AppliedBranchBarrierV2, CommitPublicationV2, LoadedRefV2, PublicationJournalCursorV2,
     PublicationJournalEntryV2, PublicationJournalPageV2, ShardedBranchPublisherV2,
 };
+pub use ref_catalog_v2::{
+    ref_catalog_shard_v2, CatalogRefV2, RefCatalogCursorV2, RefCatalogPageV2, RefCatalogUpdateV2,
+    ShardedRefCatalogV2, REF_CATALOG_SHARDS_V2,
+};
 pub use repository::{
     validate_branch, version_cursor_after_key, BranchHead, BranchPage, BranchReflogCursor,
     BranchReflogPage, CatalogBranchPage, CatalogTagPage, CloneReport, CommitClosureCleanupReport,
@@ -61,8 +67,9 @@ pub use repository::{
     TagReflogPage, TraversalBudget, VersionSummary,
 };
 pub use repository_v2::{
-    BranchIndexAdvanceReportV2, BranchIndexHealthV2, BranchIndexMaintenance, CommitReceiptV2,
-    ObjectDataV2, ObjectSummaryV2, RepositoryV2, RepositoryV2Options, VersionSummaryV2,
+    BranchCatalogPageV2, BranchHeadV2, BranchIndexAdvanceReportV2, BranchIndexHealthV2,
+    BranchIndexMaintenance, CommitReceiptV2, ObjectDataV2, ObjectSummaryV2, RefCatalogRepairPageV2,
+    RepositoryV2, RepositoryV2Options, TagCatalogPageV2, TagV2, VersionSummaryV2,
 };
 #[deprecated(
     since = "0.1.0",
@@ -71,3 +78,4 @@ pub use repository_v2::{
 pub type WriterLeaseMaintenance = ShardAuthorityMaintenance;
 pub use runtime::*;
 pub use store::{NodeCacheSnapshot, ProllyObjectStore};
+pub use tag_v2::{LoadedTagV2, TagStoreV2};

--- a/extensions/s3/core/src/lib.rs
+++ b/extensions/s3/core/src/lib.rs
@@ -32,9 +32,9 @@ pub use control_versions::{
 };
 pub use error::{Error, ErrorCode, Result, RetryAdvice};
 pub use journal_indexes_v2::{
-    JournalDerivedIndexesV2, JournalIndexAdvanceReportV2, JournalIndexRebuildCleanupV2,
-    JournalIndexRebuildCursorV2, JournalIndexRebuildPhaseV2, JournalIndexRebuildStepV2,
-    DEFAULT_JOURNAL_INDEX_MAX_UNINDEXED_EVENTS,
+    ImportedJournalIndexStateV2, JournalDerivedIndexesV2, JournalIndexAdvanceReportV2,
+    JournalIndexRebuildCleanupV2, JournalIndexRebuildCursorV2, JournalIndexRebuildPhaseV2,
+    JournalIndexRebuildStepV2, DEFAULT_JOURNAL_INDEX_MAX_UNINDEXED_EVENTS,
 };
 pub use model::*;
 pub use object_plane::*;
@@ -64,12 +64,14 @@ pub use repository::{
     RefCatalogAdvanceReport, RefMoveReceipt, RefVersionCompactionReport, RepairReport, Repository,
     RepositoryOptions, RepositoryPerformanceSnapshot, ResumableFsckCursor, ResumableFsckPage,
     ResumableFsckPhase, RetentionPinPage, ShardAuthorityMaintenance, SyncReport, Tag, TagPage,
-    TagReflogPage, TraversalBudget, VersionSummary,
+    TagReflogPage, TraversalBudget, V1ToV2MigrationCursor, V1ToV2MigrationPage,
+    V1ToV2MigrationPhase, VersionSummary,
 };
 pub use repository_v2::{
     BranchCatalogPageV2, BranchHeadV2, BranchIndexAdvanceReportV2, BranchIndexHealthV2,
-    BranchIndexMaintenance, CommitReceiptV2, ObjectDataV2, ObjectSummaryV2, RefCatalogRepairPageV2,
-    RepositoryV2, RepositoryV2Options, TagCatalogPageV2, TagV2, VersionSummaryV2,
+    BranchIndexMaintenance, CommitReceiptV2, ImportedCommitReceiptV2, ObjectDataV2,
+    ObjectSummaryV2, RefCatalogRepairPageV2, RepositoryV2, RepositoryV2Options, TagCatalogPageV2,
+    TagV2, VersionSummaryV2,
 };
 #[deprecated(
     since = "0.1.0",

--- a/extensions/s3/core/src/merge_v2.rs
+++ b/extensions/s3/core/src/merge_v2.rs
@@ -1,0 +1,190 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{CommitIdV2, ObjectVersionIdV2, OperationId, RepositoryId, TreeRootV1};
+
+/// Conflict policy applied while constructing a native protocol-v2 merge plan.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MergePolicyV2 {
+    /// Persist conflicts in the plan and refuse publication until they are
+    /// resolved by starting a new plan with an explicit policy.
+    Fail,
+    /// Keep the target branch value for conflicting keys.
+    Ours,
+    /// Select the source branch value for conflicting keys.
+    Theirs,
+}
+
+/// Durable phase of a native protocol-v2 merge job.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MergePhaseV2 {
+    DiscoveringBases,
+    CollectingBases,
+    AwaitingBase,
+    Planning,
+    BuildingVersions,
+    BuildingObjects,
+    Conflicted,
+    ReadyToPublish,
+}
+
+/// Constant-size handle for a restartable native protocol-v2 merge.
+///
+/// The potentially unbounded graph frontier, planned changes, conflicts, and
+/// output delta live in immutable Prolly trees named by this cursor.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergeCursorV2 {
+    pub repository: RepositoryId,
+    pub job: OperationId,
+    pub target_branch: String,
+    pub source_branch: String,
+    pub ours: CommitIdV2,
+    pub theirs: CommitIdV2,
+    pub requested_base: Option<CommitIdV2>,
+    pub selected_base: Option<CommitIdV2>,
+    pub policy: MergePolicyV2,
+    pub operation: OperationId,
+    pub message: String,
+    pub created_at_millis: u64,
+    pub phase: MergePhaseV2,
+    pub plan_root: TreeRootV1,
+    pub ours_diff: Option<prolly::StructuralDiffCursor>,
+    pub theirs_diff: Option<prolly::StructuralDiffCursor>,
+    pub ours_pending: Option<prolly::Diff>,
+    pub theirs_pending: Option<prolly::Diff>,
+    pub ours_finished: bool,
+    pub theirs_finished: bool,
+    pub version_diff: Option<prolly::StructuralDiffCursor>,
+    pub version_diff_finished: bool,
+    pub build_after: Option<Vec<u8>>,
+    pub final_objects: Option<TreeRootV1>,
+    pub final_versions: Option<TreeRootV1>,
+    pub delta_root: Option<TreeRootV1>,
+    pub visited_commits: u64,
+    pub best_base_count: u64,
+    pub planned_changes: u64,
+    pub conflicts: u64,
+    pub built_changes: u64,
+}
+
+/// One logical object change selected by a durable merge plan.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergeChangeV2 {
+    pub key: Vec<u8>,
+    pub from: Option<ObjectVersionIdV2>,
+    pub to: Option<ObjectVersionIdV2>,
+}
+
+/// One three-way object conflict persisted by a durable merge plan.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergeConflictV2 {
+    pub key: Vec<u8>,
+    pub base: Option<ObjectVersionIdV2>,
+    pub ours: Option<ObjectVersionIdV2>,
+    pub theirs: Option<ObjectVersionIdV2>,
+}
+
+/// Bounded work result returned while advancing a merge job.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MergeAdvancePageV2 {
+    pub cursor: MergeCursorV2,
+    pub processed: usize,
+    pub changes: Vec<MergeChangeV2>,
+    pub conflicts: Vec<MergeConflictV2>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergeBaseCursorV2 {
+    pub repository: RepositoryId,
+    pub job: OperationId,
+    pub plan_root: TreeRootV1,
+    pub after: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MergeBasePageV2 {
+    pub bases: Vec<CommitIdV2>,
+    pub continuation: Option<MergeBaseCursorV2>,
+}
+
+/// One page of persisted merge-plan changes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MergeChangePageV2 {
+    pub changes: Vec<MergeChangeV2>,
+    pub continuation: Option<MergeChangeCursorV2>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergeChangeCursorV2 {
+    pub repository: RepositoryId,
+    pub job: OperationId,
+    pub plan_root: TreeRootV1,
+    pub after: Vec<u8>,
+}
+
+/// One page of persisted merge-plan conflicts.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MergeConflictPageV2 {
+    pub conflicts: Vec<MergeConflictV2>,
+    pub continuation: Option<MergeConflictCursorV2>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergeConflictCursorV2 {
+    pub repository: RepositoryId,
+    pub job: OperationId,
+    pub plan_root: TreeRootV1,
+    pub after: Vec<u8>,
+}
+
+/// Successful publication of a durable merge plan.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MergeReceiptV2 {
+    pub id: CommitIdV2,
+    pub operation: OperationId,
+    pub branch: String,
+    pub parents: [CommitIdV2; 2],
+    pub changed_keys: u64,
+    pub conflicts: u64,
+    pub idempotent_replay: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergeCleanupCursorV2 {
+    pub repository: RepositoryId,
+    pub job: OperationId,
+    pub provider_continuation: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MergeCleanupPageV2 {
+    pub deleted: usize,
+    pub continuation: Option<MergeCleanupCursorV2>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct MergeQueueEntryV2 {
+    pub commit: CommitIdV2,
+    pub generation: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct MergeSeenEntryV2 {
+    pub generation: u64,
+    pub flags: u8,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct MergeBaseCandidateV2 {
+    pub generation: u64,
+    pub stale: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct MergePlanEntryV2 {
+    pub key: Vec<u8>,
+    pub base: Option<Vec<u8>>,
+    pub ours: Option<Vec<u8>>,
+    pub theirs: Option<Vec<u8>>,
+    pub selected: Option<Vec<u8>>,
+    pub conflict: bool,
+}

--- a/extensions/s3/core/src/model.rs
+++ b/extensions/s3/core/src/model.rs
@@ -661,6 +661,29 @@ pub struct BucketDeltaV2 {
     /// authority-stamped publication event and bounded operation index.
     pub input_digest: [u8; 32],
     pub changes: Vec<ObjectTransitionV2>,
+    /// Optional immutable Prolly root for a merge delta that is too large to
+    /// embed in one commit envelope. Tree keys are logical object keys and
+    /// values are canonical `ObjectTransitionV2` records.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub changes_root: Option<TreeRootV1>,
+    /// Exact number of records in `changes_root`. Legacy inline deltas leave
+    /// this at zero and derive their count from `changes`.
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub change_count: u64,
+}
+
+impl BucketDeltaV2 {
+    pub fn logical_change_count(&self) -> u64 {
+        if self.changes_root.is_some() {
+            self.change_count
+        } else {
+            self.changes.len() as u64
+        }
+    }
+}
+
+fn is_zero_u64(value: &u64) -> bool {
+    *value == 0
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -2253,7 +2276,25 @@ impl CommitObjectV2 {
                 ErrorCode::CorruptCommit,
                 "v2 commit object node pack does not match its logical reference",
             )),
+        }?;
+        if let Some(root) = &self.commit.delta.changes_root {
+            if !self.commit.delta.changes.is_empty()
+                || self.commit.delta.change_count == 0
+                || root.root.is_none()
+                || root.format_digest != self.commit.state.objects.format_digest
+            {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "v2 external commit delta is malformed or uses another tree format",
+                ));
+            }
+        } else if self.commit.delta.change_count != 0 {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "v2 inline commit delta carries an external change count",
+            ));
         }
+        Ok(())
     }
 
     pub fn encode_object(&self) -> Result<Vec<u8>> {

--- a/extensions/s3/core/src/model.rs
+++ b/extensions/s3/core/src/model.rs
@@ -247,6 +247,7 @@ pub struct RepositoryFormatV2 {
     pub state_tree_format: TreeFormat,
     pub canonical_limits: CanonicalLimits,
     pub idempotency_retention: IdempotencyRetentionV2,
+    pub provider_per_key_version_limit: ProviderPerKeyVersionLimitV2,
     pub min_reader_version: u32,
     pub min_writer_version: u32,
     pub created_at_millis: u64,

--- a/extensions/s3/core/src/model.rs
+++ b/extensions/s3/core/src/model.rs
@@ -2394,6 +2394,56 @@ impl StagedMutationV2 {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CommitSessionStateV2 {
+    Open,
+    Aborted,
+}
+
+/// Canonical, immutable recovery checkpoint for a protocol-v2 commit
+/// session. Checkpoints retain only logical mutation metadata and immutable
+/// payload bindings; object bodies are never copied into the manifest.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommitSessionCheckpointV2 {
+    pub session: PhysicalBatchV2,
+    pub sequence: u64,
+    pub mutations: Vec<StagedMutationV2>,
+    pub state: CommitSessionStateV2,
+}
+
+impl CommitSessionCheckpointV2 {
+    pub fn validate(&self, repository: RepositoryId, max_mutations: usize) -> Result<()> {
+        self.session.validate(repository)?;
+        if self.mutations.len() > max_mutations {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "v2 commit-session checkpoint exceeds the mutation limit",
+            ));
+        }
+        let mut previous = None;
+        for mutation in &self.mutations {
+            let key = mutation.key();
+            if key.is_empty() || previous.is_some_and(|prior: &[u8]| prior >= key) {
+                return Err(Error::new(
+                    ErrorCode::InvalidRequest,
+                    "v2 checkpoint mutations must have unique canonical key order",
+                ));
+            }
+            previous = Some(key);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CommitSessionCleanupReportV2 {
+    pub scanned: usize,
+    pub deleted: usize,
+    pub already_missing: usize,
+    pub retained: usize,
+    pub continuation: Option<String>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ObjectData {
     pub key: Vec<u8>,

--- a/extensions/s3/core/src/model.rs
+++ b/extensions/s3/core/src/model.rs
@@ -89,6 +89,7 @@ hash_id!(ObjectVersionIdV2, "pov2_");
 hash_id!(ReflogEntryId, "prl1_");
 hash_id!(ReflogEntryIdV2, "prl2_");
 hash_id!(PublicationEventIdV2, "ppe2_");
+hash_id!(JournalIndexRebuildChunkIdV2, "jrc2_");
 hash_id!(OperationIndexSegmentIdV2, "poi2_");
 hash_id!(GcDirtyRootIdV2, "pdr2_");
 hash_id!(TreeFormatDigest, "ptf1_");
@@ -1861,6 +1862,56 @@ impl PublicationEventV2 {
             && self.reflog == reference.reflog
             && self.authority == reference.authority
             && self.created_at_millis == reference.updated_at_millis)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JournalIndexRebuildChunkV2 {
+    pub repository: RepositoryId,
+    pub branch: String,
+    pub job: OperationId,
+    pub sequence: u64,
+    pub newer: Option<JournalIndexRebuildChunkIdV2>,
+    pub events: Vec<PublicationEventV2>,
+}
+
+impl JournalIndexRebuildChunkV2 {
+    pub fn id(&self) -> Result<JournalIndexRebuildChunkIdV2> {
+        let bytes = encode_canonical(self)?;
+        Ok(JournalIndexRebuildChunkIdV2(domain_hash(
+            b"prolly-s3/journal-index-rebuild-chunk/v2",
+            &[&bytes],
+        )))
+    }
+
+    pub fn validate(&self, repository: RepositoryId, branch: &str) -> Result<()> {
+        crate::repository::validate_branch(branch)?;
+        if self.repository != repository
+            || self.branch != branch
+            || self.job.is_nil()
+            || self.events.is_empty()
+            || self.events.len() > 1_000
+        {
+            return Err(Error::new(
+                ErrorCode::CorruptContent,
+                "journal-index rebuild chunk is malformed or belongs to another job",
+            ));
+        }
+        let mut previous_generation = None;
+        for event in &self.events {
+            event.validate()?;
+            if event.repository != repository
+                || event.branch != branch
+                || previous_generation.is_some_and(|previous: u64| event.generation.0 >= previous)
+            {
+                return Err(Error::new(
+                    ErrorCode::CorruptContent,
+                    "journal-index rebuild chunk events are not newest-to-oldest",
+                ));
+            }
+            previous_generation = Some(event.generation.0);
+        }
+        Ok(())
     }
 }
 

--- a/extensions/s3/core/src/model.rs
+++ b/extensions/s3/core/src/model.rs
@@ -2354,6 +2354,46 @@ impl PhysicalBatchV2 {
     }
 }
 
+/// One payload-complete logical mutation ready for an atomic protocol-v2
+/// branch publication. Put payloads use immutable content-addressed bindings;
+/// delete markers do not create physical objects.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct StagedPutV2 {
+    pub(crate) key: Vec<u8>,
+    pub(crate) size: u64,
+    pub(crate) logical_etag: String,
+    pub(crate) checksums: Checksums,
+    pub(crate) headers: ObjectHeaders,
+    pub(crate) user_metadata: BTreeMap<String, String>,
+    pub(crate) binding: PhysicalObjectBindingV2,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum StagedMutationBodyV2 {
+    Put(Box<StagedPutV2>),
+    Delete { key: Vec<u8> },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StagedMutationV2 {
+    pub(crate) body: StagedMutationBodyV2,
+}
+
+impl StagedMutationV2 {
+    pub fn delete(key: Vec<u8>) -> Self {
+        Self {
+            body: StagedMutationBodyV2::Delete { key },
+        }
+    }
+
+    pub fn key(&self) -> &[u8] {
+        match &self.body {
+            StagedMutationBodyV2::Put(staged) => &staged.key,
+            StagedMutationBodyV2::Delete { key } => key,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ObjectData {
     pub key: Vec<u8>,

--- a/extensions/s3/core/src/model.rs
+++ b/extensions/s3/core/src/model.rs
@@ -89,6 +89,7 @@ hash_id!(ObjectVersionIdV2, "pov2_");
 hash_id!(ReflogEntryId, "prl1_");
 hash_id!(ReflogEntryIdV2, "prl2_");
 hash_id!(PublicationEventIdV2, "ppe2_");
+hash_id!(RefCatalogEventIdV2, "pce2_");
 hash_id!(JournalIndexRebuildChunkIdV2, "jrc2_");
 hash_id!(OperationIndexSegmentIdV2, "poi2_");
 hash_id!(GcDirtyRootIdV2, "pdr2_");
@@ -1819,6 +1820,94 @@ pub struct PublicationEventV2 {
     pub created_at_millis: u64,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum RefKindV2 {
+    Branch,
+    Tag,
+}
+
+/// Immutable lifecycle event consumed by one prefix-sharded ref catalog.
+/// Branch publication events remain the authoritative per-branch history;
+/// this record provides a common branch/tag discovery stream whose loss can be
+/// repaired from authoritative ref objects.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefCatalogEventV2 {
+    pub repository: RepositoryId,
+    pub shard: u8,
+    pub previous: Option<RefCatalogEventIdV2>,
+    pub kind: RefKindV2,
+    pub name: String,
+    pub target: CommitIdV2,
+    pub generation: RefGeneration,
+    pub operation: OperationId,
+    pub tombstone: bool,
+    pub created_at_millis: u64,
+}
+
+impl RefCatalogEventV2 {
+    pub fn validate(&self, repository: RepositoryId, expected_shard: u8) -> Result<()> {
+        crate::repository::validate_branch(&self.name)?;
+        if self.repository != repository || self.shard != expected_shard || self.operation.is_nil()
+        {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "v2 ref-catalog event is malformed or belongs to another shard",
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn id(&self) -> Result<RefCatalogEventIdV2> {
+        let bytes = encode_canonical(self)?;
+        Ok(RefCatalogEventIdV2(domain_hash(
+            b"prolly-s3/ref-catalog-event/v2",
+            &[&bytes],
+        )))
+    }
+}
+
+/// Derived ref state stored in a catalog shard. Tombstones are retained so an
+/// old or duplicated lifecycle event cannot resurrect a deleted ref.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NativeRefCatalogEntryV2 {
+    pub target: CommitIdV2,
+    pub generation: RefGeneration,
+    pub operation: OperationId,
+    pub tombstone: bool,
+    pub updated_at_millis: u64,
+}
+
+/// Mutable root of one independently updated ref-catalog shard.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefCatalogShardHeadV2 {
+    pub repository: RepositoryId,
+    pub shard: u8,
+    pub latest_event: RefCatalogEventIdV2,
+    pub root: TreeRootV1,
+    pub generation: u64,
+    pub updated_at_millis: u64,
+}
+
+impl RefCatalogShardHeadV2 {
+    pub fn validate(
+        &self,
+        repository: RepositoryId,
+        expected_shard: u8,
+        expected_format: TreeFormatDigest,
+    ) -> Result<()> {
+        if self.repository != repository
+            || self.shard != expected_shard
+            || self.root.format_digest != expected_format
+        {
+            return Err(Error::new(
+                ErrorCode::CorruptNode,
+                "v2 ref-catalog shard head is malformed or belongs to another shard",
+            ));
+        }
+        Ok(())
+    }
+}
+
 impl PublicationEventV2 {
     pub fn id(&self) -> Result<PublicationEventIdV2> {
         self.validate()?;
@@ -2065,6 +2154,42 @@ impl RefValueV2 {
             return Err(Error::new(
                 ErrorCode::CorruptCommit,
                 "v2 branch ref does not match its authority or inline reflog",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TagValueV2 {
+    pub target: CommitIdV2,
+    pub previous_target: Option<CommitIdV2>,
+    pub generation: RefGeneration,
+    pub operation: OperationId,
+    pub inline_reflog: ReflogEntryV2,
+    pub authority: AuthorityStampV2,
+    pub updated_at_millis: u64,
+    pub tombstone: bool,
+}
+
+impl TagValueV2 {
+    pub fn validate(&self, repository: RepositoryId, name: &str) -> Result<()> {
+        crate::repository::validate_branch(name)?;
+        self.authority.validate(
+            repository,
+            &AuthorityScopeV2::System {
+                namespace: "tags".to_string(),
+            },
+        )?;
+        if self.operation.is_nil()
+            || self.inline_reflog.branch != name
+            || self.inline_reflog.old_target != self.previous_target
+            || self.inline_reflog.new_target != self.target
+            || self.inline_reflog.operation != self.operation
+        {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "v2 tag ref does not match its authority or inline reflog",
             ));
         }
         Ok(())

--- a/extensions/s3/core/src/model.rs
+++ b/extensions/s3/core/src/model.rs
@@ -235,6 +235,39 @@ pub struct InitializationIntentV1 {
     pub operation: OperationId,
 }
 
+/// Create-once format marker for a native protocol-v2 repository.
+///
+/// V2 repositories use a separate marker and namespace from v1. Readers must
+/// never reinterpret a v1 marker as v2 or maintain both formats with dual
+/// writes.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepositoryFormatV2 {
+    pub repository_id: RepositoryId,
+    pub format_version: u16,
+    pub state_tree_format: TreeFormat,
+    pub canonical_limits: CanonicalLimits,
+    pub idempotency_retention: IdempotencyRetentionV2,
+    pub min_reader_version: u32,
+    pub min_writer_version: u32,
+    pub created_at_millis: u64,
+    pub required_capability_profile: u16,
+}
+
+impl RepositoryFormatV2 {
+    pub const VERSION: u16 = 2;
+    pub const PROLLY_S3_CAPABILITY_PROFILE: u16 = 2;
+    pub const PROLLY_S3_PROTOCOL_VERSION: u32 = 2;
+    pub const CURRENT_READER_VERSION: u32 = 2;
+    pub const CURRENT_WRITER_VERSION: u32 = 2;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InitializationIntentV2 {
+    pub repository_id: RepositoryId,
+    pub format: RepositoryFormatV2,
+    pub operation: OperationId,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BucketClass {
     GeneralPurpose,
@@ -388,6 +421,17 @@ pub struct BucketStateV1 {
     pub objects: TreeRootV1,
     pub versions: TreeRootV1,
     pub operations: TreeRootV1,
+}
+
+/// Native protocol-v2 logical state.
+///
+/// Operation idempotency is intentionally absent: v2 checkpoints the bounded
+/// branch publication journal into `SegmentedOperationIndexV2` instead of
+/// retaining an operation tree in every repository snapshot.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BucketStateV2 {
+    pub objects: TreeRootV1,
+    pub versions: TreeRootV1,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -553,6 +597,13 @@ pub struct CurrentObjectV1 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CurrentObjectV2 {
+    /// Complete current version so a lookup can fetch the immutable payload
+    /// without loading the version-history tree.
+    pub version: ObjectVersionV2,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OperationKind {
     Put,
     Delete,
@@ -590,6 +641,23 @@ pub struct ObjectTransition {
 pub struct BucketDeltaV1 {
     pub operation_ids: Vec<OperationId>,
     pub changes: Vec<ObjectTransition>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObjectTransitionV2 {
+    pub key: Vec<u8>,
+    pub previous: Option<ObjectVersionIdV2>,
+    pub next: ObjectVersionIdV2,
+    pub delete_marker: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BucketDeltaV2 {
+    /// Canonical digest used to reject reuse of a publication operation ID
+    /// with different logical input. The operation ID itself lives in the
+    /// authority-stamped publication event and bounded operation index.
+    pub input_digest: [u8; 32],
+    pub changes: Vec<ObjectTransitionV2>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -1953,10 +2021,10 @@ impl RefValueV2 {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BucketCommitV2 {
-    pub state: BucketStateV1,
+    pub state: BucketStateV2,
     pub parents: Vec<CommitIdV2>,
     pub generation: CommitGeneration,
-    pub delta: BucketDeltaV1,
+    pub delta: BucketDeltaV2,
     pub node_pack: Option<NodePackRefV1>,
     pub authority: AuthorityStampV2,
     pub author: String,
@@ -2300,6 +2368,17 @@ pub(crate) fn derive_repository_id(operation: OperationId) -> RepositoryId {
     ))
 }
 
+pub(crate) fn derive_repository_id_v2(operation: OperationId) -> RepositoryId {
+    RepositoryId(domain_hash(
+        b"prolly-s3/repository/v2",
+        &[operation.as_bytes()],
+    ))
+}
+
 pub(crate) fn derive_input_digest(parts: &[&[u8]]) -> [u8; 32] {
     domain_hash(b"prolly-s3/operation-input/v1", parts)
+}
+
+pub(crate) fn derive_input_digest_v2(parts: &[&[u8]]) -> [u8; 32] {
+    domain_hash(b"prolly-s3/operation-input/v2", parts)
 }

--- a/extensions/s3/core/src/model.rs
+++ b/extensions/s3/core/src/model.rs
@@ -2372,6 +2372,24 @@ pub struct ObjectVersionV2 {
 }
 
 impl ObjectVersionV2 {
+    pub fn derive_id(
+        repository: RepositoryId,
+        key: &[u8],
+        operation: OperationId,
+        body: &LogicalObjectVersionBodyV1,
+    ) -> Result<ObjectVersionIdV2> {
+        let body_bytes = encode_canonical(body)?;
+        Ok(ObjectVersionIdV2(domain_hash(
+            b"prolly-s3/object-version/v2",
+            &[
+                repository.as_bytes(),
+                key,
+                operation.as_bytes(),
+                &body_bytes,
+            ],
+        )))
+    }
+
     pub fn derive(
         repository: RepositoryId,
         key: &[u8],
@@ -2380,17 +2398,8 @@ impl ObjectVersionV2 {
         binding: Option<PhysicalObjectBindingV2>,
     ) -> Result<Self> {
         validate_physical_object_version_v2(&body, binding.as_ref())?;
-        let body_bytes = encode_canonical(&body)?;
         Ok(Self {
-            id: ObjectVersionIdV2(domain_hash(
-                b"prolly-s3/object-version/v2",
-                &[
-                    repository.as_bytes(),
-                    key,
-                    operation.as_bytes(),
-                    &body_bytes,
-                ],
-            )),
+            id: Self::derive_id(repository, key, operation, &body)?,
             body,
             binding,
         })

--- a/extensions/s3/core/src/object_plane.rs
+++ b/extensions/s3/core/src/object_plane.rs
@@ -90,6 +90,14 @@ pub struct ImmutablePut {
 }
 
 #[derive(Clone, Debug)]
+pub struct ImmutableFilePut {
+    pub path: ObjectPath,
+    pub body_path: PathBuf,
+    pub size: u64,
+    pub expected_sha256: [u8; 32],
+}
+
+#[derive(Clone, Debug)]
 pub struct PhysicalPut {
     pub path: ObjectPath,
     pub bytes: Vec<u8>,
@@ -320,6 +328,30 @@ pub trait ObjectPlane: Send + Sync + 'static {
     async fn get(&self, request: GetRequest) -> Result<Option<StoredObject>>;
     async fn head(&self, path: &ObjectPath) -> Result<Option<StoredMetadata>>;
     async fn put_immutable(&self, request: ImmutablePut) -> Result<ImmutablePutOutcome>;
+
+    /// Upload an immutable object from a file without requiring the caller to
+    /// retain its complete body in memory. Providers with streaming upload
+    /// support should override this default implementation.
+    async fn put_immutable_file(&self, request: ImmutableFilePut) -> Result<ImmutablePutOutcome> {
+        let bytes = std::fs::read(&request.body_path).map_err(|error| {
+            Error::new(
+                ErrorCode::Transport,
+                format!("immutable spool could not be read: {error}"),
+            )
+        })?;
+        if bytes.len() as u64 != request.size || sha256(&bytes) != request.expected_sha256 {
+            return Err(Error::new(
+                ErrorCode::ChecksumMismatch,
+                "immutable spool identity changed before upload",
+            ));
+        }
+        self.put_immutable(ImmutablePut {
+            path: request.path,
+            bytes,
+            expected_sha256: request.expected_sha256,
+        })
+        .await
+    }
     async fn load_mutable(&self, path: &ObjectPath) -> Result<Option<StoredObject>>;
     async fn compare_exchange(&self, request: CompareExchange) -> Result<CompareExchangeOutcome>;
     async fn list(&self, request: ListRequest) -> Result<PhysicalListPage>;

--- a/extensions/s3/core/src/operation_index_v2.rs
+++ b/extensions/s3/core/src/operation_index_v2.rs
@@ -1,9 +1,12 @@
 use std::{collections::BTreeMap, sync::Arc};
 
+use serde::{Deserialize, Serialize};
+
 use crate::{
     decode_canonical, encode_canonical, CompareExchange, CompareExchangeOutcome, Error, ErrorCode,
-    GetRequest, IdempotencyRetentionV2, ImmutablePut, IndexedOperationV2, MutableControlStore,
-    ObjectPath, ObjectPlane, OperationId, OperationIndexHeadV2, OperationIndexSegmentIdV2,
+    GetRequest, IdempotencyRetentionV2, ImmutablePut, IndexedOperationV2,
+    JournalIndexRebuildChunkIdV2, JournalIndexRebuildChunkV2, MutableControlStore, ObjectPath,
+    ObjectPlane, OperationId, OperationIndexHeadV2, OperationIndexSegmentIdV2,
     OperationIndexSegmentRefV2, OperationIndexSegmentV2, PublicationEventIdV2, RefGeneration,
     RepositoryId, Result, RetryAdvice, ShardedBranchPublisherV2, StorageToken,
     DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,
@@ -20,6 +23,30 @@ pub struct OperationIndexAdvanceReportV2 {
     pub indexed_events: usize,
     pub segments_written: usize,
     pub initialized: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OperationIndexRebuildCursorV2 {
+    pub repository: RepositoryId,
+    pub branch: String,
+    pub job: OperationId,
+    pub snapshot: PublicationEventIdV2,
+    pub snapshot_generation: RefGeneration,
+    pub next_chunk: Option<JournalIndexRebuildChunkIdV2>,
+    pub levels: Vec<Vec<OperationIndexSegmentRefV2>>,
+    pub indexed_events: u64,
+    pub segments_written: u64,
+    pub baseline_checkpoint: Option<PublicationEventIdV2>,
+    pub baseline_generation: Option<u64>,
+    pub complete: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OperationIndexRebuildStepV2 {
+    pub cursor: OperationIndexRebuildCursorV2,
+    pub indexed_events: usize,
+    pub segments_written: usize,
+    pub complete: bool,
 }
 
 #[derive(Clone)]
@@ -276,6 +303,153 @@ impl<P: ObjectPlane> SegmentedOperationIndexV2<P> {
             indexed_events: events.len(),
             segments_written,
             initialized,
+        })
+    }
+
+    pub async fn start_rebuild(
+        &self,
+        branch: &str,
+        job: OperationId,
+        snapshot: PublicationEventIdV2,
+        snapshot_generation: RefGeneration,
+        oldest_chunk: JournalIndexRebuildChunkIdV2,
+    ) -> Result<OperationIndexRebuildCursorV2> {
+        crate::repository::validate_branch(branch)?;
+        if job.is_nil() {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "operation-index rebuild requires a non-nil job ID",
+            ));
+        }
+        let baseline = self.load_head(branch).await?;
+        Ok(OperationIndexRebuildCursorV2 {
+            repository: self.repository,
+            branch: branch.to_string(),
+            job,
+            snapshot,
+            snapshot_generation,
+            next_chunk: Some(oldest_chunk),
+            levels: Vec::new(),
+            indexed_events: 0,
+            segments_written: 0,
+            baseline_checkpoint: baseline.as_ref().map(|head| head.value.checkpoint),
+            baseline_generation: baseline.as_ref().map(|head| head.value.generation),
+            complete: false,
+        })
+    }
+
+    pub async fn advance_rebuild(
+        &self,
+        publisher: &ShardedBranchPublisherV2<P>,
+        cursor: &OperationIndexRebuildCursorV2,
+        chunk: &JournalIndexRebuildChunkV2,
+        expected_chunk: JournalIndexRebuildChunkIdV2,
+        max_events: usize,
+        now_millis: u64,
+    ) -> Result<OperationIndexRebuildStepV2> {
+        self.validate_rebuild_cursor(cursor)?;
+        chunk.validate(self.repository, &cursor.branch)?;
+        if chunk.job != cursor.job
+            || chunk.id()? != expected_chunk
+            || cursor.next_chunk != Some(expected_chunk)
+        {
+            return Err(Error::new(
+                ErrorCode::CorruptContent,
+                "operation-index rebuild received another job's journal chunk",
+            ));
+        }
+        if !(1..=1_000).contains(&max_events) || chunk.events.len() > max_events {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "operation-index rebuild page is outside the 1 to 1,000 event bound",
+            ));
+        }
+        let entries = chunk
+            .events
+            .iter()
+            .rev()
+            .filter(|event| {
+                self.retention.contains(
+                    cursor.snapshot_generation,
+                    now_millis,
+                    event.generation,
+                    event.created_at_millis,
+                )
+            })
+            .map(|event| {
+                Ok(IndexedOperationV2 {
+                    operation: event.operation,
+                    publication: event.id()?,
+                    target: event.new_target,
+                    generation: event.generation,
+                    created_at_millis: event.created_at_millis,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let mut next = cursor.clone();
+        let mut segments_written = 0usize;
+        for leaf in entries.chunks(self.leaf_entries) {
+            if let Some(reference) = self
+                .store_segment(
+                    &cursor.branch,
+                    0,
+                    leaf.to_vec(),
+                    cursor.snapshot_generation,
+                    now_millis,
+                )
+                .await?
+            {
+                segments_written += 1;
+                self.push_segment(
+                    &cursor.branch,
+                    &mut next.levels,
+                    reference,
+                    cursor.snapshot_generation,
+                    now_millis,
+                    &mut segments_written,
+                )
+                .await?;
+            }
+        }
+        self.prune_catalog(&mut next.levels, cursor.snapshot_generation, now_millis);
+        next.indexed_events = next
+            .indexed_events
+            .checked_add(u64::try_from(entries.len()).map_err(|_| {
+                Error::new(
+                    ErrorCode::InvalidLimit,
+                    "operation rebuild event count overflow",
+                )
+            })?)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InvalidLimit,
+                    "operation rebuild event count overflow",
+                )
+            })?;
+        next.segments_written = next
+            .segments_written
+            .checked_add(u64::try_from(segments_written).map_err(|_| {
+                Error::new(
+                    ErrorCode::InvalidLimit,
+                    "operation rebuild segment count overflow",
+                )
+            })?)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InvalidLimit,
+                    "operation rebuild segment count overflow",
+                )
+            })?;
+        next.next_chunk = chunk.newer;
+        if next.next_chunk.is_none() {
+            self.publish_rebuild(publisher, &next, now_millis).await?;
+            next.complete = true;
+        }
+        Ok(OperationIndexRebuildStepV2 {
+            cursor: next.clone(),
+            indexed_events: entries.len(),
+            segments_written,
+            complete: next.complete,
         })
     }
 
@@ -614,6 +788,119 @@ impl<P: ObjectPlane> SegmentedOperationIndexV2<P> {
             ));
         }
         Ok(segment)
+    }
+
+    fn validate_rebuild_cursor(&self, cursor: &OperationIndexRebuildCursorV2) -> Result<()> {
+        crate::repository::validate_branch(&cursor.branch)?;
+        if cursor.repository != self.repository
+            || cursor.job.is_nil()
+            || cursor.baseline_checkpoint.is_some() != cursor.baseline_generation.is_some()
+            || cursor.complete != cursor.next_chunk.is_none()
+            || cursor.levels.len() > self.max_levels()
+            || cursor.levels.iter().enumerate().any(|(level, segments)| {
+                segments.len() >= self.merge_fanout
+                    || segments
+                        .iter()
+                        .any(|segment| usize::from(segment.level) != level || segment.entries == 0)
+            })
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "operation-index rebuild cursor is malformed or belongs to another repository",
+            ));
+        }
+        Ok(())
+    }
+
+    async fn publish_rebuild(
+        &self,
+        publisher: &ShardedBranchPublisherV2<P>,
+        cursor: &OperationIndexRebuildCursorV2,
+        now_millis: u64,
+    ) -> Result<()> {
+        let snapshot = publisher.load_publication(cursor.snapshot).await?;
+        if snapshot.repository != self.repository
+            || snapshot.branch != cursor.branch
+            || snapshot.generation != cursor.snapshot_generation
+        {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "operation-index rebuild cursor does not match its journal snapshot",
+            ));
+        }
+        let loaded = self.load_head(&cursor.branch).await?;
+        let baseline_matches = match (
+            loaded.as_ref(),
+            cursor.baseline_checkpoint,
+            cursor.baseline_generation,
+        ) {
+            (None, None, None) => true,
+            (Some(head), Some(checkpoint), Some(generation)) => {
+                head.value.checkpoint == checkpoint && head.value.generation == generation
+            }
+            _ => false,
+        };
+        if !baseline_matches {
+            return Err(Error::new(
+                ErrorCode::RefConflict,
+                "operation index changed while its resumable rebuild was running",
+            )
+            .retry(RetryAdvice::ReloadHead));
+        }
+        let generation = loaded.as_ref().map_or(Ok(0), |head| {
+            head.value.generation.checked_add(1).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InternalInvariant,
+                    "operation-index rebuild head generation overflow",
+                )
+            })
+        })?;
+        let head = OperationIndexHeadV2 {
+            repository: self.repository,
+            branch: cursor.branch.clone(),
+            checkpoint: cursor.snapshot,
+            checkpoint_generation: cursor.snapshot_generation,
+            retention: self.retention,
+            levels: cursor.levels.clone(),
+            generation,
+            updated_at_millis: now_millis,
+        };
+        self.validate_head(&head)?;
+        let bytes = encode_canonical(&head)?;
+        let path = self.head_path(&cursor.branch)?;
+        match self
+            .controls
+            .compare_exchange(CompareExchange {
+                path: path.clone(),
+                expected: loaded.map(|head| head.token),
+                bytes: bytes.clone(),
+            })
+            .await
+        {
+            Ok(CompareExchangeOutcome::Applied(_)) => Ok(()),
+            Ok(CompareExchangeOutcome::Conflict(Some(current))) if current.bytes == bytes => Ok(()),
+            Ok(CompareExchangeOutcome::Conflict(_)) => Err(Error::new(
+                ErrorCode::RefConflict,
+                "operation-index rebuild head publication conflicted",
+            )
+            .retry(RetryAdvice::ReloadHead)),
+            Err(error) => {
+                if self
+                    .plane
+                    .load_mutable(&path)
+                    .await?
+                    .is_some_and(|current| current.bytes == bytes)
+                {
+                    Ok(())
+                } else {
+                    Err(Error::new(
+                        ErrorCode::OutcomeUnknown,
+                        format!("operation-index rebuild publication is unknown: {error}"),
+                    )
+                    .retry(RetryAdvice::ReconcileOperation))
+                }
+            }
+        }
     }
 
     async fn load_head(&self, branch: &str) -> Result<Option<LoadedHeadV2>> {

--- a/extensions/s3/core/src/payload_v2.rs
+++ b/extensions/s3/core/src/payload_v2.rs
@@ -1,8 +1,8 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use crate::{
-    codec::sha256, GetRequest, ImmutablePut, ObjectPath, ObjectPlane, PhysicalObjectBindingV2,
-    PhysicalVersion, RepositoryId, Result,
+    codec::sha256, GetRequest, ImmutableFilePut, ImmutablePut, ObjectPath, ObjectPlane,
+    PhysicalObjectBindingV2, PhysicalVersion, RepositoryId, Result,
 };
 
 #[derive(Clone)]
@@ -36,6 +36,42 @@ impl<P: ObjectPlane> ImmutablePayloadStoreV2<P> {
             crate::ImmutablePutOutcome::Created(metadata)
             | crate::ImmutablePutOutcome::AlreadyPresent(metadata) => metadata,
         };
+        let binding = PhysicalObjectBindingV2 {
+            path,
+            provider_version_id: metadata.token.version_id,
+            provider_etag: metadata.token.etag,
+            checksum_sha256,
+        };
+        binding.validate()?;
+        Ok(binding)
+    }
+
+    pub async fn put_file(
+        &self,
+        body_path: PathBuf,
+        size: u64,
+        checksum_sha256: [u8; 32],
+    ) -> Result<PhysicalObjectBindingV2> {
+        let path = self.path(checksum_sha256)?;
+        let outcome = self
+            .plane
+            .put_immutable_file(ImmutableFilePut {
+                path: path.clone(),
+                body_path,
+                size,
+                expected_sha256: checksum_sha256,
+            })
+            .await?;
+        let metadata = match outcome {
+            crate::ImmutablePutOutcome::Created(metadata)
+            | crate::ImmutablePutOutcome::AlreadyPresent(metadata) => metadata,
+        };
+        if metadata.len != size || metadata.sha256 != checksum_sha256 {
+            return Err(crate::Error::new(
+                crate::ErrorCode::ChecksumMismatch,
+                "immutable payload metadata does not match the staged file",
+            ));
+        }
         let binding = PhysicalObjectBindingV2 {
             path,
             provider_version_id: metadata.token.version_id,

--- a/extensions/s3/core/src/publication_v2.rs
+++ b/extensions/s3/core/src/publication_v2.rs
@@ -367,13 +367,32 @@ impl<P: ObjectPlane> ShardedBranchPublisherV2<P> {
                 "v2 branch ref is tombstoned or carries another authority epoch",
             ));
         }
-        let parent = self.load_commit(current.value.target).await?;
-        if request.commit.parents.first() != Some(&current.value.target)
-            || request.commit.generation.0 != parent.generation.0.saturating_add(1)
-        {
+        if request.commit.parents.first() != Some(&current.value.target) {
             return Err(Error::new(
                 ErrorCode::InvalidRequest,
                 "v2 commit does not advance the selected branch ref",
+            ));
+        }
+        let mut parent_generation = None;
+        for parent in &request.commit.parents {
+            let generation = self.load_commit(*parent).await?.generation.0;
+            parent_generation =
+                Some(parent_generation.map_or(generation, |current: u64| current.max(generation)));
+        }
+        let expected_generation =
+            parent_generation
+                .unwrap_or(0)
+                .checked_add(1)
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::InvalidRequest,
+                        "v2 parent generation cannot be advanced",
+                    )
+                })?;
+        if request.commit.generation.0 != expected_generation {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "v2 commit generation does not follow its newest parent",
             ));
         }
         let target = self

--- a/extensions/s3/core/src/publication_v2.rs
+++ b/extensions/s3/core/src/publication_v2.rs
@@ -112,6 +112,17 @@ impl<P: ObjectPlane> ShardedBranchPublisherV2<P> {
     }
 
     pub async fn load(&self, branch: &str) -> Result<LoadedRefV2> {
+        let loaded = self.load_including_tombstone(branch).await?;
+        if loaded.value.tombstone {
+            return Err(Error::new(
+                ErrorCode::InvalidRevision,
+                "v2 branch ref is deleted",
+            ));
+        }
+        Ok(loaded)
+    }
+
+    pub async fn load_including_tombstone(&self, branch: &str) -> Result<LoadedRefV2> {
         let path = self.ref_path(branch)?;
         let stored =
             self.plane.load_mutable(&path).await?.ok_or_else(|| {
@@ -123,6 +134,156 @@ impl<P: ObjectPlane> ShardedBranchPublisherV2<P> {
             value,
             token: stored.metadata.token,
         })
+    }
+
+    /// Create or recreate a branch ref at an already durable v2 commit. The
+    /// selected commit may have been authored under another branch authority;
+    /// future publications are fenced by the new branch's own permit.
+    pub async fn create_at_target(
+        &self,
+        permit: &AuthorityPermitV2,
+        branch: &str,
+        target: CommitIdV2,
+        operation: OperationId,
+        message: &str,
+        now_millis: u64,
+    ) -> Result<LoadedRefV2> {
+        crate::repository::validate_branch(branch)?;
+        if operation.is_nil() || message.trim().is_empty() {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "v2 branch creation requires an operation and message",
+            ));
+        }
+        let stamp = self.authority.validate_active(permit, now_millis).await?;
+        stamp.validate(
+            self.repository,
+            &AuthorityScopeV2::Branch {
+                name: branch.to_string(),
+            },
+        )?;
+        self.load_commit_object(target).await?;
+        let existing = match self.load_including_tombstone(branch).await {
+            Ok(existing) if !existing.value.tombstone => {
+                return Err(Error::new(
+                    ErrorCode::RefConflict,
+                    "v2 branch already exists",
+                ));
+            }
+            Ok(existing) => Some(existing),
+            Err(error) if error.code == ErrorCode::InvalidRevision => None,
+            Err(error) => return Err(error),
+        };
+        let generation = existing.as_ref().map_or(Ok(RefGeneration(0)), |current| {
+            current
+                .value
+                .generation
+                .0
+                .checked_add(1)
+                .map(RefGeneration)
+                .ok_or_else(|| {
+                    Error::new(ErrorCode::InternalInvariant, "v2 ref generation overflow")
+                })
+        })?;
+        let old_target = existing.as_ref().map(|current| current.value.target);
+        let reflog = ReflogEntryV2 {
+            branch: branch.to_string(),
+            old_target,
+            new_target: target,
+            operation,
+            actor: stamp.writer_id.clone(),
+            message: message.to_string(),
+            created_at_millis: now_millis,
+        };
+        let event = PublicationEventV2 {
+            repository: self.repository,
+            branch: branch.to_string(),
+            generation,
+            previous: existing.as_ref().map(|current| current.value.publication),
+            old_target,
+            new_target: target,
+            operation,
+            reflog: reflog.id()?,
+            authority: stamp.clone(),
+            created_at_millis: now_millis,
+        };
+        let publication = self.store_publication(&event).await?;
+        let value = RefValueV2 {
+            target,
+            previous_target: old_target,
+            generation,
+            operation,
+            reflog: reflog.id()?,
+            publication,
+            inline_reflog: reflog,
+            authority: stamp,
+            updated_at_millis: now_millis,
+            tombstone: false,
+        };
+        self.cas_ref(branch, existing.map(|current| current.token), value)
+            .await
+    }
+
+    pub async fn delete(
+        &self,
+        permit: &AuthorityPermitV2,
+        branch: &str,
+        current: LoadedRefV2,
+        expected: CommitIdV2,
+        operation: OperationId,
+        now_millis: u64,
+    ) -> Result<LoadedRefV2> {
+        current.value.validate(self.repository, branch)?;
+        let stamp = self.authority.validate_active(permit, now_millis).await?;
+        if current.value.tombstone
+            || current.value.target != expected
+            || current.value.authority != stamp
+            || operation.is_nil()
+        {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "v2 branch deletion does not match the live ref and authority",
+            ));
+        }
+        let generation =
+            RefGeneration(current.value.generation.0.checked_add(1).ok_or_else(|| {
+                Error::new(ErrorCode::InternalInvariant, "v2 ref generation overflow")
+            })?);
+        let reflog = ReflogEntryV2 {
+            branch: branch.to_string(),
+            old_target: Some(expected),
+            new_target: expected,
+            operation,
+            actor: stamp.writer_id.clone(),
+            message: "delete branch".to_string(),
+            created_at_millis: now_millis,
+        };
+        let event = PublicationEventV2 {
+            repository: self.repository,
+            branch: branch.to_string(),
+            generation,
+            previous: Some(current.value.publication),
+            old_target: Some(expected),
+            new_target: expected,
+            operation,
+            reflog: reflog.id()?,
+            authority: stamp.clone(),
+            created_at_millis: now_millis,
+        };
+        let publication = self.store_publication(&event).await?;
+        let value = RefValueV2 {
+            target: expected,
+            previous_target: Some(expected),
+            generation,
+            operation,
+            reflog: reflog.id()?,
+            publication,
+            inline_reflog: reflog,
+            authority: stamp,
+            updated_at_millis: now_millis,
+            tombstone: true,
+        };
+        self.cas_ref(branch, Some(current.token), value).await
     }
 
     pub async fn create(&self, request: CommitPublicationV2<'_>) -> Result<LoadedRefV2> {

--- a/extensions/s3/core/src/publication_v2.rs
+++ b/extensions/s3/core/src/publication_v2.rs
@@ -421,6 +421,27 @@ impl<P: ObjectPlane> ShardedBranchPublisherV2<P> {
             .await
     }
 
+    /// Store a migration/repair commit without moving a ref. The caller must
+    /// later publish an authoritative ref and a complete node/graph index
+    /// closure before exposing the imported history to readers.
+    pub(crate) async fn store_unpublished_commit(
+        &self,
+        permit: &AuthorityPermitV2,
+        commit: &BucketCommitV2,
+        node_pack: Option<NodePackV1>,
+        now_millis: u64,
+    ) -> Result<CommitIdV2> {
+        let stamp = self.authority.validate_active(permit, now_millis).await?;
+        stamp.validate(self.repository, &stamp.scope)?;
+        if commit.authority != stamp {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "unpublished v2 commit does not match migration authority",
+            ));
+        }
+        self.store_commit(commit, node_pack).await
+    }
+
     /// Publish the no-target-change ref barrier required by a pending
     /// authority takeover. The returned receipt is the only constructible
     /// input to `activate_after_barrier`.

--- a/extensions/s3/core/src/ref_catalog_v2.rs
+++ b/extensions/s3/core/src/ref_catalog_v2.rs
@@ -1,0 +1,482 @@
+use std::sync::Arc;
+
+use prolly::{AsyncProlly, Config, RuntimeConfig, Tree, TreeFormat};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    decode_canonical, encode_canonical, tree_format_digest, CompareExchange,
+    CompareExchangeOutcome, Error, ErrorCode, GetRequest, ImmutablePut, MemoryNodeCache,
+    MutableControlStore, NativeRefCatalogEntryV2, NodeCache, ObjectPath, ObjectPlane, OperationId,
+    RefCatalogEventIdV2, RefCatalogEventV2, RefCatalogShardHeadV2, RefGeneration, RefKindV2,
+    RepositoryId, Result, RetryAdvice, StorageToken, TreeRootV1,
+    DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,
+};
+
+pub const REF_CATALOG_SHARDS_V2: u8 = 16;
+const MAX_HEAD_CAS_ATTEMPTS: usize = 32;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefCatalogCursorV2 {
+    pub repository: RepositoryId,
+    pub kind: RefKindV2,
+    pub shard: u8,
+    pub after: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CatalogRefV2 {
+    pub kind: RefKindV2,
+    pub name: String,
+    pub target: crate::CommitIdV2,
+    pub generation: RefGeneration,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RefCatalogPageV2 {
+    pub entries: Vec<CatalogRefV2>,
+    pub continuation: Option<RefCatalogCursorV2>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RefCatalogUpdateV2 {
+    pub event: RefCatalogEventIdV2,
+    pub shard: u8,
+    pub generation: u64,
+    pub already_indexed: bool,
+}
+
+struct LoadedHead {
+    value: RefCatalogShardHeadV2,
+    token: StorageToken,
+}
+
+/// Event-driven, prefix-sharded catalog for native protocol-v2 refs.
+///
+/// Authoritative refs remain separate mutable objects. Each successful ref
+/// transition records one immutable lifecycle event and advances only the
+/// derived shard selected by the ref name. A missed update is repaired from
+/// authoritative refs; catalog state is never used to authorize mutation.
+pub struct ShardedRefCatalogV2<P: ObjectPlane> {
+    plane: Arc<P>,
+    controls: MutableControlStore<P>,
+    prefix: String,
+    repository: RepositoryId,
+    format: TreeFormat,
+    engine: AsyncProlly<crate::ProllyObjectStore<P>>,
+}
+
+impl<P: ObjectPlane> ShardedRefCatalogV2<P> {
+    pub fn new(
+        plane: Arc<P>,
+        prefix: impl Into<String>,
+        repository: RepositoryId,
+        format: TreeFormat,
+    ) -> Result<Self> {
+        Self::new_with_limits(
+            plane,
+            prefix,
+            repository,
+            format,
+            Arc::new(MemoryNodeCache::new(64 * 1024 * 1024)),
+            DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,
+        )
+    }
+
+    pub fn new_with_limits(
+        plane: Arc<P>,
+        prefix: impl Into<String>,
+        repository: RepositoryId,
+        format: TreeFormat,
+        node_cache: Arc<dyn NodeCache>,
+        control_versions_to_retain: usize,
+    ) -> Result<Self> {
+        let prefix = prefix.into();
+        let digest = tree_format_digest(&format)?;
+        let store = crate::ProllyObjectStore::new_cached_direct(
+            plane.clone(),
+            format!("{prefix}/ref-catalog/v2/tree"),
+            repository,
+            2,
+            digest,
+            node_cache,
+        );
+        let controls =
+            MutableControlStore::new(plane.clone(), prefix.clone(), control_versions_to_retain)?;
+        let config = Config {
+            format: format.clone(),
+            runtime: RuntimeConfig::default(),
+        };
+        Ok(Self {
+            plane,
+            controls,
+            prefix,
+            repository,
+            format,
+            engine: AsyncProlly::new(store, config),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn record(
+        &self,
+        kind: RefKindV2,
+        name: &str,
+        target: crate::CommitIdV2,
+        generation: RefGeneration,
+        operation: OperationId,
+        tombstone: bool,
+        created_at_millis: u64,
+    ) -> Result<RefCatalogUpdateV2> {
+        crate::repository::validate_branch(name)?;
+        if operation.is_nil() {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "v2 ref-catalog update requires a non-nil operation ID",
+            ));
+        }
+        let shard = ref_catalog_shard_v2(kind, name);
+        let path = self.head_path(shard)?;
+        let key = catalog_key(kind, name);
+        let desired = NativeRefCatalogEntryV2 {
+            target,
+            generation,
+            operation,
+            tombstone,
+            updated_at_millis: created_at_millis,
+        };
+
+        for _ in 0..MAX_HEAD_CAS_ATTEMPTS {
+            let loaded = self.load_head(shard).await?;
+            let tree = self.tree_from_head(loaded.as_ref());
+            if let Some(encoded) = self.engine.get(&tree, &key).await? {
+                let existing: NativeRefCatalogEntryV2 = decode_canonical(&encoded)?;
+                if existing.generation.0 > generation.0 {
+                    return Ok(RefCatalogUpdateV2 {
+                        event: loaded
+                            .as_ref()
+                            .expect("an indexed entry requires a shard head")
+                            .value
+                            .latest_event,
+                        shard,
+                        generation: loaded.as_ref().expect("head checked").value.generation,
+                        already_indexed: true,
+                    });
+                }
+                if existing.generation == generation {
+                    if existing == desired {
+                        return Ok(RefCatalogUpdateV2 {
+                            event: loaded
+                                .as_ref()
+                                .expect("an indexed entry requires a shard head")
+                                .value
+                                .latest_event,
+                            shard,
+                            generation: loaded.as_ref().expect("head checked").value.generation,
+                            already_indexed: true,
+                        });
+                    }
+                    return Err(Error::new(
+                        ErrorCode::RefConflict,
+                        "v2 ref-catalog generation is already bound to another state",
+                    ));
+                }
+            }
+
+            let event = RefCatalogEventV2 {
+                repository: self.repository,
+                shard,
+                previous: loaded.as_ref().map(|head| head.value.latest_event),
+                kind,
+                name: name.to_string(),
+                target,
+                generation,
+                operation,
+                tombstone,
+                created_at_millis,
+            };
+            event.validate(self.repository, shard)?;
+            let event_id = self.store_event(&event).await?;
+            let next_tree = self
+                .engine
+                .put(&tree, key.clone(), encode_canonical(&desired)?)
+                .await?;
+            let head_generation = loaded.as_ref().map_or(Ok(0), |head| {
+                head.value.generation.checked_add(1).ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "v2 ref-catalog shard generation overflow",
+                    )
+                })
+            })?;
+            let next = RefCatalogShardHeadV2 {
+                repository: self.repository,
+                shard,
+                latest_event: event_id,
+                root: TreeRootV1::from_tree(&next_tree)?,
+                generation: head_generation,
+                updated_at_millis: created_at_millis,
+            };
+            next.validate(self.repository, shard, tree_format_digest(&self.format)?)?;
+            let bytes = encode_canonical(&next)?;
+            let expected = loaded.map(|head| head.token);
+            match self
+                .controls
+                .compare_exchange(CompareExchange {
+                    path: path.clone(),
+                    expected,
+                    bytes: bytes.clone(),
+                })
+                .await
+            {
+                Ok(CompareExchangeOutcome::Applied(_)) => {
+                    return Ok(RefCatalogUpdateV2 {
+                        event: event_id,
+                        shard,
+                        generation: next.generation,
+                        already_indexed: false,
+                    });
+                }
+                Ok(CompareExchangeOutcome::Conflict(Some(current))) if current.bytes == bytes => {
+                    return Ok(RefCatalogUpdateV2 {
+                        event: event_id,
+                        shard,
+                        generation: next.generation,
+                        already_indexed: false,
+                    });
+                }
+                Ok(CompareExchangeOutcome::Conflict(_)) => continue,
+                Err(error) => {
+                    if self
+                        .plane
+                        .load_mutable(&path)
+                        .await?
+                        .is_some_and(|current| current.bytes == bytes)
+                    {
+                        return Ok(RefCatalogUpdateV2 {
+                            event: event_id,
+                            shard,
+                            generation: next.generation,
+                            already_indexed: false,
+                        });
+                    }
+                    return Err(Error::new(
+                        ErrorCode::OutcomeUnknown,
+                        format!("v2 ref-catalog shard publication outcome is unknown: {error}"),
+                    )
+                    .retry(RetryAdvice::ReconcileOperation)
+                    .operation(operation.to_string()));
+                }
+            }
+        }
+        Err(Error::new(
+            ErrorCode::RefConflict,
+            "v2 ref-catalog shard remained contended after bounded retries",
+        )
+        .retry(RetryAdvice::After(std::time::Duration::from_millis(10))))
+    }
+
+    pub async fn list(
+        &self,
+        kind: RefKindV2,
+        cursor: Option<RefCatalogCursorV2>,
+        limit: usize,
+    ) -> Result<RefCatalogPageV2> {
+        if !(1..=1_000).contains(&limit) {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "v2 ref-catalog page limit must be between 1 and 1,000",
+            ));
+        }
+        let cursor = cursor.unwrap_or(RefCatalogCursorV2 {
+            repository: self.repository,
+            kind,
+            shard: 0,
+            after: None,
+        });
+        self.validate_cursor(&cursor, kind)?;
+        let mut entries = Vec::with_capacity(limit);
+        let mut shard = cursor.shard;
+        let mut after = cursor.after;
+        while shard < REF_CATALOG_SHARDS_V2 {
+            let Some(head) = self.load_head(shard).await? else {
+                shard = shard.saturating_add(1);
+                after = None;
+                continue;
+            };
+            let tree = self.tree_from_head(Some(&head));
+            let prefix = catalog_prefix(kind);
+            let mut stream = self.engine.prefix(&tree, prefix).await?;
+            while let Some(entry) = stream.next().await {
+                let (key, encoded) = entry?;
+                let name = decode_catalog_name(&key, prefix)?;
+                if after
+                    .as_ref()
+                    .is_some_and(|after| name.as_str() <= after.as_str())
+                {
+                    continue;
+                }
+                let value: NativeRefCatalogEntryV2 = decode_canonical(&encoded)?;
+                if !value.tombstone {
+                    entries.push(CatalogRefV2 {
+                        kind,
+                        name: name.clone(),
+                        target: value.target,
+                        generation: value.generation,
+                    });
+                    if entries.len() == limit {
+                        return Ok(RefCatalogPageV2 {
+                            entries,
+                            continuation: Some(RefCatalogCursorV2 {
+                                repository: self.repository,
+                                kind,
+                                shard,
+                                after: Some(name),
+                            }),
+                        });
+                    }
+                }
+            }
+            shard = shard.saturating_add(1);
+            after = None;
+        }
+        Ok(RefCatalogPageV2 {
+            entries,
+            continuation: None,
+        })
+    }
+
+    pub async fn load_event(&self, id: RefCatalogEventIdV2) -> Result<RefCatalogEventV2> {
+        let stored = self
+            .plane
+            .get(GetRequest {
+                path: self.event_path(id)?,
+                range: None,
+                physical_version: None,
+            })
+            .await?
+            .ok_or_else(|| {
+                Error::new(ErrorCode::MissingClosure, "v2 ref-catalog event is missing")
+            })?;
+        let event: RefCatalogEventV2 = decode_canonical(&stored.bytes)?;
+        let expected_shard = ref_catalog_shard_v2(event.kind, &event.name);
+        event.validate(self.repository, expected_shard)?;
+        if event.id()? != id {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "v2 ref-catalog event does not match its content address",
+            ));
+        }
+        Ok(event)
+    }
+
+    async fn load_head(&self, shard: u8) -> Result<Option<LoadedHead>> {
+        if shard >= REF_CATALOG_SHARDS_V2 {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "v2 ref-catalog shard is outside the configured range",
+            ));
+        }
+        let Some(stored) = self.plane.load_mutable(&self.head_path(shard)?).await? else {
+            return Ok(None);
+        };
+        let value: RefCatalogShardHeadV2 = decode_canonical(&stored.bytes)?;
+        value.validate(self.repository, shard, tree_format_digest(&self.format)?)?;
+        Ok(Some(LoadedHead {
+            value,
+            token: stored.metadata.token,
+        }))
+    }
+
+    fn tree_from_head(&self, head: Option<&LoadedHead>) -> Tree {
+        Tree {
+            root: head.and_then(|head| head.value.root.root.clone()),
+            config: Config {
+                format: self.format.clone(),
+                runtime: RuntimeConfig::default(),
+            },
+        }
+    }
+
+    async fn store_event(&self, event: &RefCatalogEventV2) -> Result<RefCatalogEventIdV2> {
+        let id = event.id()?;
+        let bytes = encode_canonical(event)?;
+        self.plane
+            .put_immutable(ImmutablePut {
+                path: self.event_path(id)?,
+                expected_sha256: crate::codec::sha256(&bytes),
+                bytes,
+            })
+            .await?;
+        Ok(id)
+    }
+
+    fn validate_cursor(&self, cursor: &RefCatalogCursorV2, kind: RefKindV2) -> Result<()> {
+        if cursor.repository != self.repository
+            || cursor.kind != kind
+            || cursor.shard >= REF_CATALOG_SHARDS_V2
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "v2 ref-catalog cursor belongs to another repository, kind, or shard",
+            ));
+        }
+        if let Some(after) = &cursor.after {
+            crate::repository::validate_branch(after)?;
+        }
+        Ok(())
+    }
+
+    fn head_path(&self, shard: u8) -> Result<ObjectPath> {
+        ObjectPath::new(format!(
+            "{}/ref-catalog/v2/shards/{shard:02x}/head.cbor",
+            self.prefix
+        ))
+    }
+
+    fn event_path(&self, id: RefCatalogEventIdV2) -> Result<ObjectPath> {
+        let encoded = hex::encode(id.as_bytes());
+        ObjectPath::new(format!(
+            "{}/ref-events/v2/sha256/{}/{}/{}",
+            self.prefix,
+            &encoded[..2],
+            &encoded[2..4],
+            encoded
+        ))
+    }
+}
+
+pub fn ref_catalog_shard_v2(kind: RefKindV2, name: &str) -> u8 {
+    let kind = match kind {
+        RefKindV2::Branch => 0_u8,
+        RefKindV2::Tag => 1_u8,
+    };
+    let mut shard_key = Vec::with_capacity(name.len() + 1);
+    shard_key.push(kind);
+    shard_key.extend_from_slice(name.as_bytes());
+    crate::codec::sha256(&shard_key)[0] % REF_CATALOG_SHARDS_V2
+}
+
+fn catalog_prefix(kind: RefKindV2) -> &'static [u8] {
+    match kind {
+        RefKindV2::Branch => b"b\0",
+        RefKindV2::Tag => b"t\0",
+    }
+}
+
+fn catalog_key(kind: RefKindV2, name: &str) -> Vec<u8> {
+    let mut key = Vec::with_capacity(name.len() + 2);
+    key.extend_from_slice(catalog_prefix(kind));
+    key.extend_from_slice(name.as_bytes());
+    key
+}
+
+fn decode_catalog_name(key: &[u8], prefix: &[u8]) -> Result<String> {
+    let name = key.strip_prefix(prefix).ok_or_else(|| {
+        Error::new(
+            ErrorCode::CorruptNode,
+            "v2 ref-catalog entry escaped its kind prefix",
+        )
+    })?;
+    String::from_utf8(name.to_vec())
+        .map_err(|_| Error::new(ErrorCode::CorruptNode, "v2 ref-catalog name is not UTF-8"))
+}

--- a/extensions/s3/core/src/repository.rs
+++ b/extensions/s3/core/src/repository.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use crate::store::{NodeCacheNamespace, NodeLocator, PreparedNodePack};
+use crate::store::{LocatedPackedNode, NodeCacheNamespace, NodeLocator, PreparedNodePack};
 use crate::{
     decode_canonical, derive_input_digest, derive_repository_id, encode_canonical,
     tree_format_digest, BatchId, BucketCommitV1, BucketDeltaV1, BucketStateV1, CanonicalLimits,
@@ -877,13 +877,14 @@ impl<P: ObjectPlane> ProllyNodeIndex<P> {
 
 #[async_trait::async_trait]
 impl<P: ObjectPlane> NodeLocator for ProllyNodeIndex<P> {
-    async fn locate(&self, cid: &prolly::Cid) -> Result<Option<NodeIndexEntryV1>> {
+    async fn locate(&self, cid: &prolly::Cid) -> Result<Option<LocatedPackedNode>> {
         let tree = self.tree()?;
         self.engine
             .get(&tree, cid.as_bytes())
             .await?
             .map(|bytes| decode_canonical::<NodeIndexEntryV1>(&bytes))
             .transpose()
+            .map(|entry| entry.map(Into::into))
     }
 }
 

--- a/extensions/s3/core/src/repository.rs
+++ b/extensions/s3/core/src/repository.rs
@@ -8,24 +8,26 @@ use std::{
     time::Duration,
 };
 
+use crate::repository_v2::{ImportedCommitReceiptV2, V1MigrationChangeV2};
 use crate::store::{LocatedPackedNode, NodeCacheNamespace, NodeLocator, PreparedNodePack};
 use crate::{
     decode_canonical, derive_input_digest, derive_repository_id, encode_canonical,
     tree_format_digest, BatchId, BucketCommitV1, BucketDeltaV1, BucketStateV1, CanonicalLimits,
     CanonicalOperationResult, ChecksumExpectation, Clock, CommitGeneration, CommitGraphEntryV2,
-    CommitGraphHeadV2, CommitId, CommitObjectV1, CommitReceipt, CompareExchange,
+    CommitGraphHeadV2, CommitId, CommitIdV2, CommitObjectV1, CommitReceipt, CompareExchange,
     CompareExchangeOutcome, CurrentObjectV1, DeleteOutcome, Error, ErrorCode, EtagPredicateV1,
     GcCandidateV1, GcCommitWorkV2, GcCoordinatorV2, GcDirtyRootIdV2, GcDirtyRootV2, GcEpochPhaseV2,
     GcEpochV2, GcFenceV1, GcMarkRunStateV1, GcMarkRunV1, GcPlanBodyV1, GcPlanId, GcPlanV1,
     GcRunStateV1, GcRunV1, GcVersionWorkV2, GetRequest, IdSource, ImmutablePut,
-    InitializationIntentV1, ListRequest, LogicalObjectVersionBodyV1, LogicalObjectVersionKindV1,
-    MemoryNodeCache, MutableControlKind, MutableControlObserver, NodeCache, NodeIndexEntryV1,
-    NodeIndexHeadV2, ObjectData, ObjectHeaders, ObjectPath, ObjectPlane, ObjectTransition,
-    ObjectVersionId, ObjectVersionOrder, ObjectVersionV1, ObjectWriteConditionV1, OperationId,
-    OperationKind, OperationRecordV1, PhysicalBatchV1, PhysicalPreparedMutationV1, PhysicalVersion,
-    ProllyObjectStore, RandomIdSource, RefCatalogEntryV2, RefCatalogHeadV2, RefGeneration,
-    ReflogEntryV1, RepositoryFormatV1, RepositoryId, Result, RetentionPinV1, RetryAdvice,
-    StorageToken, SystemClock, TreeRootV1,
+    ImportedJournalIndexStateV2, InitializationIntentV1, ListRequest, LogicalObjectVersionBodyV1,
+    LogicalObjectVersionKindV1, MemoryNodeCache, MutableControlKind, MutableControlObserver,
+    NodeCache, NodeIndexEntryV1, NodeIndexHeadV2, ObjectData, ObjectHeaders, ObjectPath,
+    ObjectPlane, ObjectTransition, ObjectVersionId, ObjectVersionOrder, ObjectVersionV1,
+    ObjectWriteConditionV1, OperationId, OperationKind, OperationRecordV1, PhysicalBatchV1,
+    PhysicalPreparedMutationV1, PhysicalVersion, ProllyObjectStore, RandomIdSource,
+    RefCatalogEntryV2, RefCatalogHeadV2, RefGeneration, ReflogEntryV1, RepositoryFormatV1,
+    RepositoryId, RepositoryV2, Result, RetentionPinV1, RetryAdvice, StorageToken, SystemClock,
+    TreeRootV1,
 };
 use futures_util::{stream::BoxStream, Stream, StreamExt};
 use md5::{Digest as _, Md5};
@@ -434,6 +436,44 @@ pub struct PhysicalTransferPage {
     pub cursor: PhysicalTransferCursor,
     pub sync: SyncReport,
     pub processed_commits: usize,
+    pub traversal_steps: usize,
+    pub complete: bool,
+    pub budget_exhausted: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum V1ToV2MigrationPhase {
+    Copying,
+    Publishing,
+    Complete,
+}
+
+/// Constant-size checkpoint for an explicit logical v1-to-native-v2 branch
+/// migration. Commit traversal/mappings and imported index roots are durable
+/// Prolly state; callers persist this canonical cursor after every page.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct V1ToV2MigrationCursor {
+    pub closure: CommitClosureCursor,
+    pub source_branch: String,
+    pub source_head: CommitId,
+    pub source_pin: String,
+    pub destination_branch: String,
+    pub destination_repository: RepositoryId,
+    pub destination_scope: [u8; 32],
+    pub index: ImportedJournalIndexStateV2,
+    pub mapped_head: Option<CommitIdV2>,
+    pub migrated_commits: u64,
+    pub migrated_payloads: u64,
+    pub migrated_payload_bytes: u64,
+    pub phase: V1ToV2MigrationPhase,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct V1ToV2MigrationPage {
+    pub cursor: V1ToV2MigrationCursor,
+    pub processed_commits: usize,
+    pub copied_payloads: usize,
+    pub copied_payload_bytes: u64,
     pub traversal_steps: usize,
     pub complete: bool,
     pub budget_exhausted: bool,
@@ -3330,6 +3370,404 @@ impl<P: ObjectPlane> Repository<P> {
                 "physical clone source version has an invalid binding",
             )),
         }
+    }
+
+    /// Start an explicit, history-preserving migration from one v1 branch to
+    /// a separately initialized native-v2 repository. The destination branch
+    /// must not already exist; v1 and v2 are never dual-written.
+    pub async fn start_v1_to_v2_migration<Q: ObjectPlane>(
+        &self,
+        target: &RepositoryV2<Q>,
+        source_branch: &str,
+        destination_branch: &str,
+    ) -> Result<V1ToV2MigrationCursor> {
+        validate_branch(source_branch)?;
+        validate_branch(destination_branch)?;
+        let source_head = self.head(source_branch).await?;
+        let closure = self.start_commit_closure(&[source_head]).await?;
+        let source_pin = format!("v1-to-v2-{}", hex::encode(closure.traversal.as_bytes()));
+        self.create_retention_pin(
+            &source_pin,
+            source_head,
+            &self.options.writer,
+            "native-v2 migration",
+            None,
+        )
+        .await?;
+        let destination = target
+            .start_v1_migration(
+                self.format.repository_id,
+                source_head,
+                destination_branch,
+                closure.traversal,
+            )
+            .await;
+        let (index, destination_scope) = match destination {
+            Ok(destination) => destination,
+            Err(error) => {
+                let _ = self.delete_retention_pin(&source_pin, source_head).await;
+                return Err(error);
+            }
+        };
+        Ok(V1ToV2MigrationCursor {
+            closure,
+            source_branch: source_branch.to_string(),
+            source_head,
+            source_pin,
+            destination_branch: destination_branch.to_string(),
+            destination_repository: target.repository_id(),
+            destination_scope,
+            index,
+            mapped_head: None,
+            migrated_commits: 0,
+            migrated_payloads: 0,
+            migrated_payload_bytes: 0,
+            phase: V1ToV2MigrationPhase::Copying,
+        })
+    }
+
+    /// Copy and index one bounded parent-before-child migration page. Every
+    /// returned cursor is process-independent. Persist it before scheduling
+    /// the next page; replaying the previous cursor is safe and may repeat
+    /// verified immutable payload PUTs without creating duplicate content.
+    pub async fn v1_to_v2_migration_page<Q: ObjectPlane>(
+        &self,
+        target: &RepositoryV2<Q>,
+        cursor: &V1ToV2MigrationCursor,
+        max_steps: usize,
+        max_commits: usize,
+    ) -> Result<V1ToV2MigrationPage> {
+        self.validate_commit_closure_cursor(&cursor.closure)?;
+        validate_branch(&cursor.source_branch)?;
+        validate_branch(&cursor.source_pin)?;
+        validate_branch(&cursor.destination_branch)?;
+        let expected_pin = format!(
+            "v1-to-v2-{}",
+            hex::encode(cursor.closure.traversal.as_bytes())
+        );
+        if cursor.destination_repository != target.repository_id()
+            || cursor.index.job != cursor.closure.traversal
+            || cursor.source_pin != expected_pin
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "v1-to-v2 migration cursor belongs to another source or destination",
+            ));
+        }
+        target.validate_v1_migration_destination(
+            self.format.repository_id,
+            cursor.source_head,
+            &cursor.destination_branch,
+            cursor.destination_scope,
+            &cursor.index,
+        )?;
+        if cursor.phase == V1ToV2MigrationPhase::Complete {
+            let destination_head = cursor.mapped_head.ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InvalidContinuationToken,
+                    "completed v1-to-v2 migration cursor has no mapped head",
+                )
+            })?;
+            target
+                .finish_v1_migration(
+                    self.format.repository_id,
+                    cursor.source_head,
+                    &cursor.destination_branch,
+                    destination_head,
+                    cursor.destination_scope,
+                    &cursor.index,
+                )
+                .await?;
+            return Ok(V1ToV2MigrationPage {
+                cursor: cursor.clone(),
+                processed_commits: 0,
+                copied_payloads: 0,
+                copied_payload_bytes: 0,
+                traversal_steps: 0,
+                complete: true,
+                budget_exhausted: false,
+            });
+        }
+        if cursor.phase != V1ToV2MigrationPhase::Copying {
+            return Err(Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "v1-to-v2 migration cursor has an invalid phase",
+            ));
+        }
+        self.validate_v1_to_v2_migration_pin(&cursor.source_pin, cursor.source_head)
+            .await?;
+        let page = self
+            .commit_closure_page(&cursor.closure, max_steps, max_commits)
+            .await?;
+        let processed_commits = page.commits.len();
+        let traversal_steps = page.steps;
+        let budget_exhausted = page.budget_exhausted;
+        let closure_complete = page.complete;
+        let index_store = self.commit_closure_index(cursor.closure.traversal)?;
+        index_store.install_root(cursor.closure.state.root.clone())?;
+        let prior_tree = index_store.tree()?;
+        let mut page_mappings = BTreeMap::new();
+        let mut mapping_mutations = Vec::with_capacity(processed_commits);
+        let mut imported_index = cursor.index.clone();
+        let mut copied_payloads = 0usize;
+        let mut copied_payload_bytes = 0u64;
+        for (source_id, source_commit) in page.commits {
+            let mut mapped_parents = Vec::with_capacity(source_commit.parents.len());
+            for parent in &source_commit.parents {
+                let mapped = match page_mappings.get(parent) {
+                    Some(mapped) => *mapped,
+                    None => index_store
+                        .engine
+                        .get(&prior_tree, &v1_to_v2_mapping_key(*parent))
+                        .await?
+                        .map(|bytes| decode_canonical(&bytes))
+                        .transpose()?
+                        .ok_or_else(|| {
+                            Error::new(
+                                ErrorCode::MissingClosure,
+                                "v1-to-v2 migration parent was not durably mapped",
+                            )
+                        })?,
+                };
+                mapped_parents.push(mapped);
+            }
+            let mut changes = Vec::with_capacity(source_commit.delta.changes.len());
+            for transition in &source_commit.delta.changes {
+                changes.push(V1MigrationChangeV2 {
+                    key: transition.key.clone(),
+                    version: self
+                        .find_version(&source_commit, &transition.key, transition.next)
+                        .await?,
+                });
+            }
+            let ImportedCommitReceiptV2 {
+                destination,
+                index,
+                payloads,
+                payload_bytes,
+                ..
+            } = target
+                .import_v1_commit(
+                    self.plane.clone(),
+                    self.format.repository_id,
+                    source_id,
+                    source_commit,
+                    mapped_parents,
+                    changes,
+                    &cursor.destination_branch,
+                    &imported_index,
+                )
+                .await?;
+            imported_index = index;
+            copied_payloads = copied_payloads.checked_add(payloads).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InternalInvariant,
+                    "migration payload count overflow",
+                )
+            })?;
+            copied_payload_bytes =
+                copied_payload_bytes
+                    .checked_add(payload_bytes)
+                    .ok_or_else(|| {
+                        Error::new(
+                            ErrorCode::EntityTooLarge,
+                            "migration payload bytes overflow",
+                        )
+                    })?;
+            page_mappings.insert(source_id, destination);
+            mapping_mutations.push(Mutation::Upsert {
+                key: v1_to_v2_mapping_key(source_id),
+                val: encode_canonical(&destination)?,
+            });
+        }
+        let mut next_closure = page.cursor;
+        if !mapping_mutations.is_empty() {
+            index_store.install_root(next_closure.state.root.clone())?;
+            let tree = index_store
+                .engine
+                .batch(&index_store.tree()?, mapping_mutations)
+                .await?;
+            next_closure.state = TreeRootV1::from_tree(&tree)?;
+        }
+        let mut next = cursor.clone();
+        next.closure = next_closure;
+        next.index = imported_index;
+        next.migrated_commits = next
+            .migrated_commits
+            .checked_add(u64::try_from(processed_commits).map_err(|_| {
+                Error::new(ErrorCode::InvalidLimit, "migration commit page exceeds u64")
+            })?)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InternalInvariant,
+                    "migration commit count overflow",
+                )
+            })?;
+        next.migrated_payloads = next
+            .migrated_payloads
+            .checked_add(u64::try_from(copied_payloads).map_err(|_| {
+                Error::new(
+                    ErrorCode::InvalidLimit,
+                    "migration payload page exceeds u64",
+                )
+            })?)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InternalInvariant,
+                    "migration payload count overflow",
+                )
+            })?;
+        next.migrated_payload_bytes = next
+            .migrated_payload_bytes
+            .checked_add(copied_payload_bytes)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::EntityTooLarge,
+                    "migration payload bytes overflow",
+                )
+            })?;
+        if closure_complete {
+            index_store.install_root(next.closure.state.root.clone())?;
+            let destination_head = index_store
+                .engine
+                .get(
+                    &index_store.tree()?,
+                    &v1_to_v2_mapping_key(cursor.source_head),
+                )
+                .await?
+                .map(|bytes| decode_canonical(&bytes))
+                .transpose()?
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::MissingClosure,
+                        "v1-to-v2 migration did not map the source head",
+                    )
+                })?;
+            next.mapped_head = Some(destination_head);
+            next.phase = V1ToV2MigrationPhase::Publishing;
+            target
+                .finish_v1_migration(
+                    self.format.repository_id,
+                    cursor.source_head,
+                    &cursor.destination_branch,
+                    destination_head,
+                    cursor.destination_scope,
+                    &next.index,
+                )
+                .await?;
+            self.release_v1_to_v2_migration_pin(&cursor.source_pin, cursor.source_head)
+                .await?;
+            next.phase = V1ToV2MigrationPhase::Complete;
+        }
+        Ok(V1ToV2MigrationPage {
+            cursor: next,
+            processed_commits,
+            copied_payloads,
+            copied_payload_bytes,
+            traversal_steps,
+            complete: closure_complete,
+            budget_exhausted,
+        })
+    }
+
+    pub async fn cleanup_v1_to_v2_migration(
+        &self,
+        cursor: &V1ToV2MigrationCursor,
+        limit: usize,
+    ) -> Result<CommitClosureCleanupReport> {
+        if cursor.phase != V1ToV2MigrationPhase::Complete {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "v1-to-v2 migration traversal cannot be cleaned before publication",
+            ));
+        }
+        self.cleanup_commit_closure(&cursor.closure, limit).await
+    }
+
+    pub async fn abort_v1_to_v2_migration<Q: ObjectPlane>(
+        &self,
+        target: &RepositoryV2<Q>,
+        cursor: &V1ToV2MigrationCursor,
+        limit: usize,
+    ) -> Result<CommitClosureCleanupReport> {
+        self.validate_commit_closure_cursor(&cursor.closure)?;
+        if cursor.phase == V1ToV2MigrationPhase::Complete {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "completed v1-to-v2 migration must use normal cleanup",
+            ));
+        }
+        target.abandon_v1_migration(
+            self.format.repository_id,
+            cursor.source_head,
+            &cursor.destination_branch,
+            cursor.destination_scope,
+            &cursor.index,
+        )?;
+        self.release_v1_to_v2_migration_pin(&cursor.source_pin, cursor.source_head)
+            .await?;
+        self.cleanup_commit_closure(&cursor.closure, limit).await
+    }
+
+    pub async fn v1_to_v2_migration_mapping(
+        &self,
+        cursor: &V1ToV2MigrationCursor,
+        source: CommitId,
+    ) -> Result<Option<CommitIdV2>> {
+        self.validate_commit_closure_cursor(&cursor.closure)?;
+        let index = self.commit_closure_index(cursor.closure.traversal)?;
+        index.install_root(cursor.closure.state.root.clone())?;
+        index
+            .engine
+            .get(&index.tree()?, &v1_to_v2_mapping_key(source))
+            .await?
+            .map(|bytes| decode_canonical(&bytes))
+            .transpose()
+    }
+
+    async fn release_v1_to_v2_migration_pin(&self, name: &str, expected: CommitId) -> Result<()> {
+        match self.delete_retention_pin(name, expected).await {
+            Ok(()) => Ok(()),
+            Err(error)
+                if matches!(
+                    error.code,
+                    ErrorCode::InvalidRevision | ErrorCode::PreconditionFailed
+                ) =>
+            {
+                let path = retention_pin_path(&self.options.repository_prefix, name)?;
+                let Some(stored) = self.plane.load_mutable(&path).await? else {
+                    return Err(error);
+                };
+                let pin: RetentionPinV1 = decode_canonical(&stored.bytes)?;
+                if pin.target == expected && pin.tombstone {
+                    Ok(())
+                } else {
+                    Err(error)
+                }
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn validate_v1_to_v2_migration_pin(&self, name: &str, expected: CommitId) -> Result<()> {
+        let path = retention_pin_path(&self.options.repository_prefix, name)?;
+        let stored = self.plane.load_mutable(&path).await?.ok_or_else(|| {
+            Error::new(
+                ErrorCode::MissingClosure,
+                "v1-to-v2 migration source retention pin is missing",
+            )
+        })?;
+        let pin: RetentionPinV1 = decode_canonical(&stored.bytes)?;
+        if pin.target != expected
+            || pin.tombstone
+            || (pin.expires_at_millis != 0 && pin.expires_at_millis <= self.now_millis()?)
+        {
+            return Err(Error::new(
+                ErrorCode::MissingClosure,
+                "v1-to-v2 migration source retention pin is not active",
+            ));
+        }
+        Ok(())
     }
 
     /// Start an interruptible physical clone/fetch/push/repair transfer.
@@ -12356,6 +12794,12 @@ fn commit_closure_seen_key(commit: CommitId) -> Vec<u8> {
 
 fn commit_closure_mapping_key(commit: CommitId) -> Vec<u8> {
     let mut key = b"m/".to_vec();
+    key.extend_from_slice(commit.as_bytes());
+    key
+}
+
+fn v1_to_v2_mapping_key(commit: CommitId) -> Vec<u8> {
+    let mut key = b"v2m/".to_vec();
     key.extend_from_slice(commit.as_bytes());
     key
 }

--- a/extensions/s3/core/src/repository.rs
+++ b/extensions/s3/core/src/repository.rs
@@ -887,11 +887,11 @@ impl<P: ObjectPlane> NodeLocator for ProllyNodeIndex<P> {
     }
 }
 
-pub struct WriterLeaseMaintenance {
+pub struct ShardAuthorityMaintenance {
     task: tokio::task::JoinHandle<()>,
 }
 
-impl Drop for WriterLeaseMaintenance {
+impl Drop for ShardAuthorityMaintenance {
     fn drop(&mut self) {
         self.task.abort();
     }
@@ -2357,7 +2357,7 @@ impl<P: ObjectPlane> Repository<P> {
     /// Renew every cached branch/system authority permit. The repository-wide
     /// v1 lease is renewed only when this instance was opened through the
     /// legacy migration adapter.
-    pub async fn renew_writer_lease(&self) -> Result<()> {
+    pub async fn renew_shard_authorities(&self) -> Result<()> {
         let _authority_renewal = self.authority_renewal.lock().await;
         if self
             .writer_lease
@@ -2395,6 +2395,14 @@ impl<P: ObjectPlane> Repository<P> {
         }
         let _renewal = self.lease_renewal.lock().await;
         self.renew_writer_lease_inner().await
+    }
+
+    #[deprecated(
+        since = "0.1.0",
+        note = "use renew_shard_authorities; this name is retained for source compatibility"
+    )]
+    pub async fn renew_writer_lease(&self) -> Result<()> {
+        self.renew_shard_authorities().await
     }
 
     async fn renew_writer_lease_inner(&self) -> Result<()> {
@@ -2464,11 +2472,13 @@ impl<P: ObjectPlane> Repository<P> {
     /// Run independent shard-authority renewal until the returned handle is
     /// dropped. A failed or ambiguous renewal fences the affected writer
     /// instance before the task exits.
-    pub fn start_writer_lease_maintenance(self: &Arc<Self>) -> Result<WriterLeaseMaintenance> {
+    pub fn start_shard_authority_maintenance(
+        self: &Arc<Self>,
+    ) -> Result<ShardAuthorityMaintenance> {
         if self.options.read_only {
             return Err(Error::new(
                 ErrorCode::MissingCapability,
-                "writer lease maintenance requires a writable physical repository",
+                "shard-authority maintenance requires a writable repository",
             ));
         }
         let interval = Duration::from_millis((self.options.writer_lease_millis / 3).max(100));
@@ -2479,12 +2489,20 @@ impl<P: ObjectPlane> Repository<P> {
                 let Some(repository) = weak.upgrade() else {
                     break;
                 };
-                if repository.renew_writer_lease().await.is_err() {
+                if repository.renew_shard_authorities().await.is_err() {
                     break;
                 }
             }
         });
-        Ok(WriterLeaseMaintenance { task })
+        Ok(ShardAuthorityMaintenance { task })
+    }
+
+    #[deprecated(
+        since = "0.1.0",
+        note = "use start_shard_authority_maintenance; this name is retained for source compatibility"
+    )]
+    pub fn start_writer_lease_maintenance(self: &Arc<Self>) -> Result<ShardAuthorityMaintenance> {
+        self.start_shard_authority_maintenance()
     }
 
     /// Continuously advance the rebuildable v2 node index outside foreground
@@ -2637,6 +2655,10 @@ impl<P: ObjectPlane> Repository<P> {
 
     /// Legacy repository-wide takeover adapter. New deployments should call
     /// `takeover_branch_writer` independently for each authority shard.
+    #[deprecated(
+        since = "0.1.0",
+        note = "use takeover_branch_writer independently for each branch authority scope"
+    )]
     pub async fn takeover_physical_writer(
         &mut self,
         expected_writer: &str,

--- a/extensions/s3/core/src/repository.rs
+++ b/extensions/s3/core/src/repository.rs
@@ -892,6 +892,12 @@ pub struct ShardAuthorityMaintenance {
     task: tokio::task::JoinHandle<()>,
 }
 
+impl ShardAuthorityMaintenance {
+    pub(crate) fn from_task(task: tokio::task::JoinHandle<()>) -> Self {
+        Self { task }
+    }
+}
+
 impl Drop for ShardAuthorityMaintenance {
     fn drop(&mut self) {
         self.task.abort();

--- a/extensions/s3/core/src/repository_v2.rs
+++ b/extensions/s3/core/src/repository_v2.rs
@@ -16,7 +16,8 @@ use crate::store::{LocatedPackedNode, NodeCacheNamespace, NodeLocator, PreparedN
 use crate::{
     decode_canonical, encode_canonical, tree_format_digest, AuthorityPermitV2, AuthorityScopeV2,
     BucketCommitV2, BucketDeltaV2, BucketStateV2, CanonicalLimits, Checksums, Clock,
-    CommitGeneration, CommitIdV2, CommitObjectV2, CommitPublicationV2, CompareExchange,
+    CommitGeneration, CommitIdV2, CommitObjectV2, CommitPublicationV2, CommitSessionCheckpointV2,
+    CommitSessionCleanupReportV2, CommitSessionStateV2, CommitSessionStoreV2, CompareExchange,
     CompareExchangeOutcome, CurrentObjectV2, Error, ErrorCode, GetRequest, IdSource,
     IdempotencyRetentionV2, ImmutablePayloadStoreV2, InitializationIntentV2,
     JournalDerivedIndexesV2, JournalIndexAdvanceReportV2, LogicalObjectVersionBodyV1,
@@ -155,6 +156,7 @@ pub struct RepositoryV2<P: ObjectPlane> {
     authority: Arc<ShardWriterAuthorityV2<P>>,
     publisher: ShardedBranchPublisherV2<P>,
     payloads: ImmutablePayloadStoreV2<P>,
+    commit_sessions: CommitSessionStoreV2<P>,
     operation_index: SegmentedOperationIndexV2<P>,
     journal_indexes: Arc<JournalDerivedIndexesV2<P>>,
     locator: Arc<JournalNodeLocator<P>>,
@@ -374,6 +376,12 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             options.repository_prefix.clone(),
             format.repository_id,
         );
+        let commit_sessions = CommitSessionStoreV2::new(
+            plane.clone(),
+            options.repository_prefix.clone(),
+            format.repository_id,
+            format.canonical_limits.max_mutations_per_commit as usize,
+        )?;
         let operation_index = SegmentedOperationIndexV2::new_with_limits(
             plane.clone(),
             options.repository_prefix.clone(),
@@ -407,6 +415,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             authority,
             publisher,
             payloads,
+            commit_sessions,
             operation_index,
             journal_indexes,
             locator,
@@ -527,6 +536,120 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         Ok(session)
     }
 
+    pub async fn begin_durable_commit_session(
+        &self,
+        branch: &str,
+        message: impl Into<String>,
+        expires_after_millis: u64,
+    ) -> Result<CommitSessionCheckpointV2> {
+        let session = self
+            .begin_commit_session(branch, message, expires_after_millis)
+            .await?;
+        let checkpoint = CommitSessionCheckpointV2 {
+            session,
+            sequence: 0,
+            mutations: Vec::new(),
+            state: CommitSessionStateV2::Open,
+        };
+        self.commit_sessions.save(&checkpoint).await?;
+        Ok(checkpoint)
+    }
+
+    pub async fn checkpoint_commit_session(
+        &self,
+        session: &PhysicalBatchV2,
+        mutations: Vec<StagedMutationV2>,
+        sequence: u64,
+    ) -> Result<CommitSessionCheckpointV2> {
+        self.validate_commit_session(session).await?;
+        let checkpoint = CommitSessionCheckpointV2 {
+            session: session.clone(),
+            sequence,
+            mutations: self.canonical_session_mutations(mutations, true)?,
+            state: CommitSessionStateV2::Open,
+        };
+        self.commit_sessions.save(&checkpoint).await?;
+        Ok(checkpoint)
+    }
+
+    /// Resume the newest durable checkpoint and adopt it into this process's
+    /// current branch-authority epoch. Adoption is allowed only while the
+    /// original base commit is still the branch head.
+    pub async fn resume_commit_session(
+        &self,
+        batch: crate::BatchId,
+    ) -> Result<CommitSessionCheckpointV2> {
+        let mut checkpoint = self.commit_sessions.latest(batch).await?.ok_or_else(|| {
+            Error::new(
+                ErrorCode::InvalidRequest,
+                "protocol-v2 commit session does not exist",
+            )
+        })?;
+        if checkpoint.state != CommitSessionStateV2::Open {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "protocol-v2 commit session was aborted",
+            ));
+        }
+        let now = self.options.clock.now_millis()?;
+        if checkpoint.session.expires_at_millis < now {
+            return Err(Error::new(
+                ErrorCode::BatchExpired,
+                "protocol-v2 commit session expired",
+            ));
+        }
+        let permit = self.active_permit(&checkpoint.session.branch, now).await?;
+        if checkpoint.session.identity.authority.writer_id != permit.stamp().writer_id {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "another writer cannot adopt a durable protocol-v2 commit session",
+            )
+            .operation(checkpoint.session.identity.operation.to_string()));
+        }
+        let current = self.publisher.load(&checkpoint.session.branch).await?;
+        if current.value.target != checkpoint.session.base_commit {
+            return Err(Error::new(
+                ErrorCode::BatchConflict,
+                "protocol-v2 branch moved since the durable session checkpoint",
+            )
+            .operation(checkpoint.session.identity.operation.to_string()));
+        }
+        if checkpoint.session.identity.authority != permit.stamp() {
+            checkpoint.sequence = checkpoint.sequence.checked_add(1).ok_or_else(|| {
+                Error::new(ErrorCode::InvalidLimit, "v2 checkpoint sequence overflow")
+            })?;
+            checkpoint.session.identity.authority = permit.stamp();
+            self.commit_sessions.save(&checkpoint).await?;
+        }
+        Ok(checkpoint)
+    }
+
+    pub async fn abort_commit_session(
+        &self,
+        session: PhysicalBatchV2,
+        mutations: Vec<StagedMutationV2>,
+        sequence: u64,
+    ) -> Result<()> {
+        self.validate_commit_session(&session).await?;
+        let checkpoint = CommitSessionCheckpointV2 {
+            session,
+            sequence,
+            mutations: self.canonical_session_mutations(mutations, true)?,
+            state: CommitSessionStateV2::Aborted,
+        };
+        self.commit_sessions.save(&checkpoint).await
+    }
+
+    pub async fn cleanup_expired_commit_sessions(
+        &self,
+        continuation: Option<String>,
+        limit: usize,
+    ) -> Result<CommitSessionCleanupReportV2> {
+        self.commit_sessions
+            .cleanup_expired_page(self.options.clock.now_millis()?, continuation, limit)
+            .await
+    }
+
     pub async fn stage_commit_session_put(
         &self,
         session: &PhysicalBatchV2,
@@ -611,26 +734,18 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         mutations: Vec<StagedMutationV2>,
     ) -> Result<CommitReceiptV2> {
         session.validate(self.format.repository_id)?;
-        if mutations.is_empty()
-            || mutations.len() > self.format.canonical_limits.max_mutations_per_commit as usize
-            || session.expires_at_millis < self.options.clock.now_millis()?
-        {
+        if session.expires_at_millis < self.options.clock.now_millis()? {
             return Err(Error::new(
-                ErrorCode::InvalidRequest,
-                "protocol-v2 commit session is empty, expired, or exceeds the mutation limit",
+                ErrorCode::BatchExpired,
+                "protocol-v2 commit session is expired",
             ));
         }
-        let mut ordered = BTreeMap::new();
-        for mutation in mutations {
-            self.validate_key(mutation.key())?;
-            if ordered.insert(mutation.key().to_vec(), mutation).is_some() {
-                return Err(Error::new(
-                    ErrorCode::InvalidRequest,
-                    "protocol-v2 commit session contains the same key more than once",
-                ));
-            }
-        }
-        let canonical_mutations = ordered.values().cloned().collect::<Vec<_>>();
+        let canonical_mutations = self.canonical_session_mutations(mutations, false)?;
+        let ordered = canonical_mutations
+            .iter()
+            .cloned()
+            .map(|mutation| (mutation.key().to_vec(), mutation))
+            .collect::<BTreeMap<_, _>>();
         let input_digest = crate::model::derive_input_digest_v2(&[
             b"commit-session",
             session.branch.as_bytes(),
@@ -700,19 +815,6 @@ impl<P: ObjectPlane> RepositoryV2<P> {
                         binding,
                         ..
                     } = staged.as_ref();
-                    binding.validate()?;
-                    let expected_etag =
-                        checksums.md5.map(|md5| format!("\"{}\"", hex::encode(md5)));
-                    if *size > self.format.canonical_limits.max_object_bytes
-                        || binding.path != self.payloads.path(binding.checksum_sha256)?
-                        || checksums.sha256 != Some(binding.checksum_sha256)
-                        || expected_etag.as_deref() != Some(logical_etag)
-                    {
-                        return Err(Error::new(
-                            ErrorCode::ChecksumMismatch,
-                            "staged v2 payload identity does not match its immutable binding",
-                        ));
-                    }
                     (
                         LogicalObjectVersionKindV1::Live {
                             size: *size,
@@ -868,6 +970,54 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             return Err(Error::new(
                 ErrorCode::PreconditionFailed,
                 "protocol-v2 commit session belongs to another authority epoch",
+            ));
+        }
+        Ok(())
+    }
+
+    fn canonical_session_mutations(
+        &self,
+        mutations: Vec<StagedMutationV2>,
+        allow_empty: bool,
+    ) -> Result<Vec<StagedMutationV2>> {
+        if (!allow_empty && mutations.is_empty())
+            || mutations.len() > self.format.canonical_limits.max_mutations_per_commit as usize
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "protocol-v2 commit session has an invalid mutation count",
+            ));
+        }
+        let mut ordered = BTreeMap::new();
+        for mutation in mutations {
+            self.validate_key(mutation.key())?;
+            if let StagedMutationBodyV2::Put(staged) = &mutation.body {
+                self.validate_staged_put(staged)?;
+            }
+            if ordered.insert(mutation.key().to_vec(), mutation).is_some() {
+                return Err(Error::new(
+                    ErrorCode::InvalidRequest,
+                    "protocol-v2 commit session contains the same key more than once",
+                ));
+            }
+        }
+        Ok(ordered.into_values().collect())
+    }
+
+    fn validate_staged_put(&self, staged: &StagedPutV2) -> Result<()> {
+        staged.binding.validate()?;
+        let expected_etag = staged
+            .checksums
+            .md5
+            .map(|md5| format!("\"{}\"", hex::encode(md5)));
+        if staged.size > self.format.canonical_limits.max_object_bytes
+            || staged.binding.path != self.payloads.path(staged.binding.checksum_sha256)?
+            || staged.checksums.sha256 != Some(staged.binding.checksum_sha256)
+            || expected_etag.as_deref() != Some(staged.logical_etag.as_str())
+        {
+            return Err(Error::new(
+                ErrorCode::ChecksumMismatch,
+                "staged v2 payload identity does not match its immutable binding",
             ));
         }
         Ok(())

--- a/extensions/s3/core/src/repository_v2.rs
+++ b/extensions/s3/core/src/repository_v2.rs
@@ -20,14 +20,15 @@ use crate::{
     CommitSessionCleanupReportV2, CommitSessionStateV2, CommitSessionStoreV2, CompareExchange,
     CompareExchangeOutcome, CurrentObjectV2, Error, ErrorCode, GetRequest, IdSource,
     IdempotencyRetentionV2, ImmutablePayloadStoreV2, InitializationIntentV2,
-    JournalDerivedIndexesV2, JournalIndexAdvanceReportV2, LoadedRefV2, LogicalObjectVersionBodyV1,
-    LogicalObjectVersionKindV1, MemoryNodeCache, NodeCache, ObjectHeaders, ObjectPath, ObjectPlane,
-    ObjectTransitionV2, ObjectVersionIdV2, ObjectVersionOrder, ObjectVersionV2, OperationId,
-    OperationIndexAdvanceReportV2, PhysicalBatchV2, PhysicalMutationIdentityV2, ProllyObjectStore,
-    ProviderPerKeyVersionLimitV2, RandomIdSource, RefGeneration, RepositoryFormatV2, Result,
-    SegmentedOperationIndexV2, ShardWriterAuthorityV2, ShardedBranchPublisherV2,
-    StagedMutationBodyV2, StagedMutationV2, StagedPutV2, SystemClock, TakeoverRequestV2,
-    TreeRootV1,
+    JournalDerivedIndexesV2, JournalIndexAdvanceReportV2, JournalIndexRebuildCleanupV2,
+    JournalIndexRebuildCursorV2, JournalIndexRebuildStepV2, LoadedRefV2,
+    LogicalObjectVersionBodyV1, LogicalObjectVersionKindV1, MemoryNodeCache, NodeCache,
+    ObjectHeaders, ObjectPath, ObjectPlane, ObjectTransitionV2, ObjectVersionIdV2,
+    ObjectVersionOrder, ObjectVersionV2, OperationId, OperationIndexAdvanceReportV2,
+    PhysicalBatchV2, PhysicalMutationIdentityV2, ProllyObjectStore, ProviderPerKeyVersionLimitV2,
+    RandomIdSource, RefGeneration, RepositoryFormatV2, Result, SegmentedOperationIndexV2,
+    ShardWriterAuthorityV2, ShardedBranchPublisherV2, StagedMutationBodyV2, StagedMutationV2,
+    StagedPutV2, SystemClock, TakeoverRequestV2, TreeRootV1,
 };
 
 #[derive(Clone)]
@@ -44,6 +45,7 @@ pub struct RepositoryV2Options {
     pub max_cached_node_bytes: usize,
     pub node_cache: Option<Arc<dyn NodeCache>>,
     pub mutable_control_versions_to_retain: usize,
+    pub journal_index_max_unindexed_events: usize,
     pub idempotency_retention: IdempotencyRetentionV2,
     pub provider_per_key_version_limit: ProviderPerKeyVersionLimitV2,
     pub clock: Arc<dyn Clock>,
@@ -65,6 +67,7 @@ impl Default for RepositoryV2Options {
             max_cached_node_bytes: 64 * 1024 * 1024,
             node_cache: None,
             mutable_control_versions_to_retain: crate::DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,
+            journal_index_max_unindexed_events: crate::DEFAULT_JOURNAL_INDEX_MAX_UNINDEXED_EVENTS,
             idempotency_retention: IdempotencyRetentionV2::default(),
             provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Unknown,
             clock: Arc::new(SystemClock),
@@ -432,7 +435,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             format.repository_id,
             format.state_tree_format.clone(),
             node_cache,
-            crate::DEFAULT_JOURNAL_INDEX_MAX_UNINDEXED_EVENTS,
+            options.journal_index_max_unindexed_events,
             options.mutable_control_versions_to_retain,
         )?);
         let locator = Arc::new(JournalNodeLocator {
@@ -1595,6 +1598,52 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         Ok(report)
     }
 
+    pub async fn start_branch_index_rebuild(
+        &self,
+        branch: &str,
+    ) -> Result<JournalIndexRebuildCursorV2> {
+        self.locator.register(branch)?;
+        let _lane = self.lock_index_branch(branch).await;
+        self.journal_indexes
+            .start_rebuild(&self.publisher, branch, self.options.ids.operation())
+            .await
+    }
+
+    pub async fn advance_branch_index_rebuild(
+        &self,
+        cursor: &JournalIndexRebuildCursorV2,
+        max_events: usize,
+    ) -> Result<JournalIndexRebuildStepV2> {
+        self.locator.register(&cursor.branch)?;
+        let _lane = self.lock_index_branch(&cursor.branch).await;
+        let step = self
+            .journal_indexes
+            .advance_rebuild(
+                &self.publisher,
+                cursor,
+                max_events,
+                self.options.clock.now_millis()?,
+            )
+            .await?;
+        if step.complete {
+            self.index_errors
+                .write()
+                .map_err(|_| {
+                    Error::new(ErrorCode::InternalInvariant, "v2 index-error lock poisoned")
+                })?
+                .remove(&cursor.branch);
+        }
+        Ok(step)
+    }
+
+    pub async fn cleanup_branch_index_rebuild(
+        &self,
+        cursor: &JournalIndexRebuildCursorV2,
+        limit: usize,
+    ) -> Result<JournalIndexRebuildCleanupV2> {
+        self.journal_indexes.cleanup_rebuild(cursor, limit).await
+    }
+
     pub async fn branch_index_health(&self, branch: &str) -> Result<BranchIndexHealthV2> {
         self.locator.register(branch)?;
         let reference = self.publisher.load(branch).await?;
@@ -2083,6 +2132,7 @@ fn validate_options(options: &RepositoryV2Options) -> Result<()> {
         || options.max_cached_node_locations == 0
         || options.max_cached_node_bytes == 0
         || options.mutable_control_versions_to_retain < 2
+        || !(1..=1_000_000).contains(&options.journal_index_max_unindexed_events)
     {
         return Err(Error::new(
             ErrorCode::InvalidRequest,

--- a/extensions/s3/core/src/repository_v2.rs
+++ b/extensions/s3/core/src/repository_v2.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::{Arc, RwLock, Weak},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, RwLock, Weak,
+    },
     time::Duration,
 };
 
@@ -18,9 +21,9 @@ use crate::{
     JournalDerivedIndexesV2, JournalIndexAdvanceReportV2, LogicalObjectVersionBodyV1,
     LogicalObjectVersionKindV1, MemoryNodeCache, NodeCache, ObjectHeaders, ObjectPath, ObjectPlane,
     ObjectTransitionV2, ObjectVersionIdV2, ObjectVersionOrder, ObjectVersionV2, OperationId,
-    OperationIndexAdvanceReportV2, ProllyObjectStore, RandomIdSource, RepositoryFormatV2, Result,
-    SegmentedOperationIndexV2, ShardWriterAuthorityV2, ShardedBranchPublisherV2, SystemClock,
-    TakeoverRequestV2, TreeRootV1,
+    OperationIndexAdvanceReportV2, ProllyObjectStore, ProviderPerKeyVersionLimitV2, RandomIdSource,
+    RepositoryFormatV2, Result, SegmentedOperationIndexV2, ShardWriterAuthorityV2,
+    ShardedBranchPublisherV2, SystemClock, TakeoverRequestV2, TreeRootV1,
 };
 
 #[derive(Clone)]
@@ -38,6 +41,7 @@ pub struct RepositoryV2Options {
     pub node_cache: Option<Arc<dyn NodeCache>>,
     pub mutable_control_versions_to_retain: usize,
     pub idempotency_retention: IdempotencyRetentionV2,
+    pub provider_per_key_version_limit: ProviderPerKeyVersionLimitV2,
     pub clock: Arc<dyn Clock>,
     pub ids: Arc<dyn IdSource>,
 }
@@ -58,6 +62,7 @@ impl Default for RepositoryV2Options {
             node_cache: None,
             mutable_control_versions_to_retain: crate::DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,
             idempotency_retention: IdempotencyRetentionV2::default(),
+            provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Unknown,
             clock: Arc::new(SystemClock),
             ids: Arc::new(RandomIdSource),
         }
@@ -127,6 +132,7 @@ impl<P: ObjectPlane> NodeLocator for JournalNodeLocator<P> {
 /// bindings, or operation trees. Migration is implemented as an explicit
 /// logical clone into a separately initialized v2 repository.
 pub struct RepositoryV2<P: ObjectPlane> {
+    plane: Arc<P>,
     options: RepositoryV2Options,
     format: RepositoryFormatV2,
     node_store: ProllyObjectStore<P>,
@@ -138,6 +144,7 @@ pub struct RepositoryV2<P: ObjectPlane> {
     locator: Arc<JournalNodeLocator<P>>,
     permits: RwLock<BTreeMap<String, AuthorityPermitV2>>,
     publication_lanes: std::sync::Mutex<BTreeMap<String, Weak<tokio::sync::Mutex<()>>>>,
+    writable: AtomicBool,
 }
 
 impl<P: ObjectPlane> RepositoryV2<P> {
@@ -159,6 +166,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             state_tree_format: options.state_tree_format.clone(),
             canonical_limits: options.limits.clone(),
             idempotency_retention: options.idempotency_retention,
+            provider_per_key_version_limit: options.provider_per_key_version_limit,
             min_reader_version: RepositoryFormatV2::PROLLY_S3_PROTOCOL_VERSION,
             min_writer_version: RepositoryFormatV2::PROLLY_S3_PROTOCOL_VERSION,
             created_at_millis,
@@ -358,7 +366,9 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             branches: RwLock::new(BTreeSet::new()),
         });
         node_store.set_node_locator(locator.clone())?;
+        let writable = !options.read_only;
         Ok(Self {
+            plane,
             options,
             format,
             node_store,
@@ -370,11 +380,20 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             locator,
             permits: RwLock::new(BTreeMap::new()),
             publication_lanes: std::sync::Mutex::new(BTreeMap::new()),
+            writable: AtomicBool::new(writable),
         })
     }
 
     pub fn format(&self) -> &RepositoryFormatV2 {
         &self.format
+    }
+
+    pub fn repository_id(&self) -> crate::RepositoryId {
+        self.format.repository_id
+    }
+
+    pub fn plane(&self) -> Arc<P> {
+        self.plane.clone()
     }
 
     pub async fn head(&self, branch: &str) -> Result<CommitIdV2> {
@@ -387,13 +406,13 @@ impl<P: ObjectPlane> RepositoryV2<P> {
     /// Open read-only before takeover so no existing local permit or derived
     /// client can race the branch-ref barrier.
     pub async fn takeover_branch_writer(
-        &mut self,
+        &self,
         branch: &str,
         expected_writer: &str,
         expected_generation: u64,
         handoff_evidence: &str,
     ) -> Result<u64> {
-        if !self.options.read_only {
+        if self.writable.load(Ordering::Acquire) {
             return Err(Error::new(
                 ErrorCode::PreconditionFailed,
                 "protocol-v2 takeover requires a read-only repository handle",
@@ -433,7 +452,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             .activate_after_barrier(pending, applied.into_barrier(), now)
             .await?;
         self.install_permit(branch, permit)?;
-        self.options.read_only = false;
+        self.writable.store(true, Ordering::Release);
         Ok(generation)
     }
 
@@ -459,7 +478,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         user_metadata: BTreeMap<String, String>,
         operation: OperationId,
     ) -> Result<CommitReceiptV2> {
-        if self.options.read_only {
+        if !self.writable.load(Ordering::Acquire) {
             return Err(Error::new(
                 ErrorCode::PreconditionFailed,
                 "protocol-v2 repository is read-only",
@@ -872,6 +891,9 @@ impl<P: ObjectPlane> RepositoryV2<P> {
 fn validate_options(options: &RepositoryV2Options) -> Result<()> {
     crate::repository::validate_branch(&options.default_branch)?;
     options.idempotency_retention.validate()?;
+    options
+        .provider_per_key_version_limit
+        .validate_immutable_payload_profile(options.mutable_control_versions_to_retain)?;
     if options.repository_prefix.is_empty()
         || options.repository_prefix.ends_with('/')
         || options.writer.trim().is_empty()
@@ -909,6 +931,7 @@ fn validate_format_compatibility(
     if format.state_tree_format != options.state_tree_format
         || format.canonical_limits != options.limits
         || format.idempotency_retention != options.idempotency_retention
+        || format.provider_per_key_version_limit != options.provider_per_key_version_limit
     {
         return Err(Error::new(
             ErrorCode::RepositoryFormatConflict,

--- a/extensions/s3/core/src/repository_v2.rs
+++ b/extensions/s3/core/src/repository_v2.rs
@@ -1,0 +1,943 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::{Arc, RwLock, Weak},
+    time::Duration,
+};
+
+use md5::{Digest as _, Md5};
+use prolly::{AsyncProlly, Config, RuntimeConfig, Tree, TreeFormat};
+use sha2::Sha256;
+
+use crate::store::{LocatedPackedNode, NodeCacheNamespace, NodeLocator, PreparedNodePack};
+use crate::{
+    decode_canonical, encode_canonical, tree_format_digest, AuthorityPermitV2, AuthorityScopeV2,
+    BucketCommitV2, BucketDeltaV2, BucketStateV2, CanonicalLimits, Checksums, Clock,
+    CommitGeneration, CommitIdV2, CommitObjectV2, CommitPublicationV2, CompareExchange,
+    CompareExchangeOutcome, CurrentObjectV2, Error, ErrorCode, GetRequest, IdSource,
+    IdempotencyRetentionV2, ImmutablePayloadStoreV2, InitializationIntentV2,
+    JournalDerivedIndexesV2, JournalIndexAdvanceReportV2, LogicalObjectVersionBodyV1,
+    LogicalObjectVersionKindV1, MemoryNodeCache, NodeCache, ObjectHeaders, ObjectPath, ObjectPlane,
+    ObjectTransitionV2, ObjectVersionIdV2, ObjectVersionOrder, ObjectVersionV2, OperationId,
+    OperationIndexAdvanceReportV2, ProllyObjectStore, RandomIdSource, RepositoryFormatV2, Result,
+    SegmentedOperationIndexV2, ShardWriterAuthorityV2, ShardedBranchPublisherV2, SystemClock,
+    TakeoverRequestV2, TreeRootV1,
+};
+
+#[derive(Clone)]
+pub struct RepositoryV2Options {
+    pub repository_prefix: String,
+    pub default_branch: String,
+    pub writer: String,
+    pub limits: CanonicalLimits,
+    pub state_tree_format: TreeFormat,
+    pub authority_lease_millis: u64,
+    pub read_only: bool,
+    pub max_cached_node_pack_bytes: usize,
+    pub max_cached_node_locations: usize,
+    pub max_cached_node_bytes: usize,
+    pub node_cache: Option<Arc<dyn NodeCache>>,
+    pub mutable_control_versions_to_retain: usize,
+    pub idempotency_retention: IdempotencyRetentionV2,
+    pub clock: Arc<dyn Clock>,
+    pub ids: Arc<dyn IdSource>,
+}
+
+impl Default for RepositoryV2Options {
+    fn default() -> Self {
+        Self {
+            repository_prefix: ".prolly/v2".to_string(),
+            default_branch: "main".to_string(),
+            writer: "anonymous".to_string(),
+            limits: CanonicalLimits::default(),
+            state_tree_format: TreeFormat::default(),
+            authority_lease_millis: 60_000,
+            read_only: false,
+            max_cached_node_pack_bytes: 64 * 1024 * 1024,
+            max_cached_node_locations: 65_536,
+            max_cached_node_bytes: 64 * 1024 * 1024,
+            node_cache: None,
+            mutable_control_versions_to_retain: crate::DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,
+            idempotency_retention: IdempotencyRetentionV2::default(),
+            clock: Arc::new(SystemClock),
+            ids: Arc::new(RandomIdSource),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CommitReceiptV2 {
+    pub id: CommitIdV2,
+    pub operation: OperationId,
+    pub branch: String,
+    pub parents: Vec<CommitIdV2>,
+    pub changed_keys: u64,
+    pub object_versions: Vec<ObjectVersionIdV2>,
+    pub idempotent_replay: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObjectDataV2 {
+    pub key: Vec<u8>,
+    pub version: ObjectVersionV2,
+    pub bytes: Vec<u8>,
+    pub snapshot: CommitIdV2,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BranchIndexAdvanceReportV2 {
+    pub operations: OperationIndexAdvanceReportV2,
+    pub journal: JournalIndexAdvanceReportV2,
+}
+
+struct JournalNodeLocator<P: ObjectPlane> {
+    indexes: Arc<JournalDerivedIndexesV2<P>>,
+    branches: RwLock<BTreeSet<String>>,
+}
+
+impl<P: ObjectPlane> JournalNodeLocator<P> {
+    fn register(&self, branch: &str) -> Result<()> {
+        self.branches
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 locator lock poisoned"))?
+            .insert(branch.to_string());
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl<P: ObjectPlane> NodeLocator for JournalNodeLocator<P> {
+    async fn locate(&self, cid: &prolly::Cid) -> Result<Option<LocatedPackedNode>> {
+        let branches = self
+            .branches
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 locator lock poisoned"))?
+            .clone();
+        for branch in branches {
+            if let Some(entry) = self.indexes.node_location(&branch, cid).await? {
+                return Ok(Some(entry.into()));
+            }
+        }
+        Ok(None)
+    }
+}
+
+/// Native protocol-v2 repository.
+///
+/// This type never reads or writes v1 format markers, refs, commits, payload
+/// bindings, or operation trees. Migration is implemented as an explicit
+/// logical clone into a separately initialized v2 repository.
+pub struct RepositoryV2<P: ObjectPlane> {
+    options: RepositoryV2Options,
+    format: RepositoryFormatV2,
+    node_store: ProllyObjectStore<P>,
+    authority: Arc<ShardWriterAuthorityV2<P>>,
+    publisher: ShardedBranchPublisherV2<P>,
+    payloads: ImmutablePayloadStoreV2<P>,
+    operation_index: SegmentedOperationIndexV2<P>,
+    journal_indexes: Arc<JournalDerivedIndexesV2<P>>,
+    locator: Arc<JournalNodeLocator<P>>,
+    permits: RwLock<BTreeMap<String, AuthorityPermitV2>>,
+    publication_lanes: std::sync::Mutex<BTreeMap<String, Weak<tokio::sync::Mutex<()>>>>,
+}
+
+impl<P: ObjectPlane> RepositoryV2<P> {
+    pub async fn initialize(plane: Arc<P>, options: RepositoryV2Options) -> Result<Self> {
+        validate_options(&options)?;
+        if options.read_only {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "cannot initialize a protocol-v2 repository read-only",
+            ));
+        }
+        let format_path = format_path(&options.repository_prefix)?;
+        let operation = options.ids.operation();
+        let created_at_millis = options.clock.now_millis()?;
+        let repository_id = crate::model::derive_repository_id_v2(operation);
+        let proposed_format = RepositoryFormatV2 {
+            repository_id,
+            format_version: RepositoryFormatV2::VERSION,
+            state_tree_format: options.state_tree_format.clone(),
+            canonical_limits: options.limits.clone(),
+            idempotency_retention: options.idempotency_retention,
+            min_reader_version: RepositoryFormatV2::PROLLY_S3_PROTOCOL_VERSION,
+            min_writer_version: RepositoryFormatV2::PROLLY_S3_PROTOCOL_VERSION,
+            created_at_millis,
+            required_capability_profile: RepositoryFormatV2::PROLLY_S3_CAPABILITY_PROFILE,
+        };
+        let proposed_intent = InitializationIntentV2 {
+            repository_id,
+            format: proposed_format,
+            operation,
+        };
+        let intent_bytes = encode_canonical(&proposed_intent)?;
+        let intent = match plane
+            .compare_exchange(CompareExchange {
+                path: intent_path(&options.repository_prefix)?,
+                expected: None,
+                bytes: intent_bytes,
+            })
+            .await?
+        {
+            CompareExchangeOutcome::Applied(_) => proposed_intent,
+            CompareExchangeOutcome::Conflict(Some(existing)) => decode_canonical(&existing.bytes)?,
+            CompareExchangeOutcome::Conflict(None) => {
+                return Err(Error::new(
+                    ErrorCode::RefConflict,
+                    "v2 initialization intent create returned an empty conflict",
+                ))
+            }
+        };
+        validate_format_compatibility(&intent.format, &options)?;
+
+        // Advertise the v2 repository before creating any v2 ref or commit.
+        let format_bytes = encode_canonical(&intent.format)?;
+        match plane
+            .compare_exchange(CompareExchange {
+                path: format_path,
+                expected: None,
+                bytes: format_bytes.clone(),
+            })
+            .await?
+        {
+            CompareExchangeOutcome::Applied(_) => {}
+            CompareExchangeOutcome::Conflict(Some(existing)) if existing.bytes == format_bytes => {}
+            CompareExchangeOutcome::Conflict(_) => {
+                return Err(Error::new(
+                    ErrorCode::RepositoryFormatConflict,
+                    "a different protocol-v2 repository format already exists",
+                ))
+            }
+        }
+
+        let repository = Self::from_format(plane, options, intent.format)?;
+        let default_branch = repository.options.default_branch.clone();
+        match repository.publisher.load(&default_branch).await {
+            Ok(_) => {
+                repository.locator.register(&default_branch)?;
+                repository.register_unindexed_tail(&default_branch).await?;
+                return Ok(repository);
+            }
+            Err(error) if error.code == ErrorCode::InvalidRevision => {}
+            Err(error) => return Err(error),
+        }
+        let now_millis = repository.options.clock.now_millis()?;
+        let permit = repository
+            .authority
+            .acquire(
+                AuthorityScopeV2::Branch {
+                    name: default_branch.clone(),
+                },
+                &repository.options.writer,
+                now_millis,
+                repository.options.ids.operation(),
+            )
+            .await?;
+        repository.install_permit(&default_branch, permit.clone())?;
+
+        let empty = repository.engine(repository.node_store.clone()).create();
+        let repository_created_at = repository.format.created_at_millis;
+        let commit = BucketCommitV2 {
+            state: BucketStateV2 {
+                objects: TreeRootV1::from_tree(&empty)?,
+                versions: TreeRootV1::from_tree(&empty)?,
+            },
+            parents: Vec::new(),
+            generation: CommitGeneration(0),
+            delta: BucketDeltaV2 {
+                input_digest: crate::model::derive_input_digest_v2(&[b"initialize"]),
+                changes: Vec::new(),
+            },
+            node_pack: None,
+            authority: permit.stamp(),
+            author: repository.options.writer.clone(),
+            message: Some("initialize native protocol-v2 repository".to_string()),
+            created_at_millis: repository_created_at,
+            metadata: BTreeMap::new(),
+        };
+        repository
+            .publisher
+            .create(CommitPublicationV2 {
+                permit: &permit,
+                branch: &default_branch,
+                commit: &commit,
+                node_pack: None,
+                operation: intent.operation,
+                message: "initialize",
+                now_millis,
+            })
+            .await?;
+        repository.locator.register(&default_branch)?;
+        repository.advance_branch_indexes(&default_branch).await?;
+        Ok(repository)
+    }
+
+    pub async fn open(plane: Arc<P>, options: RepositoryV2Options) -> Result<Self> {
+        validate_options(&options)?;
+        let stored = plane
+            .get(GetRequest {
+                path: format_path(&options.repository_prefix)?,
+                range: None,
+                physical_version: None,
+            })
+            .await?
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::RepositoryNotInitialized,
+                    "protocol-v2 repository format marker does not exist",
+                )
+            })?;
+        let format: RepositoryFormatV2 = decode_canonical(&stored.bytes)?;
+        validate_format_compatibility(&format, &options)?;
+        let repository = Self::from_format(plane, options, format)?;
+        let branch = repository.options.default_branch.clone();
+        repository.locator.register(&branch)?;
+        repository.register_unindexed_tail(&branch).await?;
+        Ok(repository)
+    }
+
+    fn from_format(
+        plane: Arc<P>,
+        options: RepositoryV2Options,
+        format: RepositoryFormatV2,
+    ) -> Result<Self> {
+        let node_cache = options.node_cache.clone().unwrap_or_else(|| {
+            Arc::new(MemoryNodeCache::new(options.max_cached_node_bytes)) as Arc<dyn NodeCache>
+        });
+        let node_store = ProllyObjectStore::new_packed_v2_with_node_cache(
+            plane.clone(),
+            options.repository_prefix.clone(),
+            options.max_cached_node_pack_bytes,
+            options.max_cached_node_locations,
+            NodeCacheNamespace {
+                repository: format.repository_id,
+                protocol_version: RepositoryFormatV2::PROLLY_S3_PROTOCOL_VERSION,
+                tree_format: tree_format_digest(&format.state_tree_format)?,
+            },
+            node_cache.clone(),
+        );
+        let authority = Arc::new(ShardWriterAuthorityV2::new_with_control_retention(
+            plane.clone(),
+            options.repository_prefix.clone(),
+            format.repository_id,
+            Duration::from_millis(options.authority_lease_millis),
+            options.mutable_control_versions_to_retain,
+        )?);
+        let publisher = ShardedBranchPublisherV2::new_with_control_retention(
+            plane.clone(),
+            options.repository_prefix.clone(),
+            format.repository_id,
+            authority.clone(),
+            options.mutable_control_versions_to_retain,
+        )?;
+        let payloads = ImmutablePayloadStoreV2::new(
+            plane.clone(),
+            options.repository_prefix.clone(),
+            format.repository_id,
+        );
+        let operation_index = SegmentedOperationIndexV2::new_with_limits(
+            plane.clone(),
+            options.repository_prefix.clone(),
+            format.repository_id,
+            format.idempotency_retention,
+            crate::DEFAULT_OPERATION_INDEX_LEAF_ENTRIES,
+            crate::DEFAULT_OPERATION_INDEX_MERGE_FANOUT,
+            crate::DEFAULT_OPERATION_INDEX_MAX_UNINDEXED_EVENTS,
+            options.mutable_control_versions_to_retain,
+        )?;
+        let journal_indexes = Arc::new(JournalDerivedIndexesV2::new_with_limits(
+            plane.clone(),
+            options.repository_prefix.clone(),
+            format.repository_id,
+            format.state_tree_format.clone(),
+            node_cache,
+            crate::DEFAULT_JOURNAL_INDEX_MAX_UNINDEXED_EVENTS,
+            options.mutable_control_versions_to_retain,
+        )?);
+        let locator = Arc::new(JournalNodeLocator {
+            indexes: journal_indexes.clone(),
+            branches: RwLock::new(BTreeSet::new()),
+        });
+        node_store.set_node_locator(locator.clone())?;
+        Ok(Self {
+            options,
+            format,
+            node_store,
+            authority,
+            publisher,
+            payloads,
+            operation_index,
+            journal_indexes,
+            locator,
+            permits: RwLock::new(BTreeMap::new()),
+            publication_lanes: std::sync::Mutex::new(BTreeMap::new()),
+        })
+    }
+
+    pub fn format(&self) -> &RepositoryFormatV2 {
+        &self.format
+    }
+
+    pub async fn head(&self, branch: &str) -> Result<CommitIdV2> {
+        self.locator.register(branch)?;
+        Ok(self.publisher.load(branch).await?.value.target)
+    }
+
+    /// Explicitly transfer one branch shard to this repository process.
+    ///
+    /// Open read-only before takeover so no existing local permit or derived
+    /// client can race the branch-ref barrier.
+    pub async fn takeover_branch_writer(
+        &mut self,
+        branch: &str,
+        expected_writer: &str,
+        expected_generation: u64,
+        handoff_evidence: &str,
+    ) -> Result<u64> {
+        if !self.options.read_only {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "protocol-v2 takeover requires a read-only repository handle",
+            ));
+        }
+        let _lane = self.lock_branch(branch).await;
+        let now = self.options.clock.now_millis()?;
+        let pending = self
+            .authority
+            .begin_takeover(TakeoverRequestV2 {
+                scope: AuthorityScopeV2::Branch {
+                    name: branch.to_string(),
+                },
+                expected_writer: expected_writer.to_string(),
+                expected_generation,
+                next_writer: self.options.writer.clone(),
+                handoff_evidence: handoff_evidence.to_string(),
+                now_millis: now,
+                nonce: self.options.ids.operation(),
+            })
+            .await?;
+        let generation = pending.stamp().generation;
+        let current = self.publisher.load(branch).await?;
+        let applied = self
+            .publisher
+            .publish_takeover_barrier(
+                branch,
+                current,
+                &pending,
+                self.options.ids.operation(),
+                "branch authority takeover",
+                now,
+            )
+            .await?;
+        let permit = self
+            .authority
+            .activate_after_barrier(pending, applied.into_barrier(), now)
+            .await?;
+        self.install_permit(branch, permit)?;
+        self.options.read_only = false;
+        Ok(generation)
+    }
+
+    pub async fn put_object(
+        &self,
+        branch: &str,
+        key: Vec<u8>,
+        bytes: Vec<u8>,
+        headers: ObjectHeaders,
+        user_metadata: BTreeMap<String, String>,
+    ) -> Result<CommitReceiptV2> {
+        let operation = self.options.ids.operation();
+        self.put_object_with_operation(branch, key, bytes, headers, user_metadata, operation)
+            .await
+    }
+
+    pub async fn put_object_with_operation(
+        &self,
+        branch: &str,
+        key: Vec<u8>,
+        bytes: Vec<u8>,
+        headers: ObjectHeaders,
+        user_metadata: BTreeMap<String, String>,
+        operation: OperationId,
+    ) -> Result<CommitReceiptV2> {
+        if self.options.read_only {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "protocol-v2 repository is read-only",
+            ));
+        }
+        self.validate_key(&key)?;
+        if bytes.len() as u64 > self.format.canonical_limits.max_object_bytes {
+            return Err(Error::new(
+                ErrorCode::EntityTooLarge,
+                "v2 object exceeds the repository object-size limit",
+            ));
+        }
+        let metadata_bytes = encode_canonical(&user_metadata)?;
+        let headers_bytes = encode_canonical(&headers)?;
+        let size = bytes.len() as u64;
+        let checksum_md5: [u8; 16] = Md5::digest(&bytes).into();
+        let checksum_sha256: [u8; 32] = Sha256::digest(&bytes).into();
+        let input_digest = crate::model::derive_input_digest_v2(&[
+            b"put",
+            branch.as_bytes(),
+            &key,
+            &checksum_sha256,
+            &headers_bytes,
+            &metadata_bytes,
+        ]);
+        let _lane = self.lock_branch(branch).await;
+        let now = self.options.clock.now_millis()?;
+        if let Some(receipt) = self
+            .reconcile_operation(branch, operation, input_digest, now)
+            .await?
+        {
+            return Ok(receipt);
+        }
+        let permit = self.active_permit(branch, now).await?;
+        // The authority check happens before payload bytes enter the object
+        // plane. A stale process therefore fails before its payload PUT.
+        self.authority.validate_active(&permit, now).await?;
+        let binding = self.payloads.put(bytes).await?;
+
+        let current = self.publisher.load(branch).await?;
+        let base = self.load_commit_object(current.value.target).await?.commit;
+        let write_store = self.node_store.isolated_write_session();
+        let engine = self.engine(write_store.clone());
+        let mut objects = self.tree_from_root(&base.state.objects)?;
+        let mut versions = self.tree_from_root(&base.state.versions)?;
+        let previous = engine
+            .get(&objects, &key)
+            .await?
+            .map(|encoded| decode_canonical::<CurrentObjectV2>(&encoded))
+            .transpose()?
+            .map(|current| current.version.id);
+        let generation = CommitGeneration(base.generation.0.checked_add(1).ok_or_else(|| {
+            Error::new(
+                ErrorCode::InternalInvariant,
+                "v2 commit generation overflow",
+            )
+        })?);
+        let body = LogicalObjectVersionBodyV1 {
+            order: ObjectVersionOrder {
+                commit_generation: generation,
+                mutation_ordinal: 0,
+            },
+            created_at_millis: now,
+            kind: LogicalObjectVersionKindV1::Live {
+                size,
+                logical_etag: format!("\"{}\"", hex::encode(checksum_md5)),
+                headers,
+                checksums: Checksums {
+                    md5: Some(checksum_md5),
+                    sha256: Some(checksum_sha256),
+                    algorithm_values: BTreeMap::new(),
+                },
+                user_metadata,
+                tags: BTreeMap::new(),
+            },
+        };
+        let version = ObjectVersionV2::derive(
+            self.format.repository_id,
+            &key,
+            operation,
+            body,
+            Some(binding),
+        )?;
+        objects = engine
+            .put(
+                &objects,
+                key.clone(),
+                encode_canonical(&CurrentObjectV2 {
+                    version: version.clone(),
+                })?,
+            )
+            .await?;
+        versions = engine
+            .put(
+                &versions,
+                version_tree_key(&key, version.body.order, version.id),
+                encode_canonical(&version)?,
+            )
+            .await?;
+        let prepared = write_store.prepare_node_pack(
+            tree_format_digest(&self.format.state_tree_format)?,
+            Vec::new(),
+        )?;
+        let node_pack = prepared.as_ref().map(PreparedNodePack::reference);
+        let commit = BucketCommitV2 {
+            state: BucketStateV2 {
+                objects: TreeRootV1::from_tree(&objects)?,
+                versions: TreeRootV1::from_tree(&versions)?,
+            },
+            parents: vec![current.value.target],
+            generation,
+            delta: BucketDeltaV2 {
+                input_digest,
+                changes: vec![ObjectTransitionV2 {
+                    key: key.clone(),
+                    previous,
+                    next: version.id,
+                    delete_marker: false,
+                }],
+            },
+            node_pack,
+            authority: permit.stamp(),
+            author: self.options.writer.clone(),
+            message: Some("PutObject".to_string()),
+            created_at_millis: now,
+            metadata: BTreeMap::new(),
+        };
+        let published = self
+            .publisher
+            .store_and_publish(
+                current,
+                CommitPublicationV2 {
+                    permit: &permit,
+                    branch,
+                    commit: &commit,
+                    node_pack: prepared.as_ref().map(PreparedNodePack::pack),
+                    operation,
+                    message: "PutObject",
+                    now_millis: now,
+                },
+            )
+            .await?;
+        self.finalize_pack(published.value.target, &commit, prepared)
+            .await?;
+        Ok(CommitReceiptV2 {
+            id: published.value.target,
+            operation,
+            branch: branch.to_string(),
+            parents: commit.parents,
+            changed_keys: 1,
+            object_versions: vec![version.id],
+            idempotent_replay: false,
+        })
+    }
+
+    pub async fn get_object(&self, branch: &str, key: &[u8]) -> Result<Option<ObjectDataV2>> {
+        self.validate_key(key)?;
+        self.locator.register(branch)?;
+        self.register_unindexed_tail(branch).await?;
+        let reference = self.publisher.load(branch).await?;
+        let commit = self
+            .load_commit_object(reference.value.target)
+            .await?
+            .commit;
+        let objects = self.tree_from_root(&commit.state.objects)?;
+        let Some(encoded) = self
+            .engine(self.node_store.clone())
+            .get(&objects, key)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let current: CurrentObjectV2 = decode_canonical(&encoded)?;
+        current.version.validate()?;
+        let binding = current.version.binding.as_ref().ok_or_else(|| {
+            Error::new(
+                ErrorCode::CorruptCommit,
+                "live v2 object has no immutable payload binding",
+            )
+        })?;
+        let bytes = self.payloads.get(binding).await?;
+        Ok(Some(ObjectDataV2 {
+            key: key.to_vec(),
+            version: current.version,
+            bytes,
+            snapshot: reference.value.target,
+        }))
+    }
+
+    pub async fn advance_branch_indexes(&self, branch: &str) -> Result<BranchIndexAdvanceReportV2> {
+        self.locator.register(branch)?;
+        let now = self.options.clock.now_millis()?;
+        let operations = self
+            .operation_index
+            .advance(&self.publisher, branch, now)
+            .await?;
+        let journal = self
+            .journal_indexes
+            .advance(&self.publisher, branch, now)
+            .await?;
+        Ok(BranchIndexAdvanceReportV2 {
+            operations,
+            journal,
+        })
+    }
+
+    async fn reconcile_operation(
+        &self,
+        branch: &str,
+        operation: OperationId,
+        input_digest: [u8; 32],
+        now: u64,
+    ) -> Result<Option<CommitReceiptV2>> {
+        let Some(indexed) = self
+            .operation_index
+            .lookup(&self.publisher, branch, operation, now)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let commit = self.load_commit_object(indexed.target).await?.commit;
+        if commit.delta.input_digest != input_digest {
+            return Err(Error::new(
+                ErrorCode::IdempotencyConflict,
+                "protocol-v2 operation ID was reused with different input",
+            )
+            .operation(operation.to_string()));
+        }
+        Ok(Some(CommitReceiptV2 {
+            id: indexed.target,
+            operation,
+            branch: branch.to_string(),
+            parents: commit.parents,
+            changed_keys: commit.delta.changes.len() as u64,
+            object_versions: commit
+                .delta
+                .changes
+                .iter()
+                .map(|change| change.next)
+                .collect(),
+            idempotent_replay: true,
+        }))
+    }
+
+    async fn active_permit(&self, branch: &str, now: u64) -> Result<AuthorityPermitV2> {
+        let permit = self
+            .permits
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 permit lock poisoned"))?
+            .get(branch)
+            .cloned()
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::PreconditionFailed,
+                    "no active local authority permit for this v2 branch; explicitly take over or create the branch",
+                )
+            })?;
+        self.authority.validate_active(&permit, now).await?;
+        Ok(permit)
+    }
+
+    fn install_permit(&self, branch: &str, permit: AuthorityPermitV2) -> Result<()> {
+        self.permits
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 permit lock poisoned"))?
+            .insert(branch.to_string(), permit);
+        Ok(())
+    }
+
+    async fn register_unindexed_tail(&self, branch: &str) -> Result<()> {
+        let reference = self.publisher.load(branch).await?;
+        let checkpoint = self
+            .journal_indexes
+            .head(branch)
+            .await?
+            .map(|head| head.checkpoint);
+        let mut cursor = Some(self.publisher.open_journal(branch).await?);
+        let mut reached_checkpoint = checkpoint.is_none();
+        let mut visited = 0usize;
+        while let Some(current) = cursor {
+            let page = self.publisher.read_journal_page(&current, 256).await?;
+            for entry in page.entries {
+                if checkpoint == Some(entry.id) {
+                    reached_checkpoint = true;
+                    break;
+                }
+                self.load_commit_object(entry.event.new_target).await?;
+                visited += 1;
+                if visited > crate::DEFAULT_JOURNAL_INDEX_MAX_UNINDEXED_EVENTS {
+                    return Err(Error::new(
+                        ErrorCode::HistoryLimitExceeded,
+                        "v2 node-index journal tail exceeds its bounded foreground recovery limit",
+                    ));
+                }
+            }
+            if reached_checkpoint {
+                break;
+            }
+            cursor = page.continuation;
+        }
+        if checkpoint.is_some() && !reached_checkpoint {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "v2 journal index checkpoint is not reachable from the branch ref",
+            ));
+        }
+        // A generation-zero repository intentionally has no earlier indexed
+        // history. Register its commit pack directly.
+        if checkpoint.is_none() && reference.value.generation.0 == 0 {
+            self.load_commit_object(reference.value.target).await?;
+        } else if checkpoint.is_none() {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "v2 journal indexes were not initialized with branch creation",
+            ));
+        }
+        Ok(())
+    }
+
+    async fn load_commit_object(&self, id: CommitIdV2) -> Result<CommitObjectV2> {
+        let object = self.publisher.load_commit_object(id).await?;
+        let encoded = object.encode_object()?;
+        self.node_store
+            .register_commit_object_v2(id, &object, &encoded)?;
+        Ok(object)
+    }
+
+    async fn finalize_pack(
+        &self,
+        id: CommitIdV2,
+        commit: &BucketCommitV2,
+        prepared: Option<PreparedNodePack>,
+    ) -> Result<()> {
+        let Some(prepared) = prepared else {
+            return Ok(());
+        };
+        let object = CommitObjectV2::new(commit.clone(), Some(prepared.pack().clone()))?;
+        let encoded = object.encode_object()?;
+        let offset = CommitObjectV2::node_payload_offset(&encoded)?.ok_or_else(|| {
+            Error::new(
+                ErrorCode::InternalInvariant,
+                "prepared v2 node pack has no payload offset",
+            )
+        })?;
+        self.node_store
+            .commit_node_pack_v2(id, prepared, offset)
+            .await
+    }
+
+    fn engine(&self, store: ProllyObjectStore<P>) -> AsyncProlly<ProllyObjectStore<P>> {
+        AsyncProlly::new(
+            store,
+            Config {
+                format: self.format.state_tree_format.clone(),
+                runtime: RuntimeConfig::default(),
+            },
+        )
+    }
+
+    fn tree_from_root(&self, root: &TreeRootV1) -> Result<Tree> {
+        if root.format_digest != tree_format_digest(&self.format.state_tree_format)? {
+            return Err(Error::new(
+                ErrorCode::CorruptNode,
+                "protocol-v2 state root uses another tree format",
+            ));
+        }
+        Ok(Tree {
+            root: root.root.clone(),
+            config: Config {
+                format: self.format.state_tree_format.clone(),
+                runtime: RuntimeConfig::default(),
+            },
+        })
+    }
+
+    fn validate_key(&self, key: &[u8]) -> Result<()> {
+        if key.is_empty()
+            || key.len() > self.format.canonical_limits.max_key_bytes as usize
+            || std::str::from_utf8(key).is_err()
+            || key.starts_with(self.options.repository_prefix.as_bytes())
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidKey,
+                "logical key violates the protocol-v2 key contract",
+            ));
+        }
+        ObjectPath::new(std::str::from_utf8(key).expect("validated UTF-8"))?;
+        Ok(())
+    }
+
+    async fn lock_branch(&self, branch: &str) -> tokio::sync::OwnedMutexGuard<()> {
+        let lane = {
+            let mut lanes = self
+                .publication_lanes
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            lanes.retain(|_, lane| lane.strong_count() > 0);
+            if let Some(lane) = lanes.get(branch).and_then(Weak::upgrade) {
+                lane
+            } else {
+                let lane = Arc::new(tokio::sync::Mutex::new(()));
+                lanes.insert(branch.to_string(), Arc::downgrade(&lane));
+                lane
+            }
+        };
+        lane.lock_owned().await
+    }
+}
+
+fn validate_options(options: &RepositoryV2Options) -> Result<()> {
+    crate::repository::validate_branch(&options.default_branch)?;
+    options.idempotency_retention.validate()?;
+    if options.repository_prefix.is_empty()
+        || options.repository_prefix.ends_with('/')
+        || options.writer.trim().is_empty()
+        || !(10_000..=86_400_000).contains(&options.authority_lease_millis)
+        || options.max_cached_node_pack_bytes == 0
+        || options.max_cached_node_locations == 0
+        || options.max_cached_node_bytes == 0
+        || options.mutable_control_versions_to_retain < 2
+    {
+        return Err(Error::new(
+            ErrorCode::InvalidRequest,
+            "protocol-v2 repository options are invalid",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_format_compatibility(
+    format: &RepositoryFormatV2,
+    options: &RepositoryV2Options,
+) -> Result<()> {
+    if format.format_version != RepositoryFormatV2::VERSION
+        || format.required_capability_profile != RepositoryFormatV2::PROLLY_S3_CAPABILITY_PROFILE
+        || format.min_reader_version == 0
+        || format.min_writer_version == 0
+        || format.min_reader_version > RepositoryFormatV2::CURRENT_READER_VERSION
+        || format.min_writer_version > RepositoryFormatV2::CURRENT_WRITER_VERSION
+    {
+        return Err(Error::new(
+            ErrorCode::UnsupportedRepositoryFormat,
+            "repository is not a supported native protocol-v2 repository",
+        ));
+    }
+    format.idempotency_retention.validate()?;
+    if format.state_tree_format != options.state_tree_format
+        || format.canonical_limits != options.limits
+        || format.idempotency_retention != options.idempotency_retention
+    {
+        return Err(Error::new(
+            ErrorCode::RepositoryFormatConflict,
+            "protocol-v2 format does not match the requested canonical settings",
+        ));
+    }
+    Ok(())
+}
+
+fn format_path(prefix: &str) -> Result<ObjectPath> {
+    ObjectPath::new(format!("{prefix}/format/v2.cbor"))
+}
+
+fn intent_path(prefix: &str) -> Result<ObjectPath> {
+    ObjectPath::new(format!("{prefix}/format/initialization-v2.cbor"))
+}
+
+fn version_tree_key(key: &[u8], order: ObjectVersionOrder, version: ObjectVersionIdV2) -> Vec<u8> {
+    let mut output = Vec::with_capacity(key.len() + 2 + 8 + 4 + 32);
+    for byte in key {
+        if *byte == 0 {
+            output.extend_from_slice(&[0, 0xff]);
+        } else {
+            output.push(*byte);
+        }
+    }
+    output.extend_from_slice(&[0, 0]);
+    output.extend(order.commit_generation.0.to_be_bytes().map(|byte| !byte));
+    output.extend(order.mutation_ordinal.to_be_bytes().map(|byte| !byte));
+    output.extend(version.as_bytes().iter().map(|byte| !byte));
+    output
+}

--- a/extensions/s3/core/src/repository_v2.rs
+++ b/extensions/s3/core/src/repository_v2.rs
@@ -89,6 +89,19 @@ pub struct ObjectDataV2 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObjectSummaryV2 {
+    pub key: Vec<u8>,
+    pub version: ObjectVersionV2,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VersionSummaryV2 {
+    pub key: Vec<u8>,
+    pub version: ObjectVersionV2,
+    pub cursor: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BranchIndexAdvanceReportV2 {
     pub operations: OperationIndexAdvanceReportV2,
     pub journal: JournalIndexAdvanceReportV2,
@@ -668,6 +681,312 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         }))
     }
 
+    pub async fn get_object_at(
+        &self,
+        branch: &str,
+        snapshot: CommitIdV2,
+        key: &[u8],
+    ) -> Result<Option<ObjectDataV2>> {
+        self.validate_key(key)?;
+        self.locator.register(branch)?;
+        self.register_unindexed_tail(branch).await?;
+        let commit = self.load_commit_object(snapshot).await?.commit;
+        let objects = self.tree_from_root(&commit.state.objects)?;
+        let Some(encoded) = self
+            .engine(self.node_store.clone())
+            .get(&objects, key)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let current: CurrentObjectV2 = decode_canonical(&encoded)?;
+        current.version.validate()?;
+        let binding = current.version.binding.as_ref().ok_or_else(|| {
+            Error::new(
+                ErrorCode::CorruptCommit,
+                "live historical v2 object has no immutable payload binding",
+            )
+        })?;
+        let bytes = self.payloads.get(binding).await?;
+        Ok(Some(ObjectDataV2 {
+            key: key.to_vec(),
+            version: current.version,
+            bytes,
+            snapshot,
+        }))
+    }
+
+    pub async fn delete_object(&self, branch: &str, key: Vec<u8>) -> Result<CommitReceiptV2> {
+        let operation = self.options.ids.operation();
+        self.delete_object_with_operation(branch, key, operation)
+            .await
+    }
+
+    pub async fn delete_object_with_operation(
+        &self,
+        branch: &str,
+        key: Vec<u8>,
+        operation: OperationId,
+    ) -> Result<CommitReceiptV2> {
+        if !self.writable.load(Ordering::Acquire) {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "protocol-v2 repository is read-only",
+            ));
+        }
+        self.validate_key(&key)?;
+        let input_digest =
+            crate::model::derive_input_digest_v2(&[b"delete", branch.as_bytes(), &key]);
+        let _lane = self.lock_branch(branch).await;
+        let now = self.options.clock.now_millis()?;
+        if let Some(receipt) = self
+            .reconcile_operation(branch, operation, input_digest, now)
+            .await?
+        {
+            return Ok(receipt);
+        }
+        let permit = self.active_permit(branch, now).await?;
+        self.authority.validate_active(&permit, now).await?;
+        let current = self.publisher.load(branch).await?;
+        let base = self.load_commit_object(current.value.target).await?.commit;
+        let write_store = self.node_store.isolated_write_session();
+        let engine = self.engine(write_store.clone());
+        let mut objects = self.tree_from_root(&base.state.objects)?;
+        let mut versions = self.tree_from_root(&base.state.versions)?;
+        let previous = engine
+            .get(&objects, &key)
+            .await?
+            .map(|encoded| decode_canonical::<CurrentObjectV2>(&encoded))
+            .transpose()?
+            .map(|current| current.version.id);
+        let generation = CommitGeneration(base.generation.0.checked_add(1).ok_or_else(|| {
+            Error::new(
+                ErrorCode::InternalInvariant,
+                "v2 commit generation overflow",
+            )
+        })?);
+        let version = ObjectVersionV2::derive(
+            self.format.repository_id,
+            &key,
+            operation,
+            LogicalObjectVersionBodyV1 {
+                order: ObjectVersionOrder {
+                    commit_generation: generation,
+                    mutation_ordinal: 0,
+                },
+                created_at_millis: now,
+                kind: LogicalObjectVersionKindV1::DeleteMarker,
+            },
+            None,
+        )?;
+        objects = engine.delete(&objects, &key).await?;
+        versions = engine
+            .put(
+                &versions,
+                version_tree_key(&key, version.body.order, version.id),
+                encode_canonical(&version)?,
+            )
+            .await?;
+        let prepared = write_store.prepare_node_pack(
+            tree_format_digest(&self.format.state_tree_format)?,
+            Vec::new(),
+        )?;
+        let commit = BucketCommitV2 {
+            state: BucketStateV2 {
+                objects: TreeRootV1::from_tree(&objects)?,
+                versions: TreeRootV1::from_tree(&versions)?,
+            },
+            parents: vec![current.value.target],
+            generation,
+            delta: BucketDeltaV2 {
+                input_digest,
+                changes: vec![ObjectTransitionV2 {
+                    key: key.clone(),
+                    previous,
+                    next: version.id,
+                    delete_marker: true,
+                }],
+            },
+            node_pack: prepared.as_ref().map(PreparedNodePack::reference),
+            authority: permit.stamp(),
+            author: self.options.writer.clone(),
+            message: Some("DeleteObject".to_string()),
+            created_at_millis: now,
+            metadata: BTreeMap::new(),
+        };
+        let published = self
+            .publisher
+            .store_and_publish(
+                current,
+                CommitPublicationV2 {
+                    permit: &permit,
+                    branch,
+                    commit: &commit,
+                    node_pack: prepared.as_ref().map(PreparedNodePack::pack),
+                    operation,
+                    message: "DeleteObject",
+                    now_millis: now,
+                },
+            )
+            .await?;
+        self.finalize_pack(published.value.target, &commit, prepared)
+            .await?;
+        Ok(CommitReceiptV2 {
+            id: published.value.target,
+            operation,
+            branch: branch.to_string(),
+            parents: commit.parents,
+            changed_keys: 1,
+            object_versions: vec![version.id],
+            idempotent_replay: false,
+        })
+    }
+
+    pub async fn list_objects(
+        &self,
+        branch: &str,
+        prefix: &[u8],
+        after: Option<&[u8]>,
+        limit: usize,
+    ) -> Result<(CommitIdV2, Vec<ObjectSummaryV2>, bool)> {
+        std::str::from_utf8(prefix)
+            .map_err(|_| Error::new(ErrorCode::InvalidKey, "v2 list prefix is not UTF-8"))?;
+        let snapshot = self.head(branch).await?;
+        let (objects, truncated) = self
+            .list_objects_at(branch, snapshot, prefix, after, limit)
+            .await?;
+        Ok((snapshot, objects, truncated))
+    }
+
+    pub async fn list_objects_at(
+        &self,
+        branch: &str,
+        snapshot: CommitIdV2,
+        prefix: &[u8],
+        after: Option<&[u8]>,
+        limit: usize,
+    ) -> Result<(Vec<ObjectSummaryV2>, bool)> {
+        std::str::from_utf8(prefix)
+            .map_err(|_| Error::new(ErrorCode::InvalidKey, "v2 list prefix is not UTF-8"))?;
+        let limit = limit.min(self.format.canonical_limits.max_list_page as usize);
+        if limit == 0 {
+            return Ok((Vec::new(), false));
+        }
+        self.locator.register(branch)?;
+        self.register_unindexed_tail(branch).await?;
+        let commit = self.load_commit_object(snapshot).await?.commit;
+        let objects = self.tree_from_root(&commit.state.objects)?;
+        let engine = self.engine(self.node_store.clone());
+        let mut iter = engine.prefix(&objects, prefix).await?;
+        let mut result = Vec::with_capacity(limit);
+        while result.len() <= limit {
+            let Some(entry) = iter.next().await else {
+                break;
+            };
+            let (key, encoded) = entry?;
+            if after.is_some_and(|after| key.as_slice() <= after) {
+                continue;
+            }
+            let current: CurrentObjectV2 = decode_canonical(&encoded)?;
+            current.version.validate()?;
+            result.push(ObjectSummaryV2 {
+                key,
+                version: current.version,
+            });
+        }
+        let truncated = result.len() > limit;
+        result.truncate(limit);
+        Ok((result, truncated))
+    }
+
+    pub async fn list_object_versions(
+        &self,
+        branch: &str,
+        key: &[u8],
+        limit: usize,
+    ) -> Result<(CommitIdV2, Vec<ObjectVersionV2>)> {
+        self.validate_key(key)?;
+        let limit = limit.min(self.format.canonical_limits.max_list_page as usize);
+        let snapshot = self.head(branch).await?;
+        self.locator.register(branch)?;
+        self.register_unindexed_tail(branch).await?;
+        let commit = self.load_commit_object(snapshot).await?.commit;
+        let versions = self.tree_from_root(&commit.state.versions)?;
+        let prefix = version_tree_prefix(key);
+        let engine = self.engine(self.node_store.clone());
+        let mut iter = engine.prefix(&versions, &prefix).await?;
+        let mut result = Vec::with_capacity(limit);
+        while result.len() < limit {
+            let Some(entry) = iter.next().await else {
+                break;
+            };
+            let (_, encoded) = entry?;
+            let version: ObjectVersionV2 = decode_canonical(&encoded)?;
+            version.validate()?;
+            result.push(version);
+        }
+        Ok((snapshot, result))
+    }
+
+    pub async fn list_versions_prefix(
+        &self,
+        branch: &str,
+        prefix: &[u8],
+        limit: usize,
+    ) -> Result<(CommitIdV2, Vec<VersionSummaryV2>)> {
+        std::str::from_utf8(prefix)
+            .map_err(|_| Error::new(ErrorCode::InvalidKey, "v2 version prefix is not UTF-8"))?;
+        let snapshot = self.head(branch).await?;
+        let (versions, _) = self
+            .list_versions_at(branch, snapshot, prefix, None, limit)
+            .await?;
+        Ok((snapshot, versions))
+    }
+
+    pub async fn list_versions_at(
+        &self,
+        branch: &str,
+        snapshot: CommitIdV2,
+        prefix: &[u8],
+        after: Option<&[u8]>,
+        limit: usize,
+    ) -> Result<(Vec<VersionSummaryV2>, bool)> {
+        std::str::from_utf8(prefix)
+            .map_err(|_| Error::new(ErrorCode::InvalidKey, "v2 version prefix is not UTF-8"))?;
+        let limit = limit.min(self.format.canonical_limits.max_list_page as usize);
+        if limit == 0 {
+            return Ok((Vec::new(), false));
+        }
+        self.locator.register(branch)?;
+        self.register_unindexed_tail(branch).await?;
+        let commit = self.load_commit_object(snapshot).await?.commit;
+        let versions = self.tree_from_root(&commit.state.versions)?;
+        let encoded_prefix = version_tree_partial_prefix(prefix);
+        let engine = self.engine(self.node_store.clone());
+        let mut iter = engine.prefix(&versions, &encoded_prefix).await?;
+        let mut result = Vec::with_capacity(limit);
+        while result.len() <= limit {
+            let Some(entry) = iter.next().await else {
+                break;
+            };
+            let (encoded_key, encoded) = entry?;
+            if after.is_some_and(|after| encoded_key.as_slice() <= after) {
+                continue;
+            }
+            let key = decode_version_tree_logical_key(&encoded_key)?;
+            let version: ObjectVersionV2 = decode_canonical(&encoded)?;
+            version.validate()?;
+            result.push(VersionSummaryV2 {
+                key,
+                version,
+                cursor: encoded_key,
+            });
+        }
+        let truncated = result.len() > limit;
+        result.truncate(limit);
+        Ok((result, truncated))
+    }
+
     pub async fn advance_branch_indexes(&self, branch: &str) -> Result<BranchIndexAdvanceReportV2> {
         self.locator.register(branch)?;
         let now = self.options.clock.now_millis()?;
@@ -950,7 +1269,22 @@ fn intent_path(prefix: &str) -> Result<ObjectPath> {
 }
 
 fn version_tree_key(key: &[u8], order: ObjectVersionOrder, version: ObjectVersionIdV2) -> Vec<u8> {
-    let mut output = Vec::with_capacity(key.len() + 2 + 8 + 4 + 32);
+    let mut output = version_tree_prefix(key);
+    output.reserve(8 + 4 + 32);
+    output.extend(order.commit_generation.0.to_be_bytes().map(|byte| !byte));
+    output.extend(order.mutation_ordinal.to_be_bytes().map(|byte| !byte));
+    output.extend(version.as_bytes().iter().map(|byte| !byte));
+    output
+}
+
+fn version_tree_prefix(key: &[u8]) -> Vec<u8> {
+    let mut output = version_tree_partial_prefix(key);
+    output.extend_from_slice(&[0, 0]);
+    output
+}
+
+fn version_tree_partial_prefix(key: &[u8]) -> Vec<u8> {
+    let mut output = Vec::with_capacity(key.len() + 2);
     for byte in key {
         if *byte == 0 {
             output.extend_from_slice(&[0, 0xff]);
@@ -958,9 +1292,33 @@ fn version_tree_key(key: &[u8], order: ObjectVersionOrder, version: ObjectVersio
             output.push(*byte);
         }
     }
-    output.extend_from_slice(&[0, 0]);
-    output.extend(order.commit_generation.0.to_be_bytes().map(|byte| !byte));
-    output.extend(order.mutation_ordinal.to_be_bytes().map(|byte| !byte));
-    output.extend(version.as_bytes().iter().map(|byte| !byte));
     output
+}
+
+fn decode_version_tree_logical_key(encoded: &[u8]) -> Result<Vec<u8>> {
+    let mut key = Vec::new();
+    let mut index = 0;
+    while index < encoded.len() {
+        match encoded[index] {
+            0 if encoded.get(index + 1) == Some(&0) => return Ok(key),
+            0 if encoded.get(index + 1) == Some(&0xff) => {
+                key.push(0);
+                index += 2;
+            }
+            0 => {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "noncanonical v2 version-tree key escape",
+                ))
+            }
+            byte => {
+                key.push(byte);
+                index += 1;
+            }
+        }
+    }
+    Err(Error::new(
+        ErrorCode::CorruptCommit,
+        "unterminated v2 version-tree logical key",
+    ))
 }

--- a/extensions/s3/core/src/repository_v2.rs
+++ b/extensions/s3/core/src/repository_v2.rs
@@ -16,16 +16,17 @@ use sha2::Sha256;
 use crate::store::{LocatedPackedNode, NodeCacheNamespace, NodeLocator, PreparedNodePack};
 use crate::{
     decode_canonical, encode_canonical, tree_format_digest, AuthorityPermitV2, AuthorityScopeV2,
-    BucketCommitV2, BucketDeltaV2, BucketStateV2, CanonicalLimits, Checksums, Clock,
-    CommitGeneration, CommitIdV2, CommitObjectV2, CommitPublicationV2, CommitSessionCheckpointV2,
-    CommitSessionCleanupReportV2, CommitSessionStateV2, CommitSessionStoreV2, CompareExchange,
-    CompareExchangeOutcome, CurrentObjectV2, Error, ErrorCode, GetRequest, IdSource,
-    IdempotencyRetentionV2, ImmutablePayloadStoreV2, InitializationIntentV2,
-    JournalDerivedIndexesV2, JournalIndexAdvanceReportV2, JournalIndexRebuildCleanupV2,
-    JournalIndexRebuildCursorV2, JournalIndexRebuildPhaseV2, JournalIndexRebuildStepV2,
-    ListRequest, LoadedRefV2, LogicalObjectVersionBodyV1, LogicalObjectVersionKindV1,
-    MemoryNodeCache, NodeCache, ObjectHeaders, ObjectPath, ObjectPlane, ObjectTransitionV2,
-    ObjectVersionIdV2, ObjectVersionOrder, ObjectVersionV2, OperationId,
+    BucketCommitV1, BucketCommitV2, BucketDeltaV2, BucketStateV2, CanonicalLimits, Checksums,
+    Clock, CommitGeneration, CommitId, CommitIdV2, CommitObjectV2, CommitPublicationV2,
+    CommitSessionCheckpointV2, CommitSessionCleanupReportV2, CommitSessionStateV2,
+    CommitSessionStoreV2, CompareExchange, CompareExchangeOutcome, CurrentObjectV2, Error,
+    ErrorCode, GetRequest, IdSource, IdempotencyRetentionV2, ImmutablePayloadStoreV2,
+    ImportedJournalIndexStateV2, InitializationIntentV2, JournalDerivedIndexesV2,
+    JournalIndexAdvanceReportV2, JournalIndexRebuildCleanupV2, JournalIndexRebuildCursorV2,
+    JournalIndexRebuildPhaseV2, JournalIndexRebuildStepV2, ListRequest, LoadedRefV2,
+    LogicalObjectVersionBodyV1, LogicalObjectVersionKindV1, MemoryNodeCache, NodeCache,
+    ObjectHeaders, ObjectPath, ObjectPlane, ObjectTransitionV2, ObjectVersionIdV2,
+    ObjectVersionOrder, ObjectVersionV1, ObjectVersionV2, OperationId,
     OperationIndexAdvanceReportV2, OperationIndexRebuildCursorV2, OperationIndexRebuildStepV2,
     PhysicalBatchV2, PhysicalMutationIdentityV2, ProllyObjectStore, ProviderPerKeyVersionLimitV2,
     RandomIdSource, RefCatalogCursorV2, RefGeneration, RefKindV2, RepositoryFormatV2, Result,
@@ -151,6 +152,21 @@ pub struct RefCatalogRepairPageV2 {
     pub continuation: Option<String>,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct V1MigrationChangeV2 {
+    pub key: Vec<u8>,
+    pub version: ObjectVersionV1,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ImportedCommitReceiptV2 {
+    pub source: CommitId,
+    pub destination: CommitIdV2,
+    pub index: ImportedJournalIndexStateV2,
+    pub payloads: usize,
+    pub payload_bytes: u64,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BranchIndexAdvanceReportV2 {
     pub operations: OperationIndexAdvanceReportV2,
@@ -183,6 +199,7 @@ impl Drop for BranchIndexMaintenance {
 struct JournalNodeLocator<P: ObjectPlane> {
     indexes: Arc<JournalDerivedIndexesV2<P>>,
     branches: RwLock<BTreeSet<String>>,
+    imports: RwLock<BTreeMap<OperationId, ImportedJournalIndexStateV2>>,
 }
 
 impl<P: ObjectPlane> JournalNodeLocator<P> {
@@ -203,6 +220,22 @@ impl<P: ObjectPlane> JournalNodeLocator<P> {
             .cloned()
             .collect())
     }
+
+    fn register_import(&self, state: ImportedJournalIndexStateV2) -> Result<()> {
+        self.imports
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 locator lock poisoned"))?
+            .insert(state.job, state);
+        Ok(())
+    }
+
+    fn remove_import(&self, job: OperationId) -> Result<()> {
+        self.imports
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 locator lock poisoned"))?
+            .remove(&job);
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -215,6 +248,18 @@ impl<P: ObjectPlane> NodeLocator for JournalNodeLocator<P> {
             .clone();
         for branch in branches {
             if let Some(entry) = self.indexes.node_location(&branch, cid).await? {
+                return Ok(Some(entry.into()));
+            }
+        }
+        let imports = self
+            .imports
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 locator lock poisoned"))?
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        for state in imports {
+            if let Some(entry) = self.indexes.imported_node_location(&state, cid).await? {
                 return Ok(Some(entry.into()));
             }
         }
@@ -502,6 +547,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         let locator = Arc::new(JournalNodeLocator {
             indexes: journal_indexes.clone(),
             branches: RwLock::new(BTreeSet::new()),
+            imports: RwLock::new(BTreeMap::new()),
         });
         node_store.set_node_locator(locator.clone())?;
         let writable = !options.read_only;
@@ -549,6 +595,402 @@ impl<P: ObjectPlane> RepositoryV2<P> {
     pub async fn head(&self, branch: &str) -> Result<CommitIdV2> {
         self.locator.register(branch)?;
         Ok(self.publisher.load(branch).await?.value.target)
+    }
+
+    pub(crate) async fn start_v1_migration(
+        &self,
+        source_repository: crate::RepositoryId,
+        source_head: CommitId,
+        destination_branch: &str,
+        job: OperationId,
+    ) -> Result<(ImportedJournalIndexStateV2, [u8; 32])> {
+        crate::repository::validate_branch(destination_branch)?;
+        match self
+            .publisher
+            .load_including_tombstone(destination_branch)
+            .await
+        {
+            Ok(_) => {
+                return Err(Error::new(
+                    ErrorCode::RefConflict,
+                    "v1 migration destination branch already exists",
+                ))
+            }
+            Err(error) if error.code == ErrorCode::InvalidRevision => {}
+            Err(error) => return Err(error),
+        }
+        let now = self.options.clock.now_millis()?;
+        self.active_permit(destination_branch, now).await?;
+        let state = self.journal_indexes.start_imported_closure(job)?;
+        self.locator.register_import(state.clone())?;
+        Ok((
+            state,
+            self.v1_migration_destination_scope(source_repository, source_head, destination_branch),
+        ))
+    }
+
+    pub(crate) fn validate_v1_migration_destination(
+        &self,
+        source_repository: crate::RepositoryId,
+        source_head: CommitId,
+        destination_branch: &str,
+        scope: [u8; 32],
+        index: &ImportedJournalIndexStateV2,
+    ) -> Result<()> {
+        if scope
+            != self.v1_migration_destination_scope(
+                source_repository,
+                source_head,
+                destination_branch,
+            )
+            || index.repository != self.format.repository_id
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "v1 migration cursor belongs to another destination",
+            ));
+        }
+        self.locator.register_import(index.clone())
+    }
+
+    fn v1_migration_destination_scope(
+        &self,
+        source_repository: crate::RepositoryId,
+        source_head: CommitId,
+        destination_branch: &str,
+    ) -> [u8; 32] {
+        crate::model::derive_input_digest_v2(&[
+            b"v1-to-v2-migration-destination",
+            source_repository.as_bytes(),
+            source_head.as_bytes(),
+            self.format.repository_id.as_bytes(),
+            destination_branch.as_bytes(),
+        ])
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn import_v1_commit<S: ObjectPlane>(
+        &self,
+        source_plane: Arc<S>,
+        source_repository: crate::RepositoryId,
+        source_id: CommitId,
+        source_commit: BucketCommitV1,
+        mapped_parents: Vec<CommitIdV2>,
+        changes: Vec<V1MigrationChangeV2>,
+        destination_branch: &str,
+        index: &ImportedJournalIndexStateV2,
+    ) -> Result<ImportedCommitReceiptV2> {
+        crate::repository::validate_branch(destination_branch)?;
+        let changes_match_delta = source_commit.delta.changes.len() == changes.len()
+            && source_commit
+                .delta
+                .changes
+                .iter()
+                .zip(&changes)
+                .all(|(transition, change)| {
+                    transition.key == change.key
+                        && transition.next == change.version.id
+                        && transition.delete_marker
+                            == matches!(
+                                change.version.body.kind,
+                                LogicalObjectVersionKindV1::DeleteMarker
+                            )
+                });
+        if source_commit.parents.len() != mapped_parents.len() || !changes_match_delta {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "v1 migration changes do not match the source commit delta",
+            ));
+        }
+        self.locator.register_import(index.clone())?;
+        let now = self.options.clock.now_millis()?;
+        let permit = self.active_system_permit("v1-migration", now).await?;
+        self.authority.validate_active(&permit, now).await?;
+        let write_store = self.node_store.isolated_write_session();
+        let engine = self.engine(write_store.clone());
+        let empty = engine.create();
+        let mut parent_commits = Vec::with_capacity(mapped_parents.len());
+        for parent in &mapped_parents {
+            parent_commits.push(self.load_commit_object(*parent).await?.commit);
+        }
+        let base = parent_commits.first();
+        let mut objects = match &base {
+            Some(base) => self.tree_from_root(&base.state.objects)?,
+            None => empty.clone(),
+        };
+        let mut versions = match &base {
+            Some(base) => self.tree_from_root(&base.state.versions)?,
+            None => empty,
+        };
+        let mut object_mutations = Vec::with_capacity(changes.len());
+        let mut version_mutations = Vec::with_capacity(changes.len());
+        let mut transitions = Vec::with_capacity(changes.len());
+        let mut payloads = 0usize;
+        let mut payload_bytes = 0u64;
+        for change in changes {
+            self.validate_key(&change.key)?;
+            change.version.validate()?;
+            let previous = engine
+                .get(&objects, &change.key)
+                .await?
+                .map(|encoded| decode_canonical::<CurrentObjectV2>(&encoded))
+                .transpose()?
+                .map(|current| current.version.id);
+            let operation =
+                migration_version_operation(source_repository, &change.key, change.version.id);
+            let expected_version = ObjectVersionV2::derive_id(
+                self.format.repository_id,
+                &change.key,
+                operation,
+                &change.version.body,
+            )?;
+            let mut reusable = self
+                .find_v2_version_in_tree(&versions, &change.key, expected_version)
+                .await?;
+            if reusable.is_none() {
+                for parent in parent_commits.iter().skip(1) {
+                    let parent_versions = self.tree_from_root(&parent.state.versions)?;
+                    reusable = self
+                        .find_v2_version_in_tree(&parent_versions, &change.key, expected_version)
+                        .await?;
+                    if reusable.is_some() {
+                        break;
+                    }
+                }
+            }
+            if reusable
+                .as_ref()
+                .is_some_and(|version| version.body != change.version.body)
+            {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "v1 migration version identity collided with different content",
+                ));
+            }
+            let binding = match (
+                &change.version.body.kind,
+                &change.version.binding,
+                reusable
+                    .as_ref()
+                    .and_then(|version| version.binding.clone()),
+            ) {
+                (LogicalObjectVersionKindV1::Live { .. }, _, Some(binding)) => Some(binding),
+                (
+                    LogicalObjectVersionKindV1::Live {
+                        size, checksums, ..
+                    },
+                    crate::PhysicalObjectBindingV1::Live {
+                        version_id,
+                        checksum_sha256,
+                        ..
+                    },
+                    None,
+                ) => {
+                    if checksums.sha256 != Some(*checksum_sha256) {
+                        return Err(Error::new(
+                            ErrorCode::ChecksumMismatch,
+                            "v1 migration source checksum is inconsistent",
+                        ));
+                    }
+                    let spool = tempfile::NamedTempFile::new().map_err(|error| {
+                        Error::new(
+                            ErrorCode::Transport,
+                            format!("could not create v1 migration spool: {error}"),
+                        )
+                    })?;
+                    let path =
+                        ObjectPath::new(std::str::from_utf8(&change.key).map_err(|_| {
+                            Error::new(ErrorCode::InvalidKey, "v1 migration key is not UTF-8")
+                        })?)?;
+                    let fetched = source_plane
+                        .get_physical_file(crate::PhysicalFileGet {
+                            path,
+                            version_id: version_id.clone(),
+                            body_path: spool.path().to_path_buf(),
+                        })
+                        .await?;
+                    if fetched.size != *size || fetched.checksum_sha256 != *checksum_sha256 {
+                        return Err(Error::new(
+                            ErrorCode::ChecksumMismatch,
+                            "v1 migration source payload failed verification",
+                        ));
+                    }
+                    let binding = self
+                        .payloads
+                        .put_file(spool.path().to_path_buf(), *size, *checksum_sha256)
+                        .await?;
+                    payloads = payloads.checked_add(1).ok_or_else(|| {
+                        Error::new(
+                            ErrorCode::InternalInvariant,
+                            "migration payload count overflow",
+                        )
+                    })?;
+                    payload_bytes = payload_bytes.checked_add(*size).ok_or_else(|| {
+                        Error::new(
+                            ErrorCode::EntityTooLarge,
+                            "migration payload bytes overflow",
+                        )
+                    })?;
+                    Some(binding)
+                }
+                (
+                    LogicalObjectVersionKindV1::DeleteMarker,
+                    crate::PhysicalObjectBindingV1::DeleteMarker { .. },
+                    _,
+                ) => None,
+                _ => {
+                    return Err(Error::new(
+                        ErrorCode::CorruptCommit,
+                        "v1 migration source version has an invalid binding",
+                    ))
+                }
+            };
+            let version = ObjectVersionV2::derive(
+                self.format.repository_id,
+                &change.key,
+                operation,
+                change.version.body,
+                binding,
+            )?;
+            let delete_marker =
+                matches!(version.body.kind, LogicalObjectVersionKindV1::DeleteMarker);
+            object_mutations.push(if delete_marker {
+                Mutation::Delete {
+                    key: change.key.clone(),
+                }
+            } else {
+                Mutation::Upsert {
+                    key: change.key.clone(),
+                    val: encode_canonical(&CurrentObjectV2 {
+                        version: version.clone(),
+                    })?,
+                }
+            });
+            version_mutations.push(Mutation::Upsert {
+                key: version_tree_key(&change.key, version.body.order, version.id),
+                val: encode_canonical(&version)?,
+            });
+            transitions.push(ObjectTransitionV2 {
+                key: change.key,
+                previous,
+                next: version.id,
+                delete_marker,
+            });
+        }
+        objects = engine.batch(&objects, object_mutations).await?;
+        versions = engine.batch(&versions, version_mutations).await?;
+        let prepared = write_store.prepare_node_pack(
+            tree_format_digest(&self.format.state_tree_format)?,
+            Vec::new(),
+        )?;
+        let commit = BucketCommitV2 {
+            state: BucketStateV2 {
+                objects: TreeRootV1::from_tree(&objects)?,
+                versions: TreeRootV1::from_tree(&versions)?,
+            },
+            parents: mapped_parents,
+            generation: source_commit.generation,
+            delta: BucketDeltaV2 {
+                input_digest: crate::model::derive_input_digest_v2(&[
+                    b"v1-to-v2-migration",
+                    source_repository.as_bytes(),
+                    source_id.as_bytes(),
+                ]),
+                changes: transitions,
+            },
+            node_pack: prepared.as_ref().map(PreparedNodePack::reference),
+            authority: permit.stamp(),
+            author: source_commit.author,
+            message: source_commit.message,
+            created_at_millis: source_commit.created_at_millis,
+            metadata: source_commit.metadata,
+        };
+        let destination = self
+            .publisher
+            .store_unpublished_commit(
+                &permit,
+                &commit,
+                prepared.as_ref().map(PreparedNodePack::pack).cloned(),
+                now,
+            )
+            .await?;
+        self.finalize_pack(destination, &commit, prepared).await?;
+        let next_index = self
+            .journal_indexes
+            .index_imported_commit(&self.publisher, index, destination)
+            .await?;
+        self.locator.register_import(next_index.clone())?;
+        Ok(ImportedCommitReceiptV2 {
+            source: source_id,
+            destination,
+            index: next_index,
+            payloads,
+            payload_bytes,
+        })
+    }
+
+    pub(crate) async fn finish_v1_migration(
+        &self,
+        source_repository: crate::RepositoryId,
+        source_head: CommitId,
+        destination_branch: &str,
+        destination_head: CommitIdV2,
+        destination_scope: [u8; 32],
+        index: &ImportedJournalIndexStateV2,
+    ) -> Result<BranchHeadV2> {
+        self.validate_v1_migration_destination(
+            source_repository,
+            source_head,
+            destination_branch,
+            destination_scope,
+            index,
+        )?;
+        let branch = match self.publisher.load(destination_branch).await {
+            Ok(reference) if reference.value.target == destination_head => BranchHeadV2 {
+                name: destination_branch.to_string(),
+                target: reference.value.target,
+                generation: reference.value.generation,
+            },
+            Ok(_) => {
+                return Err(Error::new(
+                    ErrorCode::RefConflict,
+                    "v1 migration destination branch points to another commit",
+                ))
+            }
+            Err(error) if error.code == ErrorCode::InvalidRevision => {
+                self.create_branch(destination_branch, destination_head)
+                    .await?
+            }
+            Err(error) => return Err(error),
+        };
+        let now = self.options.clock.now_millis()?;
+        self.journal_indexes
+            .publish_imported_closure(&self.publisher, destination_branch, index, now)
+            .await?;
+        let reference = self.publisher.load(destination_branch).await?;
+        self.record_branch_catalog(&reference).await?;
+        self.mark_local_index_head(destination_branch, destination_head)?;
+        self.locator.register(destination_branch)?;
+        self.locator.remove_import(index.job)?;
+        Ok(branch)
+    }
+
+    pub(crate) fn abandon_v1_migration(
+        &self,
+        source_repository: crate::RepositoryId,
+        source_head: CommitId,
+        destination_branch: &str,
+        destination_scope: [u8; 32],
+        index: &ImportedJournalIndexStateV2,
+    ) -> Result<()> {
+        self.validate_v1_migration_destination(
+            source_repository,
+            source_head,
+            destination_branch,
+            destination_scope,
+            index,
+        )?;
+        self.locator.remove_import(index.job)
     }
 
     pub async fn create_branch(&self, name: &str, from: CommitIdV2) -> Result<BranchHeadV2> {
@@ -2468,6 +2910,25 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         Ok(object)
     }
 
+    async fn find_v2_version_in_tree(
+        &self,
+        versions: &Tree,
+        key: &[u8],
+        selected: ObjectVersionIdV2,
+    ) -> Result<Option<ObjectVersionV2>> {
+        let engine = self.engine(self.node_store.clone());
+        let mut entries = engine.prefix(versions, &version_tree_prefix(key)).await?;
+        while let Some(entry) = entries.next().await {
+            let (_, encoded) = entry?;
+            let version: ObjectVersionV2 = decode_canonical(&encoded)?;
+            if version.id == selected {
+                version.validate()?;
+                return Ok(Some(version));
+            }
+        }
+        Ok(None)
+    }
+
     async fn finalize_pack(
         &self,
         id: CommitIdV2,
@@ -2641,6 +3102,25 @@ fn version_tree_key(key: &[u8], order: ObjectVersionOrder, version: ObjectVersio
     output.extend(order.mutation_ordinal.to_be_bytes().map(|byte| !byte));
     output.extend(version.as_bytes().iter().map(|byte| !byte));
     output
+}
+
+fn migration_version_operation(
+    source_repository: crate::RepositoryId,
+    key: &[u8],
+    version: crate::ObjectVersionId,
+) -> OperationId {
+    let digest = crate::codec::sha256(
+        &[
+            b"prolly-s3/v1-to-v2-version".as_slice(),
+            source_repository.as_bytes().as_slice(),
+            key,
+            version.as_bytes().as_slice(),
+        ]
+        .concat(),
+    );
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    OperationId(uuid::Uuid::from_bytes(bytes))
 }
 
 fn version_tree_prefix(key: &[u8]) -> Vec<u8> {

--- a/extensions/s3/core/src/repository_v2.rs
+++ b/extensions/s3/core/src/repository_v2.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use md5::{Digest as _, Md5};
-use prolly::{AsyncProlly, Config, RuntimeConfig, Tree, TreeFormat};
+use prolly::{AsyncProlly, Config, Mutation, RuntimeConfig, Tree, TreeFormat};
 use sha2::Sha256;
 
 use crate::store::{LocatedPackedNode, NodeCacheNamespace, NodeLocator, PreparedNodePack};
@@ -21,9 +21,11 @@ use crate::{
     JournalDerivedIndexesV2, JournalIndexAdvanceReportV2, LogicalObjectVersionBodyV1,
     LogicalObjectVersionKindV1, MemoryNodeCache, NodeCache, ObjectHeaders, ObjectPath, ObjectPlane,
     ObjectTransitionV2, ObjectVersionIdV2, ObjectVersionOrder, ObjectVersionV2, OperationId,
-    OperationIndexAdvanceReportV2, ProllyObjectStore, ProviderPerKeyVersionLimitV2, RandomIdSource,
-    RepositoryFormatV2, Result, SegmentedOperationIndexV2, ShardWriterAuthorityV2,
-    ShardedBranchPublisherV2, SystemClock, TakeoverRequestV2, TreeRootV1,
+    OperationIndexAdvanceReportV2, PhysicalBatchV2, PhysicalMutationIdentityV2, ProllyObjectStore,
+    ProviderPerKeyVersionLimitV2, RandomIdSource, RepositoryFormatV2, Result,
+    SegmentedOperationIndexV2, ShardWriterAuthorityV2, ShardedBranchPublisherV2,
+    StagedMutationBodyV2, StagedMutationV2, StagedPutV2, SystemClock, TakeoverRequestV2,
+    TreeRootV1,
 };
 
 #[derive(Clone)]
@@ -487,6 +489,312 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         Ok(generation)
     }
 
+    pub async fn begin_commit_session(
+        &self,
+        branch: &str,
+        message: impl Into<String>,
+        expires_after_millis: u64,
+    ) -> Result<PhysicalBatchV2> {
+        crate::repository::validate_branch(branch)?;
+        let message = message.into();
+        let now = self.options.clock.now_millis()?;
+        let expires_at_millis = now.checked_add(expires_after_millis).ok_or_else(|| {
+            Error::new(
+                ErrorCode::InvalidLimit,
+                "protocol-v2 commit-session expiry overflow",
+            )
+        })?;
+        let permit = self.active_permit(branch, now).await?;
+        let session = PhysicalBatchV2 {
+            id: self.options.ids.batch(),
+            branch: branch.to_string(),
+            base_commit: self.publisher.load(branch).await?.value.target,
+            identity: PhysicalMutationIdentityV2 {
+                repository: self.format.repository_id,
+                operation: self.options.ids.operation(),
+                authority: permit.stamp(),
+            },
+            message,
+            created_at_millis: now,
+            expires_at_millis,
+        };
+        session.validate(self.format.repository_id)?;
+        Ok(session)
+    }
+
+    pub async fn stage_commit_session_put(
+        &self,
+        session: &PhysicalBatchV2,
+        key: Vec<u8>,
+        bytes: Vec<u8>,
+        headers: ObjectHeaders,
+        user_metadata: BTreeMap<String, String>,
+    ) -> Result<StagedMutationV2> {
+        self.validate_commit_session(session).await?;
+        self.validate_key(&key)?;
+        if bytes.len() as u64 > self.format.canonical_limits.max_object_bytes {
+            return Err(Error::new(
+                ErrorCode::EntityTooLarge,
+                "v2 object exceeds the repository object-size limit",
+            ));
+        }
+        let size = bytes.len() as u64;
+        let checksum_md5: [u8; 16] = Md5::digest(&bytes).into();
+        let checksum_sha256: [u8; 32] = Sha256::digest(&bytes).into();
+        let binding = self.payloads.put(bytes).await?;
+        Ok(StagedMutationV2 {
+            body: StagedMutationBodyV2::Put(Box::new(StagedPutV2 {
+                key,
+                size,
+                logical_etag: format!("\"{}\"", hex::encode(checksum_md5)),
+                checksums: Checksums {
+                    md5: Some(checksum_md5),
+                    sha256: Some(checksum_sha256),
+                    algorithm_values: BTreeMap::new(),
+                },
+                headers,
+                user_metadata,
+                binding,
+            })),
+        })
+    }
+
+    pub async fn publish_commit_session(
+        &self,
+        session: PhysicalBatchV2,
+        mutations: Vec<StagedMutationV2>,
+    ) -> Result<CommitReceiptV2> {
+        session.validate(self.format.repository_id)?;
+        if mutations.is_empty()
+            || mutations.len() > self.format.canonical_limits.max_mutations_per_commit as usize
+            || session.expires_at_millis < self.options.clock.now_millis()?
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "protocol-v2 commit session is empty, expired, or exceeds the mutation limit",
+            ));
+        }
+        let mut ordered = BTreeMap::new();
+        for mutation in mutations {
+            self.validate_key(mutation.key())?;
+            if ordered.insert(mutation.key().to_vec(), mutation).is_some() {
+                return Err(Error::new(
+                    ErrorCode::InvalidRequest,
+                    "protocol-v2 commit session contains the same key more than once",
+                ));
+            }
+        }
+        let canonical_mutations = ordered.values().cloned().collect::<Vec<_>>();
+        let input_digest = crate::model::derive_input_digest_v2(&[
+            b"commit-session",
+            session.branch.as_bytes(),
+            session.base_commit.as_bytes(),
+            &encode_canonical(&canonical_mutations)?,
+        ]);
+        let _lane = self.lock_branch(&session.branch).await;
+        let now = self.options.clock.now_millis()?;
+        if let Some(receipt) = self
+            .reconcile_operation(
+                &session.branch,
+                session.identity.operation,
+                input_digest,
+                now,
+            )
+            .await?
+        {
+            return Ok(receipt);
+        }
+        let permit = self.active_permit(&session.branch, now).await?;
+        if permit.stamp() != session.identity.authority {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "protocol-v2 commit session belongs to another authority epoch",
+            ));
+        }
+        let current = self.publisher.load(&session.branch).await?;
+        if current.value.target != session.base_commit {
+            return Err(Error::new(
+                ErrorCode::BatchConflict,
+                "protocol-v2 branch moved since commit-session creation",
+            )
+            .operation(session.identity.operation.to_string()));
+        }
+        let base = self.load_commit_object(current.value.target).await?.commit;
+        let write_store = self.node_store.isolated_write_session();
+        let engine = self.engine(write_store.clone());
+        let objects = self.tree_from_root(&base.state.objects)?;
+        let versions = self.tree_from_root(&base.state.versions)?;
+        let keys = ordered.keys().cloned().collect::<Vec<_>>();
+        let previous_values = engine.get_many(&objects, &keys).await?;
+        let generation = CommitGeneration(base.generation.0.checked_add(1).ok_or_else(|| {
+            Error::new(
+                ErrorCode::InternalInvariant,
+                "v2 commit generation overflow",
+            )
+        })?);
+        let mut object_mutations = Vec::with_capacity(ordered.len());
+        let mut version_mutations = Vec::with_capacity(ordered.len());
+        let mut transitions = Vec::with_capacity(ordered.len());
+        let mut object_versions = Vec::with_capacity(ordered.len());
+        for (ordinal, ((key, mutation), previous)) in
+            ordered.iter().zip(previous_values).enumerate()
+        {
+            let previous = previous
+                .map(|encoded| decode_canonical::<CurrentObjectV2>(&encoded))
+                .transpose()?
+                .map(|current| current.version.id);
+            let (kind, binding) = match &mutation.body {
+                StagedMutationBodyV2::Put(staged) => {
+                    let StagedPutV2 {
+                        size,
+                        logical_etag,
+                        checksums,
+                        headers,
+                        user_metadata,
+                        binding,
+                        ..
+                    } = staged.as_ref();
+                    binding.validate()?;
+                    let expected_etag =
+                        checksums.md5.map(|md5| format!("\"{}\"", hex::encode(md5)));
+                    if *size > self.format.canonical_limits.max_object_bytes
+                        || binding.path != self.payloads.path(binding.checksum_sha256)?
+                        || checksums.sha256 != Some(binding.checksum_sha256)
+                        || expected_etag.as_deref() != Some(logical_etag)
+                    {
+                        return Err(Error::new(
+                            ErrorCode::ChecksumMismatch,
+                            "staged v2 payload identity does not match its immutable binding",
+                        ));
+                    }
+                    (
+                        LogicalObjectVersionKindV1::Live {
+                            size: *size,
+                            logical_etag: logical_etag.clone(),
+                            headers: headers.clone(),
+                            checksums: checksums.clone(),
+                            user_metadata: user_metadata.clone(),
+                            tags: BTreeMap::new(),
+                        },
+                        Some(binding.clone()),
+                    )
+                }
+                StagedMutationBodyV2::Delete { .. } => {
+                    (LogicalObjectVersionKindV1::DeleteMarker, None)
+                }
+            };
+            let version = ObjectVersionV2::derive(
+                self.format.repository_id,
+                key,
+                session.identity.operation,
+                LogicalObjectVersionBodyV1 {
+                    order: ObjectVersionOrder {
+                        commit_generation: generation,
+                        mutation_ordinal: u32::try_from(ordinal).map_err(|_| {
+                            Error::new(ErrorCode::InvalidLimit, "v2 mutation ordinal overflow")
+                        })?,
+                    },
+                    created_at_millis: now,
+                    kind,
+                },
+                binding,
+            )?;
+            let delete_marker =
+                matches!(version.body.kind, LogicalObjectVersionKindV1::DeleteMarker);
+            if delete_marker {
+                object_mutations.push(Mutation::Delete { key: key.clone() });
+            } else {
+                object_mutations.push(Mutation::Upsert {
+                    key: key.clone(),
+                    val: encode_canonical(&CurrentObjectV2 {
+                        version: version.clone(),
+                    })?,
+                });
+            }
+            version_mutations.push(Mutation::Upsert {
+                key: version_tree_key(key, version.body.order, version.id),
+                val: encode_canonical(&version)?,
+            });
+            transitions.push(ObjectTransitionV2 {
+                key: key.clone(),
+                previous,
+                next: version.id,
+                delete_marker,
+            });
+            object_versions.push(version.id);
+        }
+        let objects = engine.batch(&objects, object_mutations).await?;
+        let versions = engine.batch(&versions, version_mutations).await?;
+        let prepared = write_store.prepare_node_pack(
+            tree_format_digest(&self.format.state_tree_format)?,
+            Vec::new(),
+        )?;
+        let commit = BucketCommitV2 {
+            state: BucketStateV2 {
+                objects: TreeRootV1::from_tree(&objects)?,
+                versions: TreeRootV1::from_tree(&versions)?,
+            },
+            parents: vec![current.value.target],
+            generation,
+            delta: BucketDeltaV2 {
+                input_digest,
+                changes: transitions,
+            },
+            node_pack: prepared.as_ref().map(PreparedNodePack::reference),
+            authority: permit.stamp(),
+            author: self.options.writer.clone(),
+            message: Some(session.message.clone()),
+            created_at_millis: now,
+            metadata: BTreeMap::new(),
+        };
+        let publication = self
+            .publisher
+            .store_and_publish(
+                current,
+                CommitPublicationV2 {
+                    permit: &permit,
+                    branch: &session.branch,
+                    commit: &commit,
+                    node_pack: prepared.as_ref().map(PreparedNodePack::pack),
+                    operation: session.identity.operation,
+                    message: &session.message,
+                    now_millis: now,
+                },
+            )
+            .await;
+        match publication {
+            Ok(published) => {
+                self.finalize_pack(published.value.target, &commit, prepared)
+                    .await?;
+                Ok(CommitReceiptV2 {
+                    id: published.value.target,
+                    operation: session.identity.operation,
+                    branch: session.branch,
+                    parents: commit.parents,
+                    changed_keys: object_versions.len() as u64,
+                    object_versions,
+                    idempotent_replay: false,
+                })
+            }
+            Err(error) => {
+                if let Some(receipt) = self
+                    .reconcile_operation(
+                        &session.branch,
+                        session.identity.operation,
+                        input_digest,
+                        now,
+                    )
+                    .await?
+                {
+                    self.finalize_pack(receipt.id, &commit, prepared).await?;
+                    return Ok(receipt);
+                }
+                self.fence_branch(&session.branch)?;
+                Err(error)
+            }
+        }
+    }
+
     pub async fn put_object(
         &self,
         branch: &str,
@@ -498,6 +806,25 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         let operation = self.options.ids.operation();
         self.put_object_with_operation(branch, key, bytes, headers, user_metadata, operation)
             .await
+    }
+
+    async fn validate_commit_session(&self, session: &PhysicalBatchV2) -> Result<()> {
+        session.validate(self.format.repository_id)?;
+        let now = self.options.clock.now_millis()?;
+        if session.expires_at_millis < now {
+            return Err(Error::new(
+                ErrorCode::BatchExpired,
+                "protocol-v2 commit session expired",
+            ));
+        }
+        let permit = self.active_permit(&session.branch, now).await?;
+        if permit.stamp() != session.identity.authority {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "protocol-v2 commit session belongs to another authority epoch",
+            ));
+        }
+        Ok(())
     }
 
     pub async fn put_object_with_operation(

--- a/extensions/s3/core/src/repository_v2.rs
+++ b/extensions/s3/core/src/repository_v2.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, RwLock, Weak,
@@ -425,6 +426,10 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         self.format.repository_id
     }
 
+    pub fn max_object_bytes(&self) -> u64 {
+        self.format.canonical_limits.max_object_bytes
+    }
+
     pub fn plane(&self) -> Arc<P> {
         self.plane.clone()
     }
@@ -542,6 +547,47 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         let checksum_md5: [u8; 16] = Md5::digest(&bytes).into();
         let checksum_sha256: [u8; 32] = Sha256::digest(&bytes).into();
         let binding = self.payloads.put(bytes).await?;
+        Ok(StagedMutationV2 {
+            body: StagedMutationBodyV2::Put(Box::new(StagedPutV2 {
+                key,
+                size,
+                logical_etag: format!("\"{}\"", hex::encode(checksum_md5)),
+                checksums: Checksums {
+                    md5: Some(checksum_md5),
+                    sha256: Some(checksum_sha256),
+                    algorithm_values: BTreeMap::new(),
+                },
+                headers,
+                user_metadata,
+                binding,
+            })),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn stage_commit_session_file(
+        &self,
+        session: &PhysicalBatchV2,
+        key: Vec<u8>,
+        body_path: PathBuf,
+        size: u64,
+        checksum_sha256: [u8; 32],
+        checksum_md5: [u8; 16],
+        headers: ObjectHeaders,
+        user_metadata: BTreeMap<String, String>,
+    ) -> Result<StagedMutationV2> {
+        self.validate_commit_session(session).await?;
+        self.validate_key(&key)?;
+        if size > self.format.canonical_limits.max_object_bytes {
+            return Err(Error::new(
+                ErrorCode::EntityTooLarge,
+                "v2 object exceeds the repository object-size limit",
+            ));
+        }
+        let binding = self
+            .payloads
+            .put_file(body_path, size, checksum_sha256)
+            .await?;
         Ok(StagedMutationV2 {
             body: StagedMutationBodyV2::Put(Box::new(StagedPutV2 {
                 key,

--- a/extensions/s3/core/src/repository_v2.rs
+++ b/extensions/s3/core/src/repository_v2.rs
@@ -8,6 +8,7 @@ use std::{
     time::Duration,
 };
 
+use futures_util::{stream, StreamExt};
 use md5::{Digest as _, Md5};
 use prolly::{AsyncProlly, Config, Mutation, RuntimeConfig, Tree, TreeFormat};
 use sha2::Sha256;
@@ -22,14 +23,15 @@ use crate::{
     IdempotencyRetentionV2, ImmutablePayloadStoreV2, InitializationIntentV2,
     JournalDerivedIndexesV2, JournalIndexAdvanceReportV2, JournalIndexRebuildCleanupV2,
     JournalIndexRebuildCursorV2, JournalIndexRebuildPhaseV2, JournalIndexRebuildStepV2,
-    LoadedRefV2, LogicalObjectVersionBodyV1, LogicalObjectVersionKindV1, MemoryNodeCache,
-    NodeCache, ObjectHeaders, ObjectPath, ObjectPlane, ObjectTransitionV2, ObjectVersionIdV2,
-    ObjectVersionOrder, ObjectVersionV2, OperationId, OperationIndexAdvanceReportV2,
-    OperationIndexRebuildCursorV2, OperationIndexRebuildStepV2, PhysicalBatchV2,
-    PhysicalMutationIdentityV2, ProllyObjectStore, ProviderPerKeyVersionLimitV2, RandomIdSource,
-    RefGeneration, RepositoryFormatV2, Result, SegmentedOperationIndexV2, ShardWriterAuthorityV2,
-    ShardedBranchPublisherV2, StagedMutationBodyV2, StagedMutationV2, StagedPutV2, SystemClock,
-    TakeoverRequestV2, TreeRootV1,
+    ListRequest, LoadedRefV2, LogicalObjectVersionBodyV1, LogicalObjectVersionKindV1,
+    MemoryNodeCache, NodeCache, ObjectHeaders, ObjectPath, ObjectPlane, ObjectTransitionV2,
+    ObjectVersionIdV2, ObjectVersionOrder, ObjectVersionV2, OperationId,
+    OperationIndexAdvanceReportV2, OperationIndexRebuildCursorV2, OperationIndexRebuildStepV2,
+    PhysicalBatchV2, PhysicalMutationIdentityV2, ProllyObjectStore, ProviderPerKeyVersionLimitV2,
+    RandomIdSource, RefCatalogCursorV2, RefGeneration, RefKindV2, RepositoryFormatV2, Result,
+    SegmentedOperationIndexV2, ShardWriterAuthorityV2, ShardedBranchPublisherV2,
+    ShardedRefCatalogV2, StagedMutationBodyV2, StagedMutationV2, StagedPutV2, SystemClock,
+    TagStoreV2, TakeoverRequestV2, TreeRootV1,
 };
 
 #[derive(Clone)]
@@ -117,6 +119,39 @@ pub struct VersionSummaryV2 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BranchHeadV2 {
+    pub name: String,
+    pub target: CommitIdV2,
+    pub generation: RefGeneration,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TagV2 {
+    pub name: String,
+    pub target: CommitIdV2,
+    pub generation: RefGeneration,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BranchCatalogPageV2 {
+    pub branches: Vec<BranchHeadV2>,
+    pub continuation: Option<RefCatalogCursorV2>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TagCatalogPageV2 {
+    pub tags: Vec<TagV2>,
+    pub continuation: Option<RefCatalogCursorV2>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RefCatalogRepairPageV2 {
+    pub scanned: usize,
+    pub indexed: usize,
+    pub continuation: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BranchIndexAdvanceReportV2 {
     pub operations: OperationIndexAdvanceReportV2,
     pub journal: JournalIndexAdvanceReportV2,
@@ -201,11 +236,13 @@ pub struct RepositoryV2<P: ObjectPlane> {
     publisher: ShardedBranchPublisherV2<P>,
     payloads: ImmutablePayloadStoreV2<P>,
     commit_sessions: CommitSessionStoreV2<P>,
+    tags: TagStoreV2<P>,
+    ref_catalog: Arc<ShardedRefCatalogV2<P>>,
     operation_index: SegmentedOperationIndexV2<P>,
     journal_indexes: Arc<JournalDerivedIndexesV2<P>>,
     locator: Arc<JournalNodeLocator<P>>,
-    permits: RwLock<BTreeMap<String, AuthorityPermitV2>>,
-    fenced_branches: RwLock<BTreeSet<String>>,
+    permits: RwLock<BTreeMap<AuthorityScopeV2, AuthorityPermitV2>>,
+    fenced_scopes: RwLock<BTreeSet<AuthorityScopeV2>>,
     authority_renewal: tokio::sync::Mutex<()>,
     publication_lanes: std::sync::Mutex<BTreeMap<String, Weak<tokio::sync::Mutex<()>>>>,
     index_lanes: std::sync::Mutex<BTreeMap<String, Weak<tokio::sync::Mutex<()>>>>,
@@ -289,6 +326,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         match repository.publisher.load(&default_branch).await {
             Ok(_) => {
                 repository.locator.register(&default_branch)?;
+                repository.advance_branch_indexes(&default_branch).await?;
                 return Ok(repository);
             }
             Err(error) if error.code == ErrorCode::InvalidRevision => {}
@@ -306,7 +344,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
                 repository.options.ids.operation(),
             )
             .await?;
-        repository.install_permit(&default_branch, permit.clone())?;
+        repository.install_permit(permit.clone())?;
 
         let empty = repository.engine(repository.node_store.clone()).create();
         let repository_created_at = repository.format.created_at_millis;
@@ -377,7 +415,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
                     repository.options.ids.operation(),
                 )
                 .await?;
-            repository.install_permit(&branch, permit)?;
+            repository.install_permit(permit)?;
         }
         Ok(repository)
     }
@@ -421,6 +459,21 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             options.repository_prefix.clone(),
             format.repository_id,
         );
+        let tags = TagStoreV2::new_with_control_retention(
+            plane.clone(),
+            options.repository_prefix.clone(),
+            format.repository_id,
+            authority.clone(),
+            options.mutable_control_versions_to_retain,
+        )?;
+        let ref_catalog = Arc::new(ShardedRefCatalogV2::new_with_limits(
+            plane.clone(),
+            options.repository_prefix.clone(),
+            format.repository_id,
+            format.state_tree_format.clone(),
+            node_cache.clone(),
+            options.mutable_control_versions_to_retain,
+        )?);
         let commit_sessions = CommitSessionStoreV2::new(
             plane.clone(),
             options.repository_prefix.clone(),
@@ -461,11 +514,13 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             publisher,
             payloads,
             commit_sessions,
+            tags,
+            ref_catalog,
             operation_index,
             journal_indexes,
             locator,
             permits: RwLock::new(BTreeMap::new()),
-            fenced_branches: RwLock::new(BTreeSet::new()),
+            fenced_scopes: RwLock::new(BTreeSet::new()),
             authority_renewal: tokio::sync::Mutex::new(()),
             publication_lanes: std::sync::Mutex::new(BTreeMap::new()),
             index_lanes: std::sync::Mutex::new(BTreeMap::new()),
@@ -494,6 +549,242 @@ impl<P: ObjectPlane> RepositoryV2<P> {
     pub async fn head(&self, branch: &str) -> Result<CommitIdV2> {
         self.locator.register(branch)?;
         Ok(self.publisher.load(branch).await?.value.target)
+    }
+
+    pub async fn create_branch(&self, name: &str, from: CommitIdV2) -> Result<BranchHeadV2> {
+        crate::repository::validate_branch(name)?;
+        let _lane = self.lock_branch(name).await;
+        self.load_commit_object(from).await?;
+        let now = self.options.clock.now_millis()?;
+        let permit = self.active_permit(name, now).await?;
+        let reference = self
+            .publisher
+            .create_at_target(
+                &permit,
+                name,
+                from,
+                self.options.ids.operation(),
+                "create branch",
+                now,
+            )
+            .await?;
+        self.locator.register(name)?;
+        self.advance_branch_indexes(name).await?;
+        Ok(BranchHeadV2 {
+            name: name.to_string(),
+            target: reference.value.target,
+            generation: reference.value.generation,
+        })
+    }
+
+    pub async fn delete_branch(&self, name: &str, expected: CommitIdV2) -> Result<()> {
+        crate::repository::validate_branch(name)?;
+        let _lane = self.lock_branch(name).await;
+        let current = self.publisher.load(name).await?;
+        let now = self.options.clock.now_millis()?;
+        let permit = self.active_permit(name, now).await?;
+        let deleted = self
+            .publisher
+            .delete(
+                &permit,
+                name,
+                current,
+                expected,
+                self.options.ids.operation(),
+                now,
+            )
+            .await?;
+        self.record_branch_catalog(&deleted).await?;
+        self.local_index_heads
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 local-index lock poisoned"))?
+            .remove(name);
+        Ok(())
+    }
+
+    pub async fn tag(&self, name: &str) -> Result<TagV2> {
+        let loaded = self.tags.load(name).await?;
+        Ok(TagV2 {
+            name: name.to_string(),
+            target: loaded.value.target,
+            generation: loaded.value.generation,
+        })
+    }
+
+    pub async fn create_tag(&self, name: &str, target: CommitIdV2) -> Result<TagV2> {
+        crate::repository::validate_branch(name)?;
+        let _lane = self.lock_branch(&format!("tag:{name}")).await;
+        self.load_commit_object(target).await?;
+        let now = self.options.clock.now_millis()?;
+        let permit = self.active_system_permit("tags", now).await?;
+        let tag = self
+            .tags
+            .create(
+                &permit,
+                name,
+                target,
+                self.options.ids.operation(),
+                &self.options.writer,
+                now,
+            )
+            .await?;
+        self.record_tag_catalog(name, &tag.value).await?;
+        Ok(TagV2 {
+            name: name.to_string(),
+            target,
+            generation: tag.value.generation,
+        })
+    }
+
+    pub async fn delete_tag(&self, name: &str, expected: CommitIdV2) -> Result<()> {
+        crate::repository::validate_branch(name)?;
+        let _lane = self.lock_branch(&format!("tag:{name}")).await;
+        let current = self.tags.load(name).await?;
+        let now = self.options.clock.now_millis()?;
+        let permit = self.active_system_permit("tags", now).await?;
+        let deleted = self
+            .tags
+            .delete(
+                &permit,
+                name,
+                current,
+                expected,
+                self.options.ids.operation(),
+                now,
+            )
+            .await?;
+        self.record_tag_catalog(name, &deleted.value).await?;
+        Ok(())
+    }
+
+    pub async fn list_branch_catalog_page(
+        &self,
+        cursor: Option<RefCatalogCursorV2>,
+        limit: usize,
+    ) -> Result<BranchCatalogPageV2> {
+        let page = self
+            .ref_catalog
+            .list(RefKindV2::Branch, cursor, limit)
+            .await?;
+        Ok(BranchCatalogPageV2 {
+            branches: page
+                .entries
+                .into_iter()
+                .map(|entry| BranchHeadV2 {
+                    name: entry.name,
+                    target: entry.target,
+                    generation: entry.generation,
+                })
+                .collect(),
+            continuation: page.continuation,
+        })
+    }
+
+    pub async fn list_tag_catalog_page(
+        &self,
+        cursor: Option<RefCatalogCursorV2>,
+        limit: usize,
+    ) -> Result<TagCatalogPageV2> {
+        let page = self.ref_catalog.list(RefKindV2::Tag, cursor, limit).await?;
+        Ok(TagCatalogPageV2 {
+            tags: page
+                .entries
+                .into_iter()
+                .map(|entry| TagV2 {
+                    name: entry.name,
+                    target: entry.target,
+                    generation: entry.generation,
+                })
+                .collect(),
+            continuation: page.continuation,
+        })
+    }
+
+    /// Explicit bounded repair for a catalog shard stream. Normal lifecycle
+    /// maintenance is event-driven and never calls this namespace scanner.
+    pub async fn repair_ref_catalog_page(
+        &self,
+        kind: RefKindV2,
+        continuation: Option<String>,
+        limit: usize,
+    ) -> Result<RefCatalogRepairPageV2> {
+        if !(1..=1_000).contains(&limit) {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "v2 ref-catalog repair page must contain 1 to 1,000 refs",
+            ));
+        }
+        let namespace = match kind {
+            RefKindV2::Branch => "heads",
+            RefKindV2::Tag => "tags",
+        };
+        let prefix = format!("{}/refs/v2/{namespace}/", self.options.repository_prefix);
+        let page = self
+            .plane
+            .list(ListRequest {
+                prefix: prefix.clone(),
+                continuation,
+                limit,
+                include_versions: false,
+            })
+            .await?;
+        let mut report = RefCatalogRepairPageV2 {
+            continuation: page.continuation,
+            ..RefCatalogRepairPageV2::default()
+        };
+        for entry in page.entries {
+            report.scanned += 1;
+            let encoded_name = entry.path.as_str().strip_prefix(&prefix).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::CorruptCommit,
+                    "v2 ref repair escaped its namespace",
+                )
+            })?;
+            let name = String::from_utf8(hex::decode(encoded_name).map_err(|_| {
+                Error::new(
+                    ErrorCode::CorruptCommit,
+                    "v2 ref path name is not canonical hex",
+                )
+            })?)
+            .map_err(|_| Error::new(ErrorCode::CorruptCommit, "v2 ref path name is not UTF-8"))?;
+            let Some(stored) = self.plane.load_mutable(&entry.path).await? else {
+                continue;
+            };
+            match kind {
+                RefKindV2::Branch => {
+                    let value: crate::RefValueV2 = decode_canonical(&stored.bytes)?;
+                    value.validate(self.format.repository_id, &name)?;
+                    self.ref_catalog
+                        .record(
+                            kind,
+                            &name,
+                            value.target,
+                            value.generation,
+                            value.operation,
+                            value.tombstone,
+                            value.updated_at_millis,
+                        )
+                        .await?;
+                }
+                RefKindV2::Tag => {
+                    let value: crate::TagValueV2 = decode_canonical(&stored.bytes)?;
+                    value.validate(self.format.repository_id, &name)?;
+                    self.ref_catalog
+                        .record(
+                            kind,
+                            &name,
+                            value.target,
+                            value.generation,
+                            value.operation,
+                            value.tombstone,
+                            value.updated_at_millis,
+                        )
+                        .await?;
+                }
+            }
+            report.indexed += 1;
+        }
+        Ok(report)
     }
 
     /// Explicitly transfer one branch shard to this repository process.
@@ -546,7 +837,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             .authority
             .activate_after_barrier(pending, applied.into_barrier(), now)
             .await?;
-        self.install_permit(branch, permit)?;
+        self.install_permit(permit)?;
         self.writable.store(true, Ordering::Release);
         Ok(generation)
     }
@@ -1603,6 +1894,8 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             .write()
             .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 index-error lock poisoned"))?
             .remove(branch);
+        let reference = self.publisher.load(branch).await?;
+        self.record_branch_catalog(&reference).await?;
         Ok(report)
     }
 
@@ -1841,12 +2134,21 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             .read()
             .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 permit lock poisoned"))?
             .clone();
+        let authority = self.authority.clone();
+        let results = stream::iter(permits)
+            .map(|(scope, permit)| {
+                let authority = authority.clone();
+                async move { (scope, authority.renew(permit, now).await) }
+            })
+            .buffer_unordered(32)
+            .collect::<Vec<_>>()
+            .await;
         let mut first_error = None;
-        for (branch, permit) in permits {
-            match self.authority.renew(permit, now).await {
-                Ok(renewed) => self.install_permit(&branch, renewed)?,
+        for (scope, result) in results {
+            match result {
+                Ok(renewed) => self.install_permit(renewed)?,
                 Err(error) => {
-                    self.fence_branch(&branch)?;
+                    self.fence_scope(&scope)?;
                     if first_error.is_none() {
                         first_error = Some(error);
                     }
@@ -1886,7 +2188,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
 
     pub fn fenced_branches(&self) -> Result<Vec<String>> {
         Ok(self
-            .fenced_branches
+            .fenced_scopes
             .read()
             .map_err(|_| {
                 Error::new(
@@ -1895,7 +2197,10 @@ impl<P: ObjectPlane> RepositoryV2<P> {
                 )
             })?
             .iter()
-            .cloned()
+            .filter_map(|scope| match scope {
+                AuthorityScopeV2::Branch { name } => Some(name.clone()),
+                AuthorityScopeV2::System { .. } => None,
+            })
             .collect())
     }
 
@@ -1938,13 +2243,37 @@ impl<P: ObjectPlane> RepositoryV2<P> {
     }
 
     async fn active_permit(&self, branch: &str, now: u64) -> Result<AuthorityPermitV2> {
+        self.active_scope_permit(
+            AuthorityScopeV2::Branch {
+                name: branch.to_string(),
+            },
+            now,
+        )
+        .await
+    }
+
+    async fn active_system_permit(&self, namespace: &str, now: u64) -> Result<AuthorityPermitV2> {
+        self.active_scope_permit(
+            AuthorityScopeV2::System {
+                namespace: namespace.to_string(),
+            },
+            now,
+        )
+        .await
+    }
+
+    async fn active_scope_permit(
+        &self,
+        scope: AuthorityScopeV2,
+        now: u64,
+    ) -> Result<AuthorityPermitV2> {
         if !self.writable.load(Ordering::Acquire) {
             return Err(Error::new(
                 ErrorCode::PreconditionFailed,
                 "protocol-v2 repository is read-only",
             ));
         }
-        if self.is_branch_fenced(branch)? {
+        if self.is_scope_fenced(&scope)? {
             return Err(Error::new(
                 ErrorCode::PreconditionFailed,
                 "protocol-v2 branch authority is fenced in this repository instance",
@@ -1954,14 +2283,14 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             .permits
             .read()
             .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 permit lock poisoned"))?
-            .get(branch)
+            .get(&scope)
             .cloned();
         let permit = if let Some(permit) = cached.filter(|permit| permit.expires_at_millis() > now)
         {
             permit
         } else {
             let _renewal = self.authority_renewal.lock().await;
-            if self.is_branch_fenced(branch)? {
+            if self.is_scope_fenced(&scope)? {
                 return Err(Error::new(
                     ErrorCode::PreconditionFailed,
                     "protocol-v2 branch authority is fenced in this repository instance",
@@ -1971,12 +2300,12 @@ impl<P: ObjectPlane> RepositoryV2<P> {
                 .permits
                 .read()
                 .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 permit lock poisoned"))?
-                .get(branch)
+                .get(&scope)
                 .cloned();
             let acquired = match current {
                 Some(permit) if permit.expires_at_millis() > now => permit,
                 Some(_) => {
-                    self.fence_branch(branch)?;
+                    self.fence_scope(&scope)?;
                     return Err(Error::new(
                         ErrorCode::PreconditionFailed,
                         "protocol-v2 branch authority expired; explicit takeover is required",
@@ -1985,9 +2314,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
                 None => match self
                     .authority
                     .acquire(
-                        AuthorityScopeV2::Branch {
-                            name: branch.to_string(),
-                        },
+                        scope.clone(),
                         &self.options.writer,
                         now,
                         self.options.ids.operation(),
@@ -1996,29 +2323,30 @@ impl<P: ObjectPlane> RepositoryV2<P> {
                 {
                     Ok(permit) => permit,
                     Err(error) => {
-                        self.fence_branch(branch)?;
+                        self.fence_scope(&scope)?;
                         return Err(error);
                     }
                 },
             };
-            self.install_permit(branch, acquired.clone())?;
+            self.install_permit(acquired.clone())?;
             acquired
         };
         match self.authority.validate_active(&permit, now).await {
             Ok(_) => Ok(permit),
             Err(error) => {
-                self.fence_branch(branch)?;
+                self.fence_scope(&scope)?;
                 Err(error)
             }
         }
     }
 
-    fn install_permit(&self, branch: &str, permit: AuthorityPermitV2) -> Result<()> {
+    fn install_permit(&self, permit: AuthorityPermitV2) -> Result<()> {
+        let scope = permit.stamp().scope;
         self.permits
             .write()
             .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 permit lock poisoned"))?
-            .insert(branch.to_string(), permit);
-        self.fenced_branches
+            .insert(scope.clone(), permit);
+        self.fenced_scopes
             .write()
             .map_err(|_| {
                 Error::new(
@@ -2026,16 +2354,22 @@ impl<P: ObjectPlane> RepositoryV2<P> {
                     "v2 fenced-branch lock poisoned",
                 )
             })?
-            .remove(branch);
+            .remove(&scope);
         Ok(())
     }
 
     fn fence_branch(&self, branch: &str) -> Result<()> {
+        self.fence_scope(&AuthorityScopeV2::Branch {
+            name: branch.to_string(),
+        })
+    }
+
+    fn fence_scope(&self, scope: &AuthorityScopeV2) -> Result<()> {
         self.permits
             .write()
             .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 permit lock poisoned"))?
-            .remove(branch);
-        self.fenced_branches
+            .remove(scope);
+        self.fenced_scopes
             .write()
             .map_err(|_| {
                 Error::new(
@@ -2043,13 +2377,13 @@ impl<P: ObjectPlane> RepositoryV2<P> {
                     "v2 fenced-branch lock poisoned",
                 )
             })?
-            .insert(branch.to_string());
+            .insert(scope.clone());
         Ok(())
     }
 
-    fn is_branch_fenced(&self, branch: &str) -> Result<bool> {
+    fn is_scope_fenced(&self, scope: &AuthorityScopeV2) -> Result<bool> {
         Ok(self
-            .fenced_branches
+            .fenced_scopes
             .read()
             .map_err(|_| {
                 Error::new(
@@ -2057,7 +2391,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
                     "v2 fenced-branch lock poisoned",
                 )
             })?
-            .contains(branch))
+            .contains(scope))
     }
 
     async fn require_branch_indexes_ready(&self, branch: &str) -> Result<()> {
@@ -2093,6 +2427,36 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             .write()
             .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 local-index lock poisoned"))?
             .insert(branch.to_string(), target);
+        Ok(())
+    }
+
+    async fn record_branch_catalog(&self, reference: &LoadedRefV2) -> Result<()> {
+        self.ref_catalog
+            .record(
+                RefKindV2::Branch,
+                &reference.value.inline_reflog.branch,
+                reference.value.target,
+                reference.value.generation,
+                reference.value.operation,
+                reference.value.tombstone,
+                reference.value.updated_at_millis,
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn record_tag_catalog(&self, name: &str, value: &crate::TagValueV2) -> Result<()> {
+        self.ref_catalog
+            .record(
+                RefKindV2::Tag,
+                name,
+                value.target,
+                value.generation,
+                value.operation,
+                value.tombstone,
+                value.updated_at_millis,
+            )
+            .await?;
         Ok(())
     }
 

--- a/extensions/s3/core/src/repository_v2.rs
+++ b/extensions/s3/core/src/repository_v2.rs
@@ -10,29 +10,35 @@ use std::{
 
 use futures_util::{stream, StreamExt};
 use md5::{Digest as _, Md5};
-use prolly::{AsyncProlly, Config, Mutation, RuntimeConfig, Tree, TreeFormat};
+use prolly::{AsyncProlly, Config, Diff, Mutation, RuntimeConfig, Tree, TreeFormat};
 use sha2::Sha256;
 
+use crate::merge_v2::{
+    MergeBaseCandidateV2, MergePlanEntryV2, MergeQueueEntryV2, MergeSeenEntryV2,
+};
 use crate::store::{LocatedPackedNode, NodeCacheNamespace, NodeLocator, PreparedNodePack};
 use crate::{
     decode_canonical, encode_canonical, tree_format_digest, AuthorityPermitV2, AuthorityScopeV2,
     BucketCommitV1, BucketCommitV2, BucketDeltaV2, BucketStateV2, CanonicalLimits, Checksums,
     Clock, CommitGeneration, CommitId, CommitIdV2, CommitObjectV2, CommitPublicationV2,
     CommitSessionCheckpointV2, CommitSessionCleanupReportV2, CommitSessionStateV2,
-    CommitSessionStoreV2, CompareExchange, CompareExchangeOutcome, CurrentObjectV2, Error,
-    ErrorCode, GetRequest, IdSource, IdempotencyRetentionV2, ImmutablePayloadStoreV2,
-    ImportedJournalIndexStateV2, InitializationIntentV2, JournalDerivedIndexesV2,
-    JournalIndexAdvanceReportV2, JournalIndexRebuildCleanupV2, JournalIndexRebuildCursorV2,
-    JournalIndexRebuildPhaseV2, JournalIndexRebuildStepV2, ListRequest, LoadedRefV2,
-    LogicalObjectVersionBodyV1, LogicalObjectVersionKindV1, MemoryNodeCache, NodeCache,
-    ObjectHeaders, ObjectPath, ObjectPlane, ObjectTransitionV2, ObjectVersionIdV2,
-    ObjectVersionOrder, ObjectVersionV1, ObjectVersionV2, OperationId,
-    OperationIndexAdvanceReportV2, OperationIndexRebuildCursorV2, OperationIndexRebuildStepV2,
-    PhysicalBatchV2, PhysicalMutationIdentityV2, ProllyObjectStore, ProviderPerKeyVersionLimitV2,
-    RandomIdSource, RefCatalogCursorV2, RefGeneration, RefKindV2, RepositoryFormatV2, Result,
-    SegmentedOperationIndexV2, ShardWriterAuthorityV2, ShardedBranchPublisherV2,
-    ShardedRefCatalogV2, StagedMutationBodyV2, StagedMutationV2, StagedPutV2, SystemClock,
-    TagStoreV2, TakeoverRequestV2, TreeRootV1,
+    CommitSessionStoreV2, CompareExchange, CompareExchangeOutcome, CurrentObjectV2, DeleteOutcome,
+    Error, ErrorCode, GetRequest, IdSource, IdempotencyRetentionV2, ImmutablePayloadStoreV2,
+    ImportedJournalIndexStateV2, InitializationIntentV2, JournalCommitGraphEntryV2,
+    JournalDerivedIndexesV2, JournalIndexAdvanceReportV2, JournalIndexRebuildCleanupV2,
+    JournalIndexRebuildCursorV2, JournalIndexRebuildPhaseV2, JournalIndexRebuildStepV2,
+    ListRequest, LoadedRefV2, LogicalObjectVersionBodyV1, LogicalObjectVersionKindV1,
+    MemoryNodeCache, MergeAdvancePageV2, MergeBaseCursorV2, MergeBasePageV2, MergeChangeCursorV2,
+    MergeChangePageV2, MergeChangeV2, MergeCleanupCursorV2, MergeCleanupPageV2,
+    MergeConflictCursorV2, MergeConflictPageV2, MergeConflictV2, MergeCursorV2, MergePhaseV2,
+    MergePolicyV2, MergeReceiptV2, NodeCache, ObjectHeaders, ObjectPath, ObjectPlane,
+    ObjectTransitionV2, ObjectVersionIdV2, ObjectVersionOrder, ObjectVersionV1, ObjectVersionV2,
+    OperationId, OperationIndexAdvanceReportV2, OperationIndexRebuildCursorV2,
+    OperationIndexRebuildStepV2, PhysicalBatchV2, PhysicalMutationIdentityV2, PhysicalVersion,
+    ProllyObjectStore, ProviderPerKeyVersionLimitV2, RandomIdSource, RefCatalogCursorV2,
+    RefGeneration, RefKindV2, RepositoryFormatV2, Result, SegmentedOperationIndexV2,
+    ShardWriterAuthorityV2, ShardedBranchPublisherV2, ShardedRefCatalogV2, StagedMutationBodyV2,
+    StagedMutationV2, StagedPutV2, SystemClock, TagStoreV2, TakeoverRequestV2, TreeRootV1,
 };
 
 #[derive(Clone)]
@@ -403,6 +409,8 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             delta: BucketDeltaV2 {
                 input_digest: crate::model::derive_input_digest_v2(&[b"initialize"]),
                 changes: Vec::new(),
+                changes_root: None,
+                change_count: 0,
             },
             node_pack: None,
             authority: permit.stamp(),
@@ -897,6 +905,8 @@ impl<P: ObjectPlane> RepositoryV2<P> {
                     source_id.as_bytes(),
                 ]),
                 changes: transitions,
+                changes_root: None,
+                change_count: 0,
             },
             node_pack: prepared.as_ref().map(PreparedNodePack::reference),
             authority: permit.stamp(),
@@ -1669,6 +1679,8 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             delta: BucketDeltaV2 {
                 input_digest,
                 changes: transitions,
+                changes_root: None,
+                change_count: 0,
             },
             node_pack: prepared.as_ref().map(PreparedNodePack::reference),
             authority: permit.stamp(),
@@ -1936,6 +1948,8 @@ impl<P: ObjectPlane> RepositoryV2<P> {
                     next: version.id,
                     delete_marker: false,
                 }],
+                changes_root: None,
+                change_count: 0,
             },
             node_pack,
             authority: permit.stamp(),
@@ -2134,6 +2148,8 @@ impl<P: ObjectPlane> RepositoryV2<P> {
                     next: version.id,
                     delete_marker: true,
                 }],
+                changes_root: None,
+                change_count: 0,
             },
             node_pack: prepared.as_ref().map(PreparedNodePack::reference),
             authority: permit.stamp(),
@@ -2314,6 +2330,456 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         let truncated = result.len() > limit;
         result.truncate(limit);
         Ok((result, truncated))
+    }
+
+    /// Start a durable native-v2 merge between two branch snapshots.
+    ///
+    /// The returned cursor is process-independent. Callers must persist the
+    /// cursor returned by every successful `advance_merge` call before
+    /// discarding the previous one.
+    pub async fn start_merge(
+        &self,
+        target_branch: &str,
+        source_branch: &str,
+        requested_base: Option<CommitIdV2>,
+        policy: MergePolicyV2,
+        message: impl Into<String>,
+    ) -> Result<MergeCursorV2> {
+        crate::repository::validate_branch(target_branch)?;
+        crate::repository::validate_branch(source_branch)?;
+        if target_branch == source_branch {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "v2 merge source and target branches must differ",
+            ));
+        }
+        let message = message.into();
+        if message.trim().is_empty() {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "v2 merge message is empty",
+            ));
+        }
+        self.locator.register(target_branch)?;
+        self.locator.register(source_branch)?;
+        self.advance_branch_indexes(target_branch).await?;
+        self.advance_branch_indexes(source_branch).await?;
+        self.require_branch_indexes_ready(target_branch).await?;
+        self.require_branch_indexes_ready(source_branch).await?;
+        let ours = self.head(target_branch).await?;
+        let theirs = self.head(source_branch).await?;
+        let ours_entry = self
+            .merge_graph_entry(target_branch, source_branch, ours)
+            .await?;
+        let theirs_entry = self
+            .merge_graph_entry(target_branch, source_branch, theirs)
+            .await?;
+        let job = self.options.ids.operation();
+        let operation = self.options.ids.operation();
+        let engine = self.merge_plan_engine(job)?;
+        let mut tree = engine.create();
+        let now = self.options.clock.now_millis()?;
+        let mut cursor = MergeCursorV2 {
+            repository: self.format.repository_id,
+            job,
+            target_branch: target_branch.to_string(),
+            source_branch: source_branch.to_string(),
+            ours,
+            theirs,
+            requested_base,
+            selected_base: None,
+            policy,
+            operation,
+            message,
+            created_at_millis: now,
+            phase: MergePhaseV2::DiscoveringBases,
+            plan_root: TreeRootV1::from_tree(&tree)?,
+            ours_diff: None,
+            theirs_diff: None,
+            ours_pending: None,
+            theirs_pending: None,
+            ours_finished: false,
+            theirs_finished: false,
+            version_diff: None,
+            version_diff_finished: false,
+            build_after: None,
+            final_objects: None,
+            final_versions: None,
+            delta_root: None,
+            visited_commits: 0,
+            best_base_count: 0,
+            planned_changes: 0,
+            conflicts: 0,
+            built_changes: 0,
+        };
+
+        // First-parent ancestry is the common fast-forward case. The helper
+        // consumes binary-lifting pointers from the journal-derived graph and
+        // avoids creating a general frontier when one head is already the
+        // selected base.
+        let fast_base = if self
+            .is_first_parent_ancestor_v2(target_branch, source_branch, ours, theirs)
+            .await?
+        {
+            Some(ours)
+        } else if self
+            .is_first_parent_ancestor_v2(target_branch, source_branch, theirs, ours)
+            .await?
+        {
+            Some(theirs)
+        } else {
+            None
+        };
+        if let Some(base) = fast_base {
+            tree = engine
+                .batch(
+                    &tree,
+                    vec![Mutation::Upsert {
+                        key: merge_base_result_key(base),
+                        val: Vec::new(),
+                    }],
+                )
+                .await?;
+            cursor.plan_root = TreeRootV1::from_tree(&tree)?;
+            cursor.best_base_count = 1;
+            cursor.selected_base = Some(base);
+            self.validate_requested_merge_base(&cursor, base)?;
+            cursor.phase = MergePhaseV2::Planning;
+            self.seal_merge_cursor(&mut cursor).await?;
+            return Ok(cursor);
+        }
+
+        let mut mutations = Vec::new();
+        self.seed_merge_frontier(&mut mutations, ours_entry, MERGE_LEFT)?;
+        self.seed_merge_frontier(&mut mutations, theirs_entry, MERGE_RIGHT)?;
+        tree = engine.batch(&tree, mutations).await?;
+        cursor.plan_root = TreeRootV1::from_tree(&tree)?;
+        self.seal_merge_cursor(&mut cursor).await?;
+        Ok(cursor)
+    }
+
+    /// Advance a durable merge by at most `max_steps` graph or tree records.
+    pub async fn advance_merge(
+        &self,
+        cursor: &MergeCursorV2,
+        max_steps: usize,
+    ) -> Result<MergeAdvancePageV2> {
+        if !(1..=10_000).contains(&max_steps) {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "v2 merge advance must process 1 to 10,000 records",
+            ));
+        }
+        self.validate_merge_cursor(cursor).await?;
+        let mut next = cursor.clone();
+        let mut processed = 0usize;
+        let mut changes = Vec::new();
+        let mut conflicts = Vec::new();
+        while processed < max_steps {
+            let before = next.phase;
+            let advanced = match next.phase {
+                MergePhaseV2::DiscoveringBases => self.advance_merge_base_one(&mut next).await?,
+                MergePhaseV2::CollectingBases => self.collect_merge_base_one(&mut next).await?,
+                MergePhaseV2::Planning => {
+                    self.advance_merge_plan(
+                        &mut next,
+                        max_steps - processed,
+                        &mut changes,
+                        &mut conflicts,
+                    )
+                    .await?
+                }
+                MergePhaseV2::BuildingVersions => {
+                    self.advance_merge_version_union(&mut next, max_steps - processed)
+                        .await?
+                }
+                MergePhaseV2::BuildingObjects => {
+                    self.advance_merge_object_build(&mut next, max_steps - processed)
+                        .await?
+                }
+                MergePhaseV2::AwaitingBase
+                | MergePhaseV2::Conflicted
+                | MergePhaseV2::ReadyToPublish => 0,
+            };
+            processed = processed.checked_add(advanced).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InternalInvariant,
+                    "v2 merge work counter overflow",
+                )
+            })?;
+            if advanced == 0 && next.phase == before {
+                break;
+            }
+        }
+        self.seal_merge_cursor(&mut next).await?;
+        Ok(MergeAdvancePageV2 {
+            cursor: next,
+            processed,
+            changes,
+            conflicts,
+        })
+    }
+
+    /// Select one of several best merge bases discovered by the frontier.
+    pub async fn select_merge_base(
+        &self,
+        cursor: &MergeCursorV2,
+        base: CommitIdV2,
+    ) -> Result<MergeCursorV2> {
+        self.validate_merge_cursor(cursor).await?;
+        if cursor.phase != MergePhaseV2::AwaitingBase {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "v2 merge is not awaiting an explicit merge base",
+            ));
+        }
+        let engine = self.merge_plan_engine(cursor.job)?;
+        let tree = self.tree_from_merge_root(&cursor.plan_root)?;
+        if engine
+            .get(&tree, &merge_base_result_key(base))
+            .await?
+            .is_none()
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidRevision,
+                "selected v2 merge base is not a best common ancestor",
+            ));
+        }
+        let mut next = cursor.clone();
+        next.selected_base = Some(base);
+        next.phase = MergePhaseV2::Planning;
+        self.seal_merge_cursor(&mut next).await?;
+        Ok(next)
+    }
+
+    pub async fn merge_changes_page(
+        &self,
+        cursor: &MergeCursorV2,
+        continuation: Option<&MergeChangeCursorV2>,
+        limit: usize,
+    ) -> Result<MergeChangePageV2> {
+        self.merge_change_page(cursor, continuation, limit).await
+    }
+
+    pub async fn merge_bases_page(
+        &self,
+        cursor: &MergeCursorV2,
+        continuation: Option<&MergeBaseCursorV2>,
+        limit: usize,
+    ) -> Result<MergeBasePageV2> {
+        self.merge_base_page(cursor, continuation, limit).await
+    }
+
+    pub async fn merge_conflicts_page(
+        &self,
+        cursor: &MergeCursorV2,
+        continuation: Option<&MergeConflictCursorV2>,
+        limit: usize,
+    ) -> Result<MergeConflictPageV2> {
+        self.merge_conflict_page(cursor, continuation, limit).await
+    }
+
+    /// CAS-publish a completely built merge plan. Replaying this call with the
+    /// same cursor and operation ID reconciles an ambiguous prior publication.
+    pub async fn publish_merge(&self, cursor: &MergeCursorV2) -> Result<MergeReceiptV2> {
+        self.validate_merge_cursor(cursor).await?;
+        if cursor.phase != MergePhaseV2::ReadyToPublish {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "v2 merge plan is not ready to publish",
+            ));
+        }
+        if cursor.policy == MergePolicyV2::Fail && cursor.conflicts != 0 {
+            return Err(Error::new(
+                ErrorCode::MergeConflict,
+                "v2 merge plan contains unresolved conflicts",
+            ));
+        }
+        let base = cursor.selected_base.ok_or_else(|| {
+            Error::new(
+                ErrorCode::InternalInvariant,
+                "v2 merge plan has no selected base",
+            )
+        })?;
+        let input_digest = self.merge_input_digest(cursor, base);
+        let _lane = self.lock_branch(&cursor.target_branch).await;
+        let now = self.options.clock.now_millis()?;
+        if let Some(receipt) = self
+            .reconcile_merge_operation(cursor, input_digest, now)
+            .await?
+        {
+            return Ok(receipt);
+        }
+        let current = self.publisher.load(&cursor.target_branch).await?;
+        if current.value.target != cursor.ours {
+            return Err(Error::new(
+                ErrorCode::RefConflict,
+                "v2 merge target moved after planning",
+            ));
+        }
+        let permit = self.active_permit(&cursor.target_branch, now).await?;
+        let ours = self.load_commit_object(cursor.ours).await?.commit;
+        let theirs = self.load_commit_object(cursor.theirs).await?.commit;
+        let generation = CommitGeneration(
+            ours.generation
+                .0
+                .max(theirs.generation.0)
+                .checked_add(1)
+                .ok_or_else(|| {
+                    Error::new(ErrorCode::InternalInvariant, "v2 merge generation overflow")
+                })?,
+        );
+        let commit = BucketCommitV2 {
+            state: BucketStateV2 {
+                objects: cursor.final_objects.clone().ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "v2 merge object root is absent",
+                    )
+                })?,
+                versions: cursor.final_versions.clone().ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "v2 merge version root is absent",
+                    )
+                })?,
+            },
+            parents: vec![cursor.ours, cursor.theirs],
+            generation,
+            delta: BucketDeltaV2 {
+                input_digest,
+                changes: Vec::new(),
+                changes_root: cursor.delta_root.clone(),
+                change_count: cursor.built_changes,
+            },
+            node_pack: None,
+            authority: permit.stamp(),
+            author: self.options.writer.clone(),
+            message: Some(cursor.message.clone()),
+            created_at_millis: cursor.created_at_millis,
+            metadata: BTreeMap::new(),
+        };
+        let publication = self
+            .publisher
+            .store_and_publish(
+                current,
+                CommitPublicationV2 {
+                    permit: &permit,
+                    branch: &cursor.target_branch,
+                    commit: &commit,
+                    node_pack: None,
+                    operation: cursor.operation,
+                    message: &cursor.message,
+                    now_millis: now,
+                },
+            )
+            .await;
+        match publication {
+            Ok(published) => {
+                self.mark_local_index_head(&cursor.target_branch, published.value.target)?;
+                Ok(MergeReceiptV2 {
+                    id: published.value.target,
+                    operation: cursor.operation,
+                    branch: cursor.target_branch.clone(),
+                    parents: [cursor.ours, cursor.theirs],
+                    changed_keys: cursor.built_changes,
+                    conflicts: cursor.conflicts,
+                    idempotent_replay: false,
+                })
+            }
+            Err(error) => match self
+                .reconcile_merge_operation(cursor, input_digest, now)
+                .await?
+            {
+                Some(receipt) => Ok(receipt),
+                None => {
+                    self.fence_branch(&cursor.target_branch)?;
+                    Err(error)
+                }
+            },
+        }
+    }
+
+    /// Exact-delete one bounded page of job-scoped merge-plan nodes after a
+    /// successful publication or an explicitly abandoned plan. State and
+    /// delta nodes referenced by a published commit use the repository node
+    /// namespace and are not touched here.
+    pub async fn cleanup_merge(
+        &self,
+        cursor: &MergeCursorV2,
+        continuation: Option<&MergeCleanupCursorV2>,
+        limit: usize,
+    ) -> Result<MergeCleanupPageV2> {
+        if continuation.is_none() {
+            self.validate_merge_cursor(cursor).await?;
+        } else if cursor.repository != self.format.repository_id || cursor.job.is_nil() {
+            return Err(Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "v2 merge cleanup cursor belongs to another repository",
+            ));
+        }
+        if !(1..=1_000).contains(&limit) {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "v2 merge cleanup page must contain 1 to 1,000 objects",
+            ));
+        }
+        if continuation.is_some_and(|continuation| {
+            continuation.repository != cursor.repository || continuation.job != cursor.job
+        }) {
+            return Err(Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "v2 merge cleanup cursor belongs to another job",
+            ));
+        }
+        let prefix = format!(
+            "{}/administration/v2/merge/{}/plan/",
+            self.options.repository_prefix, cursor.job
+        );
+        let page = self
+            .plane
+            .list(ListRequest {
+                prefix,
+                continuation: continuation.map(|cursor| cursor.provider_continuation.clone()),
+                limit,
+                include_versions: true,
+            })
+            .await?;
+        let mut deleted = 0usize;
+        for entry in page.entries {
+            let physical_version = entry
+                .metadata
+                .token
+                .version_id
+                .clone()
+                .map(|version_id| PhysicalVersion::Versioned { version_id })
+                .unwrap_or_else(|| PhysicalVersion::Unversioned {
+                    token: Some(entry.metadata.token),
+                });
+            match self
+                .plane
+                .delete_exact(&entry.path, physical_version)
+                .await?
+            {
+                DeleteOutcome::Deleted | DeleteOutcome::NotFound => deleted += 1,
+                DeleteOutcome::TokenMismatch => {
+                    return Err(Error::new(
+                        ErrorCode::RefConflict,
+                        "v2 merge cleanup object changed concurrently",
+                    ))
+                }
+            }
+        }
+        Ok(MergeCleanupPageV2 {
+            deleted,
+            continuation: page
+                .continuation
+                .map(|provider_continuation| MergeCleanupCursorV2 {
+                    repository: cursor.repository,
+                    job: cursor.job,
+                    provider_continuation,
+                }),
+        })
     }
 
     pub async fn advance_branch_indexes(&self, branch: &str) -> Result<BranchIndexAdvanceReportV2> {
@@ -2977,6 +3443,995 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         })
     }
 
+    fn merge_plan_engine(&self, job: OperationId) -> Result<AsyncProlly<ProllyObjectStore<P>>> {
+        if job.is_nil() {
+            return Err(Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "v2 merge job ID is nil",
+            ));
+        }
+        Ok(self.engine(ProllyObjectStore::new(
+            self.plane.clone(),
+            format!(
+                "{}/administration/v2/merge/{job}/plan",
+                self.options.repository_prefix
+            ),
+        )))
+    }
+
+    fn merge_state_engine(&self) -> AsyncProlly<ProllyObjectStore<P>> {
+        self.engine(self.node_store.durable_direct_write_session())
+    }
+
+    fn tree_from_merge_root(&self, root: &TreeRootV1) -> Result<Tree> {
+        self.tree_from_root(root).map_err(|_| {
+            Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "v2 merge cursor uses another tree format",
+            )
+        })
+    }
+
+    async fn validate_merge_cursor(&self, cursor: &MergeCursorV2) -> Result<()> {
+        crate::repository::validate_branch(&cursor.target_branch)?;
+        crate::repository::validate_branch(&cursor.source_branch)?;
+        self.tree_from_merge_root(&cursor.plan_root)?;
+        if cursor.repository != self.format.repository_id
+            || cursor.job.is_nil()
+            || cursor.operation.is_nil()
+            || cursor.target_branch == cursor.source_branch
+            || cursor.message.trim().is_empty()
+            || cursor.best_base_count == 0
+                && !matches!(
+                    cursor.phase,
+                    MergePhaseV2::DiscoveringBases | MergePhaseV2::CollectingBases
+                )
+            || cursor.selected_base.is_none()
+                && matches!(
+                    cursor.phase,
+                    MergePhaseV2::Planning
+                        | MergePhaseV2::BuildingVersions
+                        | MergePhaseV2::BuildingObjects
+                        | MergePhaseV2::Conflicted
+                        | MergePhaseV2::ReadyToPublish
+                )
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "v2 merge cursor is malformed or belongs to another repository",
+            ));
+        }
+        let engine = self.merge_plan_engine(cursor.job)?;
+        let tree = self.tree_from_merge_root(&cursor.plan_root)?;
+        let stored = engine
+            .get(&tree, MERGE_CURSOR_KEY)
+            .await?
+            .map(|bytes| decode_canonical::<MergeCursorV2>(&bytes))
+            .transpose()?
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InvalidContinuationToken,
+                    "v2 merge cursor is not anchored by its durable plan",
+                )
+            })?;
+        if normalized_merge_cursor(&stored)? != normalized_merge_cursor(cursor)? {
+            return Err(Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "v2 merge cursor state disagrees with its durable plan",
+            ));
+        }
+        Ok(())
+    }
+
+    async fn seal_merge_cursor(&self, cursor: &mut MergeCursorV2) -> Result<()> {
+        let engine = self.merge_plan_engine(cursor.job)?;
+        let mut tree = self.tree_from_merge_root(&cursor.plan_root)?;
+        tree = engine
+            .batch(
+                &tree,
+                vec![Mutation::Upsert {
+                    key: MERGE_CURSOR_KEY.to_vec(),
+                    val: normalized_merge_cursor(cursor)?,
+                }],
+            )
+            .await?;
+        cursor.plan_root = TreeRootV1::from_tree(&tree)?;
+        Ok(())
+    }
+
+    fn validate_requested_merge_base(
+        &self,
+        cursor: &MergeCursorV2,
+        discovered: CommitIdV2,
+    ) -> Result<()> {
+        if cursor
+            .requested_base
+            .is_some_and(|requested| requested != discovered)
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidRevision,
+                "requested v2 merge base is not a best common ancestor",
+            ));
+        }
+        Ok(())
+    }
+
+    async fn merge_graph_entry(
+        &self,
+        target_branch: &str,
+        source_branch: &str,
+        commit: CommitIdV2,
+    ) -> Result<JournalCommitGraphEntryV2> {
+        if let Some(entry) = self
+            .journal_indexes
+            .commit_graph_entry(target_branch, commit)
+            .await?
+        {
+            return Ok(entry);
+        }
+        if let Some(entry) = self
+            .journal_indexes
+            .commit_graph_entry(source_branch, commit)
+            .await?
+        {
+            return Ok(entry);
+        }
+        let commit_object = self.load_commit_object(commit).await?.commit;
+        Ok(JournalCommitGraphEntryV2 {
+            commit,
+            generation: commit_object.generation,
+            parents: commit_object.parents,
+            first_parent_jumps: Vec::new(),
+        })
+    }
+
+    async fn is_first_parent_ancestor_v2(
+        &self,
+        target_branch: &str,
+        source_branch: &str,
+        ancestor: CommitIdV2,
+        mut descendant: CommitIdV2,
+    ) -> Result<bool> {
+        let ancestor_entry = self
+            .merge_graph_entry(target_branch, source_branch, ancestor)
+            .await?;
+        let target_generation = ancestor_entry.generation.0;
+        loop {
+            if descendant == ancestor {
+                return Ok(true);
+            }
+            let entry = self
+                .merge_graph_entry(target_branch, source_branch, descendant)
+                .await?;
+            if entry.generation.0 <= target_generation {
+                return Ok(false);
+            }
+            let mut selected = entry.parents.first().copied();
+            for jump in entry.first_parent_jumps.iter().rev().copied() {
+                let jump_entry = self
+                    .merge_graph_entry(target_branch, source_branch, jump)
+                    .await?;
+                if jump_entry.generation.0 >= target_generation {
+                    selected = Some(jump);
+                    break;
+                }
+            }
+            let Some(next) = selected else {
+                return Ok(false);
+            };
+            descendant = next;
+        }
+    }
+
+    fn seed_merge_frontier(
+        &self,
+        mutations: &mut Vec<Mutation>,
+        entry: JournalCommitGraphEntryV2,
+        flags: u8,
+    ) -> Result<()> {
+        let seen_key = merge_seen_key(entry.commit);
+        let queue_key = merge_queue_key(entry.generation.0, entry.commit);
+        mutations.push(Mutation::Upsert {
+            key: seen_key,
+            val: encode_canonical(&MergeSeenEntryV2 {
+                generation: entry.generation.0,
+                flags,
+            })?,
+        });
+        mutations.push(Mutation::Upsert {
+            key: queue_key,
+            val: encode_canonical(&MergeQueueEntryV2 {
+                commit: entry.commit,
+                generation: entry.generation.0,
+            })?,
+        });
+        Ok(())
+    }
+
+    async fn advance_merge_base_one(&self, cursor: &mut MergeCursorV2) -> Result<usize> {
+        let engine = self.merge_plan_engine(cursor.job)?;
+        let mut tree = self.tree_from_merge_root(&cursor.plan_root)?;
+        let mut queue = engine.prefix(&tree, MERGE_QUEUE_PREFIX).await?;
+        let Some(entry) = queue.next().await else {
+            cursor.phase = MergePhaseV2::CollectingBases;
+            return Ok(0);
+        };
+        let (queue_key, encoded) = entry?;
+        let queued: MergeQueueEntryV2 = decode_canonical(&encoded)?;
+        let seen_key = merge_seen_key(queued.commit);
+        let seen: MergeSeenEntryV2 = engine
+            .get(&tree, &seen_key)
+            .await?
+            .map(|bytes| decode_canonical(&bytes))
+            .transpose()?
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::CorruptCommit,
+                    "v2 merge queue has no seen record",
+                )
+            })?;
+        if seen.generation != queued.generation {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "v2 merge queue generation disagrees with seen state",
+            ));
+        }
+        let candidate_key = merge_base_candidate_key(queued.commit);
+        let candidate = engine
+            .get(&tree, &candidate_key)
+            .await?
+            .map(|bytes| decode_canonical::<MergeBaseCandidateV2>(&bytes))
+            .transpose()?;
+        let is_common = seen.flags & MERGE_BOTH == MERGE_BOTH;
+        let is_stale = seen.flags & MERGE_STALE != 0;
+        let mut mutations = vec![Mutation::Delete { key: queue_key }];
+        if is_common && !is_stale && candidate.is_none() {
+            mutations.push(Mutation::Upsert {
+                key: candidate_key.clone(),
+                val: encode_canonical(&MergeBaseCandidateV2 {
+                    generation: seen.generation,
+                    stale: false,
+                })?,
+            });
+        } else if is_stale && candidate.as_ref().is_some_and(|candidate| !candidate.stale) {
+            mutations.push(Mutation::Upsert {
+                key: candidate_key,
+                val: encode_canonical(&MergeBaseCandidateV2 {
+                    generation: seen.generation,
+                    stale: true,
+                })?,
+            });
+        }
+        let propagated = if is_common {
+            seen.flags | MERGE_STALE
+        } else {
+            seen.flags
+        };
+        let graph = self
+            .merge_graph_entry(&cursor.target_branch, &cursor.source_branch, queued.commit)
+            .await?;
+        for parent in graph.parents {
+            let parent_graph = self
+                .merge_graph_entry(&cursor.target_branch, &cursor.source_branch, parent)
+                .await?;
+            let parent_seen_key = merge_seen_key(parent);
+            let previous = engine
+                .get(&tree, &parent_seen_key)
+                .await?
+                .map(|bytes| decode_canonical::<MergeSeenEntryV2>(&bytes))
+                .transpose()?;
+            let next_flags = previous
+                .as_ref()
+                .map_or(propagated, |entry| entry.flags | propagated);
+            if previous
+                .as_ref()
+                .is_some_and(|entry| entry.flags == next_flags)
+            {
+                continue;
+            }
+            mutations.push(Mutation::Upsert {
+                key: parent_seen_key,
+                val: encode_canonical(&MergeSeenEntryV2 {
+                    generation: parent_graph.generation.0,
+                    flags: next_flags,
+                })?,
+            });
+            mutations.push(Mutation::Upsert {
+                key: merge_queue_key(parent_graph.generation.0, parent),
+                val: encode_canonical(&MergeQueueEntryV2 {
+                    commit: parent,
+                    generation: parent_graph.generation.0,
+                })?,
+            });
+            if next_flags & MERGE_STALE != 0 {
+                let key = merge_base_candidate_key(parent);
+                if let Some(candidate) = engine
+                    .get(&tree, &key)
+                    .await?
+                    .map(|bytes| decode_canonical::<MergeBaseCandidateV2>(&bytes))
+                    .transpose()?
+                {
+                    if !candidate.stale {
+                        mutations.push(Mutation::Upsert {
+                            key,
+                            val: encode_canonical(&MergeBaseCandidateV2 {
+                                generation: candidate.generation,
+                                stale: true,
+                            })?,
+                        });
+                    }
+                }
+            }
+        }
+        tree = engine.batch(&tree, mutations).await?;
+        cursor.plan_root = TreeRootV1::from_tree(&tree)?;
+        cursor.visited_commits = cursor.visited_commits.checked_add(1).ok_or_else(|| {
+            Error::new(
+                ErrorCode::InternalInvariant,
+                "v2 merge visited count overflow",
+            )
+        })?;
+        Ok(1)
+    }
+
+    async fn collect_merge_base_one(&self, cursor: &mut MergeCursorV2) -> Result<usize> {
+        let engine = self.merge_plan_engine(cursor.job)?;
+        let mut tree = self.tree_from_merge_root(&cursor.plan_root)?;
+        let mut candidates = engine.prefix(&tree, MERGE_BASE_CANDIDATE_PREFIX).await?;
+        let Some(entry) = candidates.next().await else {
+            if cursor.best_base_count == 0 {
+                return Err(Error::new(
+                    ErrorCode::NoMergeBase,
+                    "v2 commits have no common ancestor",
+                ));
+            }
+            if let Some(requested) = cursor.requested_base {
+                if engine
+                    .get(&tree, &merge_base_result_key(requested))
+                    .await?
+                    .is_none()
+                {
+                    return Err(Error::new(
+                        ErrorCode::InvalidRevision,
+                        "requested v2 merge base is not a best common ancestor",
+                    ));
+                }
+                cursor.selected_base = Some(requested);
+                cursor.phase = MergePhaseV2::Planning;
+            } else if cursor.best_base_count == 1 {
+                let mut bases = engine.prefix(&tree, MERGE_BASE_RESULT_PREFIX).await?;
+                let (key, _) = bases.next().await.ok_or_else(|| {
+                    Error::new(ErrorCode::CorruptCommit, "v2 best-base result is absent")
+                })??;
+                cursor.selected_base = Some(commit_from_suffix(&key, MERGE_BASE_RESULT_PREFIX)?);
+                cursor.phase = MergePhaseV2::Planning;
+            } else {
+                cursor.phase = MergePhaseV2::AwaitingBase;
+            }
+            return Ok(0);
+        };
+        let (key, encoded) = entry?;
+        let candidate: MergeBaseCandidateV2 = decode_canonical(&encoded)?;
+        let commit = commit_from_suffix(&key, MERGE_BASE_CANDIDATE_PREFIX)?;
+        let mut mutations = vec![Mutation::Delete { key }];
+        if !candidate.stale {
+            mutations.push(Mutation::Upsert {
+                key: merge_base_result_key(commit),
+                val: Vec::new(),
+            });
+            cursor.best_base_count = cursor.best_base_count.checked_add(1).ok_or_else(|| {
+                Error::new(ErrorCode::InternalInvariant, "v2 best-base count overflow")
+            })?;
+        }
+        tree = engine.batch(&tree, mutations).await?;
+        cursor.plan_root = TreeRootV1::from_tree(&tree)?;
+        Ok(1)
+    }
+
+    async fn advance_merge_plan(
+        &self,
+        cursor: &mut MergeCursorV2,
+        max_steps: usize,
+        emitted_changes: &mut Vec<MergeChangeV2>,
+        emitted_conflicts: &mut Vec<MergeConflictV2>,
+    ) -> Result<usize> {
+        let base = cursor.selected_base.ok_or_else(|| {
+            Error::new(
+                ErrorCode::InternalInvariant,
+                "v2 merge plan has no selected base",
+            )
+        })?;
+        let base_commit = self.load_commit_object(base).await?.commit;
+        let ours_commit = self.load_commit_object(cursor.ours).await?.commit;
+        let theirs_commit = self.load_commit_object(cursor.theirs).await?.commit;
+        let base_tree = self.tree_from_root(&base_commit.state.objects)?;
+        let ours_tree = self.tree_from_root(&ours_commit.state.objects)?;
+        let theirs_tree = self.tree_from_root(&theirs_commit.state.objects)?;
+        let state_engine = self.engine(self.node_store.clone());
+        let plan_engine = self.merge_plan_engine(cursor.job)?;
+        let mut plan_tree = self.tree_from_merge_root(&cursor.plan_root)?;
+        let mut processed = 0usize;
+        let mut page_mutations = Vec::new();
+        while processed < max_steps {
+            if cursor.ours_pending.is_none() && !cursor.ours_finished {
+                let page = state_engine
+                    .structural_diff_page(&base_tree, &ours_tree, cursor.ours_diff.as_ref(), 1)
+                    .await?;
+                cursor.ours_pending = page.diffs.into_iter().next();
+                cursor.ours_diff = page.next_cursor;
+                if cursor.ours_diff.is_none() {
+                    cursor.ours_finished = true;
+                }
+            }
+            if cursor.theirs_pending.is_none() && !cursor.theirs_finished {
+                let page = state_engine
+                    .structural_diff_page(&base_tree, &theirs_tree, cursor.theirs_diff.as_ref(), 1)
+                    .await?;
+                cursor.theirs_pending = page.diffs.into_iter().next();
+                cursor.theirs_diff = page.next_cursor;
+                if cursor.theirs_diff.is_none() {
+                    cursor.theirs_finished = true;
+                }
+            }
+            let key_order = match (&cursor.ours_pending, &cursor.theirs_pending) {
+                (None, None) => break,
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (Some(ours), Some(theirs)) => ours.key().cmp(theirs.key()),
+            };
+            let (key, base_value, ours_value, theirs_value) = match key_order {
+                std::cmp::Ordering::Less => {
+                    let ours = cursor.ours_pending.take().expect("matched pending ours");
+                    let (key, base, ours) = merge_diff_values(ours);
+                    (key, base.clone(), ours, base)
+                }
+                std::cmp::Ordering::Greater => {
+                    let theirs = cursor
+                        .theirs_pending
+                        .take()
+                        .expect("matched pending theirs");
+                    let (key, base, theirs) = merge_diff_values(theirs);
+                    (key, base.clone(), base, theirs)
+                }
+                std::cmp::Ordering::Equal => {
+                    let ours = cursor.ours_pending.take().expect("matched pending ours");
+                    let theirs = cursor
+                        .theirs_pending
+                        .take()
+                        .expect("matched pending theirs");
+                    let (key, ours_base, ours_value) = merge_diff_values(ours);
+                    let (theirs_key, theirs_base, theirs_value) = merge_diff_values(theirs);
+                    if key != theirs_key || ours_base != theirs_base {
+                        return Err(Error::new(
+                            ErrorCode::CorruptCommit,
+                            "v2 structural merge streams disagree on their base value",
+                        ));
+                    }
+                    (key, ours_base, ours_value, theirs_value)
+                }
+            };
+            let conflict = ours_value != theirs_value
+                && ours_value != base_value
+                && theirs_value != base_value;
+            let selected = if ours_value == theirs_value {
+                ours_value.clone()
+            } else if ours_value == base_value {
+                theirs_value.clone()
+            } else if theirs_value == base_value {
+                ours_value.clone()
+            } else {
+                match cursor.policy {
+                    MergePolicyV2::Fail | MergePolicyV2::Ours => ours_value.clone(),
+                    MergePolicyV2::Theirs => theirs_value.clone(),
+                }
+            };
+            let record = MergePlanEntryV2 {
+                key: key.clone(),
+                base: base_value.clone(),
+                ours: ours_value.clone(),
+                theirs: theirs_value.clone(),
+                selected: selected.clone(),
+                conflict,
+            };
+            if selected != ours_value {
+                page_mutations.push(Mutation::Upsert {
+                    key: merge_change_key(&key),
+                    val: encode_canonical(&record)?,
+                });
+                let change = merge_change_from_record(&record)?;
+                emitted_changes.push(change);
+                cursor.planned_changes =
+                    cursor.planned_changes.checked_add(1).ok_or_else(|| {
+                        Error::new(
+                            ErrorCode::InternalInvariant,
+                            "v2 merge change count overflow",
+                        )
+                    })?;
+            }
+            if conflict {
+                page_mutations.push(Mutation::Upsert {
+                    key: merge_conflict_key(&key),
+                    val: encode_canonical(&record)?,
+                });
+                let conflict = merge_conflict_from_record(&record)?;
+                emitted_conflicts.push(conflict);
+                cursor.conflicts = cursor.conflicts.checked_add(1).ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "v2 merge conflict count overflow",
+                    )
+                })?;
+            }
+            processed += 1;
+        }
+        if !page_mutations.is_empty() {
+            plan_tree = plan_engine.batch(&plan_tree, page_mutations).await?;
+            cursor.plan_root = TreeRootV1::from_tree(&plan_tree)?;
+        }
+        if cursor.ours_pending.is_none()
+            && cursor.theirs_pending.is_none()
+            && cursor.ours_finished
+            && cursor.theirs_finished
+        {
+            if cursor.policy == MergePolicyV2::Fail && cursor.conflicts != 0 {
+                cursor.phase = MergePhaseV2::Conflicted;
+            } else {
+                cursor.final_objects = Some(ours_commit.state.objects);
+                cursor.final_versions = Some(ours_commit.state.versions);
+                let empty_delta = self.merge_state_engine().create();
+                cursor.delta_root = Some(TreeRootV1::from_tree(&empty_delta)?);
+                cursor.phase = MergePhaseV2::BuildingVersions;
+            }
+        }
+        Ok(processed)
+    }
+
+    async fn advance_merge_version_union(
+        &self,
+        cursor: &mut MergeCursorV2,
+        max_steps: usize,
+    ) -> Result<usize> {
+        let ours_commit = self.load_commit_object(cursor.ours).await?.commit;
+        let theirs_commit = self.load_commit_object(cursor.theirs).await?.commit;
+        let ours_versions = self.tree_from_root(&ours_commit.state.versions)?;
+        let theirs_versions = self.tree_from_root(&theirs_commit.state.versions)?;
+        let read_engine = self.engine(self.node_store.clone());
+        let page = read_engine
+            .structural_diff_page(
+                &ours_versions,
+                &theirs_versions,
+                cursor.version_diff.as_ref(),
+                max_steps,
+            )
+            .await?;
+        let processed = page.diffs.len();
+        let mut mutations = Vec::new();
+        for diff in page.diffs {
+            match diff {
+                Diff::Added { key, val } => mutations.push(Mutation::Upsert { key, val }),
+                Diff::Removed { .. } => {}
+                Diff::Changed { .. } => {
+                    return Err(Error::new(
+                        ErrorCode::CorruptCommit,
+                        "same v2 version-tree key has unequal immutable values",
+                    ))
+                }
+            }
+        }
+        if !mutations.is_empty() {
+            let state_engine = self.merge_state_engine();
+            let versions =
+                self.tree_from_root(cursor.final_versions.as_ref().ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::InternalInvariant,
+                        "v2 merge version root is absent",
+                    )
+                })?)?;
+            let versions = state_engine.batch(&versions, mutations).await?;
+            cursor.final_versions = Some(TreeRootV1::from_tree(&versions)?);
+        }
+        cursor.version_diff = page.next_cursor;
+        if cursor.version_diff.is_none() {
+            cursor.version_diff_finished = true;
+            cursor.phase = MergePhaseV2::BuildingObjects;
+            cursor.build_after = None;
+        }
+        Ok(processed)
+    }
+
+    async fn advance_merge_object_build(
+        &self,
+        cursor: &mut MergeCursorV2,
+        max_steps: usize,
+    ) -> Result<usize> {
+        let plan_engine = self.merge_plan_engine(cursor.job)?;
+        let plan_tree = self.tree_from_merge_root(&cursor.plan_root)?;
+        let end = prolly::prefix_range(MERGE_CHANGE_PREFIX).1;
+        let mut entries = match &cursor.build_after {
+            Some(after) => {
+                plan_engine
+                    .range_after(&plan_tree, after, end.as_deref())
+                    .await?
+            }
+            None => plan_engine.prefix(&plan_tree, MERGE_CHANGE_PREFIX).await?,
+        };
+        let mut records = Vec::with_capacity(max_steps);
+        while records.len() < max_steps {
+            let Some(entry) = entries.next().await else {
+                break;
+            };
+            let (key, encoded) = entry?;
+            if !key.starts_with(MERGE_CHANGE_PREFIX) {
+                break;
+            }
+            let record: MergePlanEntryV2 = decode_canonical(&encoded)?;
+            if merge_change_key(&record.key) != key {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "v2 merge-plan change key disagrees with its record",
+                ));
+            }
+            records.push((key, record));
+        }
+        if records.is_empty() {
+            if cursor.built_changes != cursor.planned_changes {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "v2 merge build did not consume every planned change",
+                ));
+            }
+            if cursor.built_changes == 0 {
+                cursor.delta_root = None;
+            }
+            cursor.phase = MergePhaseV2::ReadyToPublish;
+            return Ok(0);
+        }
+        let ours = self.load_commit_object(cursor.ours).await?.commit;
+        let theirs = self.load_commit_object(cursor.theirs).await?.commit;
+        let generation = CommitGeneration(
+            ours.generation
+                .0
+                .max(theirs.generation.0)
+                .checked_add(1)
+                .ok_or_else(|| {
+                    Error::new(ErrorCode::InternalInvariant, "v2 merge generation overflow")
+                })?,
+        );
+        let mut object_mutations = Vec::with_capacity(records.len());
+        let mut version_mutations = Vec::new();
+        let mut delta_mutations = Vec::with_capacity(records.len());
+        for (_, record) in &records {
+            let previous = current_v2_id(record.ours.as_deref())?;
+            let (next, delete_marker) = if let Some(selected) = &record.selected {
+                let current: CurrentObjectV2 = decode_canonical(selected)?;
+                current.version.validate()?;
+                object_mutations.push(Mutation::Upsert {
+                    key: record.key.clone(),
+                    val: selected.clone(),
+                });
+                (current.version.id, false)
+            } else {
+                object_mutations.push(Mutation::Delete {
+                    key: record.key.clone(),
+                });
+                let ordinal = u32::try_from(cursor.built_changes + delta_mutations.len() as u64)
+                    .map_err(|_| {
+                        Error::new(
+                            ErrorCode::InvalidLimit,
+                            "v2 merge delete ordinal exceeds u32",
+                        )
+                    })?;
+                let version = ObjectVersionV2::derive(
+                    self.format.repository_id,
+                    &record.key,
+                    cursor.operation,
+                    LogicalObjectVersionBodyV1 {
+                        order: ObjectVersionOrder {
+                            commit_generation: generation,
+                            mutation_ordinal: ordinal,
+                        },
+                        created_at_millis: cursor.created_at_millis,
+                        kind: LogicalObjectVersionKindV1::DeleteMarker,
+                    },
+                    None,
+                )?;
+                version_mutations.push(Mutation::Upsert {
+                    key: version_tree_key(&record.key, version.body.order, version.id),
+                    val: encode_canonical(&version)?,
+                });
+                (version.id, true)
+            };
+            let transition = ObjectTransitionV2 {
+                key: record.key.clone(),
+                previous,
+                next,
+                delete_marker,
+            };
+            delta_mutations.push(Mutation::Upsert {
+                key: record.key.clone(),
+                val: encode_canonical(&transition)?,
+            });
+        }
+        let state_engine = self.merge_state_engine();
+        let objects = self.tree_from_root(cursor.final_objects.as_ref().ok_or_else(|| {
+            Error::new(
+                ErrorCode::InternalInvariant,
+                "v2 merge object root is absent",
+            )
+        })?)?;
+        let versions = self.tree_from_root(cursor.final_versions.as_ref().ok_or_else(|| {
+            Error::new(
+                ErrorCode::InternalInvariant,
+                "v2 merge version root is absent",
+            )
+        })?)?;
+        let delta = self.tree_from_root(cursor.delta_root.as_ref().ok_or_else(|| {
+            Error::new(
+                ErrorCode::InternalInvariant,
+                "v2 merge delta root is absent",
+            )
+        })?)?;
+        let objects = state_engine.batch(&objects, object_mutations).await?;
+        let versions = if version_mutations.is_empty() {
+            versions
+        } else {
+            state_engine.batch(&versions, version_mutations).await?
+        };
+        let delta = state_engine.batch(&delta, delta_mutations).await?;
+        cursor.final_objects = Some(TreeRootV1::from_tree(&objects)?);
+        cursor.final_versions = Some(TreeRootV1::from_tree(&versions)?);
+        cursor.delta_root = Some(TreeRootV1::from_tree(&delta)?);
+        cursor.built_changes = cursor
+            .built_changes
+            .checked_add(records.len() as u64)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InternalInvariant,
+                    "v2 merge build count overflow",
+                )
+            })?;
+        cursor.build_after = records.last().map(|(key, _)| key.clone());
+        Ok(records.len())
+    }
+
+    async fn merge_base_page(
+        &self,
+        cursor: &MergeCursorV2,
+        continuation: Option<&MergeBaseCursorV2>,
+        limit: usize,
+    ) -> Result<MergeBasePageV2> {
+        self.validate_merge_cursor(cursor).await?;
+        let limit = limit.min(self.format.canonical_limits.max_list_page as usize);
+        if limit == 0 {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "v2 merge-base page limit must be greater than zero",
+            ));
+        }
+        if continuation.is_some_and(|continuation| {
+            continuation.repository != cursor.repository
+                || continuation.job != cursor.job
+                || continuation.plan_root != cursor.plan_root
+                || !continuation.after.starts_with(MERGE_BASE_RESULT_PREFIX)
+        }) {
+            return Err(Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "v2 merge-base cursor belongs to another plan",
+            ));
+        }
+        let engine = self.merge_plan_engine(cursor.job)?;
+        let tree = self.tree_from_merge_root(&cursor.plan_root)?;
+        let end = prolly::prefix_range(MERGE_BASE_RESULT_PREFIX).1;
+        let mut iter = match continuation {
+            Some(continuation) => {
+                engine
+                    .range_after(&tree, &continuation.after, end.as_deref())
+                    .await?
+            }
+            None => engine.prefix(&tree, MERGE_BASE_RESULT_PREFIX).await?,
+        };
+        let mut bases = Vec::with_capacity(limit);
+        let mut last = None;
+        while bases.len() < limit {
+            let Some(entry) = iter.next().await else {
+                break;
+            };
+            let (key, _) = entry?;
+            if !key.starts_with(MERGE_BASE_RESULT_PREFIX) {
+                break;
+            }
+            bases.push(commit_from_suffix(&key, MERGE_BASE_RESULT_PREFIX)?);
+            last = Some(key);
+        }
+        Ok(MergeBasePageV2 {
+            continuation: (bases.len() == limit).then(|| MergeBaseCursorV2 {
+                repository: cursor.repository,
+                job: cursor.job,
+                plan_root: cursor.plan_root.clone(),
+                after: last.expect("full page has a last merge base"),
+            }),
+            bases,
+        })
+    }
+
+    async fn merge_change_page(
+        &self,
+        cursor: &MergeCursorV2,
+        continuation: Option<&MergeChangeCursorV2>,
+        limit: usize,
+    ) -> Result<MergeChangePageV2> {
+        self.validate_merge_cursor(cursor).await?;
+        let limit = limit.min(self.format.canonical_limits.max_list_page as usize);
+        if limit == 0 {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "v2 merge change page limit must be greater than zero",
+            ));
+        }
+        if continuation.is_some_and(|continuation| {
+            continuation.repository != cursor.repository
+                || continuation.job != cursor.job
+                || continuation.plan_root != cursor.plan_root
+                || !continuation.after.starts_with(MERGE_CHANGE_PREFIX)
+        }) {
+            return Err(Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "v2 merge change cursor belongs to another plan",
+            ));
+        }
+        let engine = self.merge_plan_engine(cursor.job)?;
+        let tree = self.tree_from_merge_root(&cursor.plan_root)?;
+        let end = prolly::prefix_range(MERGE_CHANGE_PREFIX).1;
+        let mut iter = match continuation {
+            Some(continuation) => {
+                engine
+                    .range_after(&tree, &continuation.after, end.as_deref())
+                    .await?
+            }
+            None => engine.prefix(&tree, MERGE_CHANGE_PREFIX).await?,
+        };
+        let mut changes = Vec::with_capacity(limit);
+        let mut last = None;
+        while changes.len() < limit {
+            let Some(entry) = iter.next().await else {
+                break;
+            };
+            let (key, encoded) = entry?;
+            if !key.starts_with(MERGE_CHANGE_PREFIX) {
+                break;
+            }
+            let record: MergePlanEntryV2 = decode_canonical(&encoded)?;
+            changes.push(merge_change_from_record(&record)?);
+            last = Some(key);
+        }
+        Ok(MergeChangePageV2 {
+            continuation: (changes.len() == limit).then(|| MergeChangeCursorV2 {
+                repository: cursor.repository,
+                job: cursor.job,
+                plan_root: cursor.plan_root.clone(),
+                after: last.expect("full page has a last merge change"),
+            }),
+            changes,
+        })
+    }
+
+    async fn merge_conflict_page(
+        &self,
+        cursor: &MergeCursorV2,
+        continuation: Option<&MergeConflictCursorV2>,
+        limit: usize,
+    ) -> Result<MergeConflictPageV2> {
+        self.validate_merge_cursor(cursor).await?;
+        let limit = limit.min(self.format.canonical_limits.max_list_page as usize);
+        if limit == 0 {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "v2 merge conflict page limit must be greater than zero",
+            ));
+        }
+        if continuation.is_some_and(|continuation| {
+            continuation.repository != cursor.repository
+                || continuation.job != cursor.job
+                || continuation.plan_root != cursor.plan_root
+                || !continuation.after.starts_with(MERGE_CONFLICT_PREFIX)
+        }) {
+            return Err(Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "v2 merge conflict cursor belongs to another plan",
+            ));
+        }
+        let engine = self.merge_plan_engine(cursor.job)?;
+        let tree = self.tree_from_merge_root(&cursor.plan_root)?;
+        let end = prolly::prefix_range(MERGE_CONFLICT_PREFIX).1;
+        let mut iter = match continuation {
+            Some(continuation) => {
+                engine
+                    .range_after(&tree, &continuation.after, end.as_deref())
+                    .await?
+            }
+            None => engine.prefix(&tree, MERGE_CONFLICT_PREFIX).await?,
+        };
+        let mut conflicts = Vec::with_capacity(limit);
+        let mut last = None;
+        while conflicts.len() < limit {
+            let Some(entry) = iter.next().await else {
+                break;
+            };
+            let (key, encoded) = entry?;
+            if !key.starts_with(MERGE_CONFLICT_PREFIX) {
+                break;
+            }
+            let record: MergePlanEntryV2 = decode_canonical(&encoded)?;
+            conflicts.push(merge_conflict_from_record(&record)?);
+            last = Some(key);
+        }
+        Ok(MergeConflictPageV2 {
+            continuation: (conflicts.len() == limit).then(|| MergeConflictCursorV2 {
+                repository: cursor.repository,
+                job: cursor.job,
+                plan_root: cursor.plan_root.clone(),
+                after: last.expect("full page has a last merge conflict"),
+            }),
+            conflicts,
+        })
+    }
+
+    fn merge_input_digest(&self, cursor: &MergeCursorV2, base: CommitIdV2) -> [u8; 32] {
+        let policy = match cursor.policy {
+            MergePolicyV2::Fail => [0],
+            MergePolicyV2::Ours => [1],
+            MergePolicyV2::Theirs => [2],
+        };
+        crate::model::derive_input_digest_v2(&[
+            b"merge-v2",
+            self.format.repository_id.as_bytes(),
+            cursor.target_branch.as_bytes(),
+            cursor.ours.as_bytes(),
+            cursor.theirs.as_bytes(),
+            base.as_bytes(),
+            &policy,
+        ])
+    }
+
+    async fn reconcile_merge_operation(
+        &self,
+        cursor: &MergeCursorV2,
+        input_digest: [u8; 32],
+        now: u64,
+    ) -> Result<Option<MergeReceiptV2>> {
+        let Some(indexed) = self
+            .operation_index
+            .lookup(
+                &self.publisher,
+                &cursor.target_branch,
+                cursor.operation,
+                now,
+            )
+            .await?
+        else {
+            return Ok(None);
+        };
+        let commit = self.load_commit_object(indexed.target).await?.commit;
+        if commit.delta.input_digest != input_digest
+            || commit.parents.as_slice() != [cursor.ours, cursor.theirs]
+        {
+            return Err(Error::new(
+                ErrorCode::IdempotencyConflict,
+                "v2 merge operation ID was reused with different input",
+            )
+            .operation(cursor.operation.to_string()));
+        }
+        Ok(Some(MergeReceiptV2 {
+            id: indexed.target,
+            operation: cursor.operation,
+            branch: cursor.target_branch.clone(),
+            parents: [cursor.ours, cursor.theirs],
+            changed_keys: commit.delta.logical_change_count(),
+            conflicts: cursor.conflicts,
+            idempotent_replay: true,
+        }))
+    }
+
     fn validate_key(&self, key: &[u8]) -> Result<()> {
         if key.is_empty()
             || key.len() > self.format.canonical_limits.max_key_bytes as usize
@@ -3027,6 +4482,122 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         };
         lane.lock_owned().await
     }
+}
+
+const MERGE_LEFT: u8 = 1;
+const MERGE_RIGHT: u8 = 2;
+const MERGE_BOTH: u8 = MERGE_LEFT | MERGE_RIGHT;
+const MERGE_STALE: u8 = 4;
+const MERGE_QUEUE_PREFIX: &[u8] = b"q/";
+const MERGE_SEEN_PREFIX: &[u8] = b"s/";
+const MERGE_BASE_CANDIDATE_PREFIX: &[u8] = b"b/";
+const MERGE_BASE_RESULT_PREFIX: &[u8] = b"r/";
+const MERGE_CHANGE_PREFIX: &[u8] = b"c/";
+const MERGE_CONFLICT_PREFIX: &[u8] = b"f/";
+const MERGE_CURSOR_KEY: &[u8] = b"x/cursor";
+
+fn normalized_merge_cursor(cursor: &MergeCursorV2) -> Result<Vec<u8>> {
+    let mut normalized = cursor.clone();
+    normalized.plan_root.root = None;
+    encode_canonical(&normalized)
+}
+
+fn merge_queue_key(generation: u64, commit: CommitIdV2) -> Vec<u8> {
+    let mut key = Vec::with_capacity(MERGE_QUEUE_PREFIX.len() + 8 + 32);
+    key.extend_from_slice(MERGE_QUEUE_PREFIX);
+    key.extend_from_slice(&(u64::MAX - generation).to_be_bytes());
+    key.extend_from_slice(commit.as_bytes());
+    key
+}
+
+fn merge_seen_key(commit: CommitIdV2) -> Vec<u8> {
+    merge_commit_key(MERGE_SEEN_PREFIX, commit)
+}
+
+fn merge_base_candidate_key(commit: CommitIdV2) -> Vec<u8> {
+    merge_commit_key(MERGE_BASE_CANDIDATE_PREFIX, commit)
+}
+
+fn merge_base_result_key(commit: CommitIdV2) -> Vec<u8> {
+    merge_commit_key(MERGE_BASE_RESULT_PREFIX, commit)
+}
+
+fn merge_commit_key(prefix: &[u8], commit: CommitIdV2) -> Vec<u8> {
+    let mut key = Vec::with_capacity(prefix.len() + 32);
+    key.extend_from_slice(prefix);
+    key.extend_from_slice(commit.as_bytes());
+    key
+}
+
+fn merge_change_key(logical_key: &[u8]) -> Vec<u8> {
+    let mut key = Vec::with_capacity(MERGE_CHANGE_PREFIX.len() + logical_key.len());
+    key.extend_from_slice(MERGE_CHANGE_PREFIX);
+    key.extend_from_slice(logical_key);
+    key
+}
+
+fn merge_conflict_key(logical_key: &[u8]) -> Vec<u8> {
+    let mut key = Vec::with_capacity(MERGE_CONFLICT_PREFIX.len() + logical_key.len());
+    key.extend_from_slice(MERGE_CONFLICT_PREFIX);
+    key.extend_from_slice(logical_key);
+    key
+}
+
+fn commit_from_suffix(key: &[u8], prefix: &[u8]) -> Result<CommitIdV2> {
+    let suffix = key.strip_prefix(prefix).ok_or_else(|| {
+        Error::new(
+            ErrorCode::CorruptCommit,
+            "v2 merge-state key uses the wrong namespace",
+        )
+    })?;
+    let hash: [u8; 32] = suffix.try_into().map_err(|_| {
+        Error::new(
+            ErrorCode::CorruptCommit,
+            "v2 merge-state commit key has the wrong length",
+        )
+    })?;
+    Ok(CommitIdV2::from_hash(hash))
+}
+
+fn merge_diff_values(diff: Diff) -> (Vec<u8>, Option<Vec<u8>>, Option<Vec<u8>>) {
+    match diff {
+        Diff::Added { key, val } => (key, None, Some(val)),
+        Diff::Removed { key, val } => (key, Some(val), None),
+        Diff::Changed { key, old, new } => (key, Some(old), Some(new)),
+    }
+}
+
+fn current_v2_id(value: Option<&[u8]>) -> Result<Option<ObjectVersionIdV2>> {
+    value
+        .map(|value| {
+            let current: CurrentObjectV2 = decode_canonical(value)?;
+            current.version.validate()?;
+            Ok(current.version.id)
+        })
+        .transpose()
+}
+
+fn merge_change_from_record(record: &MergePlanEntryV2) -> Result<MergeChangeV2> {
+    Ok(MergeChangeV2 {
+        key: record.key.clone(),
+        from: current_v2_id(record.ours.as_deref())?,
+        to: current_v2_id(record.selected.as_deref())?,
+    })
+}
+
+fn merge_conflict_from_record(record: &MergePlanEntryV2) -> Result<MergeConflictV2> {
+    if !record.conflict {
+        return Err(Error::new(
+            ErrorCode::CorruptCommit,
+            "v2 merge conflict index points to a non-conflict record",
+        ));
+    }
+    Ok(MergeConflictV2 {
+        key: record.key.clone(),
+        base: current_v2_id(record.base.as_deref())?,
+        ours: current_v2_id(record.ours.as_deref())?,
+        theirs: current_v2_id(record.theirs.as_deref())?,
+    })
 }
 
 fn validate_options(options: &RepositoryV2Options) -> Result<()> {

--- a/extensions/s3/core/src/repository_v2.rs
+++ b/extensions/s3/core/src/repository_v2.rs
@@ -156,6 +156,8 @@ pub struct RepositoryV2<P: ObjectPlane> {
     journal_indexes: Arc<JournalDerivedIndexesV2<P>>,
     locator: Arc<JournalNodeLocator<P>>,
     permits: RwLock<BTreeMap<String, AuthorityPermitV2>>,
+    fenced_branches: RwLock<BTreeSet<String>>,
+    authority_renewal: tokio::sync::Mutex<()>,
     publication_lanes: std::sync::Mutex<BTreeMap<String, Weak<tokio::sync::Mutex<()>>>>,
     writable: AtomicBool,
 }
@@ -313,6 +315,20 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         let branch = repository.options.default_branch.clone();
         repository.locator.register(&branch)?;
         repository.register_unindexed_tail(&branch).await?;
+        if !repository.options.read_only {
+            let permit = repository
+                .authority
+                .acquire(
+                    AuthorityScopeV2::Branch {
+                        name: branch.clone(),
+                    },
+                    &repository.options.writer,
+                    repository.options.clock.now_millis()?,
+                    repository.options.ids.operation(),
+                )
+                .await?;
+            repository.install_permit(&branch, permit)?;
+        }
         Ok(repository)
     }
 
@@ -392,6 +408,8 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             journal_indexes,
             locator,
             permits: RwLock::new(BTreeMap::new()),
+            fenced_branches: RwLock::new(BTreeSet::new()),
+            authority_renewal: tokio::sync::Mutex::new(()),
             publication_lanes: std::sync::Mutex::new(BTreeMap::new()),
             writable: AtomicBool::new(writable),
         })
@@ -1004,6 +1022,81 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         })
     }
 
+    /// Renew every locally held branch-authority permit. A failed or ambiguous
+    /// renewal fences only that branch in this repository instance; permits for
+    /// independent branches continue to renew.
+    pub async fn renew_shard_authorities(&self) -> Result<()> {
+        if !self.writable.load(Ordering::Acquire) {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "shard-authority renewal requires a writable protocol-v2 repository",
+            ));
+        }
+        let _renewal = self.authority_renewal.lock().await;
+        let now = self.options.clock.now_millis()?;
+        let permits = self
+            .permits
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 permit lock poisoned"))?
+            .clone();
+        let mut first_error = None;
+        for (branch, permit) in permits {
+            match self.authority.renew(permit, now).await {
+                Ok(renewed) => self.install_permit(&branch, renewed)?,
+                Err(error) => {
+                    self.fence_branch(&branch)?;
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                }
+            }
+        }
+        first_error.map_or(Ok(()), Err)
+    }
+
+    /// Run independent branch-authority renewal until the returned handle is
+    /// dropped. A fenced shard is removed from renewal while healthy shards
+    /// continue to make progress.
+    pub fn start_shard_authority_maintenance(
+        self: &Arc<Self>,
+    ) -> Result<crate::ShardAuthorityMaintenance> {
+        if !self.writable.load(Ordering::Acquire) {
+            return Err(Error::new(
+                ErrorCode::MissingCapability,
+                "shard-authority maintenance requires a writable protocol-v2 repository",
+            ));
+        }
+        let interval = Duration::from_millis((self.options.authority_lease_millis / 3).max(100));
+        let weak = Arc::downgrade(self);
+        let task = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(interval).await;
+                let Some(repository) = weak.upgrade() else {
+                    break;
+                };
+                // Renewal failures fence only their branch. Keep the task alive
+                // so independent branch shards do not lose their authorities.
+                let _ = repository.renew_shard_authorities().await;
+            }
+        });
+        Ok(crate::ShardAuthorityMaintenance::from_task(task))
+    }
+
+    pub fn fenced_branches(&self) -> Result<Vec<String>> {
+        Ok(self
+            .fenced_branches
+            .read()
+            .map_err(|_| {
+                Error::new(
+                    ErrorCode::InternalInvariant,
+                    "v2 fenced-branch lock poisoned",
+                )
+            })?
+            .iter()
+            .cloned()
+            .collect())
+    }
+
     async fn reconcile_operation(
         &self,
         branch: &str,
@@ -1043,20 +1136,79 @@ impl<P: ObjectPlane> RepositoryV2<P> {
     }
 
     async fn active_permit(&self, branch: &str, now: u64) -> Result<AuthorityPermitV2> {
-        let permit = self
+        if !self.writable.load(Ordering::Acquire) {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "protocol-v2 repository is read-only",
+            ));
+        }
+        if self.is_branch_fenced(branch)? {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "protocol-v2 branch authority is fenced in this repository instance",
+            ));
+        }
+        let cached = self
             .permits
             .read()
             .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 permit lock poisoned"))?
             .get(branch)
-            .cloned()
-            .ok_or_else(|| {
-                Error::new(
+            .cloned();
+        let permit = if let Some(permit) = cached.filter(|permit| permit.expires_at_millis() > now)
+        {
+            permit
+        } else {
+            let _renewal = self.authority_renewal.lock().await;
+            if self.is_branch_fenced(branch)? {
+                return Err(Error::new(
                     ErrorCode::PreconditionFailed,
-                    "no active local authority permit for this v2 branch; explicitly take over or create the branch",
-                )
-            })?;
-        self.authority.validate_active(&permit, now).await?;
-        Ok(permit)
+                    "protocol-v2 branch authority is fenced in this repository instance",
+                ));
+            }
+            let current = self
+                .permits
+                .read()
+                .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 permit lock poisoned"))?
+                .get(branch)
+                .cloned();
+            let acquired = match current {
+                Some(permit) if permit.expires_at_millis() > now => permit,
+                Some(_) => {
+                    self.fence_branch(branch)?;
+                    return Err(Error::new(
+                        ErrorCode::PreconditionFailed,
+                        "protocol-v2 branch authority expired; explicit takeover is required",
+                    ));
+                }
+                None => match self
+                    .authority
+                    .acquire(
+                        AuthorityScopeV2::Branch {
+                            name: branch.to_string(),
+                        },
+                        &self.options.writer,
+                        now,
+                        self.options.ids.operation(),
+                    )
+                    .await
+                {
+                    Ok(permit) => permit,
+                    Err(error) => {
+                        self.fence_branch(branch)?;
+                        return Err(error);
+                    }
+                },
+            };
+            self.install_permit(branch, acquired.clone())?;
+            acquired
+        };
+        match self.authority.validate_active(&permit, now).await {
+            Ok(_) => Ok(permit),
+            Err(error) => {
+                self.fence_branch(branch)?;
+                Err(error)
+            }
+        }
     }
 
     fn install_permit(&self, branch: &str, permit: AuthorityPermitV2) -> Result<()> {
@@ -1064,7 +1216,46 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             .write()
             .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 permit lock poisoned"))?
             .insert(branch.to_string(), permit);
+        self.fenced_branches
+            .write()
+            .map_err(|_| {
+                Error::new(
+                    ErrorCode::InternalInvariant,
+                    "v2 fenced-branch lock poisoned",
+                )
+            })?
+            .remove(branch);
         Ok(())
+    }
+
+    fn fence_branch(&self, branch: &str) -> Result<()> {
+        self.permits
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 permit lock poisoned"))?
+            .remove(branch);
+        self.fenced_branches
+            .write()
+            .map_err(|_| {
+                Error::new(
+                    ErrorCode::InternalInvariant,
+                    "v2 fenced-branch lock poisoned",
+                )
+            })?
+            .insert(branch.to_string());
+        Ok(())
+    }
+
+    fn is_branch_fenced(&self, branch: &str) -> Result<bool> {
+        Ok(self
+            .fenced_branches
+            .read()
+            .map_err(|_| {
+                Error::new(
+                    ErrorCode::InternalInvariant,
+                    "v2 fenced-branch lock poisoned",
+                )
+            })?
+            .contains(branch))
     }
 
     async fn register_unindexed_tail(&self, branch: &str) -> Result<()> {

--- a/extensions/s3/core/src/repository_v2.rs
+++ b/extensions/s3/core/src/repository_v2.rs
@@ -21,14 +21,15 @@ use crate::{
     CompareExchangeOutcome, CurrentObjectV2, Error, ErrorCode, GetRequest, IdSource,
     IdempotencyRetentionV2, ImmutablePayloadStoreV2, InitializationIntentV2,
     JournalDerivedIndexesV2, JournalIndexAdvanceReportV2, JournalIndexRebuildCleanupV2,
-    JournalIndexRebuildCursorV2, JournalIndexRebuildStepV2, LoadedRefV2,
-    LogicalObjectVersionBodyV1, LogicalObjectVersionKindV1, MemoryNodeCache, NodeCache,
-    ObjectHeaders, ObjectPath, ObjectPlane, ObjectTransitionV2, ObjectVersionIdV2,
+    JournalIndexRebuildCursorV2, JournalIndexRebuildPhaseV2, JournalIndexRebuildStepV2,
+    LoadedRefV2, LogicalObjectVersionBodyV1, LogicalObjectVersionKindV1, MemoryNodeCache,
+    NodeCache, ObjectHeaders, ObjectPath, ObjectPlane, ObjectTransitionV2, ObjectVersionIdV2,
     ObjectVersionOrder, ObjectVersionV2, OperationId, OperationIndexAdvanceReportV2,
-    PhysicalBatchV2, PhysicalMutationIdentityV2, ProllyObjectStore, ProviderPerKeyVersionLimitV2,
-    RandomIdSource, RefGeneration, RepositoryFormatV2, Result, SegmentedOperationIndexV2,
-    ShardWriterAuthorityV2, ShardedBranchPublisherV2, StagedMutationBodyV2, StagedMutationV2,
-    StagedPutV2, SystemClock, TakeoverRequestV2, TreeRootV1,
+    OperationIndexRebuildCursorV2, OperationIndexRebuildStepV2, PhysicalBatchV2,
+    PhysicalMutationIdentityV2, ProllyObjectStore, ProviderPerKeyVersionLimitV2, RandomIdSource,
+    RefGeneration, RepositoryFormatV2, Result, SegmentedOperationIndexV2, ShardWriterAuthorityV2,
+    ShardedBranchPublisherV2, StagedMutationBodyV2, StagedMutationV2, StagedPutV2, SystemClock,
+    TakeoverRequestV2, TreeRootV1,
 };
 
 #[derive(Clone)]
@@ -46,6 +47,9 @@ pub struct RepositoryV2Options {
     pub node_cache: Option<Arc<dyn NodeCache>>,
     pub mutable_control_versions_to_retain: usize,
     pub journal_index_max_unindexed_events: usize,
+    pub operation_index_leaf_entries: usize,
+    pub operation_index_merge_fanout: usize,
+    pub operation_index_max_unindexed_events: usize,
     pub idempotency_retention: IdempotencyRetentionV2,
     pub provider_per_key_version_limit: ProviderPerKeyVersionLimitV2,
     pub clock: Arc<dyn Clock>,
@@ -68,6 +72,10 @@ impl Default for RepositoryV2Options {
             node_cache: None,
             mutable_control_versions_to_retain: crate::DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,
             journal_index_max_unindexed_events: crate::DEFAULT_JOURNAL_INDEX_MAX_UNINDEXED_EVENTS,
+            operation_index_leaf_entries: crate::DEFAULT_OPERATION_INDEX_LEAF_ENTRIES,
+            operation_index_merge_fanout: crate::DEFAULT_OPERATION_INDEX_MERGE_FANOUT,
+            operation_index_max_unindexed_events:
+                crate::DEFAULT_OPERATION_INDEX_MAX_UNINDEXED_EVENTS,
             idempotency_retention: IdempotencyRetentionV2::default(),
             provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Unknown,
             clock: Arc::new(SystemClock),
@@ -424,9 +432,9 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             options.repository_prefix.clone(),
             format.repository_id,
             format.idempotency_retention,
-            crate::DEFAULT_OPERATION_INDEX_LEAF_ENTRIES,
-            crate::DEFAULT_OPERATION_INDEX_MERGE_FANOUT,
-            crate::DEFAULT_OPERATION_INDEX_MAX_UNINDEXED_EVENTS,
+            options.operation_index_leaf_entries,
+            options.operation_index_merge_fanout,
+            options.operation_index_max_unindexed_events,
             options.mutable_control_versions_to_retain,
         )?;
         let journal_indexes = Arc::new(JournalDerivedIndexesV2::new_with_limits(
@@ -1638,10 +1646,88 @@ impl<P: ObjectPlane> RepositoryV2<P> {
 
     pub async fn cleanup_branch_index_rebuild(
         &self,
-        cursor: &JournalIndexRebuildCursorV2,
+        journal: &JournalIndexRebuildCursorV2,
+        operations: &OperationIndexRebuildCursorV2,
         limit: usize,
     ) -> Result<JournalIndexRebuildCleanupV2> {
-        self.journal_indexes.cleanup_rebuild(cursor, limit).await
+        if !operations.complete
+            || operations.next_chunk.is_some()
+            || operations.repository != journal.repository
+            || operations.branch != journal.branch
+            || operations.job != journal.job
+            || operations.snapshot != journal.snapshot
+            || operations.snapshot_generation != journal.snapshot_generation
+        {
+            return Err(Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "journal rebuild chunks remain live until the matching operation-index rebuild completes",
+            ));
+        }
+        self.journal_indexes.cleanup_rebuild(journal, limit).await
+    }
+
+    pub async fn start_operation_index_rebuild(
+        &self,
+        journal: &JournalIndexRebuildCursorV2,
+    ) -> Result<OperationIndexRebuildCursorV2> {
+        if journal.phase != JournalIndexRebuildPhaseV2::Complete {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "operation-index rebuild starts after journal-index application completes",
+            ));
+        }
+        let oldest_chunk = journal.oldest_chunk.ok_or_else(|| {
+            Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "completed journal-index rebuild has no discovery chunks",
+            )
+        })?;
+        let _lane = self.lock_index_branch(&journal.branch).await;
+        self.operation_index
+            .start_rebuild(
+                &journal.branch,
+                journal.job,
+                journal.snapshot,
+                journal.snapshot_generation,
+                oldest_chunk,
+            )
+            .await
+    }
+
+    pub async fn advance_operation_index_rebuild(
+        &self,
+        cursor: &OperationIndexRebuildCursorV2,
+        max_events: usize,
+    ) -> Result<OperationIndexRebuildStepV2> {
+        if cursor.complete {
+            return Ok(OperationIndexRebuildStepV2 {
+                cursor: cursor.clone(),
+                indexed_events: 0,
+                segments_written: 0,
+                complete: true,
+            });
+        }
+        let expected = cursor.next_chunk.ok_or_else(|| {
+            Error::new(
+                ErrorCode::InvalidContinuationToken,
+                "completed operation-index rebuild has no next chunk",
+            )
+        })?;
+        let _lane = self.lock_index_branch(&cursor.branch).await;
+        let chunk = self
+            .journal_indexes
+            .load_rebuild_chunk(&cursor.branch, cursor.job, expected)
+            .await?;
+        self.operation_index
+            .advance_rebuild(
+                &self.publisher,
+                cursor,
+                &chunk,
+                expected,
+                max_events,
+                self.options.clock.now_millis()?,
+            )
+            .await
     }
 
     pub async fn branch_index_health(&self, branch: &str) -> Result<BranchIndexHealthV2> {
@@ -2133,6 +2219,10 @@ fn validate_options(options: &RepositoryV2Options) -> Result<()> {
         || options.max_cached_node_bytes == 0
         || options.mutable_control_versions_to_retain < 2
         || !(1..=1_000_000).contains(&options.journal_index_max_unindexed_events)
+        || !(1..=65_536).contains(&options.operation_index_leaf_entries)
+        || !(2..=32).contains(&options.operation_index_merge_fanout)
+        || options.operation_index_max_unindexed_events < options.operation_index_leaf_entries
+        || options.operation_index_max_unindexed_events > 1_000_000
     {
         return Err(Error::new(
             ErrorCode::InvalidRequest,

--- a/extensions/s3/core/src/repository_v2.rs
+++ b/extensions/s3/core/src/repository_v2.rs
@@ -20,11 +20,11 @@ use crate::{
     CommitSessionCleanupReportV2, CommitSessionStateV2, CommitSessionStoreV2, CompareExchange,
     CompareExchangeOutcome, CurrentObjectV2, Error, ErrorCode, GetRequest, IdSource,
     IdempotencyRetentionV2, ImmutablePayloadStoreV2, InitializationIntentV2,
-    JournalDerivedIndexesV2, JournalIndexAdvanceReportV2, LogicalObjectVersionBodyV1,
+    JournalDerivedIndexesV2, JournalIndexAdvanceReportV2, LoadedRefV2, LogicalObjectVersionBodyV1,
     LogicalObjectVersionKindV1, MemoryNodeCache, NodeCache, ObjectHeaders, ObjectPath, ObjectPlane,
     ObjectTransitionV2, ObjectVersionIdV2, ObjectVersionOrder, ObjectVersionV2, OperationId,
     OperationIndexAdvanceReportV2, PhysicalBatchV2, PhysicalMutationIdentityV2, ProllyObjectStore,
-    ProviderPerKeyVersionLimitV2, RandomIdSource, RepositoryFormatV2, Result,
+    ProviderPerKeyVersionLimitV2, RandomIdSource, RefGeneration, RepositoryFormatV2, Result,
     SegmentedOperationIndexV2, ShardWriterAuthorityV2, ShardedBranchPublisherV2,
     StagedMutationBodyV2, StagedMutationV2, StagedPutV2, SystemClock, TakeoverRequestV2,
     TreeRootV1,
@@ -111,6 +111,29 @@ pub struct BranchIndexAdvanceReportV2 {
     pub journal: JournalIndexAdvanceReportV2,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BranchIndexHealthV2 {
+    pub branch: String,
+    pub target: CommitIdV2,
+    pub ref_generation: RefGeneration,
+    pub indexed_target: Option<CommitIdV2>,
+    pub indexed_generation: Option<RefGeneration>,
+    pub lag_generations: u64,
+    pub ready: bool,
+    pub locally_registered: bool,
+    pub last_error: Option<String>,
+}
+
+pub struct BranchIndexMaintenance {
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for BranchIndexMaintenance {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
 struct JournalNodeLocator<P: ObjectPlane> {
     indexes: Arc<JournalDerivedIndexesV2<P>>,
     branches: RwLock<BTreeSet<String>>,
@@ -123,6 +146,16 @@ impl<P: ObjectPlane> JournalNodeLocator<P> {
             .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 locator lock poisoned"))?
             .insert(branch.to_string());
         Ok(())
+    }
+
+    fn registered_branches(&self) -> Result<Vec<String>> {
+        Ok(self
+            .branches
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 locator lock poisoned"))?
+            .iter()
+            .cloned()
+            .collect())
     }
 }
 
@@ -164,6 +197,9 @@ pub struct RepositoryV2<P: ObjectPlane> {
     fenced_branches: RwLock<BTreeSet<String>>,
     authority_renewal: tokio::sync::Mutex<()>,
     publication_lanes: std::sync::Mutex<BTreeMap<String, Weak<tokio::sync::Mutex<()>>>>,
+    index_lanes: std::sync::Mutex<BTreeMap<String, Weak<tokio::sync::Mutex<()>>>>,
+    local_index_heads: RwLock<BTreeMap<String, CommitIdV2>>,
+    index_errors: RwLock<BTreeMap<String, String>>,
     writable: AtomicBool,
 }
 
@@ -242,7 +278,6 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         match repository.publisher.load(&default_branch).await {
             Ok(_) => {
                 repository.locator.register(&default_branch)?;
-                repository.register_unindexed_tail(&default_branch).await?;
                 return Ok(repository);
             }
             Err(error) if error.code == ErrorCode::InvalidRevision => {}
@@ -319,7 +354,6 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         let repository = Self::from_format(plane, options, format)?;
         let branch = repository.options.default_branch.clone();
         repository.locator.register(&branch)?;
-        repository.register_unindexed_tail(&branch).await?;
         if !repository.options.read_only {
             let permit = repository
                 .authority
@@ -423,6 +457,9 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             fenced_branches: RwLock::new(BTreeSet::new()),
             authority_renewal: tokio::sync::Mutex::new(()),
             publication_lanes: std::sync::Mutex::new(BTreeMap::new()),
+            index_lanes: std::sync::Mutex::new(BTreeMap::new()),
+            local_index_heads: RwLock::new(BTreeMap::new()),
+            index_errors: RwLock::new(BTreeMap::new()),
             writable: AtomicBool::new(writable),
         })
     }
@@ -772,6 +809,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
                 "protocol-v2 commit session belongs to another authority epoch",
             ));
         }
+        self.require_branch_indexes_ready(&session.branch).await?;
         let current = self.publisher.load(&session.branch).await?;
         if current.value.target != session.base_commit {
             return Err(Error::new(
@@ -914,6 +952,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             Ok(published) => {
                 self.finalize_pack(published.value.target, &commit, prepared)
                     .await?;
+                self.mark_local_index_head(&session.branch, published.value.target)?;
                 Ok(CommitReceiptV2 {
                     id: published.value.target,
                     operation: session.identity.operation,
@@ -1070,6 +1109,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         // The authority check happens before payload bytes enter the object
         // plane. A stale process therefore fails before its payload PUT.
         self.authority.validate_active(&permit, now).await?;
+        self.require_branch_indexes_ready(branch).await?;
         let binding = self.payloads.put(bytes).await?;
 
         let current = self.publisher.load(branch).await?;
@@ -1177,6 +1217,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             .await?;
         self.finalize_pack(published.value.target, &commit, prepared)
             .await?;
+        self.mark_local_index_head(branch, published.value.target)?;
         Ok(CommitReceiptV2 {
             id: published.value.target,
             operation,
@@ -1191,8 +1232,9 @@ impl<P: ObjectPlane> RepositoryV2<P> {
     pub async fn get_object(&self, branch: &str, key: &[u8]) -> Result<Option<ObjectDataV2>> {
         self.validate_key(key)?;
         self.locator.register(branch)?;
-        self.register_unindexed_tail(branch).await?;
         let reference = self.publisher.load(branch).await?;
+        self.require_branch_indexes_ready_for(branch, &reference)
+            .await?;
         let commit = self
             .load_commit_object(reference.value.target)
             .await?
@@ -1230,7 +1272,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
     ) -> Result<Option<ObjectDataV2>> {
         self.validate_key(key)?;
         self.locator.register(branch)?;
-        self.register_unindexed_tail(branch).await?;
+        self.require_branch_indexes_ready(branch).await?;
         let commit = self.load_commit_object(snapshot).await?.commit;
         let objects = self.tree_from_root(&commit.state.objects)?;
         let Some(encoded) = self
@@ -1288,6 +1330,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         }
         let permit = self.active_permit(branch, now).await?;
         self.authority.validate_active(&permit, now).await?;
+        self.require_branch_indexes_ready(branch).await?;
         let current = self.publisher.load(branch).await?;
         let base = self.load_commit_object(current.value.target).await?.commit;
         let write_store = self.node_store.isolated_write_session();
@@ -1372,6 +1415,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             .await?;
         self.finalize_pack(published.value.target, &commit, prepared)
             .await?;
+        self.mark_local_index_head(branch, published.value.target)?;
         Ok(CommitReceiptV2 {
             id: published.value.target,
             operation,
@@ -1414,7 +1458,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             return Ok((Vec::new(), false));
         }
         self.locator.register(branch)?;
-        self.register_unindexed_tail(branch).await?;
+        self.require_branch_indexes_ready(branch).await?;
         let commit = self.load_commit_object(snapshot).await?.commit;
         let objects = self.tree_from_root(&commit.state.objects)?;
         let engine = self.engine(self.node_store.clone());
@@ -1450,7 +1494,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         let limit = limit.min(self.format.canonical_limits.max_list_page as usize);
         let snapshot = self.head(branch).await?;
         self.locator.register(branch)?;
-        self.register_unindexed_tail(branch).await?;
+        self.require_branch_indexes_ready(branch).await?;
         let commit = self.load_commit_object(snapshot).await?.commit;
         let versions = self.tree_from_root(&commit.state.versions)?;
         let prefix = version_tree_prefix(key);
@@ -1499,7 +1543,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             return Ok((Vec::new(), false));
         }
         self.locator.register(branch)?;
-        self.register_unindexed_tail(branch).await?;
+        self.require_branch_indexes_ready(branch).await?;
         let commit = self.load_commit_object(snapshot).await?.commit;
         let versions = self.tree_from_root(&commit.state.versions)?;
         let encoded_prefix = version_tree_partial_prefix(prefix);
@@ -1530,6 +1574,7 @@ impl<P: ObjectPlane> RepositoryV2<P> {
 
     pub async fn advance_branch_indexes(&self, branch: &str) -> Result<BranchIndexAdvanceReportV2> {
         self.locator.register(branch)?;
+        let _lane = self.lock_index_branch(branch).await;
         let now = self.options.clock.now_millis()?;
         let operations = self
             .operation_index
@@ -1539,10 +1584,109 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             .journal_indexes
             .advance(&self.publisher, branch, now)
             .await?;
-        Ok(BranchIndexAdvanceReportV2 {
+        let report = BranchIndexAdvanceReportV2 {
             operations,
             journal,
+        };
+        self.index_errors
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 index-error lock poisoned"))?
+            .remove(branch);
+        Ok(report)
+    }
+
+    pub async fn branch_index_health(&self, branch: &str) -> Result<BranchIndexHealthV2> {
+        self.locator.register(branch)?;
+        let reference = self.publisher.load(branch).await?;
+        self.branch_index_health_for(branch, &reference).await
+    }
+
+    async fn branch_index_health_for(
+        &self,
+        branch: &str,
+        reference: &LoadedRefV2,
+    ) -> Result<BranchIndexHealthV2> {
+        let indexed = self.journal_indexes.head(branch).await?;
+        if indexed
+            .as_ref()
+            .is_some_and(|head| head.checkpoint_generation.0 > reference.value.generation.0)
+        {
+            return Err(Error::new(
+                ErrorCode::CorruptNode,
+                "v2 journal index is ahead of the branch ref",
+            ));
+        }
+        let locally_registered = self
+            .local_index_heads
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 local-index lock poisoned"))?
+            .get(branch)
+            .is_some_and(|target| *target == reference.value.target);
+        // Node closure is ready when the durable index has already covered
+        // this exact target. A takeover barrier may advance the publication
+        // journal without changing the target; background maintenance still
+        // consumes that event, but reads need not wait for it.
+        let durable_ready = indexed
+            .as_ref()
+            .is_some_and(|head| head.target == reference.value.target);
+        let indexed_generation = indexed.as_ref().map(|head| head.checkpoint_generation);
+        let lag_generations = reference
+            .value
+            .generation
+            .0
+            .saturating_sub(indexed_generation.map_or(0, |generation| generation.0));
+        let last_error = self
+            .index_errors
+            .read()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 index-error lock poisoned"))?
+            .get(branch)
+            .cloned();
+        Ok(BranchIndexHealthV2 {
+            branch: branch.to_string(),
+            target: reference.value.target,
+            ref_generation: reference.value.generation,
+            indexed_target: indexed.as_ref().map(|head| head.target),
+            indexed_generation,
+            lag_generations,
+            ready: durable_ready || locally_registered,
+            locally_registered,
+            last_error,
         })
+    }
+
+    pub fn start_branch_index_maintenance(
+        self: &Arc<Self>,
+        interval: Duration,
+    ) -> Result<BranchIndexMaintenance> {
+        if interval < Duration::from_millis(10) {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "v2 branch-index maintenance interval must be at least 10 milliseconds",
+            ));
+        }
+        let repository = Arc::downgrade(self);
+        let task = tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                ticker.tick().await;
+                let Some(repository) = repository.upgrade() else {
+                    return;
+                };
+                let branches = match repository.locator.registered_branches() {
+                    Ok(branches) => branches,
+                    Err(_) => return,
+                };
+                for branch in branches {
+                    if let Err(error) = repository.advance_branch_indexes(&branch).await {
+                        if let Ok(mut errors) = repository.index_errors.write() {
+                            errors.insert(branch, error.to_string());
+                        }
+                    }
+                }
+            }
+        });
+        Ok(BranchIndexMaintenance { task })
     }
 
     /// Renew every locally held branch-authority permit. A failed or ambiguous
@@ -1781,53 +1925,39 @@ impl<P: ObjectPlane> RepositoryV2<P> {
             .contains(branch))
     }
 
-    async fn register_unindexed_tail(&self, branch: &str) -> Result<()> {
-        let reference = self.publisher.load(branch).await?;
-        let checkpoint = self
-            .journal_indexes
-            .head(branch)
-            .await?
-            .map(|head| head.checkpoint);
-        let mut cursor = Some(self.publisher.open_journal(branch).await?);
-        let mut reached_checkpoint = checkpoint.is_none();
-        let mut visited = 0usize;
-        while let Some(current) = cursor {
-            let page = self.publisher.read_journal_page(&current, 256).await?;
-            for entry in page.entries {
-                if checkpoint == Some(entry.id) {
-                    reached_checkpoint = true;
-                    break;
-                }
-                self.load_commit_object(entry.event.new_target).await?;
-                visited += 1;
-                if visited > crate::DEFAULT_JOURNAL_INDEX_MAX_UNINDEXED_EVENTS {
-                    return Err(Error::new(
-                        ErrorCode::HistoryLimitExceeded,
-                        "v2 node-index journal tail exceeds its bounded foreground recovery limit",
-                    ));
-                }
-            }
-            if reached_checkpoint {
-                break;
-            }
-            cursor = page.continuation;
+    async fn require_branch_indexes_ready(&self, branch: &str) -> Result<()> {
+        let health = self.branch_index_health(branch).await?;
+        Self::check_branch_index_health(health)
+    }
+
+    async fn require_branch_indexes_ready_for(
+        &self,
+        branch: &str,
+        reference: &LoadedRefV2,
+    ) -> Result<()> {
+        let health = self.branch_index_health_for(branch, reference).await?;
+        Self::check_branch_index_health(health)
+    }
+
+    fn check_branch_index_health(health: BranchIndexHealthV2) -> Result<()> {
+        if health.ready {
+            return Ok(());
         }
-        if checkpoint.is_some() && !reached_checkpoint {
-            return Err(Error::new(
-                ErrorCode::CorruptCommit,
-                "v2 journal index checkpoint is not reachable from the branch ref",
-            ));
-        }
-        // A generation-zero repository intentionally has no earlier indexed
-        // history. Register its commit pack directly.
-        if checkpoint.is_none() && reference.value.generation.0 == 0 {
-            self.load_commit_object(reference.value.target).await?;
-        } else if checkpoint.is_none() {
-            return Err(Error::new(
-                ErrorCode::PreconditionFailed,
-                "v2 journal indexes were not initialized with branch creation",
-            ));
-        }
+        Err(Error::new(
+            ErrorCode::MissingClosure,
+            format!(
+                "protocol-v2 branch indexes lag {} generation(s); background catch-up is required",
+                health.lag_generations
+            ),
+        )
+        .retry(crate::RetryAdvice::After(Duration::from_millis(250))))
+    }
+
+    fn mark_local_index_head(&self, branch: &str, target: CommitIdV2) -> Result<()> {
+        self.local_index_heads
+            .write()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "v2 local-index lock poisoned"))?
+            .insert(branch.to_string(), target);
         Ok(())
     }
 
@@ -1906,6 +2036,24 @@ impl<P: ObjectPlane> RepositoryV2<P> {
         let lane = {
             let mut lanes = self
                 .publication_lanes
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            lanes.retain(|_, lane| lane.strong_count() > 0);
+            if let Some(lane) = lanes.get(branch).and_then(Weak::upgrade) {
+                lane
+            } else {
+                let lane = Arc::new(tokio::sync::Mutex::new(()));
+                lanes.insert(branch.to_string(), Arc::downgrade(&lane));
+                lane
+            }
+        };
+        lane.lock_owned().await
+    }
+
+    async fn lock_index_branch(&self, branch: &str) -> tokio::sync::OwnedMutexGuard<()> {
+        let lane = {
+            let mut lanes = self
+                .index_lanes
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             lanes.retain(|_, lane| lane.strong_count() > 0);

--- a/extensions/s3/core/src/store.rs
+++ b/extensions/s3/core/src/store.rs
@@ -219,6 +219,7 @@ pub struct ProllyObjectStore<P> {
     packed: Option<Arc<PackedNodeState>>,
     packed_pending: Option<PackedPendingNodes>,
     direct: Option<Arc<DirectNodeState>>,
+    write_direct: bool,
 }
 
 impl<P> Clone for ProllyObjectStore<P> {
@@ -229,6 +230,7 @@ impl<P> Clone for ProllyObjectStore<P> {
             packed: self.packed.clone(),
             packed_pending: self.packed_pending.clone(),
             direct: self.direct.clone(),
+            write_direct: self.write_direct,
         }
     }
 }
@@ -241,6 +243,7 @@ impl<P> ProllyObjectStore<P> {
             packed: None,
             packed_pending: None,
             direct: None,
+            write_direct: false,
         }
     }
 
@@ -283,6 +286,7 @@ impl<P> ProllyObjectStore<P> {
             })),
             packed_pending: Some(Arc::new(RwLock::new(BTreeMap::new()))),
             direct: None,
+            write_direct: false,
         }
     }
 
@@ -315,6 +319,7 @@ impl<P> ProllyObjectStore<P> {
                 coalesced_waits: AtomicU64::new(0),
                 object_fetches: AtomicU64::new(0),
             })),
+            write_direct: true,
         }
     }
 
@@ -406,6 +411,16 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
         if self.packed.is_some() {
             session.packed_pending = Some(Arc::new(RwLock::new(BTreeMap::new())));
         }
+        session
+    }
+
+    /// Read through the packed-node locator and cache while writing newly
+    /// created immutable nodes to their deterministic direct CID paths. This
+    /// is used by restartable protocol-v2 builders whose intermediate roots
+    /// must survive process loss before a final commit envelope exists.
+    pub(crate) fn durable_direct_write_session(&self) -> Self {
+        let mut session = self.clone();
+        session.write_direct = true;
         session
     }
 
@@ -928,6 +943,14 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
                 return Ok(Some(bytes));
             }
         }
+        // Protocol-v2 administrative builders (notably resumable merges) may
+        // checkpoint immutable state nodes directly at their deterministic CID
+        // paths. This point lookup is the scale-safe fallback after the
+        // journal-derived packed-node index misses; it never scans a namespace.
+        if let Some(bytes) = self.get_uncached_direct(key).await? {
+            self.admit_node(cid, bytes.clone()).await;
+            return Ok(Some(bytes));
+        }
         Ok(None)
     }
 
@@ -1295,7 +1318,7 @@ impl<P: ObjectPlane> AsyncStore for ProllyObjectStore<P> {
                 "attempted Prolly node write under the wrong CID",
             ));
         }
-        if self.packed.is_some() {
+        if self.packed.is_some() && !self.write_direct {
             self.packed_pending
                 .as_ref()
                 .ok_or_else(|| {
@@ -1320,12 +1343,15 @@ impl<P: ObjectPlane> AsyncStore for ProllyObjectStore<P> {
         if self.direct.is_some() {
             self.admit_direct_node(Cid(key.try_into().expect("length checked")), value.to_vec())
                 .await;
+        } else if self.packed.is_some() {
+            self.admit_node(Cid(key.try_into().expect("length checked")), value.to_vec())
+                .await;
         }
         Ok(())
     }
 
     async fn delete(&self, key: &[u8]) -> Result<()> {
-        if self.packed.is_some() {
+        if self.packed.is_some() && !self.write_direct {
             if key.len() != 32 {
                 return Err(Error::new(
                     ErrorCode::CorruptNode,

--- a/extensions/s3/core/src/store.rs
+++ b/extensions/s3/core/src/store.rs
@@ -10,15 +10,22 @@ use futures_util::StreamExt;
 use prolly::{AsyncStore, BatchOp, Cid};
 
 use crate::{
-    codec::sha256, CommitId, CommitObjectV1, DeleteOutcome, Error, ErrorCode, GetRequest,
-    ImmutablePut, ListRequest, NodeCache, NodeCacheKey, NodeIndexEntryV1, NodePackAttachmentKindV1,
-    NodePackAttachmentV1, NodePackEntryV1, NodePackId, NodePackRefV1, NodePackV1, ObjectPath,
-    ObjectPlane, PhysicalVersion, RepositoryId, Result, TreeFormatDigest,
+    codec::sha256, CommitId, CommitIdV2, CommitObjectV1, CommitObjectV2, DeleteOutcome, Error,
+    ErrorCode, GetRequest, ImmutablePut, JournalNodeIndexEntryV2, ListRequest, NodeCache,
+    NodeCacheKey, NodeIndexEntryV1, NodePackAttachmentKindV1, NodePackAttachmentV1,
+    NodePackEntryV1, NodePackId, NodePackRefV1, NodePackV1, ObjectPath, ObjectPlane,
+    PhysicalVersion, RepositoryId, Result, TreeFormatDigest,
 };
+
+#[derive(Clone, Copy)]
+enum PackedCommitId {
+    V1(CommitId),
+    V2(CommitIdV2),
+}
 
 #[derive(Clone)]
 struct PackedNodeLocation {
-    container: CommitId,
+    container: PackedCommitId,
     pack: NodePackId,
     absolute_offset: u64,
     len: u32,
@@ -41,6 +48,7 @@ struct PackedNodeState {
     coalesced_waits: AtomicU64,
     ranged_fetches: AtomicU64,
     locator: RwLock<Option<Arc<dyn NodeLocator>>>,
+    allow_namespace_scan: bool,
 }
 
 struct DirectNodeState {
@@ -93,7 +101,43 @@ impl BoundedNodeLocations {
 
 #[async_trait::async_trait]
 pub(crate) trait NodeLocator: Send + Sync + 'static {
-    async fn locate(&self, cid: &Cid) -> Result<Option<NodeIndexEntryV1>>;
+    async fn locate(&self, cid: &Cid) -> Result<Option<LocatedPackedNode>>;
+}
+
+#[derive(Clone)]
+pub(crate) struct LocatedPackedNode {
+    cid: Cid,
+    container: PackedCommitId,
+    pack: NodePackId,
+    absolute_offset: u64,
+    len: u32,
+    sha256: [u8; 32],
+}
+
+impl From<NodeIndexEntryV1> for LocatedPackedNode {
+    fn from(entry: NodeIndexEntryV1) -> Self {
+        Self {
+            cid: entry.cid,
+            container: PackedCommitId::V1(entry.container),
+            pack: entry.pack,
+            absolute_offset: entry.absolute_offset,
+            len: entry.len,
+            sha256: entry.sha256,
+        }
+    }
+}
+
+impl From<JournalNodeIndexEntryV2> for LocatedPackedNode {
+    fn from(entry: JournalNodeIndexEntryV2) -> Self {
+        Self {
+            cid: entry.cid,
+            container: PackedCommitId::V2(entry.container),
+            pack: entry.pack,
+            absolute_offset: entry.absolute_offset,
+            len: entry.len,
+            sha256: entry.sha256,
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -235,6 +279,7 @@ impl<P> ProllyObjectStore<P> {
                 coalesced_waits: AtomicU64::new(0),
                 ranged_fetches: AtomicU64::new(0),
                 locator: RwLock::new(None),
+                allow_namespace_scan: true,
             })),
             packed_pending: Some(Arc::new(RwLock::new(BTreeMap::new()))),
             direct: None,
@@ -294,6 +339,28 @@ impl<P> ProllyObjectStore<P> {
         store
     }
 
+    pub(crate) fn new_packed_v2_with_node_cache(
+        plane: Arc<P>,
+        repository_prefix: impl Into<String>,
+        max_cached_pack_bytes: usize,
+        max_cached_locations: usize,
+        cache_namespace: NodeCacheNamespace,
+        node_cache: Arc<dyn NodeCache>,
+    ) -> Self {
+        let mut store = Self::new_packed_with_node_cache(
+            plane,
+            repository_prefix,
+            max_cached_pack_bytes,
+            max_cached_locations,
+            cache_namespace,
+            node_cache,
+        );
+        let state = Arc::get_mut(store.packed.as_mut().expect("packed state was created"))
+            .expect("newly created packed state has one owner");
+        state.allow_namespace_scan = false;
+        store
+    }
+
     fn path_for_key(&self, key: &[u8]) -> Result<ObjectPath> {
         if key.len() != 32 {
             return Err(Error::new(
@@ -311,10 +378,14 @@ impl<P> ProllyObjectStore<P> {
         ))
     }
 
-    fn commit_path(&self, id: CommitId) -> Result<ObjectPath> {
-        let encoded = hex::encode(id.as_bytes());
+    fn commit_path(&self, id: PackedCommitId) -> Result<ObjectPath> {
+        let (version, encoded) = match id {
+            PackedCommitId::V1(id) => (None, hex::encode(id.as_bytes())),
+            PackedCommitId::V2(id) => (Some("v2"), hex::encode(id.as_bytes())),
+        };
+        let version = version.map_or_else(String::new, |version| format!("{version}/"));
         ObjectPath::new(format!(
-            "{}/commits/sha256/{}/{}/{}",
+            "{}/commits/{version}sha256/{}/{}/{}",
             self.repository_prefix,
             &encoded[..2],
             &encoded[2..4],
@@ -387,17 +458,28 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
             .locations
             .read()
             .map_err(|_| Error::new(ErrorCode::InternalInvariant, "packed-node lock poisoned"))?;
-        Ok(locations
+        locations
             .iter()
-            .map(|(cid, location)| NodeIndexEntryV1 {
-                cid: cid.clone(),
-                container: location.container,
-                pack: location.pack,
-                absolute_offset: location.absolute_offset,
-                len: location.len,
-                sha256: location.sha256,
+            .map(|(cid, location)| {
+                let container = match location.container {
+                    PackedCommitId::V1(container) => container,
+                    PackedCommitId::V2(_) => {
+                        return Err(Error::new(
+                            ErrorCode::InternalInvariant,
+                            "cannot export v2 node locations through the v1 checkpoint API",
+                        ))
+                    }
+                };
+                Ok(NodeIndexEntryV1 {
+                    cid: cid.clone(),
+                    container,
+                    pack: location.pack,
+                    absolute_offset: location.absolute_offset,
+                    len: location.len,
+                    sha256: location.sha256,
+                })
             })
-            .collect())
+            .collect()
     }
 
     pub fn import_node_index(&self, entries: &[NodeIndexEntryV1]) -> Result<()> {
@@ -424,7 +506,7 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
             locations.insert(
                 entry.cid.clone(),
                 PackedNodeLocation {
-                    container: entry.container,
+                    container: PackedCommitId::V1(entry.container),
                     pack: entry.pack,
                     absolute_offset: entry.absolute_offset,
                     len: entry.len,
@@ -436,7 +518,11 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
     }
 
     pub async fn rebuild_node_index(&self) -> Result<()> {
-        if self.packed.is_some() {
+        if self
+            .packed
+            .as_ref()
+            .is_some_and(|state| state.allow_namespace_scan)
+        {
             self.scan_commit_objects_for(None).await?;
         }
         Ok(())
@@ -494,14 +580,24 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
                 }
             }
         }
-        Ok(location.map(|location| NodeIndexEntryV1 {
-            cid: cid.clone(),
-            container: location.container,
-            pack: location.pack,
-            absolute_offset: location.absolute_offset,
-            len: location.len,
-            sha256: location.sha256,
-        }))
+        location
+            .map(|location| {
+                let PackedCommitId::V1(container) = location.container else {
+                    return Err(Error::new(
+                        ErrorCode::InternalInvariant,
+                        "cannot resolve a v2 node through the v1 checkpoint API",
+                    ));
+                };
+                Ok(NodeIndexEntryV1 {
+                    cid: cid.clone(),
+                    container,
+                    pack: location.pack,
+                    absolute_offset: location.absolute_offset,
+                    len: location.len,
+                    sha256: location.sha256,
+                })
+            })
+            .transpose()
     }
 
     pub(crate) fn clear_node_locations(&self) -> Result<()> {
@@ -598,6 +694,26 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
         prepared: PreparedNodePack,
         payload_offset: u64,
     ) -> Result<()> {
+        self.commit_node_pack_for(PackedCommitId::V1(container), prepared, payload_offset)
+            .await
+    }
+
+    pub(crate) async fn commit_node_pack_v2(
+        &self,
+        container: CommitIdV2,
+        prepared: PreparedNodePack,
+        payload_offset: u64,
+    ) -> Result<()> {
+        self.commit_node_pack_for(PackedCommitId::V2(container), prepared, payload_offset)
+            .await
+    }
+
+    async fn commit_node_pack_for(
+        &self,
+        container: PackedCommitId,
+        prepared: PreparedNodePack,
+        payload_offset: u64,
+    ) -> Result<()> {
         let Some(state) = &self.packed else {
             return Err(Error::new(
                 ErrorCode::InternalInvariant,
@@ -649,13 +765,41 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
         object: &CommitObjectV1,
         encoded: &[u8],
     ) -> Result<()> {
-        let Some(pack) = object.node_pack.as_ref() else {
+        let payload_offset = CommitObjectV1::node_payload_offset(encoded)?;
+        self.register_node_pack(
+            PackedCommitId::V1(container),
+            object.node_pack.as_ref(),
+            payload_offset,
+        )
+    }
+
+    pub(crate) fn register_commit_object_v2(
+        &self,
+        container: CommitIdV2,
+        object: &CommitObjectV2,
+        encoded: &[u8],
+    ) -> Result<()> {
+        let payload_offset = CommitObjectV2::node_payload_offset(encoded)?;
+        self.register_node_pack(
+            PackedCommitId::V2(container),
+            object.node_pack.as_ref(),
+            payload_offset,
+        )
+    }
+
+    fn register_node_pack(
+        &self,
+        container: PackedCommitId,
+        pack: Option<&NodePackV1>,
+        payload_offset: Option<u64>,
+    ) -> Result<()> {
+        let Some(pack) = pack else {
             return Ok(());
         };
         let Some(state) = &self.packed else {
             return Ok(());
         };
-        let payload_offset = CommitObjectV1::node_payload_offset(encoded)?.ok_or_else(|| {
+        let payload_offset = payload_offset.ok_or_else(|| {
             Error::new(
                 ErrorCode::CorruptCommit,
                 "commit node-pack payload is absent",
@@ -692,7 +836,12 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
     }
 
     async fn get_packed(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        self.get_packed_with_fallback(key, true).await
+        let allow_namespace_scan = self
+            .packed
+            .as_ref()
+            .is_some_and(|state| state.allow_namespace_scan);
+        self.get_packed_with_fallback(key, allow_namespace_scan)
+            .await
     }
 
     pub(crate) async fn get_indexed_packed(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {

--- a/extensions/s3/core/src/tag_v2.rs
+++ b/extensions/s3/core/src/tag_v2.rs
@@ -1,0 +1,259 @@
+use std::sync::Arc;
+
+use crate::{
+    decode_canonical, encode_canonical, AuthorityPermitV2, AuthorityScopeV2, CommitIdV2,
+    CompareExchange, CompareExchangeOutcome, Error, ErrorCode, MutableControlStore, ObjectPath,
+    ObjectPlane, OperationId, RefGeneration, ReflogEntryV2, RepositoryId, Result, RetryAdvice,
+    ShardWriterAuthorityV2, StorageToken, TagValueV2, DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,
+};
+
+#[derive(Clone, Debug)]
+pub struct LoadedTagV2 {
+    pub value: TagValueV2,
+    pub token: StorageToken,
+}
+
+pub struct TagStoreV2<P: ObjectPlane> {
+    plane: Arc<P>,
+    controls: MutableControlStore<P>,
+    authority: Arc<ShardWriterAuthorityV2<P>>,
+    prefix: String,
+    repository: RepositoryId,
+}
+
+impl<P: ObjectPlane> TagStoreV2<P> {
+    pub fn new(
+        plane: Arc<P>,
+        prefix: impl Into<String>,
+        repository: RepositoryId,
+        authority: Arc<ShardWriterAuthorityV2<P>>,
+    ) -> Result<Self> {
+        Self::new_with_control_retention(
+            plane,
+            prefix,
+            repository,
+            authority,
+            DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,
+        )
+    }
+
+    pub fn new_with_control_retention(
+        plane: Arc<P>,
+        prefix: impl Into<String>,
+        repository: RepositoryId,
+        authority: Arc<ShardWriterAuthorityV2<P>>,
+        control_versions_to_retain: usize,
+    ) -> Result<Self> {
+        let prefix = prefix.into();
+        let controls =
+            MutableControlStore::new(plane.clone(), prefix.clone(), control_versions_to_retain)?;
+        Ok(Self {
+            plane,
+            controls,
+            authority,
+            prefix,
+            repository,
+        })
+    }
+
+    pub async fn load(&self, name: &str) -> Result<LoadedTagV2> {
+        let loaded = self.load_including_tombstone(name).await?;
+        if loaded.value.tombstone {
+            return Err(Error::new(ErrorCode::InvalidRevision, "v2 tag is deleted"));
+        }
+        Ok(loaded)
+    }
+
+    pub async fn load_including_tombstone(&self, name: &str) -> Result<LoadedTagV2> {
+        let path = self.path(name)?;
+        let stored = self
+            .plane
+            .load_mutable(&path)
+            .await?
+            .ok_or_else(|| Error::new(ErrorCode::InvalidRevision, "v2 tag is missing"))?;
+        let value: TagValueV2 = decode_canonical(&stored.bytes)?;
+        value.validate(self.repository, name)?;
+        Ok(LoadedTagV2 {
+            value,
+            token: stored.metadata.token,
+        })
+    }
+
+    pub async fn create(
+        &self,
+        permit: &AuthorityPermitV2,
+        name: &str,
+        target: CommitIdV2,
+        operation: OperationId,
+        actor: &str,
+        now_millis: u64,
+    ) -> Result<LoadedTagV2> {
+        crate::repository::validate_branch(name)?;
+        if operation.is_nil() || actor.is_empty() {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "v2 tag creation requires an operation and actor",
+            ));
+        }
+        let stamp = self.authority.validate_active(permit, now_millis).await?;
+        stamp.validate(
+            self.repository,
+            &AuthorityScopeV2::System {
+                namespace: "tags".to_string(),
+            },
+        )?;
+        let existing = match self.load_including_tombstone(name).await {
+            Ok(existing) if !existing.value.tombstone => {
+                return Err(Error::new(ErrorCode::RefConflict, "v2 tag already exists"));
+            }
+            Ok(existing) => Some(existing),
+            Err(error) if error.code == ErrorCode::InvalidRevision => None,
+            Err(error) => return Err(error),
+        };
+        let generation = existing.as_ref().map_or(Ok(RefGeneration(0)), |current| {
+            current
+                .value
+                .generation
+                .0
+                .checked_add(1)
+                .map(RefGeneration)
+                .ok_or_else(|| {
+                    Error::new(ErrorCode::InternalInvariant, "v2 tag generation overflow")
+                })
+        })?;
+        let previous_target = existing.as_ref().map(|current| current.value.target);
+        let value = TagValueV2 {
+            target,
+            previous_target,
+            generation,
+            operation,
+            inline_reflog: ReflogEntryV2 {
+                branch: name.to_string(),
+                old_target: previous_target,
+                new_target: target,
+                operation,
+                actor: actor.to_string(),
+                message: "create tag".to_string(),
+                created_at_millis: now_millis,
+            },
+            authority: stamp,
+            updated_at_millis: now_millis,
+            tombstone: false,
+        };
+        self.cas(name, existing.map(|current| current.token), value)
+            .await
+    }
+
+    pub async fn delete(
+        &self,
+        permit: &AuthorityPermitV2,
+        name: &str,
+        current: LoadedTagV2,
+        expected: CommitIdV2,
+        operation: OperationId,
+        now_millis: u64,
+    ) -> Result<LoadedTagV2> {
+        crate::repository::validate_branch(name)?;
+        current.value.validate(self.repository, name)?;
+        let stamp = self.authority.validate_active(permit, now_millis).await?;
+        stamp.validate(
+            self.repository,
+            &AuthorityScopeV2::System {
+                namespace: "tags".to_string(),
+            },
+        )?;
+        if current.value.tombstone
+            || current.value.target != expected
+            || current.value.authority != stamp
+            || operation.is_nil()
+        {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "v2 tag deletion does not match the live tag and authority",
+            ));
+        }
+        let generation =
+            RefGeneration(current.value.generation.0.checked_add(1).ok_or_else(|| {
+                Error::new(ErrorCode::InternalInvariant, "v2 tag generation overflow")
+            })?);
+        let value = TagValueV2 {
+            target: expected,
+            previous_target: Some(expected),
+            generation,
+            operation,
+            inline_reflog: ReflogEntryV2 {
+                branch: name.to_string(),
+                old_target: Some(expected),
+                new_target: expected,
+                operation,
+                actor: stamp.writer_id.clone(),
+                message: "delete tag".to_string(),
+                created_at_millis: now_millis,
+            },
+            authority: stamp,
+            updated_at_millis: now_millis,
+            tombstone: true,
+        };
+        self.cas(name, Some(current.token), value).await
+    }
+
+    async fn cas(
+        &self,
+        name: &str,
+        expected: Option<StorageToken>,
+        value: TagValueV2,
+    ) -> Result<LoadedTagV2> {
+        value.validate(self.repository, name)?;
+        let path = self.path(name)?;
+        let bytes = encode_canonical(&value)?;
+        match self
+            .controls
+            .compare_exchange(CompareExchange {
+                path: path.clone(),
+                expected,
+                bytes: bytes.clone(),
+            })
+            .await
+        {
+            Ok(CompareExchangeOutcome::Applied(metadata)) => Ok(LoadedTagV2 {
+                value,
+                token: metadata.token,
+            }),
+            Ok(CompareExchangeOutcome::Conflict(Some(current))) if current.bytes == bytes => {
+                Ok(LoadedTagV2 {
+                    value,
+                    token: current.metadata.token,
+                })
+            }
+            Ok(CompareExchangeOutcome::Conflict(_)) => Err(Error::new(
+                ErrorCode::RefConflict,
+                "v2 tag changed concurrently",
+            )),
+            Err(error) => {
+                if let Some(current) = self.plane.load_mutable(&path).await? {
+                    if current.bytes == bytes {
+                        return Ok(LoadedTagV2 {
+                            value,
+                            token: current.metadata.token,
+                        });
+                    }
+                }
+                Err(Error::new(
+                    ErrorCode::OutcomeUnknown,
+                    format!("v2 tag publication outcome is unknown: {error}"),
+                )
+                .retry(RetryAdvice::ReconcileOperation)
+                .operation(value.operation.to_string()))
+            }
+        }
+    }
+
+    fn path(&self, name: &str) -> Result<ObjectPath> {
+        crate::repository::validate_branch(name)?;
+        ObjectPath::new(format!(
+            "{}/refs/v2/tags/{}",
+            self.prefix,
+            hex::encode(name.as_bytes())
+        ))
+    }
+}

--- a/extensions/s3/core/tests/control_version_compaction.rs
+++ b/extensions/s3/core/tests/control_version_compaction.rs
@@ -51,6 +51,7 @@ fn every_mutable_control_family_has_one_canonical_classification() {
         ("refs/heads/6d61696e", MutableControlKind::BranchRefV1),
         ("refs/v2/heads/6d61696e", MutableControlKind::BranchRefV2),
         ("refs/tags/7631", MutableControlKind::TagRefV1),
+        ("refs/v2/tags/7631", MutableControlKind::TagRefV2),
         (
             "retention/pins/6c6567616c",
             MutableControlKind::RetentionPinV1,
@@ -66,6 +67,10 @@ fn every_mutable_control_family_has_one_canonical_classification() {
         (
             "ref-catalog/v2/head.cbor",
             MutableControlKind::RefCatalogHeadV2,
+        ),
+        (
+            "ref-catalog/v2/shards/0a/head.cbor",
+            MutableControlKind::RefCatalogShardHeadV2,
         ),
         (
             "commit-graph/v2/head.cbor",

--- a/extensions/s3/core/tests/journal_indexes_v2.rs
+++ b/extensions/s3/core/tests/journal_indexes_v2.rs
@@ -32,6 +32,8 @@ fn commit(
         delta: BucketDeltaV2 {
             input_digest: [0; 32],
             changes: Vec::new(),
+            changes_root: None,
+            change_count: 0,
         },
         node_pack: pack.map(|pack| pack.reference().unwrap()),
         authority,

--- a/extensions/s3/core/tests/journal_indexes_v2.rs
+++ b/extensions/s3/core/tests/journal_indexes_v2.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use prolly::TreeFormat;
 use prolly_s3_core::{
-    AuthorityScopeV2, AuthorityStampV2, BucketCommitV2, BucketDeltaV1, BucketStateV1,
+    AuthorityScopeV2, AuthorityStampV2, BucketCommitV2, BucketDeltaV2, BucketStateV2,
     CommitGeneration, CommitIdV2, CommitPublicationV2, JournalDerivedIndexesV2, MemoryObjectPlane,
     NodePackEntryV1, NodePackV1, OperationId, RepositoryId, ShardWriterAuthorityV2,
     ShardedBranchPublisherV2, TreeFormatDigest, TreeRootV1,
@@ -23,15 +23,14 @@ fn commit(
         format_digest: TreeFormatDigest::from_hash([0x51; 32]),
     };
     BucketCommitV2 {
-        state: BucketStateV1 {
+        state: BucketStateV2 {
             objects: root.clone(),
-            versions: root.clone(),
-            operations: root,
+            versions: root,
         },
         parents,
         generation: CommitGeneration(generation),
-        delta: BucketDeltaV1 {
-            operation_ids: Vec::new(),
+        delta: BucketDeltaV2 {
+            input_digest: [0; 32],
             changes: Vec::new(),
         },
         node_pack: pack.map(|pack| pack.reference().unwrap()),

--- a/extensions/s3/core/tests/merge_v2.rs
+++ b/extensions/s3/core/tests/merge_v2.rs
@@ -1,0 +1,591 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use prolly_s3_core::{
+    decode_canonical, encode_canonical, FixedClock, LogicalObjectVersionKindV1, MemoryObjectPlane,
+    MergeCursorV2, MergePhaseV2, MergePolicy, MergePolicyV2, ObjectHeaders,
+    ProviderPerKeyVersionLimitV2, Repository, RepositoryOptions, RepositoryV2, RepositoryV2Options,
+    SequenceIdSource,
+};
+
+fn options(clock: Arc<FixedClock>) -> RepositoryV2Options {
+    RepositoryV2Options {
+        repository_prefix: ".tests/native-v2-merge".to_string(),
+        writer: "merge-writer".to_string(),
+        clock,
+        ids: Arc::new(SequenceIdSource::new(0x44, 1)),
+        provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Finite(10_000),
+        ..RepositoryV2Options::default()
+    }
+}
+
+async fn put(repository: &RepositoryV2<MemoryObjectPlane>, branch: &str, key: &str, value: &str) {
+    repository
+        .put_object(
+            branch,
+            key.as_bytes().to_vec(),
+            value.as_bytes().to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn native_v2_merge_is_structural_paged_restartable_and_replayable() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(10_000));
+    let options = options(clock.clone());
+    let repository = RepositoryV2::initialize(plane.clone(), options.clone())
+        .await
+        .unwrap();
+
+    clock.advance(1).unwrap();
+    put(&repository, "main", "conflict.txt", "base").await;
+    let base = repository.head("main").await.unwrap();
+    repository.create_branch("feature", base).await.unwrap();
+
+    clock.advance(1).unwrap();
+    put(&repository, "main", "conflict.txt", "ours").await;
+    put(&repository, "main", "ours-only.txt", "ours-only").await;
+    clock.advance(1).unwrap();
+    put(&repository, "feature", "conflict.txt", "theirs").await;
+    put(&repository, "feature", "theirs-only.txt", "theirs-only").await;
+    repository.advance_branch_indexes("main").await.unwrap();
+    repository.advance_branch_indexes("feature").await.unwrap();
+
+    let mut cursor = repository
+        .start_merge(
+            "main",
+            "feature",
+            None,
+            MergePolicyV2::Theirs,
+            "merge feature",
+        )
+        .await
+        .unwrap();
+    let mut tampered = cursor.clone();
+    tampered.planned_changes = 1;
+    assert_eq!(
+        repository
+            .advance_merge(&tampered, 1)
+            .await
+            .unwrap_err()
+            .code,
+        prolly_s3_core::ErrorCode::InvalidContinuationToken
+    );
+    drop(repository);
+
+    let mut total_processed = 0usize;
+    while cursor.phase != MergePhaseV2::ReadyToPublish {
+        let reopened = RepositoryV2::open(plane.clone(), options.clone())
+            .await
+            .unwrap();
+        let persisted = encode_canonical(&cursor).unwrap();
+        let restored: MergeCursorV2 = decode_canonical(&persisted).unwrap();
+        let page = reopened.advance_merge(&restored, 2).await.unwrap();
+        assert!(page.processed <= 2);
+        total_processed += page.processed;
+        cursor = page.cursor;
+        drop(reopened);
+    }
+    assert!(total_processed > 0);
+    assert_eq!(cursor.conflicts, 1);
+    assert_eq!(cursor.planned_changes, 2);
+    assert_eq!(cursor.built_changes, 2);
+
+    let reopened = RepositoryV2::open(plane.clone(), options.clone())
+        .await
+        .unwrap();
+    let conflict_page = reopened
+        .merge_conflicts_page(&cursor, None, 1)
+        .await
+        .unwrap();
+    assert_eq!(conflict_page.conflicts.len(), 1);
+    assert_eq!(conflict_page.conflicts[0].key, b"conflict.txt");
+    let change_page = reopened.merge_changes_page(&cursor, None, 1).await.unwrap();
+    assert_eq!(change_page.changes.len(), 1);
+    assert!(change_page.continuation.is_some());
+    let second_page = reopened
+        .merge_changes_page(&cursor, change_page.continuation.as_ref(), 1)
+        .await
+        .unwrap();
+    assert_eq!(second_page.changes.len(), 1);
+
+    let receipt = reopened.publish_merge(&cursor).await.unwrap();
+    assert_eq!(receipt.changed_keys, 2);
+    assert_eq!(receipt.conflicts, 1);
+    assert_eq!(receipt.parents, [cursor.ours, cursor.theirs]);
+    reopened.advance_branch_indexes("main").await.unwrap();
+    let replay = reopened.publish_merge(&cursor).await.unwrap();
+    assert_eq!(replay.id, receipt.id);
+    assert!(replay.idempotent_replay);
+    let mut cleanup_cursor = None;
+    let mut deleted_plan_nodes = 0usize;
+    loop {
+        let page = reopened
+            .cleanup_merge(&cursor, cleanup_cursor.as_ref(), 1)
+            .await
+            .unwrap();
+        deleted_plan_nodes += page.deleted;
+        cleanup_cursor = page.continuation;
+        if cleanup_cursor.is_none() {
+            break;
+        }
+    }
+    assert!(deleted_plan_nodes > 0);
+    drop(reopened);
+
+    let reader = RepositoryV2::open(
+        plane,
+        RepositoryV2Options {
+            read_only: true,
+            ..options
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        reader
+            .get_object("main", b"conflict.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"theirs"
+    );
+    assert_eq!(
+        reader
+            .get_object("main", b"theirs-only.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"theirs-only"
+    );
+    assert_eq!(
+        reader
+            .get_object("main", b"ours-only.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"ours-only"
+    );
+}
+
+#[tokio::test]
+async fn native_v2_fail_policy_persists_conflicts_without_publication() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(30_000));
+    let options = RepositoryV2Options {
+        repository_prefix: ".tests/native-v2-merge-fail".to_string(),
+        ..options(clock.clone())
+    };
+    let repository = RepositoryV2::initialize(plane, options).await.unwrap();
+    clock.advance(1).unwrap();
+    put(&repository, "main", "same.txt", "base").await;
+    let base = repository.head("main").await.unwrap();
+    repository.create_branch("feature", base).await.unwrap();
+    put(&repository, "main", "same.txt", "ours").await;
+    put(&repository, "feature", "same.txt", "theirs").await;
+    repository.advance_branch_indexes("main").await.unwrap();
+    repository.advance_branch_indexes("feature").await.unwrap();
+    let mut cursor = repository
+        .start_merge(
+            "main",
+            "feature",
+            None,
+            MergePolicyV2::Fail,
+            "detect conflict",
+        )
+        .await
+        .unwrap();
+    while !matches!(cursor.phase, MergePhaseV2::Conflicted) {
+        cursor = repository.advance_merge(&cursor, 1).await.unwrap().cursor;
+    }
+    assert_eq!(cursor.conflicts, 1);
+    assert_eq!(
+        repository.publish_merge(&cursor).await.unwrap_err().code,
+        prolly_s3_core::ErrorCode::PreconditionFailed
+    );
+}
+
+#[tokio::test]
+async fn native_v2_merge_materializes_a_source_delete_and_preserves_history() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(40_000));
+    let options = RepositoryV2Options {
+        repository_prefix: ".tests/native-v2-merge-delete".to_string(),
+        ..options(clock.clone())
+    };
+    let repository = RepositoryV2::initialize(plane, options).await.unwrap();
+    put(&repository, "main", "removed.txt", "base").await;
+    let base = repository.head("main").await.unwrap();
+    repository.create_branch("feature", base).await.unwrap();
+    repository
+        .delete_object("feature", b"removed.txt".to_vec())
+        .await
+        .unwrap();
+
+    let mut cursor = repository
+        .start_merge(
+            "main",
+            "feature",
+            None,
+            MergePolicyV2::Fail,
+            "accept source delete",
+        )
+        .await
+        .unwrap();
+    while cursor.phase != MergePhaseV2::ReadyToPublish {
+        cursor = repository.advance_merge(&cursor, 2).await.unwrap().cursor;
+    }
+    let receipt = repository.publish_merge(&cursor).await.unwrap();
+    assert_eq!(receipt.changed_keys, 1);
+    repository.advance_branch_indexes("main").await.unwrap();
+    assert!(repository
+        .get_object("main", b"removed.txt")
+        .await
+        .unwrap()
+        .is_none());
+    let (_, versions) = repository
+        .list_object_versions("main", b"removed.txt", 10)
+        .await
+        .unwrap();
+    assert_eq!(versions.len(), 3);
+    assert!(matches!(
+        versions[0].body.kind,
+        LogicalObjectVersionKindV1::DeleteMarker
+    ));
+    assert!(matches!(
+        versions[1].body.kind,
+        LogicalObjectVersionKindV1::DeleteMarker
+    ));
+}
+
+#[tokio::test]
+async fn native_v2_merge_refuses_to_publish_after_the_target_branch_moves() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(45_000));
+    let options = RepositoryV2Options {
+        repository_prefix: ".tests/native-v2-merge-ref-move".to_string(),
+        ..options(clock.clone())
+    };
+    let repository = RepositoryV2::initialize(plane, options).await.unwrap();
+    let base = repository.head("main").await.unwrap();
+    repository.create_branch("feature", base).await.unwrap();
+    put(&repository, "feature", "source.txt", "source").await;
+
+    let mut cursor = repository
+        .start_merge(
+            "main",
+            "feature",
+            None,
+            MergePolicyV2::Fail,
+            "plan against stable target",
+        )
+        .await
+        .unwrap();
+    while cursor.phase != MergePhaseV2::ReadyToPublish {
+        cursor = repository.advance_merge(&cursor, 2).await.unwrap().cursor;
+    }
+    put(&repository, "main", "concurrent.txt", "winner").await;
+    let moved = repository.head("main").await.unwrap();
+
+    let error = repository.publish_merge(&cursor).await.unwrap_err();
+    assert_eq!(error.code, prolly_s3_core::ErrorCode::RefConflict);
+    assert_eq!(repository.head("main").await.unwrap(), moved);
+    assert!(repository.fenced_branches().unwrap().is_empty());
+    assert!(repository
+        .get_object("main", b"source.txt")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn native_v2_criss_cross_frontier_returns_every_best_base_in_pages() {
+    let source_plane = Arc::new(MemoryObjectPlane::new(true));
+    let source = Repository::initialize(
+        source_plane,
+        RepositoryOptions {
+            repository_prefix: ".tests/native-v2-criss-cross-source".to_string(),
+            writer: "source-writer".to_string(),
+            ..RepositoryOptions::default()
+        },
+    )
+    .await
+    .unwrap();
+    let base = source
+        .put_bytes(
+            "main",
+            b"base.txt".to_vec(),
+            b"base".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    source.create_branch("left", base.id).await.unwrap();
+    source.create_branch("right", base.id).await.unwrap();
+    let left_one = source
+        .put_bytes(
+            "left",
+            b"left.txt".to_vec(),
+            b"left".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let right_one = source
+        .put_bytes(
+            "right",
+            b"right.txt".to_vec(),
+            b"right".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let left_two = source
+        .merge(
+            "left",
+            right_one.id,
+            None,
+            MergePolicy::Fail,
+            None,
+            Some("left merges right-one".to_string()),
+        )
+        .await
+        .unwrap();
+    let right_two = source
+        .merge(
+            "right",
+            left_one.id,
+            None,
+            MergePolicy::Fail,
+            None,
+            Some("right merges left-one".to_string()),
+        )
+        .await
+        .unwrap();
+    source.create_branch("all", left_two.id).await.unwrap();
+    source
+        .merge(
+            "all",
+            right_two.id,
+            Some(left_one.id),
+            MergePolicy::Fail,
+            None,
+            Some("retain both criss-cross heads".to_string()),
+        )
+        .await
+        .unwrap();
+
+    let destination_plane = Arc::new(MemoryObjectPlane::new(true));
+    let destination_options = RepositoryV2Options {
+        repository_prefix: ".tests/native-v2-criss-cross-destination".to_string(),
+        writer: "destination-writer".to_string(),
+        provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Finite(10_000),
+        ..RepositoryV2Options::default()
+    };
+    let destination = RepositoryV2::initialize(destination_plane, destination_options)
+        .await
+        .unwrap();
+    let mut migration = source
+        .start_v1_to_v2_migration(&destination, "all", "imported-all")
+        .await
+        .unwrap();
+    loop {
+        let page = source
+            .v1_to_v2_migration_page(&destination, &migration, 100, 2)
+            .await
+            .unwrap();
+        migration = page.cursor;
+        if page.complete {
+            break;
+        }
+    }
+    let mapped_left_two = source
+        .v1_to_v2_migration_mapping(&migration, left_two.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let mapped_right_two = source
+        .v1_to_v2_migration_mapping(&migration, right_two.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let mapped_left_one = source
+        .v1_to_v2_migration_mapping(&migration, left_one.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let mapped_right_one = source
+        .v1_to_v2_migration_mapping(&migration, right_one.id)
+        .await
+        .unwrap()
+        .unwrap();
+    destination
+        .create_branch("left-v2", mapped_left_two)
+        .await
+        .unwrap();
+    destination
+        .create_branch("right-v2", mapped_right_two)
+        .await
+        .unwrap();
+    // Keep the imported closure registered: both criss-cross heads reuse
+    // ancestor packs that are indexed by the imported branch.
+    destination.head("imported-all").await.unwrap();
+    let mut cursor = destination
+        .start_merge(
+            "left-v2",
+            "right-v2",
+            None,
+            MergePolicyV2::Ours,
+            "criss-cross merge",
+        )
+        .await
+        .unwrap();
+    while cursor.phase != MergePhaseV2::AwaitingBase {
+        cursor = destination.advance_merge(&cursor, 1).await.unwrap().cursor;
+    }
+    assert_eq!(cursor.best_base_count, 2);
+    let first = destination
+        .merge_bases_page(&cursor, None, 1)
+        .await
+        .unwrap();
+    assert_eq!(first.bases.len(), 1);
+    let second = destination
+        .merge_bases_page(&cursor, first.continuation.as_ref(), 1)
+        .await
+        .unwrap();
+    assert_eq!(second.bases.len(), 1);
+    let discovered = [first.bases[0], second.bases[0]];
+    assert!(discovered.contains(&mapped_left_one));
+    assert!(discovered.contains(&mapped_right_one));
+    let selected = destination
+        .select_merge_base(&cursor, mapped_left_one)
+        .await
+        .unwrap();
+    assert_eq!(selected.phase, MergePhaseV2::Planning);
+    assert_eq!(selected.selected_base, Some(mapped_left_one));
+}
+
+#[tokio::test]
+#[ignore = "10K sparse-merge scale gate"]
+async fn native_v2_sparse_merge_prunes_unchanged_10k_snapshot() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(50_000));
+    let options = RepositoryV2Options {
+        repository_prefix: ".tests/native-v2-sparse-merge-10k".to_string(),
+        ..options(clock.clone())
+    };
+    let repository = RepositoryV2::initialize(plane, options).await.unwrap();
+    let session = repository
+        .begin_commit_session("main", "10K baseline", 60_000)
+        .await
+        .unwrap();
+    let mut mutations = Vec::with_capacity(10_000);
+    for index in 0..10_000usize {
+        mutations.push(
+            repository
+                .stage_commit_session_put(
+                    &session,
+                    format!("objects/{index:05}.txt").into_bytes(),
+                    format!("base-{index:05}").into_bytes(),
+                    ObjectHeaders::default(),
+                    BTreeMap::new(),
+                )
+                .await
+                .unwrap(),
+        );
+    }
+    let baseline = repository
+        .publish_commit_session(session, mutations)
+        .await
+        .unwrap();
+    repository
+        .create_branch("feature", baseline.id)
+        .await
+        .unwrap();
+    put(&repository, "main", "objects/00001.txt", "changed-on-main").await;
+    put(
+        &repository,
+        "feature",
+        "objects/09998.txt",
+        "changed-on-feature",
+    )
+    .await;
+    let mut cursor = repository
+        .start_merge(
+            "main",
+            "feature",
+            None,
+            MergePolicyV2::Fail,
+            "sparse 10K merge",
+        )
+        .await
+        .unwrap();
+    let mut processed = 0usize;
+    while cursor.phase != MergePhaseV2::ReadyToPublish {
+        let page = repository.advance_merge(&cursor, 8).await.unwrap();
+        processed += page.processed;
+        cursor = page.cursor;
+    }
+    assert_eq!(cursor.planned_changes, 1);
+    assert_eq!(cursor.conflicts, 0);
+    assert!(
+        processed < 32,
+        "sparse structural merge processed {processed} logical records"
+    );
+    repository.publish_merge(&cursor).await.unwrap();
+    assert_eq!(
+        repository
+            .get_object("main", b"objects/09998.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"changed-on-feature"
+    );
+}
+
+#[tokio::test]
+#[ignore = "4K commit-graph skip-pointer gate"]
+async fn native_v2_merge_base_skips_deep_first_parent_history() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(70_000));
+    let options = RepositoryV2Options {
+        repository_prefix: ".tests/native-v2-deep-merge-base".to_string(),
+        journal_index_max_unindexed_events: 8_192,
+        operation_index_max_unindexed_events: 8_192,
+        ..options(clock.clone())
+    };
+    let repository = RepositoryV2::initialize(plane, options).await.unwrap();
+    put(&repository, "main", "counter.txt", "0").await;
+    let base = repository.head("main").await.unwrap();
+    repository.create_branch("stale", base).await.unwrap();
+    for generation in 1..=4_096usize {
+        put(&repository, "main", "counter.txt", &generation.to_string()).await;
+    }
+    repository.advance_branch_indexes("main").await.unwrap();
+    let cursor = repository
+        .start_merge(
+            "stale",
+            "main",
+            None,
+            MergePolicyV2::Theirs,
+            "fast-forward-shaped merge",
+        )
+        .await
+        .unwrap();
+    assert_eq!(cursor.phase, MergePhaseV2::Planning);
+    assert_eq!(cursor.selected_base, Some(base));
+    assert_eq!(cursor.visited_commits, 0);
+}

--- a/extensions/s3/core/tests/migration_v2.rs
+++ b/extensions/s3/core/tests/migration_v2.rs
@@ -1,0 +1,246 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use prolly_s3_core::{
+    decode_canonical, encode_canonical, MemoryObjectPlane, MergePolicy, ObjectHeaders,
+    ProviderPerKeyVersionLimitV2, Repository, RepositoryOptions, RepositoryV2, RepositoryV2Options,
+    V1ToV2MigrationCursor,
+};
+
+fn source_options() -> RepositoryOptions {
+    RepositoryOptions {
+        repository_prefix: ".tests/migration-v1-source".to_string(),
+        writer: "migration-source-writer".to_string(),
+        ..RepositoryOptions::default()
+    }
+}
+
+fn destination_options() -> RepositoryV2Options {
+    RepositoryV2Options {
+        repository_prefix: ".tests/migration-v2-destination".to_string(),
+        writer: "migration-destination-writer".to_string(),
+        provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Finite(10_000),
+        ..RepositoryV2Options::default()
+    }
+}
+
+#[tokio::test]
+async fn v1_history_migrates_in_restartable_parent_first_pages() {
+    let source_plane = Arc::new(MemoryObjectPlane::new(true));
+    let source = Repository::initialize(source_plane, source_options())
+        .await
+        .unwrap();
+    let first = source
+        .put_bytes(
+            "main",
+            b"docs/history.txt".to_vec(),
+            b"first".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    source.create_branch("feature", first.id).await.unwrap();
+    let feature = source
+        .put_bytes(
+            "feature",
+            b"docs/feature.txt".to_vec(),
+            b"from feature".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    source
+        .put_bytes(
+            "main",
+            b"docs/history.txt".to_vec(),
+            b"second".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    source
+        .merge(
+            "main",
+            feature.id,
+            None,
+            MergePolicy::Fail,
+            None,
+            Some("merge feature before migration".to_string()),
+        )
+        .await
+        .unwrap();
+    source
+        .put_bytes(
+            "main",
+            b"docs/other.txt".to_vec(),
+            b"other".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let destination_plane = Arc::new(MemoryObjectPlane::new(true));
+    let mut destination =
+        RepositoryV2::initialize(destination_plane.clone(), destination_options())
+            .await
+            .unwrap();
+    let initial = source
+        .start_v1_to_v2_migration(&destination, "main", "imported-main")
+        .await
+        .unwrap();
+
+    let first_page = source
+        .v1_to_v2_migration_page(&destination, &initial, 100, 1)
+        .await
+        .unwrap();
+    assert_eq!(first_page.processed_commits, 1);
+    assert!(!first_page.complete);
+
+    // Replay the previous durable cursor after reopening the destination.
+    // Immutable payload/commit writes and index roots must reconcile exactly.
+    drop(destination);
+    destination = RepositoryV2::open(destination_plane.clone(), destination_options())
+        .await
+        .unwrap();
+    let replay = source
+        .v1_to_v2_migration_page(&destination, &initial, 100, 1)
+        .await
+        .unwrap();
+    assert_eq!(replay.cursor.index, first_page.cursor.index);
+
+    let mut cursor = replay.cursor;
+    loop {
+        let encoded = encode_canonical(&cursor).unwrap();
+        cursor = decode_canonical::<V1ToV2MigrationCursor>(&encoded).unwrap();
+        drop(destination);
+        destination = RepositoryV2::open(destination_plane.clone(), destination_options())
+            .await
+            .unwrap();
+        let page = source
+            .v1_to_v2_migration_page(&destination, &cursor, 100, 1)
+            .await
+            .unwrap();
+        cursor = page.cursor;
+        if page.complete {
+            break;
+        }
+    }
+
+    assert_eq!(cursor.migrated_commits, 6);
+    assert_eq!(cursor.migrated_payloads, 4);
+    assert!(cursor.mapped_head.is_some());
+    assert!(source.list_retention_pins().await.unwrap().is_empty());
+    assert!(
+        source
+            .v1_to_v2_migration_page(&destination, &cursor, 100, 1)
+            .await
+            .unwrap()
+            .complete
+    );
+    let imported_feature = source
+        .v1_to_v2_migration_mapping(&cursor, feature.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        destination
+            .create_tag("imported-feature", imported_feature)
+            .await
+            .unwrap()
+            .target,
+        imported_feature
+    );
+    assert_eq!(
+        destination
+            .get_object("imported-main", b"docs/history.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"second"
+    );
+    assert_eq!(
+        destination
+            .get_object("imported-main", b"docs/other.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"other"
+    );
+    assert_eq!(
+        destination
+            .get_object("imported-main", b"docs/feature.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"from feature"
+    );
+    let imported_head = destination.head("imported-main").await.unwrap();
+    let (versions, truncated) = destination
+        .list_versions_at("imported-main", imported_head, b"docs/history", None, 100)
+        .await
+        .unwrap();
+    assert!(!truncated);
+    assert_eq!(versions.len(), 2);
+    loop {
+        let cleanup = source.cleanup_v1_to_v2_migration(&cursor, 1).await.unwrap();
+        if cleanup.complete {
+            break;
+        }
+    }
+
+    let abandoned = source
+        .start_v1_to_v2_migration(&destination, "main", "abandoned-import")
+        .await
+        .unwrap();
+    let abandoned = source
+        .v1_to_v2_migration_page(&destination, &abandoned, 100, 2)
+        .await
+        .unwrap()
+        .cursor;
+    loop {
+        if source
+            .abort_v1_to_v2_migration(&destination, &abandoned, 1)
+            .await
+            .unwrap()
+            .complete
+        {
+            break;
+        }
+    }
+    assert!(source.list_retention_pins().await.unwrap().is_empty());
+    assert_eq!(
+        destination.head("abandoned-import").await.unwrap_err().code,
+        prolly_s3_core::ErrorCode::InvalidRevision
+    );
+
+    // Prove a completely cold reader resolves ancestor-packed nodes through
+    // the imported durable index rather than process-local migration state.
+    drop(destination);
+    let cold = RepositoryV2::open(
+        destination_plane,
+        RepositoryV2Options {
+            read_only: true,
+            ..destination_options()
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        cold.get_object("imported-main", b"docs/history.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"second"
+    );
+}

--- a/extensions/s3/core/tests/operation_index_v2.rs
+++ b/extensions/s3/core/tests/operation_index_v2.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use prolly_s3_core::{
-    AuthorityScopeV2, AuthorityStampV2, BucketCommitV2, BucketDeltaV1, BucketStateV1,
+    AuthorityScopeV2, AuthorityStampV2, BucketCommitV2, BucketDeltaV2, BucketStateV2,
     CommitGeneration, CommitIdV2, CommitPublicationV2, IdempotencyRetentionV2, MemoryObjectPlane,
     ObjectPath, ObjectPlane, OperationId, OperationIndexHeadV2, RefGeneration, RepositoryId,
     SegmentedOperationIndexV2, ShardWriterAuthorityV2, ShardedBranchPublisherV2, TreeFormatDigest,
@@ -22,15 +22,14 @@ fn commit(
         format_digest: TreeFormatDigest::from_hash([0x31; 32]),
     };
     BucketCommitV2 {
-        state: BucketStateV1 {
+        state: BucketStateV2 {
             objects: root.clone(),
-            versions: root.clone(),
-            operations: root,
+            versions: root,
         },
         parents,
         generation: CommitGeneration(generation),
-        delta: BucketDeltaV1 {
-            operation_ids: Vec::new(),
+        delta: BucketDeltaV2 {
+            input_digest: [0; 32],
             changes: Vec::new(),
         },
         node_pack: None,

--- a/extensions/s3/core/tests/operation_index_v2.rs
+++ b/extensions/s3/core/tests/operation_index_v2.rs
@@ -31,6 +31,8 @@ fn commit(
         delta: BucketDeltaV2 {
             input_digest: [0; 32],
             changes: Vec::new(),
+            changes_root: None,
+            change_count: 0,
         },
         node_pack: None,
         authority,

--- a/extensions/s3/core/tests/prolly_s3_profile.rs
+++ b/extensions/s3/core/tests/prolly_s3_profile.rs
@@ -2491,7 +2491,7 @@ async fn explicit_takeover_barrier_fences_the_old_writer() {
         .unwrap();
 
     assert_eq!(
-        old_writer.renew_writer_lease().await.unwrap_err().code,
+        old_writer.renew_shard_authorities().await.unwrap_err().code,
         ErrorCode::PreconditionFailed
     );
     plane.reset_request_counts();

--- a/extensions/s3/core/tests/protocol_v2.rs
+++ b/extensions/s3/core/tests/protocol_v2.rs
@@ -102,6 +102,8 @@ fn v2_publication_records_have_frozen_content_identities() {
         delta: BucketDeltaV2 {
             input_digest: [0; 32],
             changes: Vec::new(),
+            changes_root: None,
+            change_count: 0,
         },
         node_pack: None,
         authority: authority.clone(),
@@ -175,6 +177,8 @@ fn v2_commit_envelope_is_range_readable_and_wire_separated_from_v1() {
         delta: BucketDeltaV2 {
             input_digest: [0; 32],
             changes: Vec::new(),
+            changes_root: None,
+            change_count: 0,
         },
         node_pack: None,
         authority: lease().stamp(),
@@ -197,6 +201,18 @@ fn v2_commit_envelope_is_range_readable_and_wire_separated_from_v1() {
         .is_some());
     assert_eq!(
         CommitObjectV1::decode_object(&encoded).unwrap_err().code,
+        ErrorCode::CorruptCommit
+    );
+
+    let mut external_delta = commit;
+    external_delta.node_pack = None;
+    external_delta.delta.changes_root = Some(external_delta.state.objects.clone());
+    external_delta.delta.change_count = 1;
+    CommitObjectV2::new(external_delta.clone(), None).unwrap();
+
+    external_delta.delta.changes_root.as_mut().unwrap().root = None;
+    assert_eq!(
+        CommitObjectV2::new(external_delta, None).unwrap_err().code,
         ErrorCode::CorruptCommit
     );
 }

--- a/extensions/s3/core/tests/protocol_v2.rs
+++ b/extensions/s3/core/tests/protocol_v2.rs
@@ -1,6 +1,6 @@
 use prolly_s3_core::{
     encode_canonical, AuthorityLeaseStateV2, AuthorityLeaseV2, AuthorityScopeV2, AuthorityStampV2,
-    BucketCommitV2, BucketDeltaV1, BucketStateV1, CommitGeneration, CommitIdV2, CommitObjectV1,
+    BucketCommitV2, BucketDeltaV2, BucketStateV2, CommitGeneration, CommitIdV2, CommitObjectV1,
     CommitObjectV2, ErrorCode, NodePackEntryV1, NodePackV1, ObjectHeaders, OperationId,
     PhysicalMultipartSessionV2, PhysicalMutationIdentityV2, PublicationEventV2, RefGeneration,
     RefValueV2, ReflogEntryV2, RepositoryId, TreeFormatDigest, TreeRootV1,
@@ -93,15 +93,14 @@ fn v2_publication_records_have_frozen_content_identities() {
         format_digest: TreeFormatDigest::from_hash([0x44; 32]),
     };
     let commit = BucketCommitV2 {
-        state: BucketStateV1 {
+        state: BucketStateV2 {
             objects: root.clone(),
-            versions: root.clone(),
-            operations: root,
+            versions: root,
         },
         parents: Vec::new(),
         generation: CommitGeneration(0),
-        delta: BucketDeltaV1 {
-            operation_ids: Vec::new(),
+        delta: BucketDeltaV2 {
+            input_digest: [0; 32],
             changes: Vec::new(),
         },
         node_pack: None,
@@ -135,7 +134,7 @@ fn v2_publication_records_have_frozen_content_identities() {
     );
     assert_eq!(
         commit.id().unwrap().to_string(),
-        "pbc2_k5quoflouuch4crelfudtng432li2tenqar65viagucs3iuzompa"
+        "pbc2_clgxccuoet2nnicx5n5uc7xtlhrp2ii3elwlbkk43ycuyh76zupq"
     );
     assert_eq!(
         publication.id().unwrap().to_string(),
@@ -167,15 +166,14 @@ fn v2_commit_envelope_is_range_readable_and_wire_separated_from_v1() {
         format_digest: pack.format_digest,
     };
     let mut commit = BucketCommitV2 {
-        state: BucketStateV1 {
+        state: BucketStateV2 {
             objects: root.clone(),
-            versions: root.clone(),
-            operations: root,
+            versions: root,
         },
         parents: Vec::new(),
         generation: CommitGeneration(0),
-        delta: BucketDeltaV1 {
-            operation_ids: Vec::new(),
+        delta: BucketDeltaV2 {
+            input_digest: [0; 32],
             changes: Vec::new(),
         },
         node_pack: None,

--- a/extensions/s3/core/tests/ref_catalog_v2.rs
+++ b/extensions/s3/core/tests/ref_catalog_v2.rs
@@ -1,0 +1,123 @@
+use std::sync::Arc;
+
+use prolly::TreeFormat;
+use prolly_s3_core::{
+    ref_catalog_shard_v2, CommitIdV2, MemoryObjectPlane, OperationId, RefGeneration, RefKindV2,
+    RepositoryId, ShardedRefCatalogV2,
+};
+
+fn operation(value: u128) -> OperationId {
+    OperationId(uuid::Uuid::from_u128(value))
+}
+
+#[tokio::test]
+async fn ref_catalog_shards_merge_concurrent_events_and_reject_regression() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = RepositoryId::from_hash([0x31; 32]);
+    let catalog = Arc::new(
+        ShardedRefCatalogV2::new(
+            plane.clone(),
+            ".tests/ref-catalog-v2",
+            repository,
+            TreeFormat::default(),
+        )
+        .unwrap(),
+    );
+    let first = "branch-0".to_string();
+    let shard = ref_catalog_shard_v2(RefKindV2::Branch, &first);
+    let second = (1..10_000)
+        .map(|ordinal| format!("branch-{ordinal}"))
+        .find(|name| ref_catalog_shard_v2(RefKindV2::Branch, name) == shard)
+        .unwrap();
+    let left = {
+        let catalog = catalog.clone();
+        let first = first.clone();
+        tokio::spawn(async move {
+            catalog
+                .record(
+                    RefKindV2::Branch,
+                    &first,
+                    CommitIdV2::from_hash([0x41; 32]),
+                    RefGeneration(0),
+                    operation(1),
+                    false,
+                    1_000,
+                )
+                .await
+        })
+    };
+    let right = {
+        let catalog = catalog.clone();
+        let second = second.clone();
+        tokio::spawn(async move {
+            catalog
+                .record(
+                    RefKindV2::Branch,
+                    &second,
+                    CommitIdV2::from_hash([0x42; 32]),
+                    RefGeneration(0),
+                    operation(2),
+                    false,
+                    1_001,
+                )
+                .await
+        })
+    };
+    let left = left.await.unwrap().unwrap();
+    let right = right.await.unwrap().unwrap();
+    let left_event = catalog.load_event(left.event).await.unwrap();
+    let right_event = catalog.load_event(right.event).await.unwrap();
+    assert!(
+        left_event.previous == Some(right.event)
+            || right_event.previous == Some(left.event)
+            || left.event == right.event,
+        "successful same-shard updates must form one linked history"
+    );
+
+    let page = catalog.list(RefKindV2::Branch, None, 100).await.unwrap();
+    let mut names = page
+        .entries
+        .into_iter()
+        .map(|entry| entry.name)
+        .collect::<Vec<_>>();
+    names.sort();
+    let mut expected = vec![first.clone(), second];
+    expected.sort();
+    assert_eq!(names, expected);
+
+    catalog
+        .record(
+            RefKindV2::Branch,
+            &first,
+            CommitIdV2::from_hash([0x51; 32]),
+            RefGeneration(1),
+            operation(3),
+            false,
+            2_000,
+        )
+        .await
+        .unwrap();
+    let stale = catalog
+        .record(
+            RefKindV2::Branch,
+            &first,
+            CommitIdV2::from_hash([0x41; 32]),
+            RefGeneration(0),
+            operation(1),
+            false,
+            1_000,
+        )
+        .await
+        .unwrap();
+    assert!(stale.already_indexed);
+    let current = catalog
+        .list(RefKindV2::Branch, None, 100)
+        .await
+        .unwrap()
+        .entries
+        .into_iter()
+        .find(|entry| entry.name == first)
+        .unwrap();
+    assert_eq!(current.target, CommitIdV2::from_hash([0x51; 32]));
+    assert_eq!(current.generation, RefGeneration(1));
+}

--- a/extensions/s3/core/tests/repository_v2.rs
+++ b/extensions/s3/core/tests/repository_v2.rs
@@ -619,3 +619,75 @@ async fn native_v2_expired_session_cleanup_is_bounded_and_exact() {
         .unwrap_err();
     assert_eq!(error.code, prolly_s3_core::ErrorCode::InvalidRequest);
 }
+
+#[tokio::test]
+async fn native_v2_cold_reads_fail_fast_until_background_indexes_catch_up() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(90_000));
+    let options = RepositoryV2Options {
+        repository_prefix: ".tests/native-v2-background-index".to_string(),
+        writer: "index-writer".to_string(),
+        clock: clock.clone(),
+        ids: Arc::new(SequenceIdSource::new(0xee, 1)),
+        provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Finite(10_000),
+        ..RepositoryV2Options::default()
+    };
+    let writer = RepositoryV2::initialize(plane.clone(), options.clone())
+        .await
+        .unwrap();
+    for index in 0..3 {
+        clock.advance(1).unwrap();
+        writer
+            .put_object(
+                "main",
+                format!("cold/{index}.txt").into_bytes(),
+                format!("value-{index}").into_bytes(),
+                ObjectHeaders::default(),
+                BTreeMap::new(),
+            )
+            .await
+            .unwrap();
+    }
+
+    let reader = Arc::new(
+        RepositoryV2::open(
+            plane.clone(),
+            RepositoryV2Options {
+                read_only: true,
+                ..options
+            },
+        )
+        .await
+        .unwrap(),
+    );
+    plane.reset_request_counts();
+    let error = reader.get_object("main", b"cold/2.txt").await.unwrap_err();
+    assert_eq!(error.code, prolly_s3_core::ErrorCode::MissingClosure);
+    assert!(
+        plane.request_snapshot().get <= 3,
+        "a foreground read may inspect ref/index heads but must not replay the journal tail"
+    );
+
+    let _maintenance = reader
+        .start_branch_index_maintenance(std::time::Duration::from_millis(10))
+        .unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            if reader.branch_index_health("main").await.unwrap().ready {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        reader
+            .get_object("main", b"cold/2.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"value-2"
+    );
+}

--- a/extensions/s3/core/tests/repository_v2.rs
+++ b/extensions/s3/core/tests/repository_v2.rs
@@ -702,15 +702,19 @@ async fn native_v2_over_limit_index_lag_rebuilds_in_restartable_pages() {
         clock: clock.clone(),
         ids: Arc::new(SequenceIdSource::new(0xfa, 1)),
         journal_index_max_unindexed_events: 2,
+        operation_index_leaf_entries: 2,
+        operation_index_merge_fanout: 2,
+        operation_index_max_unindexed_events: 8,
         provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Finite(10_000),
         ..RepositoryV2Options::default()
     };
     let writer = RepositoryV2::initialize(plane.clone(), options.clone())
         .await
         .unwrap();
+    let mut original = None;
     for index in 0..5 {
         clock.advance(1).unwrap();
-        writer
+        let receipt = writer
             .put_object(
                 "main",
                 format!("rebuild/{index}.txt").into_bytes(),
@@ -720,12 +724,17 @@ async fn native_v2_over_limit_index_lag_rebuilds_in_restartable_pages() {
             )
             .await
             .unwrap();
+        if index == 4 {
+            original = Some(receipt);
+        }
     }
+    drop(writer);
     let reader = RepositoryV2::open(
-        plane,
+        plane.clone(),
         RepositoryV2Options {
             read_only: true,
-            ..options
+            operation_index_max_unindexed_events: 2,
+            ..options.clone()
         },
     )
     .await
@@ -771,10 +780,32 @@ async fn native_v2_over_limit_index_lag_rebuilds_in_restartable_pages() {
         b"value-4"
     );
 
+    let mut operation = reader.start_operation_index_rebuild(&cursor).await.unwrap();
+    let early_cleanup = reader
+        .cleanup_branch_index_rebuild(&cursor, &operation, 1)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        early_cleanup.code,
+        prolly_s3_core::ErrorCode::InvalidContinuationToken
+    );
+    loop {
+        let encoded = prolly_s3_core::encode_canonical(&operation).unwrap();
+        operation = prolly_s3_core::decode_canonical(&encoded).unwrap();
+        let step = reader
+            .advance_operation_index_rebuild(&operation, 2)
+            .await
+            .unwrap();
+        operation = step.cursor;
+        if step.complete {
+            break;
+        }
+    }
+
     let mut deleted = 0;
     loop {
         let cleanup = reader
-            .cleanup_branch_index_rebuild(&cursor, 1)
+            .cleanup_branch_index_rebuild(&cursor, &operation, 1)
             .await
             .unwrap();
         deleted += cleanup.deleted_objects;
@@ -783,4 +814,29 @@ async fn native_v2_over_limit_index_lag_rebuilds_in_restartable_pages() {
         }
     }
     assert_eq!(deleted, 3);
+
+    drop(reader);
+    let replay_writer = RepositoryV2::open(
+        plane,
+        RepositoryV2Options {
+            operation_index_max_unindexed_events: 2,
+            ..options
+        },
+    )
+    .await
+    .unwrap();
+    let original = original.unwrap();
+    let replay = replay_writer
+        .put_object_with_operation(
+            "main",
+            b"rebuild/4.txt".to_vec(),
+            b"value-4".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+            original.operation,
+        )
+        .await
+        .unwrap();
+    assert!(replay.idempotent_replay);
+    assert_eq!(replay.id, original.id);
 }

--- a/extensions/s3/core/tests/repository_v2.rs
+++ b/extensions/s3/core/tests/repository_v2.rs
@@ -1,10 +1,12 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, io::Write as _, sync::Arc};
 
+use md5::{Digest as _, Md5};
 use prolly_s3_core::{
     FixedClock, GetRequest, ListRequest, LogicalObjectVersionKindV1, MemoryObjectPlane,
     ObjectHeaders, ObjectPath, ObjectPlane, ProviderPerKeyVersionLimitV2, RepositoryFormatV2,
     RepositoryV2, RepositoryV2Options, SequenceIdSource,
 };
+use sha2::Sha256;
 
 #[tokio::test]
 async fn native_v2_put_read_replay_and_reopen_use_only_v2_authority() {
@@ -450,11 +452,17 @@ async fn native_v2_commit_session_batches_payloads_into_one_replayable_publicati
         )
         .await
         .unwrap();
+    let mut spool = tempfile::NamedTempFile::new().unwrap();
+    spool.write_all(b"second").unwrap();
+    spool.flush().unwrap();
     let second = repository
-        .stage_commit_session_put(
+        .stage_commit_session_file(
             &session,
             b"batch/b.txt".to_vec(),
-            b"second".to_vec(),
+            spool.path().to_path_buf(),
+            6,
+            Sha256::digest(b"second").into(),
+            Md5::digest(b"second").into(),
             ObjectHeaders::default(),
             BTreeMap::new(),
         )

--- a/extensions/s3/core/tests/repository_v2.rs
+++ b/extensions/s3/core/tests/repository_v2.rs
@@ -1,0 +1,175 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use prolly_s3_core::{
+    FixedClock, GetRequest, MemoryObjectPlane, ObjectHeaders, ObjectPath, ObjectPlane,
+    RepositoryFormatV2, RepositoryV2, RepositoryV2Options, SequenceIdSource,
+};
+
+#[tokio::test]
+async fn native_v2_put_read_replay_and_reopen_use_only_v2_authority() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(10_000));
+    let prefix = ".tests/native-v2";
+    let options = RepositoryV2Options {
+        repository_prefix: prefix.to_string(),
+        writer: "writer-a".to_string(),
+        clock: clock.clone(),
+        ids: Arc::new(SequenceIdSource::new(0x55, 1)),
+        ..RepositoryV2Options::default()
+    };
+    let repository = RepositoryV2::initialize(plane.clone(), options.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        repository.format().format_version,
+        RepositoryFormatV2::VERSION
+    );
+    assert!(plane
+        .get(GetRequest {
+            path: ObjectPath::new(format!("{prefix}/format/v2.cbor")).unwrap(),
+            range: None,
+            physical_version: None,
+        })
+        .await
+        .unwrap()
+        .is_some());
+    assert!(plane
+        .get(GetRequest {
+            path: ObjectPath::new(format!("{prefix}/format/v1.cbor")).unwrap(),
+            range: None,
+            physical_version: None,
+        })
+        .await
+        .unwrap()
+        .is_none());
+
+    clock.advance(1).unwrap();
+    let operation = options.ids.operation();
+    let first = repository
+        .put_object_with_operation(
+            "main",
+            b"docs/readme.txt".to_vec(),
+            b"native v2".to_vec(),
+            ObjectHeaders {
+                content_type: Some("text/plain".to_string()),
+                ..ObjectHeaders::default()
+            },
+            BTreeMap::from([("source".to_string(), "test".to_string())]),
+            operation,
+        )
+        .await
+        .unwrap();
+    assert!(!first.idempotent_replay);
+    let replay = repository
+        .put_object_with_operation(
+            "main",
+            b"docs/readme.txt".to_vec(),
+            b"native v2".to_vec(),
+            ObjectHeaders {
+                content_type: Some("text/plain".to_string()),
+                ..ObjectHeaders::default()
+            },
+            BTreeMap::from([("source".to_string(), "test".to_string())]),
+            operation,
+        )
+        .await
+        .unwrap();
+    assert_eq!(replay.id, first.id);
+    assert!(replay.idempotent_replay);
+
+    let object = repository
+        .get_object("main", b"docs/readme.txt")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(object.bytes, b"native v2");
+    let binding = object.version.binding.unwrap();
+    assert!(binding.path.as_str().starts_with(&format!(
+        "{prefix}/payloads/v2/{}/sha256/",
+        hex::encode(repository.format().repository_id.as_bytes())
+    )));
+    assert_ne!(binding.path.as_str(), "docs/readme.txt");
+
+    repository.advance_branch_indexes("main").await.unwrap();
+    let read_only = RepositoryV2::open(
+        plane.clone(),
+        RepositoryV2Options {
+            read_only: true,
+            ..options
+        },
+    )
+    .await
+    .unwrap();
+    plane.reset_request_counts();
+    assert_eq!(
+        read_only
+            .get_object("main", b"docs/readme.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"native v2"
+    );
+    assert_eq!(plane.request_snapshot().list, 0);
+}
+
+#[tokio::test]
+async fn native_v2_takeover_fences_old_writer_before_payload_put() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(20_000));
+    let prefix = ".tests/native-v2-takeover";
+    let old_options = RepositoryV2Options {
+        repository_prefix: prefix.to_string(),
+        writer: "writer-a".to_string(),
+        clock: clock.clone(),
+        ids: Arc::new(SequenceIdSource::new(0x66, 1)),
+        ..RepositoryV2Options::default()
+    };
+    let old = RepositoryV2::initialize(plane.clone(), old_options.clone())
+        .await
+        .unwrap();
+    let mut replacement = RepositoryV2::open(
+        plane.clone(),
+        RepositoryV2Options {
+            writer: "writer-b".to_string(),
+            read_only: true,
+            ids: Arc::new(SequenceIdSource::new(0x77, 1)),
+            ..old_options
+        },
+    )
+    .await
+    .unwrap();
+    clock.advance(1).unwrap();
+    assert_eq!(
+        replacement
+            .takeover_branch_writer("main", "writer-a", 1, "writer-a credentials revoked")
+            .await
+            .unwrap(),
+        2
+    );
+
+    plane.reset_request_counts();
+    let error = old
+        .put_object(
+            "main",
+            b"stale.txt".to_vec(),
+            b"must not upload".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, prolly_s3_core::ErrorCode::PreconditionFailed);
+    assert_eq!(plane.request_snapshot().immutable_put, 0);
+
+    replacement
+        .put_object(
+            "main",
+            b"current.txt".to_vec(),
+            b"writer-b".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+}

--- a/extensions/s3/core/tests/repository_v2.rs
+++ b/extensions/s3/core/tests/repository_v2.rs
@@ -691,3 +691,96 @@ async fn native_v2_cold_reads_fail_fast_until_background_indexes_catch_up() {
         b"value-2"
     );
 }
+
+#[tokio::test]
+async fn native_v2_over_limit_index_lag_rebuilds_in_restartable_pages() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(100_000));
+    let options = RepositoryV2Options {
+        repository_prefix: ".tests/native-v2-index-rebuild".to_string(),
+        writer: "rebuild-writer".to_string(),
+        clock: clock.clone(),
+        ids: Arc::new(SequenceIdSource::new(0xfa, 1)),
+        journal_index_max_unindexed_events: 2,
+        provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Finite(10_000),
+        ..RepositoryV2Options::default()
+    };
+    let writer = RepositoryV2::initialize(plane.clone(), options.clone())
+        .await
+        .unwrap();
+    for index in 0..5 {
+        clock.advance(1).unwrap();
+        writer
+            .put_object(
+                "main",
+                format!("rebuild/{index}.txt").into_bytes(),
+                format!("value-{index}").into_bytes(),
+                ObjectHeaders::default(),
+                BTreeMap::new(),
+            )
+            .await
+            .unwrap();
+    }
+    let reader = RepositoryV2::open(
+        plane,
+        RepositoryV2Options {
+            read_only: true,
+            ..options
+        },
+    )
+    .await
+    .unwrap();
+    let error = reader.advance_branch_indexes("main").await.unwrap_err();
+    assert_eq!(error.code, prolly_s3_core::ErrorCode::HistoryLimitExceeded);
+    assert!(!reader.branch_index_health("main").await.unwrap().ready);
+
+    let mut cursor = reader.start_branch_index_rebuild("main").await.unwrap();
+    let mut steps = 0;
+    loop {
+        // A workflow may persist this canonical cursor and resume in another
+        // process between every bounded step.
+        let encoded = prolly_s3_core::encode_canonical(&cursor).unwrap();
+        cursor = prolly_s3_core::decode_canonical(&encoded).unwrap();
+        let step = reader
+            .advance_branch_index_rebuild(&cursor, 2)
+            .await
+            .unwrap();
+        cursor = step.cursor;
+        steps += 1;
+        if step.complete {
+            break;
+        }
+        assert!(steps < 16);
+    }
+    assert!(
+        steps >= 6,
+        "discovery and application are independently paged"
+    );
+    let health = reader.branch_index_health("main").await.unwrap();
+    assert!(
+        health.ready,
+        "rebuild must publish the selected snapshot roots"
+    );
+    assert_eq!(
+        reader
+            .get_object("main", b"rebuild/4.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"value-4"
+    );
+
+    let mut deleted = 0;
+    loop {
+        let cleanup = reader
+            .cleanup_branch_index_rebuild(&cursor, 1)
+            .await
+            .unwrap();
+        deleted += cleanup.deleted_objects;
+        if cleanup.complete {
+            break;
+        }
+    }
+    assert_eq!(deleted, 3);
+}

--- a/extensions/s3/core/tests/repository_v2.rs
+++ b/extensions/s3/core/tests/repository_v2.rs
@@ -514,3 +514,108 @@ async fn native_v2_commit_session_batches_payloads_into_one_replayable_publicati
     assert_eq!(replay.id, receipt.id);
     assert!(replay.idempotent_replay);
 }
+
+#[tokio::test]
+async fn native_v2_durable_session_resumes_after_process_authority_reacquisition() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(70_000));
+    let options = RepositoryV2Options {
+        repository_prefix: ".tests/native-v2-durable-session".to_string(),
+        writer: "restartable-writer".to_string(),
+        clock: clock.clone(),
+        ids: Arc::new(SequenceIdSource::new(0xcc, 1)),
+        authority_lease_millis: 10_000,
+        provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Finite(10_000),
+        ..RepositoryV2Options::default()
+    };
+    let original = RepositoryV2::initialize(plane.clone(), options.clone())
+        .await
+        .unwrap();
+    let checkpoint = original
+        .begin_durable_commit_session("main", "restartable import", 60_000)
+        .await
+        .unwrap();
+    let staged = original
+        .stage_commit_session_put(
+            &checkpoint.session,
+            b"resume/object.txt".to_vec(),
+            b"uploaded exactly once".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+    original
+        .checkpoint_commit_session(&checkpoint.session, vec![staged], 1)
+        .await
+        .unwrap();
+    let payload_puts = plane.request_snapshot().immutable_put;
+    drop(original);
+
+    clock.advance(1).unwrap();
+    let reopened = RepositoryV2::open(plane.clone(), options).await.unwrap();
+    let resumed = reopened
+        .resume_commit_session(checkpoint.session.id)
+        .await
+        .unwrap();
+    assert_eq!(resumed.mutations.len(), 1);
+    let receipt = reopened
+        .publish_commit_session(resumed.session, resumed.mutations)
+        .await
+        .unwrap();
+    assert_eq!(receipt.operation, checkpoint.session.identity.operation);
+    assert_eq!(
+        reopened
+            .get_object("main", b"resume/object.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"uploaded exactly once"
+    );
+    assert!(
+        plane.request_snapshot().immutable_put <= payload_puts + 3,
+        "resume may checkpoint authority adoption and publish commit/event, but must not upload a payload"
+    );
+}
+
+#[tokio::test]
+async fn native_v2_expired_session_cleanup_is_bounded_and_exact() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(80_000));
+    let repository = RepositoryV2::initialize(
+        plane,
+        RepositoryV2Options {
+            repository_prefix: ".tests/native-v2-session-cleanup".to_string(),
+            writer: "cleanup-writer".to_string(),
+            clock: clock.clone(),
+            ids: Arc::new(SequenceIdSource::new(0xdd, 1)),
+            authority_lease_millis: 10_000,
+            provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Finite(10_000),
+            ..RepositoryV2Options::default()
+        },
+    )
+    .await
+    .unwrap();
+    let checkpoint = repository
+        .begin_durable_commit_session("main", "expire me", 100)
+        .await
+        .unwrap();
+    clock.advance(101).unwrap();
+    let report = repository
+        .cleanup_expired_commit_sessions(None, 1)
+        .await
+        .unwrap();
+    assert_eq!(report.scanned, 1);
+    assert_eq!(report.deleted, 1);
+    let final_page = repository
+        .cleanup_expired_commit_sessions(report.continuation, 1)
+        .await
+        .unwrap();
+    assert!(final_page.continuation.is_none());
+    let error = repository
+        .resume_commit_session(checkpoint.session.id)
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, prolly_s3_core::ErrorCode::InvalidRequest);
+}

--- a/extensions/s3/core/tests/repository_v2.rs
+++ b/extensions/s3/core/tests/repository_v2.rs
@@ -2,7 +2,8 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use prolly_s3_core::{
     FixedClock, GetRequest, MemoryObjectPlane, ObjectHeaders, ObjectPath, ObjectPlane,
-    RepositoryFormatV2, RepositoryV2, RepositoryV2Options, SequenceIdSource,
+    ProviderPerKeyVersionLimitV2, RepositoryFormatV2, RepositoryV2, RepositoryV2Options,
+    SequenceIdSource,
 };
 
 #[tokio::test]
@@ -15,6 +16,7 @@ async fn native_v2_put_read_replay_and_reopen_use_only_v2_authority() {
         writer: "writer-a".to_string(),
         clock: clock.clone(),
         ids: Arc::new(SequenceIdSource::new(0x55, 1)),
+        provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Finite(10_000),
         ..RepositoryV2Options::default()
     };
     let repository = RepositoryV2::initialize(plane.clone(), options.clone())
@@ -123,12 +125,13 @@ async fn native_v2_takeover_fences_old_writer_before_payload_put() {
         writer: "writer-a".to_string(),
         clock: clock.clone(),
         ids: Arc::new(SequenceIdSource::new(0x66, 1)),
+        provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Finite(10_000),
         ..RepositoryV2Options::default()
     };
     let old = RepositoryV2::initialize(plane.clone(), old_options.clone())
         .await
         .unwrap();
-    let mut replacement = RepositoryV2::open(
+    let replacement = RepositoryV2::open(
         plane.clone(),
         RepositoryV2Options {
             writer: "writer-b".to_string(),

--- a/extensions/s3/core/tests/repository_v2.rs
+++ b/extensions/s3/core/tests/repository_v2.rs
@@ -1,9 +1,9 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use prolly_s3_core::{
-    FixedClock, GetRequest, MemoryObjectPlane, ObjectHeaders, ObjectPath, ObjectPlane,
-    ProviderPerKeyVersionLimitV2, RepositoryFormatV2, RepositoryV2, RepositoryV2Options,
-    SequenceIdSource,
+    FixedClock, GetRequest, ListRequest, LogicalObjectVersionKindV1, MemoryObjectPlane,
+    ObjectHeaders, ObjectPath, ObjectPlane, ProviderPerKeyVersionLimitV2, RepositoryFormatV2,
+    RepositoryV2, RepositoryV2Options, SequenceIdSource,
 };
 
 #[tokio::test]
@@ -113,6 +113,149 @@ async fn native_v2_put_read_replay_and_reopen_use_only_v2_authority() {
         b"native v2"
     );
     assert_eq!(plane.request_snapshot().list, 0);
+}
+
+#[tokio::test]
+async fn native_v2_history_listing_delete_markers_and_payload_dedup_are_stable() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(30_000));
+    let prefix = ".tests/native-v2-object-semantics";
+    let options = RepositoryV2Options {
+        repository_prefix: prefix.to_string(),
+        writer: "writer-a".to_string(),
+        clock: clock.clone(),
+        ids: Arc::new(SequenceIdSource::new(0x88, 1)),
+        provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Finite(10_000),
+        ..RepositoryV2Options::default()
+    };
+    let repository = RepositoryV2::initialize(plane.clone(), options)
+        .await
+        .unwrap();
+
+    clock.advance(1).unwrap();
+    let first = repository
+        .put_object(
+            "main",
+            b"docs/readme.txt".to_vec(),
+            b"shared payload".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+    clock.advance(1).unwrap();
+    repository
+        .put_object(
+            "main",
+            b"docs/guide.txt".to_vec(),
+            b"shared payload".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+    clock.advance(1).unwrap();
+    repository
+        .put_object(
+            "main",
+            b"docs/readme.txt".to_vec(),
+            b"current payload".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let historical = repository
+        .get_object_at("main", first.id, b"docs/readme.txt")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(historical.bytes, b"shared payload");
+    assert_eq!(historical.snapshot, first.id);
+
+    let (snapshot, first_page, truncated) = repository
+        .list_objects("main", b"docs/", None, 1)
+        .await
+        .unwrap();
+    assert!(truncated);
+    assert_eq!(first_page.len(), 1);
+    assert_eq!(first_page[0].key, b"docs/guide.txt");
+    let (second_page, truncated) = repository
+        .list_objects_at("main", snapshot, b"docs/", Some(&first_page[0].key), 1)
+        .await
+        .unwrap();
+    assert!(!truncated);
+    assert_eq!(second_page.len(), 1);
+    assert_eq!(second_page[0].key, b"docs/readme.txt");
+
+    let (_, versions) = repository
+        .list_object_versions("main", b"docs/readme.txt", 10)
+        .await
+        .unwrap();
+    assert_eq!(versions.len(), 2);
+    assert!(matches!(
+        versions[0].body.kind,
+        LogicalObjectVersionKindV1::Live { .. }
+    ));
+    assert!(
+        versions[0].body.order.commit_generation.0 > versions[1].body.order.commit_generation.0
+    );
+
+    let (version_page, truncated) = repository
+        .list_versions_at("main", snapshot, b"docs/", None, 2)
+        .await
+        .unwrap();
+    assert!(truncated);
+    assert_eq!(version_page.len(), 2);
+    let (remaining_versions, truncated) = repository
+        .list_versions_at("main", snapshot, b"docs/", Some(&version_page[1].cursor), 2)
+        .await
+        .unwrap();
+    assert!(!truncated);
+    assert_eq!(remaining_versions.len(), 1);
+
+    clock.advance(1).unwrap();
+    let deleted = repository
+        .delete_object("main", b"docs/readme.txt".to_vec())
+        .await
+        .unwrap();
+    assert_eq!(deleted.changed_keys, 1);
+    assert!(repository
+        .get_object("main", b"docs/readme.txt")
+        .await
+        .unwrap()
+        .is_none());
+    let (_, versions) = repository
+        .list_object_versions("main", b"docs/readme.txt", 10)
+        .await
+        .unwrap();
+    assert_eq!(versions.len(), 3);
+    assert!(matches!(
+        versions[0].body.kind,
+        LogicalObjectVersionKindV1::DeleteMarker
+    ));
+    assert!(versions[0].binding.is_none());
+
+    let payload_prefix = format!(
+        "{prefix}/payloads/v2/{}/sha256/",
+        hex::encode(repository.repository_id().as_bytes())
+    );
+    let payloads = plane
+        .list(ListRequest {
+            prefix: payload_prefix,
+            continuation: None,
+            limit: 100,
+            include_versions: true,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        payloads.entries.len(),
+        2,
+        "equal logical payloads must share one immutable physical object"
+    );
+    assert!(payloads.entries.iter().all(|entry| entry.is_latest));
 }
 
 #[tokio::test]

--- a/extensions/s3/core/tests/repository_v2.rs
+++ b/extensions/s3/core/tests/repository_v2.rs
@@ -319,3 +319,102 @@ async fn native_v2_takeover_fences_old_writer_before_payload_put() {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn native_v2_writable_reopen_reacquires_authority_and_fences_the_old_handle() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(40_000));
+    let prefix = ".tests/native-v2-writable-reopen";
+    let options = RepositoryV2Options {
+        repository_prefix: prefix.to_string(),
+        writer: "writer-a".to_string(),
+        clock: clock.clone(),
+        ids: Arc::new(SequenceIdSource::new(0x99, 1)),
+        authority_lease_millis: 10_000,
+        provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Finite(10_000),
+        ..RepositoryV2Options::default()
+    };
+    let old = RepositoryV2::initialize(plane.clone(), options.clone())
+        .await
+        .unwrap();
+    clock.advance(1).unwrap();
+    old.put_object(
+        "main",
+        b"before-reopen.txt".to_vec(),
+        b"old handle".to_vec(),
+        ObjectHeaders::default(),
+        BTreeMap::new(),
+    )
+    .await
+    .unwrap();
+    old.advance_branch_indexes("main").await.unwrap();
+
+    clock.advance(1).unwrap();
+    let reopened = RepositoryV2::open(plane.clone(), options).await.unwrap();
+    reopened
+        .put_object(
+            "main",
+            b"after-reopen.txt".to_vec(),
+            b"new handle".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+
+    clock.advance(1).unwrap();
+    plane.reset_request_counts();
+    let renewal_error = old.renew_shard_authorities().await.unwrap_err();
+    assert_eq!(
+        renewal_error.code,
+        prolly_s3_core::ErrorCode::PreconditionFailed
+    );
+    assert_eq!(old.fenced_branches().unwrap(), vec!["main"]);
+    let error = old
+        .put_object(
+            "main",
+            b"stale-after-reopen.txt".to_vec(),
+            b"must not upload".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, prolly_s3_core::ErrorCode::PreconditionFailed);
+    assert_eq!(plane.request_snapshot().immutable_put, 0);
+}
+
+#[tokio::test]
+async fn native_v2_manual_authority_renewal_extends_the_write_window() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(50_000));
+    let repository = RepositoryV2::initialize(
+        plane,
+        RepositoryV2Options {
+            repository_prefix: ".tests/native-v2-renewal".to_string(),
+            writer: "writer-a".to_string(),
+            clock: clock.clone(),
+            ids: Arc::new(SequenceIdSource::new(0xaa, 1)),
+            authority_lease_millis: 10_000,
+            provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Finite(10_000),
+            ..RepositoryV2Options::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    clock.advance(4_000).unwrap();
+    repository.renew_shard_authorities().await.unwrap();
+    clock.advance(7_000).unwrap();
+    repository
+        .put_object(
+            "main",
+            b"after-original-expiry.txt".to_vec(),
+            b"renewed".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+    assert!(repository.fenced_branches().unwrap().is_empty());
+}

--- a/extensions/s3/core/tests/repository_v2.rs
+++ b/extensions/s3/core/tests/repository_v2.rs
@@ -418,3 +418,91 @@ async fn native_v2_manual_authority_renewal_extends_the_write_window() {
         .unwrap();
     assert!(repository.fenced_branches().unwrap().is_empty());
 }
+
+#[tokio::test]
+async fn native_v2_commit_session_batches_payloads_into_one_replayable_publication() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(60_000));
+    let repository = RepositoryV2::initialize(
+        plane.clone(),
+        RepositoryV2Options {
+            repository_prefix: ".tests/native-v2-commit-session".to_string(),
+            writer: "writer-a".to_string(),
+            clock: clock.clone(),
+            ids: Arc::new(SequenceIdSource::new(0xbb, 1)),
+            provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Finite(10_000),
+            ..RepositoryV2Options::default()
+        },
+    )
+    .await
+    .unwrap();
+    let session = repository
+        .begin_commit_session("main", "atomic import", 60_000)
+        .await
+        .unwrap();
+    let first = repository
+        .stage_commit_session_put(
+            &session,
+            b"batch/a.txt".to_vec(),
+            b"first".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+    let second = repository
+        .stage_commit_session_put(
+            &session,
+            b"batch/b.txt".to_vec(),
+            b"second".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+    let mutations = vec![
+        second,
+        prolly_s3_core::StagedMutationV2::delete(b"batch/removed.txt".to_vec()),
+        first,
+    ];
+
+    clock.advance(1).unwrap();
+    let receipt = repository
+        .publish_commit_session(session.clone(), mutations.clone())
+        .await
+        .unwrap();
+    assert_eq!(receipt.changed_keys, 3);
+    assert_eq!(receipt.object_versions.len(), 3);
+    assert!(!receipt.idempotent_replay);
+    assert_eq!(repository.head("main").await.unwrap(), receipt.id);
+    assert_eq!(
+        repository
+            .get_object("main", b"batch/a.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"first"
+    );
+    assert_eq!(
+        repository
+            .get_object("main", b"batch/b.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"second"
+    );
+    assert!(repository
+        .get_object("main", b"batch/removed.txt")
+        .await
+        .unwrap()
+        .is_none());
+
+    let replay = repository
+        .publish_commit_session(session, mutations)
+        .await
+        .unwrap();
+    assert_eq!(replay.id, receipt.id);
+    assert!(replay.idempotent_replay);
+}

--- a/extensions/s3/core/tests/repository_v2.rs
+++ b/extensions/s3/core/tests/repository_v2.rs
@@ -840,3 +840,109 @@ async fn native_v2_over_limit_index_lag_rebuilds_in_restartable_pages() {
     assert!(replay.idempotent_replay);
     assert_eq!(replay.id, original.id);
 }
+
+#[tokio::test]
+async fn native_v2_ref_lifecycle_uses_event_driven_sharded_catalogs() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(110_000));
+    let repository = RepositoryV2::initialize(
+        plane.clone(),
+        RepositoryV2Options {
+            repository_prefix: ".tests/native-v2-ref-catalog".to_string(),
+            writer: "writer-a".to_string(),
+            clock: clock.clone(),
+            ids: Arc::new(SequenceIdSource::new(0xdd, 1)),
+            provider_per_key_version_limit: ProviderPerKeyVersionLimitV2::Finite(10_000),
+            ..RepositoryV2Options::default()
+        },
+    )
+    .await
+    .unwrap();
+    let main = repository.head("main").await.unwrap();
+
+    clock.advance(1).unwrap();
+    let feature = repository.create_branch("feature", main).await.unwrap();
+    assert_eq!(feature.target, main);
+    let feature_commit = repository
+        .put_object(
+            "feature",
+            b"feature.txt".to_vec(),
+            b"branch-local".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+    repository.advance_branch_indexes("feature").await.unwrap();
+    assert_eq!(repository.head("main").await.unwrap(), main);
+
+    clock.advance(1).unwrap();
+    let tag = repository
+        .create_tag("release-1", feature_commit.id)
+        .await
+        .unwrap();
+    assert_eq!(repository.tag("release-1").await.unwrap(), tag);
+
+    plane.reset_request_counts();
+    let mut branch_cursor = None;
+    let mut branches = Vec::new();
+    loop {
+        let page = repository
+            .list_branch_catalog_page(branch_cursor, 1)
+            .await
+            .unwrap();
+        branches.extend(page.branches.into_iter().map(|branch| branch.name));
+        branch_cursor = page.continuation;
+        if branch_cursor.is_none() {
+            break;
+        }
+    }
+    branches.sort();
+    assert_eq!(branches, vec!["feature", "main"]);
+    let tags = repository.list_tag_catalog_page(None, 10).await.unwrap();
+    assert_eq!(tags.tags, vec![tag.clone()]);
+    assert_eq!(
+        plane.request_snapshot().list,
+        0,
+        "steady-state catalog listing must not scan the ref namespace"
+    );
+
+    clock.advance(1).unwrap();
+    repository
+        .delete_tag("release-1", feature_commit.id)
+        .await
+        .unwrap();
+    repository
+        .delete_branch("feature", feature_commit.id)
+        .await
+        .unwrap();
+    assert!(repository
+        .list_tag_catalog_page(None, 10)
+        .await
+        .unwrap()
+        .tags
+        .is_empty());
+    assert_eq!(
+        repository
+            .list_branch_catalog_page(None, 10)
+            .await
+            .unwrap()
+            .branches
+            .into_iter()
+            .map(|branch| branch.name)
+            .collect::<Vec<_>>(),
+        vec!["main"]
+    );
+
+    plane.reset_request_counts();
+    let repair = repository
+        .repair_ref_catalog_page(prolly_s3_core::RefKindV2::Branch, None, 100)
+        .await
+        .unwrap();
+    assert_eq!(repair.scanned, 2);
+    assert_eq!(repair.indexed, 2);
+    assert!(
+        plane.request_snapshot().list > 0,
+        "namespace listing is reserved for explicit repair"
+    );
+}

--- a/extensions/s3/core/tests/sharded_publication_v2.rs
+++ b/extensions/s3/core/tests/sharded_publication_v2.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use prolly_s3_core::{
-    AuthorityScopeV2, AuthorityStampV2, BucketCommitV2, BucketDeltaV1, BucketStateV1,
+    AuthorityScopeV2, AuthorityStampV2, BucketCommitV2, BucketDeltaV2, BucketStateV2,
     CommitGeneration, CommitIdV2, CommitObjectV2, CommitPublicationV2, ErrorCode, GetRequest,
     ListRequest, MemoryObjectPlane, NodePackEntryV1, NodePackV1, ObjectPath, ObjectPlane,
     OperationId, RefGeneration, RepositoryId, ShardWriterAuthorityV2, ShardedBranchPublisherV2,
@@ -29,15 +29,14 @@ fn commit(
         format_digest: TreeFormatDigest::from_hash([0x66; 32]),
     };
     BucketCommitV2 {
-        state: BucketStateV1 {
+        state: BucketStateV2 {
             objects: root.clone(),
-            versions: root.clone(),
-            operations: root,
+            versions: root,
         },
         parents,
         generation: CommitGeneration(generation),
-        delta: BucketDeltaV1 {
-            operation_ids: Vec::new(),
+        delta: BucketDeltaV2 {
+            input_digest: [0; 32],
             changes: Vec::new(),
         },
         node_pack: None,

--- a/extensions/s3/core/tests/sharded_publication_v2.rs
+++ b/extensions/s3/core/tests/sharded_publication_v2.rs
@@ -38,6 +38,8 @@ fn commit(
         delta: BucketDeltaV2 {
             input_digest: [0; 32],
             changes: Vec::new(),
+            changes_root: None,
+            change_count: 0,
         },
         node_pack: None,
         authority,

--- a/extensions/s3/docs/adr/0007-resumable-structural-merge.md
+++ b/extensions/s3/docs/adr/0007-resumable-structural-merge.md
@@ -1,0 +1,79 @@
+# ADR 0007: Persist native-v2 merge work as structural Prolly state
+
+Status: accepted
+
+## Context
+
+The legacy merge path constructs complete ancestor sets and materializes the
+base, target, and source object maps. Its memory and restart cost therefore
+grow with total history and snapshot cardinality even when the branches change
+only a few keys. A cursor containing those collections would only move the
+unbounded state into a continuation token.
+
+Native-v2 branch publication is independently fenced and its journal-derived
+commit graph records generation plus first-parent binary-lifting pointers. The
+state and version maps already support structural diff cursors that prune equal
+content-addressed subtrees.
+
+## Decision
+
+Represent merge as a caller-driven durable job:
+
+1. Snapshot the target and source commit IDs at start.
+2. Use first-parent skip pointers for the ancestry fast path. Otherwise persist
+   a generation-priority, bidirectional paint-down frontier, seen flags, stale
+   candidates, and best-base results in a job-scoped Prolly tree.
+3. Require explicit selection when criss-cross history yields several best
+   bases.
+4. Structurally diff base-to-target and base-to-source with constant-size
+   cursors and at most one pending record from each stream.
+5. Persist selected changes and conflicts under separate plan prefixes. Batch
+   every requested work page into one new plan root.
+6. Union immutable version trees and build the output object tree in bounded
+   pages. Store intermediate output nodes at deterministic repository CID paths
+   so another process can resume before a final commit envelope exists.
+7. Store non-empty merge deltas as a Prolly root plus exact record count instead
+   of an unbounded inline vector.
+8. Publish one two-parent commit only after revalidating the target ref. Resolve
+   an ambiguous CAS by operation ID before fencing the target branch.
+9. Require explicit, bounded cleanup of the job-scoped plan prefix after
+   success or abandonment.
+
+Every returned `MergeCursorV2` is sealed into the plan tree. Validation compares
+the caller's canonical cursor state with that durable record, excluding only
+the self-referential root CID. A modified phase, count, selected root, branch,
+or operation ID is therefore rejected.
+
+## Invariants
+
+- Work and output per call are bounded by the caller's record limit.
+- Cursor size does not grow with history, snapshot size, changes, or conflicts.
+- Best-base discovery returns every best common ancestor; it does not silently
+  choose one in a criss-cross graph.
+- Equal Prolly subtrees are never expanded during merge planning.
+- A source-selected deletion creates a new logical delete-marker version in
+  the merge commit.
+- Version-tree entries are immutable. The same key with unequal bytes is
+  corruption.
+- The first parent is the target observed at planning time. Commit generation
+  is `max(parent generations) + 1`.
+- Target movement after planning is a ref conflict, never an implicit rebase.
+- Plan cleanup cannot address repository state/output nodes.
+- Missing packed-node locations fall back to deterministic CID point reads,
+  never namespace scans.
+
+## Consequences
+
+Sparse merge cost is proportional to changed structural paths rather than the
+complete object count. Deep and criss-cross histories can be processed across
+process restarts without rebuilding prior frontier state. Conflict and change
+reporting remain pageable at arbitrary result cardinality.
+
+The workflow owner must durably save each returned cursor and schedule cleanup
+for completed, conflicted, or abandoned jobs. Intermediate plan and output
+nodes add immutable storage until cleanup and repository GC. Cold readers may
+issue CID point reads for merge-built nodes until the verified cache is warm.
+
+This ADR does not make an individual unbounded job instantaneous. Deployments
+must still bound concurrent merge workers, page sizes, deadlines, cache space,
+and object-store request rates.

--- a/extensions/s3/qualification/downstream-client/Cargo.lock
+++ b/extensions/s3/qualification/downstream-client/Cargo.lock
@@ -2098,6 +2098,7 @@ dependencies = [
  "serde_cbor",
  "sha2 0.10.9",
  "slatedb",
+ "tempfile",
  "thiserror 2.0.20",
  "tokio",
 ]

--- a/extensions/s3/spec/prolly-s3/v1/conformance/verify.py
+++ b/extensions/s3/spec/prolly-s3/v1/conformance/verify.py
@@ -106,9 +106,13 @@ def check_source_defaults() -> None:
     ]
     for marker in forbidden_defaults:
         assert marker not in default_surface, f"forbidden v2 default marker: {marker}"
+    format_impl = re.search(
+        r"impl RepositoryFormatV1 \{(?P<body>.*?)\n\}", model, re.DOTALL
+    )
+    assert format_impl is not None, "missing RepositoryFormatV1 implementation"
     constants = re.findall(
         r"(?:VERSION|CAPABILITY_PROFILE|PROTOCOL_VERSION|CURRENT_READER_VERSION|CURRENT_WRITER_VERSION):\s*u(?:16|32)\s*=\s*(\d+)",
-        model,
+        format_impl.group("body"),
     )
     assert constants and set(constants) == {"1"}, f"non-v1 protocol constants: {constants}"
 

--- a/extensions/s3/spec/prolly-s3/v2/conformance/verify.py
+++ b/extensions/s3/spec/prolly-s3/v2/conformance/verify.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Dependency-free structural verifier for native Prolly S3 Protocol v2."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+V2 = HERE.parent
+S3 = V2.parents[2]
+
+
+def check_source_surface() -> None:
+    model = (S3 / "core/src/model.rs").read_text()
+    repository = (S3 / "core/src/repository_v2.rs").read_text()
+    client = (S3 / "client/src/client_v2.rs").read_text()
+    combined = model + repository + client
+    required = [
+        'hash_id!(CommitIdV2, "pbc2_")',
+        'hash_id!(ObjectVersionIdV2, "pov2_")',
+        "pub struct RepositoryFormatV2",
+        "pub struct BucketCommitV2",
+        "pub struct RefValueV2",
+        'repository_prefix: ".prolly/v2".to_string()',
+        'b"prolly-s3/object-version/v2"',
+        'b"prolly-s3/commit/v2"',
+        "pub async fn start_merge",
+        "pub async fn advance_merge",
+        "pub async fn publish_merge",
+    ]
+    for marker in required:
+        assert marker in combined, f"missing v2 source marker: {marker}"
+
+    format_impl = re.search(
+        r"impl RepositoryFormatV2 \{(?P<body>.*?)\n\}", model, re.DOTALL
+    )
+    assert format_impl is not None, "missing RepositoryFormatV2 implementation"
+    constants = re.findall(
+        r"(?:VERSION|CAPABILITY_PROFILE|PROTOCOL_VERSION|CURRENT_READER_VERSION|CURRENT_WRITER_VERSION):\s*u(?:16|32)\s*=\s*(\d+)",
+        format_impl.group("body"),
+    )
+    assert constants and set(constants) == {"2"}, (
+        f"non-v2 protocol constants: {constants}"
+    )
+
+
+def check_spec_surface() -> None:
+    paths = (V2 / "paths.md").read_text()
+    states = (V2 / "state-machines.md").read_text()
+    required_paths = [
+        "P/format/v2.cbor",
+        "P/refs/v2/heads/N",
+        "P/commits/v2/sha256/H0/H1/H",
+        "P/publications/v2/sha256/H0/H1/H",
+        "P/payloads/v2/R/sha256/H0/H1/H",
+        "P/administration/v2/merge/E/plan/nodes/sha256/H0/H1/H",
+    ]
+    for marker in required_paths:
+        assert marker in paths, f"missing v2 path marker: {marker}"
+    required_states = [
+        "## Branch-shard lease",
+        "## Durable commit session",
+        "## Ref lifecycle and sharded catalog",
+        "## Explicit v1-to-v2 branch migration",
+        "## Resumable structural merge",
+    ]
+    for marker in required_states:
+        assert marker in states, f"missing v2 state machine: {marker}"
+
+
+def main() -> int:
+    check_source_surface()
+    check_spec_surface()
+    print("prolly-s3 v2 conformance structure: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (AssertionError, KeyError, ValueError) as error:
+        print(f"prolly-s3 v2 conformance structure: FAILED: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/extensions/s3/spec/prolly-s3/v2/paths.md
+++ b/extensions/s3/spec/prolly-s3/v2/paths.md
@@ -9,8 +9,12 @@ any protocol v1 record. `P` is the configured repository prefix.
 | system authority lease | `P/authority/v2/system/N/lease.cbor` |
 | maintenance gate | `P/authority/v2/maintenance/gate.cbor` |
 | branch ref | `P/refs/v2/heads/N` |
+| tag ref | `P/refs/v2/tags/N` |
 | authority-stamped commit object | `P/commits/v2/sha256/H0/H1/H` |
 | publication event | `P/publications/v2/sha256/H0/H1/H` |
+| ref-catalog lifecycle event | `P/ref-events/v2/sha256/H0/H1/H` |
+| ref-catalog shard head | `P/ref-catalog/v2/shards/SS/head.cbor` |
+| ref-catalog node tree | `P/ref-catalog/v2/tree/nodes/sha256/H0/H1/H` |
 | immutable payload | `P/payloads/v2/R/sha256/H0/H1/H` |
 | commit-session checkpoint | `P/staging/v2/R/B/checkpoints/Q.cbor` |
 | operation-index head | `P/operation-index/v2/heads/N.cbor` |
@@ -44,6 +48,23 @@ previous event for the same branch. Consumers open the mutable ref once and
 then page newest-to-oldest through an immutable snapshot without listing a
 namespace. A losing CAS may leave an unreachable event, but it cannot enter the
 journal and is safe for GC to reclaim.
+
+Tag refs use the same canonical name encoding and mutable-control retention as
+branch refs. They are fenced by the `tags` system-authority scope. A tag
+create, recreation, or delete validates that authority before its exact CAS;
+deletion publishes a tombstone rather than removing the mutable key.
+
+Ref enumeration is derived from 16 independently published catalog shards.
+Each branch or tag transition stores one immutable lifecycle event and updates
+the shard selected by hashing its kind and name. The event links to the prior
+event for that shard, while the mutable shard head points to a Prolly root
+containing the latest generation for every ref. Tombstones remain in that tree
+so delayed events cannot resurrect deleted refs. Readers page shard-by-shard
+using a canonical cursor and issue point GETs only; they never list the ref
+namespace. The catalog is advisory: callers resolve an entry through its
+authoritative ref before mutation. A crash between ref publication and catalog
+publication is repaired by the explicit bounded ref scanner; namespace scans
+are not part of normal reads or writes.
 
 `R` is lowercase hex of the repository ID. A live `ObjectVersionV2` carries
 the full derived payload path and optional provider VersionId; a delete marker

--- a/extensions/s3/spec/prolly-s3/v2/paths.md
+++ b/extensions/s3/spec/prolly-s3/v2/paths.md
@@ -80,6 +80,13 @@ proportional only to the unindexed journal tail. The head also records the
 derived current target, providing exact per-branch ref freshness; global branch
 enumeration remains a separate resumable administrative concern.
 
+Foreground object reads compare the selected ref target with the durable index
+target and never replay publication events. A locally published target is
+immediately readable from its registered commit pack. A cold process reports
+`MissingClosure` with retry advice until branch-local background maintenance
+advances the durable node and graph roots. Index lag and the last maintenance
+error are exposed as branch health rather than hidden inside read latency.
+
 Whole-history administration first pages refs, tags, and pins, incrementally
 attaches their targets to a `CommitClosureCursor`, and advances under explicit
 step and output budgets. The constant-size cursor names immutable Prolly state

--- a/extensions/s3/spec/prolly-s3/v2/paths.md
+++ b/extensions/s3/spec/prolly-s3/v2/paths.md
@@ -12,6 +12,7 @@ any protocol v1 record. `P` is the configured repository prefix.
 | authority-stamped commit object | `P/commits/v2/sha256/H0/H1/H` |
 | publication event | `P/publications/v2/sha256/H0/H1/H` |
 | immutable payload | `P/payloads/v2/R/sha256/H0/H1/H` |
+| commit-session checkpoint | `P/staging/v2/R/B/checkpoints/Q.cbor` |
 | operation-index head | `P/operation-index/v2/heads/N.cbor` |
 | operation-index segment | `P/operation-index/v2/segments/N/sha256/H0/H1/H` |
 | journal-derived index head | `P/journal-index/v2/heads/N.cbor` |
@@ -50,6 +51,15 @@ create different immutable payload keys instead of accumulating provider
 versions at that user key. Identical content reuses the same immutable object.
 An original-key object, when materialized for external compatibility, is a
 rebuildable projection and is never part of repository closure.
+
+`B` is a protocol-v2 batch ID and `Q` is a fixed-width checkpoint sequence.
+Commit-session checkpoints are immutable, canonical snapshots containing the
+batch operation ID, base commit, authority stamp, expiry, and sorted staged
+mutations. Put mutations retain only verified immutable payload bindings, not
+object bodies. Resume lists only the selected batch prefix and adopts the
+checkpoint only when the writer ID and base branch head still match. Expired
+checkpoint versions are removed through bounded, cursor-based exact deletion;
+there is no hot mutable staging head.
 
 The operation-ID index is advisory and branch-local. Its bounded mutable head
 checkpoints one publication event and references immutable, sorted LSM-style

--- a/extensions/s3/spec/prolly-s3/v2/paths.md
+++ b/extensions/s3/spec/prolly-s3/v2/paths.md
@@ -121,6 +121,14 @@ buffering the DAG. Finished or abandoned jobs exact-delete `E` in bounded
 cleanup calls; the state is not a GC candidate while its externally persisted
 cursor may still be live.
 
+An explicit v1-to-v2 migration reuses this closure namespace. Keys under the
+closure root retain source-to-native commit mappings alongside traversal work.
+Target imported node and commit-graph roots use the normal journal-index node
+namespaces, but are not installed as a branch head until the full pinned source
+closure is durable. Imported commits use the `v1-migration` system-authority
+scope, giving shared source commits stable target identities across separately
+named branch migrations performed in the same authority epoch.
+
 Physical clone, fetch, push, and repair consume that traversal in pages of at
 most 256 commits. Each completed source commit records an immutable
 source-to-destination mapping. A later transfer resolves the mapping with one

--- a/extensions/s3/spec/prolly-s3/v2/paths.md
+++ b/extensions/s3/spec/prolly-s3/v2/paths.md
@@ -5,6 +5,7 @@ any protocol v1 record. `P` is the configured repository prefix.
 
 | Object | Key |
 |---|---|
+| repository format marker | `P/format/v2.cbor` |
 | branch authority lease | `P/authority/v2/branches/N/lease.cbor` |
 | system authority lease | `P/authority/v2/system/N/lease.cbor` |
 | maintenance gate | `P/authority/v2/maintenance/gate.cbor` |
@@ -25,6 +26,8 @@ any protocol v1 record. `P` is the configured repository prefix.
 | journal-index rebuild chunk | `P/administration/v2/index-rebuild/N/E/chunks/sha256/H0/H1/H` |
 | resumable commit-closure state | `P/administration/v2/closure/E/tree/nodes/sha256/H0/H1/H` |
 | physical transfer mapping | `P/administration/v2/transfer-mappings/sha256/H0/H1/H` |
+| resumable merge plan node | `P/administration/v2/merge/E/plan/nodes/sha256/H0/H1/H` |
+| durable administrative output node | `P/nodes/sha256/H0/H1/H` |
 | GC coordinator | `P/gc/v2/coordinator.cbor` |
 | GC dirty root | `P/gc/v2/dirty-roots/E/S/H` |
 
@@ -138,6 +141,21 @@ mapped commit, the stale mapping is exact-deleted and safely rebuilt. Mapping
 nodes inside the active traversal are committed only after all destination
 side effects for that page succeed, so retrying an interrupted page is
 idempotent.
+
+A native-v2 merge cursor names one `E`-scoped plan root. The plan tree stores
+the bidirectional graph frontier, seen flags, best-base candidates/results,
+selected object changes, conflicts, and a sealed copy of the cursor state.
+Cursor tokens never contain those unbounded collections. Each successful page
+creates a new immutable plan root; successful and abandoned jobs exact-delete
+only their merge-plan prefix through bounded cleanup.
+
+Partially built object, version, and external-delta trees use deterministic
+`P/nodes/sha256/...` point-addressed nodes. These nodes are outside the
+job-cleanup prefix because a published commit may reference them. Packed-node
+readers fall back to the exact CID path after the journal-derived locator
+misses; they must not list the node namespace. A merge commit with a non-empty
+external delta carries an empty inline change vector, the delta root manifest,
+and its exact logical change count.
 
 `E` is the hex GC epoch operation ID and `S` is a fixed-width, monotonically
 increasing dirty-root sequence. While an epoch is active, every branch, tag,

--- a/extensions/s3/spec/prolly-s3/v2/paths.md
+++ b/extensions/s3/spec/prolly-s3/v2/paths.md
@@ -18,6 +18,7 @@ any protocol v1 record. `P` is the configured repository prefix.
 | journal-derived index head | `P/journal-index/v2/heads/N.cbor` |
 | journal-derived node tree | `P/journal-index/v2/node-tree/nodes/sha256/H0/H1/H` |
 | journal-derived graph tree | `P/journal-index/v2/graph-tree/nodes/sha256/H0/H1/H` |
+| journal-index rebuild chunk | `P/administration/v2/index-rebuild/N/E/chunks/sha256/H0/H1/H` |
 | resumable commit-closure state | `P/administration/v2/closure/E/tree/nodes/sha256/H0/H1/H` |
 | physical transfer mapping | `P/administration/v2/transfer-mappings/sha256/H0/H1/H` |
 | GC coordinator | `P/gc/v2/coordinator.cbor` |

--- a/extensions/s3/spec/prolly-s3/v2/paths.md
+++ b/extensions/s3/spec/prolly-s3/v2/paths.md
@@ -70,6 +70,9 @@ bounded journal tail after the checkpoint and then the compact segment levels.
 Index heads must be initialized with branch creation. If lag exceeds the
 configured tail bound, normal advancement fails closed and requires the
 resumable rebuild path instead of scanning unbounded history in one call.
+The operation-index rebuild reuses the journal-index rebuild's immutable
+linked chunks after node/graph application completes. Chunk cleanup therefore
+waits for both replacement heads to publish.
 
 `JournalDerivedIndexesV2` consumes the same stable branch journal to maintain
 the node locator and commit graph. One mutable branch-local checkpoint CAS

--- a/extensions/s3/spec/prolly-s3/v2/state-machines.md
+++ b/extensions/s3/spec/prolly-s3/v2/state-machines.md
@@ -73,6 +73,33 @@ must fail closed for a sharded repository.
 - Bounded cleanup pages physical checkpoint versions and exact-deletes only
   records whose embedded expiry is in the past.
 
+## Ref lifecycle and sharded catalog
+
+Authoritative branch states are:
+
+`Absent -> Live(g) -> Live(g+1) -> Tombstone(g+1) -> Live(g+2)`
+
+Tags follow the same generation progression. Branch moves first publish their
+immutable `PublicationEventV2`; tag transitions retain an inline reflog. Every
+transition then emits a common immutable `RefCatalogEventV2` and attempts one
+CAS against only the selected catalog shard.
+
+- A catalog event links to the previous event in its shard, not to an event in
+  another shard.
+- Concurrent writers to different shards never contend on a mutable catalog
+  object. Same-shard CAS losers reload the head, retain the winner's update,
+  apply their event to the new tree, and retry.
+- An update with a lower generation is ignored. Equal generation with
+  different state is corruption/conflict, while an exact repeat is idempotent.
+- A catalog failure cannot authorize or roll back a ref transition. Ordinary
+  branch index maintenance retries it from the authoritative branch head.
+- Branch and tag creation/deletion wait for their catalog update so lifecycle
+  APIs provide read-after-write enumeration. The bounded repair scanner closes
+  gaps after crashes and is the only path that lists the ref namespace.
+- Tombstoned entries remain in the derived tree but are omitted from listings.
+  Native GC may reclaim unreachable event/tree objects only after accounting
+  for every live shard head and in-progress repair/administration root.
+
 ## Journal-index rebuild
 
 `Discovering → Applying → Complete → Cleaned`

--- a/extensions/s3/spec/prolly-s3/v2/state-machines.md
+++ b/extensions/s3/spec/prolly-s3/v2/state-machines.md
@@ -124,3 +124,34 @@ CAS against only the selected catalog shard.
   immutable snapshot; ordinary incremental catch-up consumes later events.
 - Successful and abandoned jobs exact-delete chunk objects in bounded pages.
   Cleanup starts only after every consumer of the shared chunks is complete.
+
+## Explicit v1-to-v2 branch migration
+
+`Pinned -> Copying -> Publishing -> Complete -> Cleaned`
+
+- Start snapshots one authoritative v1 branch head, creates a non-expiring v1
+  retention pin, and opens a constant-size parent-before-child closure cursor.
+- Copying transforms at most the caller's commit budget. V1 live versions are
+  streamed through a verified disk spool into native immutable payload keys;
+  delete markers remain logical-only. A stable derivation maps each v1 object
+  version to one v2 identity. Versions already present through another merge
+  parent reuse their immutable binding without another payload transfer.
+- Imported commits preserve parent topology, generation, author, message,
+  timestamp, and metadata. They carry the target `v1-migration` system
+  authority stamp and remain unreachable until publication.
+- Every completed commit adds a source-to-destination mapping to the source
+  closure tree and adds its node pack plus binary-lifting ancestry entry to
+  target-side imported index roots. Both roots are in the returned cursor.
+- On restart, those imported roots serve ancestor-packed node lookups before
+  any user ref exists. A page is therefore resumable without rebuilding whole
+  historical snapshots or depending on process-local node locations.
+- Publishing creates the destination branch at the mapped source head and
+  atomically replaces its bootstrap index with the complete imported closure.
+  Only then is the source retention pin tombstoned and completion returned.
+- Replaying a completed cursor verifies the destination ref and exact durable
+  index roots. Cleanup exact-deletes source traversal nodes in bounded pages.
+- Abort unregisters the transient target index root, tombstones the source pin,
+  and exact-deletes traversal nodes in bounded pages. It never publishes a
+  partial branch; unreachable immutable imports are left for native-v2 GC.
+- V1 and v2 prefixes are physically separate. The protocol never dual-writes
+  mutations or changes an existing repository's format marker.

--- a/extensions/s3/spec/prolly-s3/v2/state-machines.md
+++ b/extensions/s3/spec/prolly-s3/v2/state-machines.md
@@ -48,3 +48,27 @@ Repository-wide maintenance may not infer exclusivity from one branch permit.
 Until the v2 maintenance gate, stable snapshot generations, and dirty-root
 journal are implemented, GC and other destructive whole-repository operations
 must fail closed for a sharded repository.
+
+## Durable commit session
+
+`Absent → Open(0) → Open(n) → Published`
+
+`Open(n) → Aborted(n+1) → Expired/Cleaned`
+
+- Session creation persists checkpoint zero with the stable batch ID,
+  operation ID, base commit, authority stamp, and expiry.
+- Staging uploads whole payloads to immutable content-addressed keys. A
+  checkpoint contains only sorted logical mutations and verified bindings.
+- Every checkpoint is a create-once object at a monotonically increasing
+  sequence; an ambiguous create is reconciled by exact canonical bytes.
+- Resume lists only the batch checkpoint prefix and selects the greatest
+  canonical sequence. A process may adopt the session into a newer authority
+  epoch only when its writer ID is unchanged and the branch still points to
+  the original base commit.
+- Publication revalidates authority and base, applies both Prolly trees in
+  batch, and reconciles the operation ID before treating an ambiguous ref CAS
+  as fencing evidence.
+- A successfully published session needs no additional mutable completion
+  record: replaying its final checkpoint resolves through the operation index.
+- Bounded cleanup pages physical checkpoint versions and exact-deletes only
+  records whose embedded expiry is in the past.

--- a/extensions/s3/spec/prolly-s3/v2/state-machines.md
+++ b/extensions/s3/spec/prolly-s3/v2/state-machines.md
@@ -89,7 +89,11 @@ must fail closed for a sharded repository.
 - Each apply step consumes one chunk oldest-to-newest and updates fresh node
   and commit-graph roots. It never materializes the complete journal or commit
   set in memory.
+- After node/graph application completes, the operation-index rebuild consumes
+  the same oldest-to-newest chunk chain into bounded LSM segment levels and
+  conditionally publishes its replacement head.
 - Final head CAS is allowed only if the durable index still matches the
   baseline captured at job start. A moving branch does not invalidate the
   immutable snapshot; ordinary incremental catch-up consumes later events.
 - Successful and abandoned jobs exact-delete chunk objects in bounded pages.
+  Cleanup starts only after every consumer of the shared chunks is complete.

--- a/extensions/s3/spec/prolly-s3/v2/state-machines.md
+++ b/extensions/s3/spec/prolly-s3/v2/state-machines.md
@@ -155,3 +155,37 @@ CAS against only the selected catalog shard.
   partial branch; unreachable immutable imports are left for native-v2 GC.
 - V1 and v2 prefixes are physically separate. The protocol never dual-writes
   mutations or changes an existing repository's format marker.
+
+## Resumable structural merge
+
+`DiscoveringBases -> CollectingBases -> Planning -> BuildingVersions -> BuildingObjects -> ReadyToPublish`
+
+Optional stops are `CollectingBases -> AwaitingBase -> Planning` for several
+best bases and `Planning -> Conflicted` for the fail-on-conflict policy.
+
+- Start snapshots the target and source commit IDs and first advances both
+  branch-local node/graph indexes. A first-parent ancestor is found through
+  binary-lifting pointers; other histories seed a generation-priority,
+  bidirectional paint-down frontier in the job plan.
+- A common commit becomes a candidate. Painting its ancestors stale removes
+  non-best common ancestors. Several surviving candidates are all exposed and
+  require an explicit caller selection.
+- Planning structurally diffs base-to-target and base-to-source. Equal CID
+  subtrees are pruned. The cursor retains at most one pending record from each
+  stream, and one advance batches its selected changes/conflicts into one new
+  durable plan root.
+- Version construction structurally unions the immutable parent version trees.
+  Unequal values at the same version-tree key are corruption. Object
+  construction applies only selected changes and creates deterministic logical
+  delete markers for source-selected deletions.
+- A large merge delta is an immutable Prolly root and exact count. The final
+  commit has parents `[observed-target, observed-source]` and generation one
+  greater than the newest parent.
+- Publication locks only the target branch, reconciles the operation ID first,
+  and then requires the target ref still to equal the observed target. A moved
+  target is a conflict; the implementation never rebases the plan.
+- Replaying publication with the same cursor returns the prior merge receipt.
+  An ambiguous, unreconciled publication fences only the target branch.
+- The caller exact-deletes merge-plan nodes in bounded pages after success or
+  abandonment. Output nodes referenced by a commit are never job-cleanup
+  candidates.

--- a/extensions/s3/spec/prolly-s3/v2/state-machines.md
+++ b/extensions/s3/spec/prolly-s3/v2/state-machines.md
@@ -72,3 +72,24 @@ must fail closed for a sharded repository.
   record: replaying its final checkpoint resolves through the operation index.
 - Bounded cleanup pages physical checkpoint versions and exact-deletes only
   records whose embedded expiry is in the past.
+
+## Journal-index rebuild
+
+`Discovering → Applying → Complete → Cleaned`
+
+- The job opens one immutable branch-journal snapshot and records its ref
+  generation and target.
+- Each discovery step reads at most the requested event limit and stores one
+  immutable content-addressed chunk. A chunk points to the previously written,
+  newer chunk, so the final oldest chunk is also the start of chronological
+  replay.
+- The constant-size cursor is canonical and process-independent. It contains
+  only the job/snapshot identity, one journal cursor or chunk ID, fresh Prolly
+  roots, counters, and the index-head baseline.
+- Each apply step consumes one chunk oldest-to-newest and updates fresh node
+  and commit-graph roots. It never materializes the complete journal or commit
+  set in memory.
+- Final head CAS is allowed only if the durable index still matches the
+  baseline captured at job start. A moving branch does not invalidate the
+  immutable snapshot; ordinary incremental catch-up consumes later events.
+- Successful and abandoned jobs exact-delete chunk objects in bounded pages.


### PR DESCRIPTION
## Summary

- add a physically and logically separate native protocol-v2 repository and AWS client
- expose branch-scoped writer takeover, automatic bounded-concurrency authority renewal, and per-branch fencing
- provide native-v2 put, get, delete, listing, history, immutable payload deduplication, and history-preserving v1 migration
- stream durable atomic commit sessions through bounded-memory disk spools, resume after process loss, and retain the N + 3 publication shape
- move journal/index catch-up out of foreground reads and rebuild over-limit node, commit-graph, and operation indexes in resumable pages
- maintain 16 event-driven ref-catalog shards so normal branch/tag lifecycle and enumeration do not scan S3 namespaces
- add restartable structural three-way merge with commit-graph skip pointers, paged best bases, changes and conflicts, durable Prolly plan roots, and operation-ID CAS reconciliation
- batch each merge planning/build page and store large merge deltas in an immutable Prolly tree instead of amplifying the commit envelope
- document the client surface, operator workflow, protocol paths/state machines, scale boundaries, and merge architecture decision

## Why

The legacy path mixed repository-wide writer authority, foreground index recovery, inline or memory-bound administrative work, and a chunk-oriented object model. Those constraints prevented independent branches from publishing concurrently and made large ingestion, recovery, ref enumeration, migration, and merge workloads difficult to bound or resume.

Native v2 gives each branch an independent publication lane while keeping user objects whole and immutable. Unbounded work lives in durable content-addressed trees behind constant-size cursors, so a process can restart without replaying complete histories or keyspaces.

## User and operator impact

- independent branches can publish concurrently; takeover fences only the affected branch
- the recommended ingestion API batches N payloads into N + 3 foreground PUTs
- durable sessions resume without re-uploading verified payloads
- branch/tag enumeration uses point reads over sharded catalogs rather than ListObjects
- v1 history migrates without dual writes
- merge planning is structural, paged, restartable, conflict-inspectable, and safe to replay after ambiguous publication

## Verification

- cargo fmt --check
- strict all-feature/all-target Clippy with warnings denied
- complete all-feature S3 workspace suite and doc tests
- dependency/security policy gate
- exact core 1.89 and client 1.94.1 clean-downstream checks, including minimal and slatedb-index features
- independent v1 and v2 protocol structure verifiers
- live RustFS authority fencing, v1 migration, durable 1 MiB session resume, zero-LIST ref catalog, N + 3 publication, and restartable merge tests
- release 10K sparse structural merge gate: passed in 1.60s
- release 4,096-commit skip-pointer ancestry gate: passed in 200.88s
- 10K concurrent commit, batching, cache persistence, and request-budget regression gates retained in the qualification suite

## Remaining operator qualification

- run the fail-closed AWS performance gate against the deployment's versioned general-purpose bucket, expected latency/throttling profile, hot-branch traffic, and cost SLOs
- qualify million-object and higher catalog cardinalities on the target AWS account; unlimited files, commits, and refs are not claimed
- complete native-v2 GC root coverage and durable multi-process background-maintenance ownership before enabling those operations in a multi-writer production deployment
- freeze the remaining v2 wire registry and publish an independent language implementation before claiming cross-language compatibility
