### PR TITLE
fix(s3): wire Foyer cache admission and metrics

### DIFF
--- a/extensions/s3/CACHE-AND-SCALE-DESIGN.md
+++ b/extensions/s3/CACHE-AND-SCALE-DESIGN.md
@@ -111,8 +111,9 @@ full scan, not infinite provider resources.
 
 Prefer retaining upper tree levels, current branch roots, recent commit graph
 nodes, and hot payload bindings. Leaf pages and old branch histories may use
-frequency/recency eviction. Cache admission should reject objects larger than
-the configured cache entry bound.
+frequency/recency eviction. Foyer cache admission rejects objects larger than
+the usable entry space in its configured disk block, including Foyer's
+block-index and entry overhead.
 
 Prewarming is advisory and cancellable. A reader remains correct if prewarming
 never runs or the cache directory is deleted.

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -369,21 +369,29 @@ let cache = FoyerNodeCache::open(FoyerNodeCacheConfig {
     directory: PathBuf::from("./prolly-node-cache"),
     memory_capacity_bytes: 64 * 1024 * 1024,
     disk_capacity_bytes: 4 * 1024 * 1024 * 1024,
-    disk_block_size_bytes: 4 * 1024 * 1024,
+    // 32 MiB accommodates the repository format's 16 MiB hard node bound
+    // plus Foyer's block index and entry envelope.
+    disk_block_size_bytes: 32 * 1024 * 1024,
     memory_shards: 8,
 })
 .await?;
 
 let client = Client::builder()
     // supply the same required provider and bucket settings
-    .node_cache(cache)
+    .node_cache(cache.clone())
     .open()
     .await?;
