### PR TITLE
Refactor S3 client checkout and bulk write APIs

### DIFF
--- a/extensions/s3/API.md
+++ b/extensions/s3/API.md
@@ -11,14 +11,14 @@ operations from administrative maintenance.
 | Create or reopen a repository | `Client::builder`, then `initialize` or `open` |
 | Write one interactive file | `put_object` or `put_object_with_metadata` |
 | Retry a write after an ambiguous response | `put_object_with_operation` with the same `OperationId` and input |
-| Atomically write many files | `begin_commit`, or `ingest_objects` for bulk loading |
+| Atomically write many files | `begin_commit`, or `put_objects` for bulk loading |
 | Read current or historical data | `get_object`, `get_object_at` |
 | Read metadata or a byte range | `head_object`, `get_object_range` |
 | Copy without re-uploading the payload | `copy_object` |
 | Delete one or many files | `delete_object`, `delete_objects` |
 | List current or historical objects | `list_objects`, `list_objects_at`, `list_objects_delimited` |
 | Inspect object-version history | `list_object_versions`, `list_versions_prefix`, `list_versions_at` |
-| Work on an independent line of history | `create_branch`, `for_branch`, `delete_branch` |
+| Select a branch, tag, or commit | `checkout`, `checked_out_ref`, `branch` |
 | Name or retain a commit | `create_tag`, `tag`, `delete_tag`, `create_retention_pin` |
 | Compare or inspect history | `log_bounded`, `diff_bounded`, `commit` |
 | Inspect or recover ref movement | `open_reflog`, `read_reflog_page`, `recover_branch` |
@@ -32,12 +32,17 @@ operations from administrative maintenance.
 | Verify a logical backup | `start_backup_verification`, `advance_backup_verification` |
 | Inspect cache and provider requests | `prewarm_node_cache`, `node_cache_snapshot`, `s3_operation_metrics` |
 
-## Client identity and branch selection
+## Client identity and checkout
 
-- `bucket`, `branch`, and `repository_id` return the selected physical bucket,
-  logical branch, and immutable repository identity.
-- `head` returns the selected branch's current `CommitId`.
-- `for_branch` cheaply clones a client handle and selects another branch.
+- `bucket` and `repository_id` return the physical bucket and immutable
+  repository identity.
+- `checkout` accepts unqualified names, `refs/heads/...`, `refs/tags/...`, a
+  typed `CheckoutRef`, or a `CommitId`.
+- `checked_out_ref` reports the resolved `CheckedOutRef`. `branch` returns
+  `Some(name)` for an attached branch and `None` for a detached tag/commit.
+- `CheckedOutRef::target` returns the immutable target for tag/commit
+  checkouts; attached branches remain live and therefore return `None`.
+- `head` returns the attached branch head or detached tag/commit target.
 - `fenced_branches` reports branches this process can no longer publish.
 
 `Client` clones share repository state, caches, authority maintenance, and S3
@@ -96,9 +101,9 @@ When an object listing is truncated, pass the last returned logical key as
 `after`. Version-prefix pages use the opaque byte cursor returned in each
 `VersionSummary`.
 
-## Atomic commit sessions and ingestion
+## Atomic commit sessions and bulk writes
 
-`ingest_objects` is the concise bulk path. It divides `IngestObject` values
+`put_objects` is the concise bulk path. It divides `PutObjectInput` values
 into durable atomic batches and returns one receipt per published batch.
 
 For explicit control, call `begin_commit`. `CommitSessionBuilder` supports:

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -121,9 +121,9 @@ let receipt = client
 After an ambiguous response, repeat the exact call with the same operation ID.
 The client reconciles an already-applied commit before fencing the writer.
 
-## Batch ingestion
+## Batch writes
 
-Batching is the recommended ingestion path. It uploads payloads while staging
+Batching is the recommended bulk-write path. It uploads payloads while staging
 and publishes all tree changes with one branch compare-and-swap.
 
 ```rust
@@ -155,15 +155,15 @@ let receipt = commit.publish().await?;
 For a disposable job, add `.ephemeral()`. That removes checkpoint requests
 but cannot recover process-local staged metadata after a crash.
 
-For a collection already in memory, `ingest_objects` creates durable batches
+For a collection already in memory, `put_objects` creates durable batches
 for you:
 
 ```rust
-use prolly_s3_client::IngestObject;
+use prolly_s3_client::PutObjectInput;
 
 let receipts = client