+
+// During graceful shutdown, release cache users before flushing Foyer.
+drop(client);
+cache.close().await?;
 ```
 
 Cache keys include repository identity, tree format, and immutable CID. Cached
 bytes are verified before use. Persisted caches improve cold-start traversal
-but are never authoritative.
+but are never authoritative. `max_entry_size_bytes()` reports the largest node
+that fits the configured disk block; larger nodes are deliberately rejected
+from cache admission and continue to use the provider fallback.
 
 Use `prewarm_node_cache(snapshot)` during startup to traverse both state trees.
 Use `node_cache_snapshot()` before and after to observe hits, misses,

--- a/extensions/s3/client/src/cache.rs
+++ b/extensions/s3/client/src/cache.rs
@@ -10,6 +10,10 @@ use crate::{Error, ErrorCode, Result};
 
 const CACHE_VALUE_PREFIX: &[u8] = b"PS3C\x01";
 const CACHE_TOMBSTONE: &[u8] = b"PS3C\x00";
+const FOYER_PAGE_BYTES: usize = 4 * 1024;
+// Foyer 0.22.3 block entries contain a 36-byte header, length-prefixed
+// key/value vectors, our 96-byte key, and the adapter value prefix.
+const FOYER_ENTRY_OVERHEAD_BYTES: usize = 36 + 8 + 96 + 8 + CACHE_VALUE_PREFIX.len();
 
 #[derive(Clone, Debug)]
 pub struct FoyerNodeCacheConfig {
@@ -21,16 +25,30 @@ pub struct FoyerNodeCacheConfig {
 }
 
 impl FoyerNodeCacheConfig {
+    fn effective_disk_block_size_bytes(&self) -> Option<usize> {
+        self.disk_block_size_bytes
+            .checked_add(FOYER_PAGE_BYTES - 1)
+            .map(|bytes| bytes / FOYER_PAGE_BYTES * FOYER_PAGE_BYTES)
+    }
+
+    fn max_entry_size_bytes(&self) -> Option<usize> {
+        self.effective_disk_block_size_bytes()?
+            .checked_sub(FOYER_PAGE_BYTES + FOYER_ENTRY_OVERHEAD_BYTES)
+    }
+
     pub fn validate(&self) -> Result<()> {
+        let effective_block_size = self.effective_disk_block_size_bytes();
         if self.memory_capacity_bytes == 0
             || self.disk_capacity_bytes == 0
             || self.disk_block_size_bytes == 0
             || self.memory_shards == 0
-            || self.disk_block_size_bytes > self.disk_capacity_bytes
+            || effective_block_size.is_none()
+            || effective_block_size.is_some_and(|bytes| bytes > self.disk_capacity_bytes)
+            || self.max_entry_size_bytes().is_none_or(|bytes| bytes == 0)
         {
             return Err(Error::new(
                 ErrorCode::InvalidLimit,
-                "Foyer cache capacities, block size, and shard count must be nonzero, and the block size must fit the disk capacity",
+                "Foyer cache capacities, effective 4 KiB-aligned block size, and shard count must be nonzero, and at least one cache entry and disk block must fit",
             ));
         }
         if self.directory.as_os_str().is_empty() {
@@ -50,11 +68,15 @@ impl FoyerNodeCacheConfig {
 /// owner; sharing the returned `Arc` within a process is supported.
 pub struct FoyerNodeCache {
     cache: HybridCache<Vec<u8>, Vec<u8>>,
+    max_entry_size_bytes: usize,
 }
 
 impl FoyerNodeCache {
     pub async fn open(config: FoyerNodeCacheConfig) -> Result<Arc<Self>> {
         config.validate()?;
+        let max_entry_size_bytes = config
+            .max_entry_size_bytes()
+            .expect("validated Foyer block size has entry capacity");
         std::fs::create_dir_all(&config.directory).map_err(|error| {
             Error::new(
                 ErrorCode::Transport,
@@ -93,7 +115,15 @@ impl FoyerNodeCache {
                     format!("Foyer cache could not be opened: {error}"),
                 )
             })?;
-        Ok(Arc::new(Self { cache }))
+        Ok(Arc::new(Self {
+            cache,
+            max_entry_size_bytes,
+        }))
+    }
+
+    /// Largest node value guaranteed to fit one configured Foyer disk block.
+    pub fn max_entry_size_bytes(&self) -> usize {
+        self.max_entry_size_bytes
     }
 
     pub async fn close(&self) -> Result<()> {
@@ -108,6 +138,10 @@ impl FoyerNodeCache {
 
 #[async_trait::async_trait]
 impl NodeCache for FoyerNodeCache {
+    fn admits(&self, _key: &NodeCacheKey, value_len: usize) -> bool {
+        value_len <= self.max_entry_size_bytes
+    }
+
     async fn get(
         &self,
         key: &NodeCacheKey,
@@ -132,6 +166,9 @@ impl NodeCache for FoyerNodeCache {
         key: NodeCacheKey,
         value: Vec<u8>,
     ) -> std::result::Result<(), NodeCacheError> {
+        if !self.admits(&key, value.len()) {
+            return Ok(());
+        }
         let encoded = key.encode().to_vec();
         let mut encoded_value = Vec::with_capacity(CACHE_VALUE_PREFIX.len() + value.len());
         encoded_value.extend_from_slice(CACHE_VALUE_PREFIX);
@@ -153,7 +190,12 @@ impl NodeCache for FoyerNodeCache {
 
 #[cfg(test)]
 mod tests {
-    use prolly_s3_core::{Cid, RepositoryId, TreeFormatDigest};
+    use std::collections::BTreeMap;
+
+    use prolly_s3_core::{
+        Cid, MemoryObjectPlane, ObjectHeaders, ProviderPerKeyVersionLimit, Repository,
+        RepositoryId, RepositoryOptions, TreeFormatDigest,
+    };
 
     use super::*;
 
@@ -165,48 +207,151 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn hybrid_cache_persists_verified_node_values() {
-        let directory = tempfile::tempdir().unwrap();
-        let cache = FoyerNodeCache::open(FoyerNodeCacheConfig {
-            directory: directory.path().to_path_buf(),
+    fn config(directory: PathBuf) -> FoyerNodeCacheConfig {
+        FoyerNodeCacheConfig {
+            directory,
             memory_capacity_bytes: 1024 * 1024,
             disk_capacity_bytes: 16 * 1024 * 1024,
             disk_block_size_bytes: 1024 * 1024,
             memory_shards: 1,
-        })
+        }
+    }
+
+    #[test]
+    fn config_rejects_a_block_that_only_fits_before_foyer_alignment() {
+        let directory = tempfile::tempdir().unwrap();
+        let invalid = FoyerNodeCacheConfig {
+            directory: directory.path().to_path_buf(),
+            memory_capacity_bytes: 1024,
+            disk_capacity_bytes: 4097,
+            disk_block_size_bytes: 4097,
+            memory_shards: 1,
+        };
+        assert_eq!(
+            invalid.validate().unwrap_err().code,
+            ErrorCode::InvalidLimit
+        );
+    }
+
+    #[tokio::test]
+    async fn hybrid_cache_rejects_nodes_that_cannot_fit_a_disk_block() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = FoyerNodeCache::open(config(directory.path().to_path_buf()))
+            .await
+            .unwrap();
+        let oversized = vec![9; cache.max_entry_size_bytes() + 1];
+        cache.insert(key(), oversized).await.unwrap();
+        assert_eq!(cache.get(&key()).await.unwrap(), None);
+        cache.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn repository_reopen_reads_nodes_from_persisted_foyer_cache() {
+        let directory = tempfile::tempdir().unwrap();
+        let plane = Arc::new(MemoryObjectPlane::new(true));
+        let cache = FoyerNodeCache::open(config(directory.path().to_path_buf()))
+            .await
+            .unwrap();
+        let prefix = ".tests/foyer-repository-restart";
+        let repository = Repository::initialize(
+            plane.clone(),
+            RepositoryOptions {
+                repository_prefix: prefix.to_string(),
+                writer: "foyer-writer".to_string(),
+                node_cache: Some(cache.clone()),
+                provider_per_key_version_limit: ProviderPerKeyVersionLimit::Finite(10_000),
+                ..RepositoryOptions::default()
+            },
+        )
         .await
         .unwrap();
+        repository
+            .put_object(
+                "main",
+                b"cached.txt".to_vec(),
+                b"persisted through Foyer".to_vec(),
+                ObjectHeaders::default(),
+                BTreeMap::new(),
+            )
+            .await
+            .unwrap();
+        repository.advance_branch_indexes("main").await.unwrap();
+        drop(repository);
+        cache.close().await.unwrap();
+        drop(cache);
+
+        let reopened_cache = FoyerNodeCache::open(config(directory.path().to_path_buf()))
+            .await
+            .unwrap();
+        let reopened = Repository::open(
+            plane,
+            RepositoryOptions {
+                repository_prefix: prefix.to_string(),
+                writer: "foyer-reader".to_string(),
+                read_only: true,
+                node_cache: Some(reopened_cache.clone()),
+                provider_per_key_version_limit: ProviderPerKeyVersionLimit::Finite(10_000),
+                ..RepositoryOptions::default()
+            },
+        )
+        .await
+        .unwrap();
+        let before = reopened.node_cache_snapshot();
+        let object = reopened
+            .get_object("main", b"cached.txt")
+            .await
+            .unwrap()
+            .unwrap();
+        let after = reopened.node_cache_snapshot();
+        assert_eq!(object.bytes, b"persisted through Foyer");
+        assert!(after.hits > before.hits);
+        assert_eq!(after.ranged_fetches, before.ranged_fetches);
+        drop(reopened);
+        reopened_cache.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn hybrid_cache_persists_verified_node_values() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = FoyerNodeCache::open(config(directory.path().to_path_buf()))
+            .await
+            .unwrap();
         cache.insert(key(), vec![9; 1024]).await.unwrap();
         assert_eq!(cache.get(&key()).await.unwrap(), Some(vec![9; 1024]));
         cache.close().await.unwrap();
         drop(cache);
 
-        let reopened = FoyerNodeCache::open(FoyerNodeCacheConfig {
-            directory: directory.path().to_path_buf(),
-            memory_capacity_bytes: 1024 * 1024,
-            disk_capacity_bytes: 16 * 1024 * 1024,
-            disk_block_size_bytes: 1024 * 1024,
-            memory_shards: 1,
-        })
-        .await
-        .unwrap();
+        let reopened = FoyerNodeCache::open(config(directory.path().to_path_buf()))
+            .await
+            .unwrap();
         assert_eq!(reopened.get(&key()).await.unwrap(), Some(vec![9; 1024]));
         reopened.remove(&key()).await.unwrap();
         assert_eq!(reopened.get(&key()).await.unwrap(), None);
         reopened.close().await.unwrap();
         drop(reopened);
 
-        let reopened_after_remove = FoyerNodeCache::open(FoyerNodeCacheConfig {
-            directory: directory.path().to_path_buf(),
-            memory_capacity_bytes: 1024 * 1024,
-            disk_capacity_bytes: 16 * 1024 * 1024,
-            disk_block_size_bytes: 1024 * 1024,
-            memory_shards: 1,
-        })
-        .await
-        .unwrap();
+        let reopened_after_remove = FoyerNodeCache::open(config(directory.path().to_path_buf()))
+            .await
+            .unwrap();
         assert_eq!(reopened_after_remove.get(&key()).await.unwrap(), None);
+        reopened_after_remove
+            .insert(key(), vec![7; 1024])
+            .await
+            .unwrap();
+        assert_eq!(
+            reopened_after_remove.get(&key()).await.unwrap(),
+            Some(vec![7; 1024])
+        );
         reopened_after_remove.close().await.unwrap();
+        drop(reopened_after_remove);
+
+        let reopened_after_reinsert = FoyerNodeCache::open(config(directory.path().to_path_buf()))
+            .await
+            .unwrap();
+        assert_eq!(
+            reopened_after_reinsert.get(&key()).await.unwrap(),
+            Some(vec![7; 1024])
+        );
+        reopened_after_reinsert.close().await.unwrap();
     }
 }

--- a/extensions/s3/core/src/cache.rs
+++ b/extensions/s3/core/src/cache.rs
@@ -50,6 +50,13 @@ impl NodeCacheError {
 /// this trait never becomes part of the repository's correctness authority.
 #[async_trait::async_trait]
 pub trait NodeCache: Send + Sync + 'static {
+    /// Return whether this cache's admission policy can accept a value of this
+    /// size. Implementations may override the default to make deliberate
+    /// rejections observable without treating them as cache failures.
+    fn admits(&self, _key: &NodeCacheKey, _value_len: usize) -> bool {
+        true
+    }
+
     async fn get(&self, key: &NodeCacheKey)
         -> std::result::Result<Option<Vec<u8>>, NodeCacheError>;
 
@@ -110,6 +117,10 @@ impl MemoryNodeCache {
 
 #[async_trait::async_trait]
 impl NodeCache for MemoryNodeCache {
+    fn admits(&self, _key: &NodeCacheKey, value_len: usize) -> bool {
+        self.max_bytes > 0 && value_len <= self.max_bytes
+    }
+
     async fn get(
         &self,
         key: &NodeCacheKey,
@@ -131,7 +142,7 @@ impl NodeCache for MemoryNodeCache {
         key: NodeCacheKey,
         value: Vec<u8>,
     ) -> std::result::Result<(), NodeCacheError> {
-        if self.max_bytes == 0 || value.len() > self.max_bytes {
+        if !self.admits(&key, value.len()) {
             return Ok(());
         }
         let mut state = self

--- a/extensions/s3/core/src/journal_indexes.rs
+++ b/extensions/s3/core/src/journal_indexes.rs
@@ -92,6 +92,13 @@ pub struct JournalDerivedIndexes<P: ObjectPlane> {
 }
 
 impl<P: ObjectPlane> JournalDerivedIndexes<P> {
+    pub(crate) fn node_cache_snapshot(&self) -> crate::NodeCacheSnapshot {
+        self.node_engine
+            .store()
+            .node_cache_snapshot()
+            .saturating_add(self.graph_engine.store().node_cache_snapshot())
+    }
+
     pub fn new(
         plane: Arc<P>,
         prefix: impl Into<String>,

--- a/extensions/s3/core/src/ref_catalog.rs
+++ b/extensions/s3/core/src/ref_catalog.rs
@@ -65,6 +65,10 @@ pub struct ShardedRefCatalog<P: ObjectPlane> {
 }
 
 impl<P: ObjectPlane> ShardedRefCatalog<P> {
+    pub(crate) fn node_cache_snapshot(&self) -> crate::NodeCacheSnapshot {
+        self.engine.store().node_cache_snapshot()
+    }
+
     pub fn new(
         plane: Arc<P>,
         prefix: impl Into<String>,

--- a/extensions/s3/core/src/repository.rs
+++ b/extensions/s3/core/src/repository.rs
@@ -961,7 +961,10 @@ impl<P: ObjectPlane> Repository<P> {
     }
 
     pub fn node_cache_snapshot(&self) -> crate::NodeCacheSnapshot {
-        self.node_store.node_cache_snapshot()
+        self.node_store
+            .node_cache_snapshot()
+            .saturating_add(self.ref_catalog.node_cache_snapshot())
+            .saturating_add(self.journal_indexes.node_cache_snapshot())
     }
 
     /// Traverse both current-state trees to populate the configured node

--- a/extensions/s3/core/src/store.rs
+++ b/extensions/s3/core/src/store.rs
@@ -137,6 +137,20 @@ pub struct NodeCacheSnapshot {
     pub ranged_fetches: u64,
 }
 
+impl NodeCacheSnapshot {
+    pub(crate) fn saturating_add(self, other: Self) -> Self {
+        Self {
+            hits: self.hits.saturating_add(other.hits),
+            misses: self.misses.saturating_add(other.misses),
+            insertions: self.insertions.saturating_add(other.insertions),
+            errors: self.errors.saturating_add(other.errors),
+            corruptions: self.corruptions.saturating_add(other.corruptions),
+            coalesced_waits: self.coalesced_waits.saturating_add(other.coalesced_waits),
+            ranged_fetches: self.ranged_fetches.saturating_add(other.ranged_fetches),
+        }
+    }
+}
+
 struct PackedNodeCache {
     entries: BTreeMap<NodePackId, (Arc<NodePack>, usize)>,
     order: VecDeque<NodePackId>,
@@ -747,6 +761,9 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
         let Some(key) = self.node_cache_key(cid) else {
             return;
         };
+        if !cache.admits(&key, bytes.len()) {
+            return;
+        }
         match cache.insert(key, bytes).await {
             Ok(()) => {
                 state.cache_insertions.fetch_add(1, Ordering::Relaxed);
@@ -905,6 +922,9 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
         let Some(key) = self.direct_cache_key(cid) else {
             return;
         };
+        if !state.node_cache.admits(&key, bytes.len()) {
+            return;
+        }
         match state.node_cache.insert(key, bytes).await {
             Ok(()) => {
                 state.cache_insertions.fetch_add(1, Ordering::Relaxed);

--- a/extensions/s3/core/tests/repository.rs
+++ b/extensions/s3/core/tests/repository.rs
@@ -2,11 +2,48 @@ use std::{collections::BTreeMap, io::Write as _, sync::Arc};
 
 use md5::{Digest as _, Md5};
 use prolly_s3_core::{
-    FixedClock, GetRequest, ListRequest, LogicalObjectVersionKind, MemoryObjectPlane,
-    ObjectHeaders, ObjectPath, ObjectPlane, ProviderPerKeyVersionLimit, Repository,
-    RepositoryOptions, SequenceIdSource,
+    FixedClock, GetRequest, ListRequest, LogicalObjectVersionKind, MemoryNodeCache,
+    MemoryObjectPlane, ObjectHeaders, ObjectPath, ObjectPlane, ProviderPerKeyVersionLimit,
+    Repository, RepositoryOptions, SequenceIdSource,
 };
 use sha2::Sha256;
+
+#[tokio::test]
+async fn repository_cache_snapshot_includes_ref_catalog_reads_after_reopen() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let cache = Arc::new(MemoryNodeCache::new(64 * 1024 * 1024));
+    let options = RepositoryOptions {
+        repository_prefix: ".tests/repository-cache-metrics".to_string(),
+        writer: "cache-writer".to_string(),
+        node_cache: Some(cache.clone()),
+        provider_per_key_version_limit: ProviderPerKeyVersionLimit::Finite(10_000),
+        ..RepositoryOptions::default()
+    };
+    let repository = Repository::initialize(plane.clone(), options.clone())
+        .await
+        .unwrap();
+    let root = repository.head("main").await.unwrap();
+    repository.create_branch("cached", root).await.unwrap();
+    drop(repository);
+
+    let reopened = Repository::open(
+        plane,
+        RepositoryOptions {
+            read_only: true,
+            ..options
+        },
+    )
+    .await
+    .unwrap();
+    let before = reopened.node_cache_snapshot();
+    let page = reopened.list_branch_catalog_page(None, 100).await.unwrap();
+    assert_eq!(page.branches.len(), 2);
+    let after = reopened.node_cache_snapshot();
+    assert!(
+        after.hits > before.hits,
+        "ref-catalog cache hits must be included in the repository snapshot"
+    );
+}
 
 #[tokio::test]
 async fn repository_put_read_replay_and_reopen_use_only_authority() {


### PR DESCRIPTION
## What changed

- validate Foyer's effective 4 KiB-aligned disk block geometry and expose the usable maximum entry size
- reject nodes that cannot fit one Foyer block without counting the rejection as a cache insertion
- aggregate cache metrics across state trees, journal node/graph indexes, and the ref catalog
- add restart coverage proving persisted Foyer nodes serve repository reads without ranged node-pack fetches
- document production-sized blocks and graceful cache shutdown

## Why

The cache was connected to all tree stores, but repository snapshots reported only the main state-tree counters. Foyer configuration also validated the requested block size before Foyer alignment and could report oversized entries as inserted even when the disk engine could not persist them.

## Impact

Operators now get complete cache observability and deterministic admission behavior. Cached bytes remain advisory and CID-verified; provider reads remain the authoritative fallback.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `bash extensions/s3/scripts/check_clean_downstream.sh`
- focused persisted-Foyer repository restart regression