-    .ingest_objects(
-        vec![IngestObject {
+    .put_objects(
+        vec![PutObjectInput {
             key: "incoming/0004.json".into(),
             bytes: fourth_body,
             headers: Default::default(),
@@ -204,7 +204,7 @@ use prolly_s3_client::core::{MergePhase, MergePolicy};
 let base = client.head().await?;
 client.create_branch("feature", Some(base)).await?;
 
-let feature = client.for_branch("feature")?;
+let feature = client.checkout("feature").await?;
 feature
     .put_object("documents/feature.txt", b"feature\n".to_vec())
     .await?;
@@ -225,6 +225,38 @@ let receipt = client.publish_merge(&merge).await?;
 Merge work is immutable and restartable. Persist the canonical `MergeCursor`
 returned by each bounded advance. Use `merge_conflicts_page` before publishing
 when the policy can produce conflicts.
+
+## Checkout branches, tags, and commits
+
+`checkout` follows Git-like revision rules. An unqualified name resolves a
+branch before a tag. Fully qualified names remove ambiguity, and a `CommitId`
+creates a detached checkout:
+
+```rust
+use prolly_s3_client::{CheckedOutRef, CheckoutRef};
+
+let commit_id = client.head().await?;
+client.create_tag("v1.0", commit_id).await?;
+
+let feature = client.checkout("feature").await?;
+assert_eq!(feature.branch(), Some("feature"));
+
+let release = client.checkout("refs/tags/v1.0").await?;
+assert_eq!(release.branch(), None);
+
+let historical = client.checkout(commit_id).await?;
+let object = historical.get_object("documents/readme.txt").await?;
+
+// The typed form is useful when a branch and tag have the same name.
+let release = client
+    .checkout(CheckoutRef::Tag("v1.0".to_string()))
+    .await?;
+assert!(matches!(release.checked_out_ref(), CheckedOutRef::Tag { .. }));
+```
+
+Branch checkouts remain writable. Tag and commit checkouts are detached:
+`head`, `get_object`, `head_object`, listings, and `log` use their immutable
+snapshot, while mutation and branch-ref APIs return `InvalidRevision`.
 
 ## History, diff, and recovery
 

--- a/extensions/s3/client/examples/atomic_batch_and_streaming.rs
+++ b/extensions/s3/client/examples/atomic_batch_and_streaming.rs
@@ -1,4 +1,4 @@
-//! Atomic multi-file ingestion with durable checkpoints and streaming input.
+//! Atomic multi-file writes with durable checkpoints and streaming input.
 
 mod common;
 
@@ -11,7 +11,7 @@ async fn main() -> ExampleResult {
     let client = repository.client;
 
     // A durable session uploads payloads as they are staged and checkpoints
-    // canonical metadata remotely. Persist `batch_id` in a real ingest job so
+    // canonical metadata remotely. Persist `batch_id` in a real bulk job so
     // another process can call `client.resume_commit(batch_id)` after failure.
     let mut session = client
         .begin_commit()

--- a/extensions/s3/client/examples/branch_diff_merge.rs
+++ b/extensions/s3/client/examples/branch_diff_merge.rs
@@ -15,7 +15,7 @@ async fn main() -> ExampleResult {
         .await?
         .id;
     main.create_branch("feature", Some(base)).await?;
-    let feature = main.for_branch("feature")?;
+    let feature = main.checkout("feature").await?;
 
     // Branches publish through independent ref lanes. Here each branch changes
     // a different key, so Fail policy can merge without resolving conflicts.
@@ -42,6 +42,19 @@ async fn main() -> ExampleResult {
     let planned = main.merge_changes_page(&merge, None, 100).await?;
     let merged = main.publish_merge(&merge).await?;
 
+    // Tags and commit IDs produce detached, immutable checkouts. Current-read
+    // APIs automatically use the selected snapshot; mutation APIs reject a
+    // detached checkout instead of accidentally publishing to another branch.
+    main.create_tag("release-2026.8", merged.id).await?;
+    let release = main.checkout("refs/tags/release-2026.8").await?;
+    let exact_commit = main.checkout(merged.id).await?;
+    let released_feature = release
+        .get_object("features/search.txt")
+        .await?
+        .ok_or("released feature is missing")?;
+    assert_eq!(release.branch(), None);
+    assert_eq!(exact_commit.head().await?, merged.id);
+
     let history = main.log(10).await?;
     let reflog = main.open_reflog().await?;
     let reflog_page = main.read_reflog_page(&reflog, 10).await?;
@@ -53,5 +66,9 @@ async fn main() -> ExampleResult {
     println!("planned_changes={}", planned.changes.len());
     println!("log_entries={}", history.len());
     println!("reflog_entries={}", reflog_page.entries.len());
+    println!(
+        "released_feature={}",
+        String::from_utf8_lossy(&released_feature.bytes).trim()
+    );
     Ok(())
 }

--- a/extensions/s3/client/examples/history_transfer_and_backup.rs
+++ b/extensions/s3/client/examples/history_transfer_and_backup.rs
@@ -22,7 +22,8 @@ async fn main() -> ExampleResult {
         .put_object("data/main.txt", b"main\n".to_vec())
         .await?;
     source
-        .for_branch("feature")?
+        .checkout("feature")
+        .await?
         .put_object("data/feature.txt", b"feature\n".to_vec())
         .await?;
     let mut merge = source

--- a/extensions/s3/client/examples/integrity_gc_and_observability.rs
+++ b/extensions/s3/client/examples/integrity_gc_and_observability.rs
@@ -24,7 +24,8 @@ async fn main() -> ExampleResult {
     // valid GC candidate after its branch is deleted and the grace period ends.
     client.create_branch("pinned-work", Some(main_head)).await?;
     let pinned = client
-        .for_branch("pinned-work")?
+        .checkout("pinned-work")
+        .await?
         .put_object("archive/pinned.txt", b"legal hold\n".to_vec())
         .await?
         .id;
@@ -35,7 +36,8 @@ async fn main() -> ExampleResult {
         .create_branch("abandoned-work", Some(main_head))
         .await?;
     let abandoned = client
-        .for_branch("abandoned-work")?
+        .checkout("abandoned-work")
+        .await?
         .put_object("scratch/abandoned.txt", b"collect me\n".to_vec())
         .await?
         .id;

--- a/extensions/s3/client/examples/rustfs_versioned_bucket.rs
+++ b/extensions/s3/client/examples/rustfs_versioned_bucket.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     client.create_branch("feature", Some(first.id)).await?;
 
-    let feature = client.for_branch("feature")?;
+    let feature = client.checkout("feature").await?;
     feature
         .put_object("demo/feature.txt", b"created on feature\n".to_vec())
         .await?;

--- a/extensions/s3/client/src/client.rs
+++ b/extensions/s3/client/src/client.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::BTreeMap,
     io::Write as _,
+    str::FromStr as _,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -40,7 +41,10 @@ use crate::{
 pub struct Client {
     repository: Arc<Repository<AwsS3ObjectPlane>>,
     bucket: String,
+    /// Branch used to resolve branch-local packed-node indexes. For a detached
+    /// checkout this remains the branch from which checkout was requested.
     branch: String,
+    checked_out: CheckedOutRef,
     provider_attestation: ProviderAttestation,
     shard_authority_maintenance: Arc<Mutex<Option<prolly_s3_core::ShardAuthorityMaintenance>>>,
     _branch_index_maintenance: Arc<Mutex<Option<prolly_s3_core::BranchIndexMaintenance>>>,
@@ -73,11 +77,71 @@ pub struct ClientBuilder {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct IngestObject {
+pub struct PutObjectInput {
     pub key: String,
     pub bytes: Vec<u8>,
     pub headers: ObjectHeaders,
     pub user_metadata: BTreeMap<String, String>,
+}
+
+/// A revision accepted by [`Client::checkout`].
+///
+/// Unqualified names resolve branches before tags. Use `Branch` or `Tag` (or
+/// the `refs/heads/` and `refs/tags/` string forms) when both have the same
+/// name. Commit IDs always create a detached checkout.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CheckoutRef {
+    Name(String),
+    Branch(String),
+    Tag(String),
+    Commit(CommitId),
+}
+
+impl From<String> for CheckoutRef {
+    fn from(value: String) -> Self {
+        Self::Name(value)
+    }
+}
+
+impl From<&str> for CheckoutRef {
+    fn from(value: &str) -> Self {
+        Self::Name(value.to_string())
+    }
+}
+
+impl From<&String> for CheckoutRef {
+    fn from(value: &String) -> Self {
+        Self::Name(value.clone())
+    }
+}
+
+impl From<CommitId> for CheckoutRef {
+    fn from(value: CommitId) -> Self {
+        Self::Commit(value)
+    }
+}
+
+impl From<&CommitId> for CheckoutRef {
+    fn from(value: &CommitId) -> Self {
+        Self::Commit(*value)
+    }
+}
+
+/// The resolved revision selected by a client handle.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CheckedOutRef {
+    Branch(String),
+    Tag { name: String, target: CommitId },
+    Commit(CommitId),
+}
+
+impl CheckedOutRef {
+    pub fn target(&self) -> Option<CommitId> {
+        match self {
+            Self::Branch(_) => None,
+            Self::Tag { target, .. } | Self::Commit(target) => Some(*target),
+        }
+    }
 }
 
 impl Client {
@@ -89,8 +153,16 @@ impl Client {
         &self.bucket
     }
 
-    pub fn branch(&self) -> &str {
-        &self.branch
+    /// Return the attached branch, or `None` for a tag/commit checkout.
+    pub fn branch(&self) -> Option<&str> {
+        match &self.checked_out {
+            CheckedOutRef::Branch(branch) => Some(branch),
+            CheckedOutRef::Tag { .. } | CheckedOutRef::Commit(_) => None,
+        }
+    }
+
+    pub fn checked_out_ref(&self) -> &CheckedOutRef {
+        &self.checked_out
     }
 
     pub fn repository_id(&self) -> prolly_s3_core::RepositoryId {
@@ -108,17 +180,79 @@ impl Client {
             .await
     }
 
-    pub fn for_branch(&self, branch: impl Into<String>) -> Result<Self> {
-        let branch = branch.into();
+    /// Select a branch, tag, or immutable commit, following Git-like ref
+    /// precedence. Branch checkouts are writable; tag and commit checkouts are
+    /// detached and reject mutation APIs with `InvalidRevision`.
+    pub async fn checkout(&self, reference: impl Into<CheckoutRef>) -> Result<Self> {
+        self.ensure_provider_qualified()?;
+        match reference.into() {
+            CheckoutRef::Commit(id) => self.checkout_commit(id).await,
+            CheckoutRef::Branch(name) => self.checkout_branch(name).await,
+            CheckoutRef::Tag(name) => self.checkout_tag(name).await,
+            CheckoutRef::Name(name) => {
+                if let Some(name) = name.strip_prefix("refs/heads/") {
+                    return self.checkout_branch(name.to_string()).await;
+                }
+                if let Some(name) = name.strip_prefix("refs/tags/") {
+                    return self.checkout_tag(name.to_string()).await;
+                }
+                if let Ok(id) = CommitId::from_str(&name) {
+                    return self.checkout_commit(id).await;
+                }
+                match self.checkout_branch(name.clone()).await {
+                    Ok(client) => Ok(client),
+                    Err(error) if error.code == ErrorCode::InvalidRevision => {
+                        self.checkout_tag(name).await
+                    }
+                    Err(error) => Err(error),
+                }
+            }
+        }
+    }
+
+    async fn checkout_branch(&self, branch: String) -> Result<Self> {
         prolly_s3_core::validate_branch(&branch)?;
+        self.repository.head(&branch).await?;
         let mut client = self.clone();
-        client.branch = branch;
+        client.branch = branch.clone();
+        client.checked_out = CheckedOutRef::Branch(branch);
         Ok(client)
+    }
+
+    async fn checkout_tag(&self, name: String) -> Result<Self> {
+        prolly_s3_core::validate_branch(&name)?;
+        let tag = self.repository.tag(&name).await?;
+        self.repository.commit(tag.target).await?;
+        let mut client = self.clone();
+        client.checked_out = CheckedOutRef::Tag {
+            name,
+            target: tag.target,
+        };
+        Ok(client)
+    }
+
+    async fn checkout_commit(&self, id: CommitId) -> Result<Self> {
+        self.repository.commit(id).await?;
+        let mut client = self.clone();
+        client.checked_out = CheckedOutRef::Commit(id);
+        Ok(client)
+    }
+
+    fn attached_branch(&self) -> Result<&str> {
+        self.branch().ok_or_else(|| {
+            Error::new(
+                ErrorCode::InvalidRevision,
+                "mutation or branch-ref operation requires an attached branch checkout",
+            )
+        })
     }
 
     pub async fn head(&self) -> Result<CommitId> {
         self.ensure_provider_qualified()?;
-        self.repository.head(&self.branch).await
+        match self.checked_out.target() {
+            Some(target) => Ok(target),
+            None => self.repository.head(&self.branch).await,
+        }
     }
 
     pub async fn create_branch(
@@ -127,20 +261,23 @@ impl Client {
         from: Option<CommitId>,
     ) -> Result<BranchHead> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         let from = match from {
             Some(from) => from,
-            None => self.repository.head(&self.branch).await?,
+            None => self.head().await?,
         };
         self.repository.create_branch(name.as_ref(), from).await
     }
 
     pub async fn delete_branch(&self, name: impl AsRef<str>, expected: CommitId) -> Result<()> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository.delete_branch(name.as_ref(), expected).await
     }
 
     pub async fn create_tag(&self, name: impl AsRef<str>, target: CommitId) -> Result<Tag> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository.create_tag(name.as_ref(), target).await
     }
 
@@ -151,6 +288,7 @@ impl Client {
 
     pub async fn delete_tag(&self, name: impl AsRef<str>, expected: CommitId) -> Result<()> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository.delete_tag(name.as_ref(), expected).await
     }
 
@@ -160,6 +298,7 @@ impl Client {
         target: CommitId,
     ) -> Result<RetentionPin> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository
             .create_retention_pin(name.as_ref(), target)
             .await
@@ -176,6 +315,7 @@ impl Client {
         expected: CommitId,
     ) -> Result<()> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository
             .delete_retention_pin(name.as_ref(), expected)
             .await
@@ -199,7 +339,20 @@ impl Client {
 
     pub async fn log(&self, limit: usize) -> Result<Vec<(CommitId, prolly_s3_core::BucketCommit)>> {
         self.ensure_provider_qualified()?;
-        self.repository.log(&self.branch, limit).await
+        match self.checked_out.target() {
+            Some(target) => Ok(self
+                .repository
+                .log_page_bounded(
+                    &self.branch,
+                    target,
+                    None,
+                    limit,
+                    TraversalBudget::default(),
+                )
+                .await?
+                .commits),
+            None => self.repository.log(&self.branch, limit).await,
+        }
     }
 
     pub async fn log_bounded(
@@ -235,7 +388,7 @@ impl Client {
 
     pub async fn open_reflog(&self) -> Result<PublicationJournalCursor> {
         self.ensure_provider_qualified()?;
-        self.repository.open_reflog(&self.branch).await
+        self.repository.open_reflog(self.attached_branch()?).await
     }
 
     pub async fn read_reflog_page(
@@ -254,8 +407,9 @@ impl Client {
         reason: impl AsRef<str>,
     ) -> Result<RefMoveReceipt> {
         self.ensure_provider_qualified()?;
+        let branch = self.attached_branch()?;
         self.repository
-            .reset_branch(&self.branch, to, expected_head, reason.as_ref())
+            .reset_branch(branch, to, expected_head, reason.as_ref())
             .await
     }
 
@@ -266,33 +420,40 @@ impl Client {
         reason: impl AsRef<str>,
     ) -> Result<RefMoveReceipt> {
         self.ensure_provider_qualified()?;
+        let branch = self.attached_branch()?;
         self.repository
-            .recover_branch(&self.branch, reflog, expected_head, reason.as_ref())
+            .recover_branch(branch, reflog, expected_head, reason.as_ref())
             .await
     }
 
     pub async fn start_fsck(&self, deep: bool) -> Result<FsckCursor> {
         self.ensure_provider_qualified()?;
-        self.repository.start_fsck(&self.branch, deep).await
+        self.repository
+            .start_fsck(self.attached_branch()?, deep)
+            .await
     }
 
     pub async fn advance_fsck(&self, cursor: &FsckCursor, max_steps: usize) -> Result<FsckPage> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository.advance_fsck(cursor, max_steps).await
     }
 
     pub async fn start_gc(&self, grace_millis: u64) -> Result<GcCursor> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository.start_gc(grace_millis).await
     }
 
     pub async fn advance_gc(&self, cursor: &GcCursor, max_steps: usize) -> Result<GcPage> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository.advance_gc(cursor, max_steps).await
     }
 
     pub async fn sweep_gc(&self, cursor: &GcCursor, max_candidates: usize) -> Result<GcPage> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository.sweep_gc(cursor, max_candidates).await
     }
 
@@ -305,12 +466,13 @@ impl Client {
     ) -> Result<RepairCursor> {
         self.ensure_provider_qualified()?;
         source.ensure_provider_qualified()?;
+        let destination_branch = self.attached_branch()?;
         self.repository
             .start_repair_from(
                 source.repository.as_ref(),
                 &source.branch,
                 source_snapshot,
-                &self.branch,
+                destination_branch,
                 expected_head,
                 message,
             )
@@ -325,6 +487,7 @@ impl Client {
     ) -> Result<RepairPage> {
         self.ensure_provider_qualified()?;
         source.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository
             .advance_repair_from(source.repository.as_ref(), cursor, max_steps)
             .await
@@ -338,12 +501,13 @@ impl Client {
     ) -> Result<HistoryTransferCursor> {
         self.ensure_provider_qualified()?;
         source.ensure_provider_qualified()?;
+        let destination_branch = self.attached_branch()?;
         self.repository
             .start_history_transfer_from(
                 source.repository.as_ref(),
                 &source.branch,
                 source_snapshot,
-                &self.branch,
+                destination_branch,
                 expected_head,
             )
             .await
@@ -357,6 +521,7 @@ impl Client {
     ) -> Result<HistoryTransferPage> {
         self.ensure_provider_qualified()?;
         source.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository
             .advance_history_transfer_from(source.repository.as_ref(), cursor, max_steps)
             .await
@@ -368,6 +533,7 @@ impl Client {
         reason: impl AsRef<str>,
     ) -> Result<RefMoveReceipt> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository
             .publish_history_transfer(cursor, reason.as_ref())
             .await
@@ -493,8 +659,9 @@ impl Client {
         message: impl Into<String>,
     ) -> Result<RestoreCursor> {
         self.ensure_provider_qualified()?;
+        let branch = self.attached_branch()?;
         self.repository
-            .start_restore(&self.branch, source, expected_head, message)
+            .start_restore(branch, source, expected_head, message)
             .await
     }
 
@@ -504,6 +671,7 @@ impl Client {
         max_steps: usize,
     ) -> Result<RestorePage> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository.advance_restore(cursor, max_steps).await
     }
 
@@ -517,9 +685,10 @@ impl Client {
         message: impl Into<String>,
     ) -> Result<MergeCursor> {
         self.ensure_provider_qualified()?;
+        let branch = self.attached_branch()?;
         self.repository
             .start_merge(
-                &self.branch,
+                branch,
                 source_branch.as_ref(),
                 selected_base,
                 policy,
@@ -534,6 +703,7 @@ impl Client {
         max_steps: usize,
     ) -> Result<MergeAdvancePage> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository.advance_merge(cursor, max_steps).await
     }
 
@@ -543,6 +713,7 @@ impl Client {
         base: CommitId,
     ) -> Result<MergeCursor> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository.select_merge_base(cursor, base).await
     }
 
@@ -584,6 +755,7 @@ impl Client {
 
     pub async fn publish_merge(&self, cursor: &MergeCursor) -> Result<MergeReceipt> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository.publish_merge(cursor).await
     }
 
@@ -594,6 +766,7 @@ impl Client {
         limit: usize,
     ) -> Result<MergeCleanupPage> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository
             .cleanup_merge(cursor, continuation, limit)
             .await
@@ -625,6 +798,7 @@ impl Client {
         limit: usize,
     ) -> Result<RefCatalogRepairPage> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository
             .repair_ref_catalog_page(RefKind::Branch, continuation, limit)
             .await
@@ -636,6 +810,7 @@ impl Client {
         limit: usize,
     ) -> Result<RefCatalogRepairPage> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository
             .repair_ref_catalog_page(RefKind::Tag, continuation, limit)
             .await
@@ -658,14 +833,9 @@ impl Client {
         metadata: BTreeMap<String, String>,
     ) -> Result<CommitReceipt> {
         self.ensure_provider_qualified()?;
+        let branch = self.attached_branch()?;
         self.repository
-            .put_object(
-                &self.branch,
-                key.into().into_bytes(),
-                bytes,
-                headers,
-                metadata,
-            )
+            .put_object(branch, key.into().into_bytes(), bytes, headers, metadata)
             .await
     }
 
@@ -679,9 +849,10 @@ impl Client {
         operation: OperationId,
     ) -> Result<CommitReceipt> {
         self.ensure_provider_qualified()?;
+        let branch = self.attached_branch()?;
         self.repository
             .put_object_with_operation(
-                &self.branch,
+                branch,
                 key.into().into_bytes(),
                 bytes,
                 ObjectHeaders::default(),
@@ -691,15 +862,16 @@ impl Client {
             .await
     }
 
-    /// Ingest objects through durable atomic batches. This is the recommended
+    /// Put objects through durable atomic batches. This is the recommended
     /// path for bulk loading because publication and checkpoint costs are
     /// amortized across each batch.
-    pub async fn ingest_objects(
+    pub async fn put_objects(
         &self,
-        objects: Vec<IngestObject>,
+        objects: Vec<PutObjectInput>,
         batch_size: usize,
     ) -> Result<Vec<CommitReceipt>> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         let max = self
             .repository
             .format()
@@ -707,7 +879,7 @@ impl Client {
             .max_mutations_per_commit as usize;
         if batch_size == 0 || batch_size > max {
             return Err(invalid(
-                "ingest batch size exceeds the canonical mutation limit",
+                "put_objects batch size exceeds the canonical mutation limit",
             ));
         }
         let mut receipts = Vec::new();
@@ -719,7 +891,7 @@ impl Client {
             }
             let mut session = self
                 .begin_commit()
-                .message("bulk ingest")
+                .message("bulk object write")
                 .checkpoint_every(batch_size.min(1_000))
                 .start()
                 .await?;
@@ -740,9 +912,18 @@ impl Client {
 
     pub async fn get_object(&self, key: impl AsRef<str>) -> Result<Option<ObjectData>> {
         self.ensure_provider_qualified()?;
-        self.repository
-            .get_object(&self.branch, key.as_ref().as_bytes())
-            .await
+        match self.checked_out.target() {
+            Some(snapshot) => {
+                self.repository
+                    .get_object_at(&self.branch, snapshot, key.as_ref().as_bytes())
+                    .await
+            }
+            None => {
+                self.repository
+                    .get_object(&self.branch, key.as_ref().as_bytes())
+                    .await
+            }
+        }
     }
 
     pub async fn get_object_at(
@@ -761,9 +942,18 @@ impl Client {
         key: impl AsRef<str>,
     ) -> Result<Option<(CommitId, ObjectSummary)>> {
         self.ensure_provider_qualified()?;
-        self.repository
-            .head_object(&self.branch, key.as_ref().as_bytes())
-            .await
+        match self.checked_out.target() {
+            Some(snapshot) => Ok(self
+                .repository
+                .head_object_at(&self.branch, snapshot, key.as_ref().as_bytes())
+                .await?
+                .map(|summary| (snapshot, summary))),
+            None => {
+                self.repository
+                    .head_object(&self.branch, key.as_ref().as_bytes())
+                    .await
+            }
+        }
     }
 
     pub async fn get_object_range(
@@ -785,9 +975,10 @@ impl Client {
         destination_key: impl Into<String>,
     ) -> Result<CommitReceipt> {
         self.ensure_provider_qualified()?;
+        let branch = self.attached_branch()?;
         self.repository
             .copy_object(
-                &self.branch,
+                branch,
                 source_snapshot,
                 source_key.as_ref().as_bytes(),
                 destination_key.into().into_bytes(),
@@ -801,17 +992,19 @@ impl Client {
         K: Into<String>,
     {
         self.ensure_provider_qualified()?;
+        let branch = self.attached_branch()?;
         let keys = keys
             .into_iter()
             .map(|key| key.into().into_bytes())
             .collect();
-        self.repository.delete_objects(&self.branch, keys).await
+        self.repository.delete_objects(branch, keys).await
     }
 
     pub async fn delete_object(&self, key: impl Into<String>) -> Result<CommitReceipt> {
         self.ensure_provider_qualified()?;
+        let branch = self.attached_branch()?;
         self.repository
-            .delete_object(&self.branch, key.into().into_bytes())
+            .delete_object(branch, key.into().into_bytes())
             .await
     }
 
@@ -832,6 +1025,7 @@ impl Client {
     /// immutable payload bindings are reused; bodies are not uploaded again.
     pub async fn resume_commit(&self, batch: BatchId) -> Result<CommitSession> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         let checkpoint = self.repository.resume_commit_session(batch).await?;
         Ok(CommitSession {
             client: self.clone(),
@@ -855,14 +1049,31 @@ impl Client {
         limit: usize,
     ) -> Result<(CommitId, Vec<ObjectSummary>, bool)> {
         self.ensure_provider_qualified()?;
-        self.repository
-            .list_objects(
-                &self.branch,
-                prefix.as_ref().as_bytes(),
-                after.map(str::as_bytes),
-                limit,
-            )
-            .await
+        match self.checked_out.target() {
+            Some(snapshot) => {
+                let (objects, truncated) = self
+                    .repository
+                    .list_objects_at(
+                        &self.branch,
+                        snapshot,
+                        prefix.as_ref().as_bytes(),
+                        after.map(str::as_bytes),
+                        limit,
+                    )
+                    .await?;
+                Ok((snapshot, objects, truncated))
+            }
+            None => {
+                self.repository
+                    .list_objects(
+                        &self.branch,
+                        prefix.as_ref().as_bytes(),
+                        after.map(str::as_bytes),
+                        limit,
+                    )
+                    .await
+            }
+        }
     }
 
     pub async fn list_objects_delimited(
@@ -873,15 +1084,31 @@ impl Client {
         limit: usize,
     ) -> Result<DelimitedObjectPage> {
         self.ensure_provider_qualified()?;
-        self.repository
-            .list_objects_delimited(
-                &self.branch,
-                prefix.as_ref().as_bytes(),
-                delimiter.as_ref().as_bytes(),
-                after.map(str::as_bytes),
-                limit,
-            )
-            .await
+        match self.checked_out.target() {
+            Some(snapshot) => {
+                self.repository
+                    .list_objects_delimited_at(
+                        &self.branch,
+                        snapshot,
+                        prefix.as_ref().as_bytes(),
+                        delimiter.as_ref().as_bytes(),
+                        after.map(str::as_bytes),
+                        limit,
+                    )
+                    .await
+            }
+            None => {
+                self.repository
+                    .list_objects_delimited(
+                        &self.branch,
+                        prefix.as_ref().as_bytes(),
+                        delimiter.as_ref().as_bytes(),
+                        after.map(str::as_bytes),
+                        limit,
+                    )
+                    .await
+            }
+        }
     }
 
     pub async fn list_objects_at(
@@ -909,9 +1136,19 @@ impl Client {
         limit: usize,
     ) -> Result<(CommitId, Vec<ObjectVersion>)> {
         self.ensure_provider_qualified()?;
-        self.repository
-            .list_object_versions(&self.branch, key.as_ref().as_bytes(), limit)
-            .await
+        match self.checked_out.target() {
+            Some(snapshot) => Ok((
+                snapshot,
+                self.repository
+                    .list_object_versions_at(&self.branch, snapshot, key.as_ref().as_bytes(), limit)
+                    .await?,
+            )),
+            None => {
+                self.repository
+                    .list_object_versions(&self.branch, key.as_ref().as_bytes(), limit)
+                    .await
+            }
+        }
     }
 
     pub async fn list_versions_prefix(
@@ -920,9 +1157,26 @@ impl Client {
         limit: usize,
     ) -> Result<(CommitId, Vec<VersionSummary>)> {
         self.ensure_provider_qualified()?;
-        self.repository
-            .list_versions_prefix(&self.branch, prefix.as_ref().as_bytes(), limit)
-            .await
+        match self.checked_out.target() {
+            Some(snapshot) => Ok((
+                snapshot,
+                self.repository
+                    .list_versions_at(
+                        &self.branch,
+                        snapshot,
+                        prefix.as_ref().as_bytes(),
+                        None,
+                        limit,
+                    )
+                    .await?
+                    .0,
+            )),
+            None => {
+                self.repository
+                    .list_versions_prefix(&self.branch, prefix.as_ref().as_bytes(), limit)
+                    .await
+            }
+        }
     }
 
     pub async fn list_versions_at(
@@ -952,6 +1206,7 @@ impl Client {
         handoff_evidence: &str,
     ) -> Result<u64> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         let generation = self
             .repository
             .takeover_branch_writer(
@@ -967,18 +1222,22 @@ impl Client {
 
     pub async fn advance_branch_indexes(&self) -> Result<BranchIndexAdvanceReport> {
         self.ensure_provider_qualified()?;
-        self.repository.advance_branch_indexes(&self.branch).await
+        self.repository
+            .advance_branch_indexes(self.attached_branch()?)
+            .await
     }
 
     pub async fn branch_index_health(&self) -> Result<BranchIndexHealth> {
         self.ensure_provider_qualified()?;
-        self.repository.branch_index_health(&self.branch).await
+        self.repository
+            .branch_index_health(self.attached_branch()?)
+            .await
     }
 
     pub async fn start_branch_index_rebuild(&self) -> Result<JournalIndexRebuildCursor> {
         self.ensure_provider_qualified()?;
         self.repository
-            .start_branch_index_rebuild(&self.branch)
+            .start_branch_index_rebuild(self.attached_branch()?)
             .await
     }
 
@@ -988,6 +1247,7 @@ impl Client {
         max_events: usize,
     ) -> Result<JournalIndexRebuildStep> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository
             .advance_branch_index_rebuild(cursor, max_events)
             .await
@@ -1000,6 +1260,7 @@ impl Client {
         limit: usize,
     ) -> Result<JournalIndexRebuildCleanup> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository
             .cleanup_branch_index_rebuild(journal, operations, limit)
             .await
@@ -1010,6 +1271,7 @@ impl Client {
         journal: &JournalIndexRebuildCursor,
     ) -> Result<OperationIndexRebuildCursor> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository.start_operation_index_rebuild(journal).await
     }
 
@@ -1019,6 +1281,7 @@ impl Client {
         max_events: usize,
     ) -> Result<OperationIndexRebuildStep> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository
             .advance_operation_index_rebuild(cursor, max_events)
             .await
@@ -1026,9 +1289,10 @@ impl Client {
 
     pub async fn wait_for_branch_indexes(&self, timeout: Duration) -> Result<BranchIndexHealth> {
         self.ensure_provider_qualified()?;
+        let branch = self.attached_branch()?;
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
-            let health = self.repository.branch_index_health(&self.branch).await?;
+            let health = self.repository.branch_index_health(branch).await?;
             if health.ready {
                 return Ok(health);
             }
@@ -1053,6 +1317,7 @@ impl Client {
         limit: usize,
     ) -> Result<prolly_s3_core::CommitSessionCleanupReport> {
         self.ensure_provider_qualified()?;
+        self.attached_branch()?;
         self.repository
             .cleanup_expired_commit_sessions(continuation, limit)
             .await
@@ -1125,6 +1390,7 @@ impl CommitSessionBuilder {
 
     pub async fn start(self) -> Result<CommitSession> {
         self.client.ensure_provider_qualified()?;
+        let branch = self.client.attached_branch()?.to_string();
         let expires_after_millis = u64::try_from(self.expires_after.as_millis())
             .map_err(|_| invalid("commit-session expiry exceeds u64 milliseconds"))?;
         if self.durable && self.checkpoint_every == 0 {
@@ -1134,18 +1400,14 @@ impl CommitSessionBuilder {
             let checkpoint = self
                 .client
                 .repository
-                .begin_durable_commit_session(
-                    &self.client.branch,
-                    self.message,
-                    expires_after_millis,
-                )
+                .begin_durable_commit_session(&branch, self.message, expires_after_millis)
                 .await?;
             (checkpoint.session, checkpoint.sequence)
         } else {
             (
                 self.client
                     .repository
-                    .begin_commit_session(&self.client.branch, self.message, expires_after_millis)
+                    .begin_commit_session(&branch, self.message, expires_after_millis)
                     .await?,
                 0,
             )
@@ -1616,7 +1878,8 @@ impl ClientBuilder {
         let client = Client {
             repository,
             bucket,
-            branch,
+            branch: branch.clone(),
+            checked_out: CheckedOutRef::Branch(branch),
             provider_attestation: attestation,
             shard_authority_maintenance: Arc::new(Mutex::new(shard_authority_maintenance)),
             _branch_index_maintenance: Arc::new(Mutex::new(branch_index_maintenance)),

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -16,7 +16,7 @@ use prolly_s3_client::{
         decode_canonical, encode_canonical, LogicalObjectVersionKind, MergeCursor, MergePhase,
         MergePolicy, ProviderPerKeyVersionLimit,
     },
-    Client, HmacAttestationSigner, ProviderIdentity,
+    CheckoutRef, Client, HmacAttestationSigner, ProviderIdentity,
 };
 
 fn rustfs_enabled() -> bool {
@@ -302,13 +302,42 @@ async fn rustfs_ref_lifecycle_uses_catalog_shards_without_ref_scans() {
         .unwrap();
     let main = client.head().await.unwrap();
     client.create_branch("feature", Some(main)).await.unwrap();
-    let feature = client.for_branch("feature").unwrap();
+    let feature = client.checkout("feature").await.unwrap();
     let committed = feature
         .put_object("docs/feature.txt", b"branch-local".to_vec())
         .await
         .unwrap();
     feature.advance_branch_indexes().await.unwrap();
     let tag = client.create_tag("release-1", committed.id).await.unwrap();
+
+    let explicit_branch = client.checkout("refs/heads/feature").await.unwrap();
+    assert_eq!(explicit_branch.branch(), Some("feature"));
+    let tagged = client
+        .checkout(CheckoutRef::Tag("release-1".to_string()))
+        .await
+        .unwrap();
+    assert_eq!(tagged.branch(), None);
+    assert_eq!(tagged.head().await.unwrap(), committed.id);
+    assert_eq!(
+        tagged
+            .get_object("docs/feature.txt")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"branch-local"
+    );
+    assert_eq!(
+        tagged
+            .put_object("docs/rejected.txt", b"detached".to_vec())
+            .await
+            .unwrap_err()
+            .code,
+        prolly_s3_client::ErrorCode::InvalidRevision
+    );
+    let detached = client.checkout(committed.id).await.unwrap();
+    assert_eq!(detached.branch(), None);
+    assert_eq!(detached.head().await.unwrap(), committed.id);
 
     client.reset_s3_operation_metrics();
     let branches = client.list_branch_catalog_page(None, 100).await.unwrap();
@@ -455,7 +484,7 @@ async fn rustfs_merge_resumes_and_publishes_structural_plan() {
         .put_object("merge/conflict.txt", b"ours".to_vec())
         .await
         .unwrap();
-    let feature = client.for_branch("feature").unwrap();
+    let feature = client.checkout("feature").await.unwrap();
     feature
         .put_object("merge/conflict.txt", b"theirs".to_vec())
         .await

--- a/extensions/s3/core/src/repository.rs
+++ b/extensions/s3/core/src/repository.rs
@@ -2431,14 +2431,30 @@ impl<P: ObjectPlane> Repository<P> {
         after: Option<&[u8]>,
         limit: usize,
     ) -> Result<DelimitedObjectPage> {
+        let snapshot = self.head(branch).await?;
+        self.list_objects_delimited_at(branch, snapshot, prefix, delimiter, after, limit)
+            .await
+    }
+
+    /// S3-style delimiter projection over an explicit immutable snapshot.
+    pub async fn list_objects_delimited_at(
+        &self,
+        branch: &str,
+        snapshot: CommitId,
+        prefix: &[u8],
+        delimiter: &[u8],
+        after: Option<&[u8]>,
+        limit: usize,
+    ) -> Result<DelimitedObjectPage> {
         if delimiter.is_empty() {
             return Err(Error::new(
                 ErrorCode::InvalidRequest,
                 "list delimiter must not be empty",
             ));
         }
-        let (snapshot, candidates, truncated) =
-            self.list_objects(branch, prefix, after, limit).await?;
+        let (candidates, truncated) = self
+            .list_objects_at(branch, snapshot, prefix, after, limit)
+            .await?;
         let mut objects = Vec::new();
         let mut common_prefixes = BTreeSet::new();
         for object in candidates {
@@ -2516,9 +2532,22 @@ impl<P: ObjectPlane> Repository<P> {
         key: &[u8],
         limit: usize,
     ) -> Result<(CommitId, Vec<ObjectVersion>)> {
+        let snapshot = self.head(branch).await?;
+        let versions = self
+            .list_object_versions_at(branch, snapshot, key, limit)
+            .await?;
+        Ok((snapshot, versions))
+    }
+
+    pub async fn list_object_versions_at(
+        &self,
+        branch: &str,
+        snapshot: CommitId,
+        key: &[u8],
+        limit: usize,
+    ) -> Result<Vec<ObjectVersion>> {
         self.validate_key(key)?;
         let limit = limit.min(self.format.canonical_limits.max_list_page as usize);
-        let snapshot = self.head(branch).await?;
         self.locator.register(branch)?;
         self.require_branch_indexes_ready(branch).await?;
         let commit = self.load_commit_object(snapshot).await?.commit;
@@ -2536,7 +2565,7 @@ impl<P: ObjectPlane> Repository<P> {
             version.validate()?;
             result.push(version);
         }
-        Ok((snapshot, result))
+        Ok(result)
     }
 
     pub async fn list_versions_prefix(

--- a/extensions/s3/core/tests/history_recovery.rs
+++ b/extensions/s3/core/tests/history_recovery.rs
@@ -205,6 +205,13 @@ async fn history_diff_reflog_reset_and_recovery_are_bounded_and_audited() {
         .await
         .unwrap();
     assert_eq!(delimited.common_prefixes, vec![b"archive/".to_vec()]);
+    let historical_delimited = repository
+        .list_objects_delimited_at("main", second.id, b"", b"/", None, 100)
+        .await
+        .unwrap();
+    assert_eq!(historical_delimited.snapshot, second.id);
+    assert_eq!(historical_delimited.objects.len(), 2);
+    assert!(historical_delimited.common_prefixes.is_empty());
 
     clock.advance(1).unwrap();
     let deleted = repository

--- a/extensions/s3/core/tests/repository.rs
+++ b/extensions/s3/core/tests/repository.rs
@@ -226,6 +226,11 @@ async fn repository_history_listing_delete_markers_and_payload_dedup_are_stable(
     assert!(
         versions[0].body.order.commit_generation.0 > versions[1].body.order.commit_generation.0
     );
+    let historical_versions = repository
+        .list_object_versions_at("main", first.id, b"docs/readme.txt", 10)
+        .await
+        .unwrap();
+    assert_eq!(historical_versions.len(), 1);
 
     let (version_page, truncated) = repository
         .list_versions_at("main", snapshot, b"docs/", None, 2)


### PR DESCRIPTION
## Summary

- replace `Client::for_branch` with async, Git-like `Client::checkout`
- support branch names, qualified branch/tag refs, typed refs, and commit IDs
- make tag and commit checkouts immutable detached snapshots while preserving writable branch behavior
- rename `ingest_objects` to `put_objects` and `IngestObject` to `PutObjectInput`
- update the API guide, README, runnable examples, and RustFS regression coverage
- add explicit-snapshot delimiter and object-version listing support in the core repository

## Why

The client previously exposed a branch-only selector and used ingestion terminology for bulk object writes. The new surface mirrors familiar Git checkout semantics, makes ref resolution explicit, prevents detached handles from accidentally mutating the source branch, and uses clearer object API naming.

## API impact

This is an intentional pre-1.0 source-level rename:

- `client.for_branch("feature")?` becomes `client.checkout("feature").await?`
- `client.ingest_objects(...)` becomes `client.put_objects(...)`
- `IngestObject` becomes `PutObjectInput`
- `client.branch()` now returns `Option<&str>`; detached tag/commit checkouts return `None`

## Validation

- `cargo fmt --manifest-path extensions/s3/Cargo.toml --all -- --check`
- `cargo clippy --locked --manifest-path extensions/s3/Cargo.toml --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --manifest-path extensions/s3/Cargo.toml --workspace --all-features`
- `bash extensions/s3/scripts/check_clean_downstream.sh`
- `python3 extensions/s3/spec/prolly-s3/conformance/verify.py`
- live RustFS ref checkout regression
- live RustFS `branch_diff_merge` example
