### PR TITLE
Scale S3 client for production workloads

### DIFF
--- a/extensions/s3/API.md
+++ b/extensions/s3/API.md
@@ -78,8 +78,11 @@ provider profile. Use a stable workload identity for `writer`.
 - `delete_object` publishes one delete marker.
 - `delete_objects` publishes many delete markers atomically.
 
-One logical file is one immutable payload object. The client deliberately does
-not chunk or multipart a logical file.
+A standalone or larger logical file is one immutable content-addressed payload
+object. Bulk staging combines non-empty files up to 4 KiB into deterministic
+immutable segments capped at 4 MiB. Tree bindings carry each logical checksum
+and inclusive extent, and reads use byte ranges; empty and larger files retain
+the direct representation.
 
 ### Reads
 
@@ -93,6 +96,9 @@ not chunk or multipart a logical file.
 - `list_objects` returns `(snapshot, objects, truncated)`.
 - `list_objects_at` holds the supplied snapshot stable across pages.
 - `list_objects_delimited` returns objects plus S3-style common prefixes.
+- `list_objects_page` returns a snapshot-bound opaque cursor and resumes with a
+  direct tree seek; `stream_objects` lazily consumes those pages with bounded
+  memory.
 - `list_object_versions` lists versions for one logical key.
 - `list_versions_prefix` and `list_versions_at` scan version history across a
   logical key prefix.
@@ -103,8 +109,12 @@ When an object listing is truncated, pass the last returned logical key as
 
 ## Atomic commit sessions and bulk writes
 
-`put_objects` is the concise bulk path. It divides `PutObjectInput` values
-into durable atomic batches and returns one receipt per published batch.
+`put_objects` is the concise in-memory bulk path. It divides `PutObjectInput`
+values into durable atomic batches, uploads each checkpoint window with bounded
+concurrency, and returns one receipt per published batch. `put_object_stream`
+accepts a fallible `Stream` plus `BulkWriteOptions` for bounded-memory ingestion
+from an unbounded source. Completed checkpoint windows remain resumable after
+cancellation or a source/object failure.
 
 For explicit control, call `begin_commit`. `CommitSessionBuilder` supports:
 

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -106,8 +106,11 @@ assert_eq!(current.bytes, b"second revision\n");
 assert_eq!(historical.bytes, b"first revision\n");
 ```
 
-A write uploads one whole payload. It does not split a 64 KiB or larger file
-into chunks. The content-addressed key deduplicates identical bytes.
+A standalone write uploads one whole content-addressed payload. Bulk ingestion
+packs non-empty files up to 4 KiB into immutable segments capped at 4 MiB;
+logical bindings retain checksums and byte extents, while empty and larger
+files keep the direct representation. Identical bytes in a segment share one
+extent, and replaying the same segment reuses its content-addressed object.
 
 For safe retries, generate and persist one operation ID:
 
@@ -156,7 +159,7 @@ For a disposable job, add `.ephemeral()`. That removes checkpoint requests
 but cannot recover process-local staged metadata after a crash.
 
 For a collection already in memory, `put_objects` creates durable batches
-for you:
+for you. Payload uploads use bounded concurrency by default:
 
 ```rust
 use prolly_s3_client::PutObjectInput;
@@ -173,6 +176,30 @@ let receipts = client
     )
     .await?;
 ```
+
+For an unbounded or fallible source, pass a `Stream` so memory stays bounded
+by one checkpoint window:
+
+```rust
+use prolly_s3_client::{BulkWriteOptions, PutObjectInput};
+
+let receipts = client
+    .put_object_stream(
+        incoming_objects, // Stream<Item = prolly_s3_client::Result<PutObjectInput>>
+        BulkWriteOptions {
+            batch_size: 10_000,
+            concurrency: 32,
+            checkpoint_every: 1_000,
+        },
+    )
+    .await?;
+```
+
+Completed windows are durably checkpointed. On an input or per-object staging
+failure, the error's `operation_id` contains the resumable batch ID and its
+message identifies the failed object or completed checkpoint size. Dropping the
+future cancels in-flight work; the last completed remote checkpoint remains
+available to `resume_commit`.
 
 ## List files and versions
 
@@ -195,6 +222,25 @@ loop {
 let (_head, versions) =
     client.list_object_versions("documents/readme.txt", 100).await?;
 ```
+
+For large scans, prefer the snapshot-bound cursor or streaming APIs:
+
+```rust
+use futures_util::StreamExt;
+
+let mut objects = client.stream_objects("incoming/", 1_000);
+while let Some(object) = objects.next().await {
+    consume(object?);
+}
+```
+
+`list_objects_page` returns an opaque continuation that seeks directly into the
+same immutable snapshot. A continuation is bound to its repository, branch,
+and prefix and cannot be reused for another query. Hold a retention pin on the
+returned snapshot if traversal may overlap garbage collection. Disable
+`background_index_maintenance` on a dedicated measurement client when provider
+telemetry must attribute only foreground reads; foreground listing itself never
+writes index state.
 
 ## Branch and merge
 
@@ -411,7 +457,8 @@ while gc.phase != GcPhase::Complete {
 }
 ```
 
-The collector sweeps only immutable commit, direct-node, and payload objects.
+The collector sweeps only immutable commit, direct-node, direct-payload, and
+payload-pack objects.
 It never sweeps mutable refs, derived indexes, publication journals, format
 markers, or administration data. Branch and tag updates during an epoch write
 dirty-root records before their CAS; sweep batches fence publication and catch
@@ -457,13 +504,15 @@ from cache admission and continue to use the provider fallback.
 
 Use `prewarm_node_cache(snapshot)` during startup to traverse both state trees.
 Use `node_cache_snapshot()` before and after to observe hits, misses,
-insertions, corruptions, coalesced waits, and ranged fetches.
+insertions, corruptions, coalesced waits, ranged fetches, fetched and avoided
+bytes, and admission rejections.
 
 ## Performance model
 
 - A single-file write uploads one payload and publishes immutable metadata.
-- A batch uploads one payload per changed file, then amortizes tree and
-  publication requests across the batch.
+- A tiny-file batch uploads one payload pack per segment; direct payloads use
+  bounded parallel uploads. Tree and publication requests are amortized across
+  the batch.
 - A current or historical read resolves a ref/commit/tree path and one payload.
 - Warm immutable-node caches remove most repeated metadata reads.
 - Same-branch writers contend on one ref CAS; different branches publish

--- a/extensions/s3/client/src/client.rs
+++ b/extensions/s3/client/src/client.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, VecDeque},
     io::Write as _,
     str::FromStr as _,
     sync::{Arc, Mutex},
@@ -7,6 +7,7 @@ use std::{
 };
 
 use aws_sdk_s3::primitives::ByteStream;
+use futures_util::{stream, Stream, StreamExt};
 use md5::Md5;
 use prolly_s3_core::{
     BackupVerificationCursor, BackupVerificationPage, BatchId, BranchCatalogPage, BranchHead,
@@ -14,11 +15,11 @@ use prolly_s3_core::{
     CommitSessionManifest, DelimitedObjectPage, Error, ErrorCode, FsckCursor, FsckPage, GcCursor,
     GcPage, HistoryCursor, HistoryTransferCursor, HistoryTransferMapping, HistoryTransferPage,
     JournalIndexRebuildCleanup, JournalIndexRebuildCursor, JournalIndexRebuildStep,
-    MergeAdvancePage, MergeBaseCursor, MergeBasePage, MergeChangeCursor, MergeChangePage,
-    MergeCleanupCursor, MergeCleanupPage, MergeConflictCursor, MergeConflictPage, MergeCursor,
-    MergePolicy, MergeReceipt, NodeCachePrewarmReport, ObjectData, ObjectDiff, ObjectDiffCursor,
-    ObjectDiffPage, ObjectHeaders, ObjectRangeData, ObjectSummary, ObjectVersion, OperationId,
-    OperationIndexRebuildCursor, OperationIndexRebuildStep, ProviderAttestation,
+    ListObjectsPage, MergeAdvancePage, MergeBaseCursor, MergeBasePage, MergeChangeCursor,
+    MergeChangePage, MergeCleanupCursor, MergeCleanupPage, MergeConflictCursor, MergeConflictPage,
+    MergeCursor, MergePolicy, MergeReceipt, NodeCachePrewarmReport, ObjectData, ObjectDiff,
+    ObjectDiffCursor, ObjectDiffPage, ObjectHeaders, ObjectRangeData, ObjectSummary, ObjectVersion,
+    OperationId, OperationIndexRebuildCursor, OperationIndexRebuildStep, ProviderAttestation,
     ProviderPerKeyVersionLimit, ProviderProfileId, PublicationJournalCursor,
     PublicationJournalPage, RefCatalogCursor, RefCatalogRepairPage, RefKind, RefMoveReceipt,
     RepairCursor, RepairPage, Repository, RepositoryOptions, RestoreCursor, RestorePage, Result,
@@ -82,6 +83,27 @@ pub struct PutObjectInput {
     pub bytes: Vec<u8>,
     pub headers: ObjectHeaders,
     pub user_metadata: BTreeMap<String, String>,
+}
+
+/// Bounded resource controls for [`Client::put_object_stream`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BulkWriteOptions {
+    /// Maximum logical mutations published by one atomic commit.
+    pub batch_size: usize,
+    /// Maximum payload uploads in flight at once.
+    pub concurrency: usize,
+    /// Successfully staged mutations durably checkpointed as one window.
+    pub checkpoint_every: usize,
+}
+
+impl Default for BulkWriteOptions {
+    fn default() -> Self {
+        Self {
+            batch_size: 10_000,
+            concurrency: 32,
+            checkpoint_every: 1_000,
+        }
+    }
 }
 
 /// A revision accepted by [`Client::checkout`].
@@ -870,6 +892,29 @@ impl Client {
         objects: Vec<PutObjectInput>,
         batch_size: usize,
     ) -> Result<Vec<CommitReceipt>> {
+        self.put_object_stream(
+            stream::iter(objects.into_iter().map(Ok)),
+            BulkWriteOptions {
+                batch_size,
+                checkpoint_every: batch_size.min(1_000),
+                ..BulkWriteOptions::default()
+            },
+        )
+        .await
+    }
+
+    /// Consume a fallible object stream using bounded memory and concurrent
+    /// payload uploads. Each checkpoint window is fully resolved before its
+    /// canonical mutation metadata is saved, so cancellation or a staging
+    /// failure leaves the last completed window resumable by batch ID.
+    pub async fn put_object_stream<S>(
+        &self,
+        objects: S,
+        options: BulkWriteOptions,
+    ) -> Result<Vec<CommitReceipt>>
+    where
+        S: Stream<Item = Result<PutObjectInput>> + Send,
+    {
         self.ensure_provider_qualified()?;
         self.attached_branch()?;
         let max = self
@@ -877,33 +922,89 @@ impl Client {
             .format()
             .canonical_limits
             .max_mutations_per_commit as usize;
-        if batch_size == 0 || batch_size > max {
+        if options.batch_size == 0 || options.batch_size > max {
             return Err(invalid(
-                "put_objects batch size exceeds the canonical mutation limit",
+                "bulk-write batch size exceeds the canonical mutation limit",
             ));
         }
+        if options.concurrency == 0 || options.concurrency > 1_024 {
+            return Err(invalid("bulk-write concurrency must be 1..=1024"));
+        }
+        if options.checkpoint_every == 0 || options.checkpoint_every > options.batch_size {
+            return Err(invalid(
+                "bulk-write checkpoint interval must be within the batch size",
+            ));
+        }
+
+        futures_util::pin_mut!(objects);
         let mut receipts = Vec::new();
-        let mut objects = objects.into_iter();
-        loop {
-            let batch = objects.by_ref().take(batch_size).collect::<Vec<_>>();
-            if batch.is_empty() {
-                break;
-            }
+        let mut next = objects.next().await.transpose()?;
+        while next.is_some() {
             let mut session = self
                 .begin_commit()
                 .message("bulk object write")
-                .checkpoint_every(batch_size.min(1_000))
+                .checkpoint_every(options.checkpoint_every)
                 .start()
                 .await?;
-            for object in batch {
-                session
-                    .put_object_with_metadata(
-                        object.key,
-                        object.bytes,
-                        object.headers,
-                        object.user_metadata,
+            let mut batch_items = 0_usize;
+            while batch_items < options.batch_size && next.is_some() {
+                let window_limit = options
+                    .checkpoint_every
+                    .min(options.batch_size - batch_items);
+                let mut window = Vec::with_capacity(window_limit);
+                while window.len() < window_limit {
+                    let Some(object) = next.take() else {
+                        break;
+                    };
+                    window.push(object);
+                    next = match objects.next().await {
+                        Some(Ok(object)) => Some(object),
+                        Some(Err(mut error)) => {
+                            session.checkpoint().await?;
+                            error.message = format!(
+                                "bulk input failed after {} staged objects: {}",
+                                session.staged_objects(),
+                                error.message
+                            );
+                            error.operation_id = Some(session.id().to_string());
+                            return Err(error);
+                        }
+                        None => None,
+                    };
+                }
+
+                batch_items = batch_items.saturating_add(window.len());
+                let staged = self
+                    .repository
+                    .stage_commit_session_put_batch(
+                        &session.manifest,
+                        window
+                            .into_iter()
+                            .map(|object| {
+                                (
+                                    object.key.into_bytes(),
+                                    object.bytes,
+                                    object.headers,
+                                    object.user_metadata,
+                                )
+                            })
+                            .collect(),
+                        options.concurrency,
                     )
-                    .await?;
+                    .await;
+                let staged = match staged {
+                    Ok(staged) => staged,
+                    Err(mut error) => {
+                        session.checkpoint().await?;
+                        error.message = format!("bulk payload staging failed: {}", error.message);
+                        error.operation_id = Some(session.id().to_string());
+                        return Err(error);
+                    }
+                };
+                for mutation in staged {
+                    session.insert_staged(mutation);
+                }
+                session.checkpoint().await?;
             }
             receipts.push(session.publish().await?);
         }
@@ -1074,6 +1175,74 @@ impl Client {
                     .await
             }
         }
+    }
+
+    pub async fn list_objects_page(
+        &self,
+        prefix: impl AsRef<str>,
+        continuation: Option<&str>,
+        limit: usize,
+    ) -> Result<ListObjectsPage> {
+        self.ensure_provider_qualified()?;
+        self.repository
+            .list_objects_page(
+                &self.branch,
+                prefix.as_ref().as_bytes(),
+                continuation,
+                limit,
+            )
+            .await
+    }
+
+    /// Lazily stream a snapshot-bound prefix listing. The first page captures
+    /// the branch snapshot; subsequent pages seek through its opaque cursor.
+    pub fn stream_objects(
+        &self,
+        prefix: impl Into<String>,
+        page_size: usize,
+    ) -> impl Stream<Item = Result<ObjectSummary>> + Send + 'static {
+        struct State {
+            client: Client,
+            prefix: String,
+            page_size: usize,
+            continuation: Option<String>,
+            buffered: VecDeque<ObjectSummary>,
+            complete: bool,
+        }
+        stream::try_unfold(
+            State {
+                client: self.clone(),
+                prefix: prefix.into(),
+                page_size,
+                continuation: None,
+                buffered: VecDeque::new(),
+                complete: false,
+            },
+            |mut state| async move {
+                loop {
+                    if let Some(object) = state.buffered.pop_front() {
+                        return Ok(Some((object, state)));
+                    }
+                    if state.complete {
+                        return Ok(None);
+                    }
+                    let page = state
+                        .client
+                        .list_objects_page(
+                            &state.prefix,
+                            state.continuation.as_deref(),
+                            state.page_size,
+                        )
+                        .await?;
+                    state.continuation = page.continuation;
+                    state.complete = state.continuation.is_none();
+                    state.buffered = page.objects.into();
+                    if state.buffered.is_empty() && state.complete {
+                        return Ok(None);
+                    }
+                }
+            },
+        )
     }
 
     pub async fn list_objects_delimited(
@@ -1455,6 +1624,11 @@ impl CommitSession {
         self.durable
     }
 
+    fn insert_staged(&mut self, staged: StagedMutation) {
+        self.staged.insert(staged.key().to_vec(), staged);
+        self.dirty_mutations = self.dirty_mutations.saturating_add(1);
+    }
+
     pub async fn put_object(&mut self, key: impl Into<String>, bytes: Vec<u8>) -> Result<()> {
         self.put_object_with_metadata(key, bytes, ObjectHeaders::default(), BTreeMap::new())
             .await
@@ -1479,7 +1653,7 @@ impl CommitSession {
                 metadata,
             )
             .await?;
-        self.staged.insert(staged.key().to_vec(), staged);
+        self.insert_staged(staged);
         self.mark_staged_and_checkpoint_if_due().await?;
         Ok(())
     }
@@ -1558,7 +1732,7 @@ impl CommitSession {
                 metadata,
             )
             .await?;
-        self.staged.insert(staged.key().to_vec(), staged);
+        self.insert_staged(staged);
         self.mark_staged_and_checkpoint_if_due().await?;
         Ok(())
     }
@@ -1622,7 +1796,6 @@ impl CommitSession {
     }
 
     async fn mark_staged_and_checkpoint_if_due(&mut self) -> Result<()> {
-        self.dirty_mutations = self.dirty_mutations.saturating_add(1);
         if self.durable && self.dirty_mutations >= self.checkpoint_every {
             self.checkpoint().await?;
         }

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -13,10 +13,10 @@ use aws_sdk_s3::{
 use futures_util::{stream, StreamExt};
 use prolly_s3_client::{
     core::{
-        decode_canonical, encode_canonical, LogicalObjectVersionKind, MergeCursor, MergePhase,
-        MergePolicy, ProviderPerKeyVersionLimit,
+        decode_canonical, encode_canonical, BatchId, Error, ErrorCode, LogicalObjectVersionKind,
+        MergeCursor, MergePhase, MergePolicy, ProviderPerKeyVersionLimit,
     },
-    CheckoutRef, Client, HmacAttestationSigner, ProviderIdentity,
+    BulkWriteOptions, CheckoutRef, Client, HmacAttestationSigner, ProviderIdentity, PutObjectInput,
 };
 
 fn rustfs_enabled() -> bool {
@@ -812,6 +812,297 @@ async fn rustfs_over_limit_index_rebuild_resumes_from_canonical_cursor() {
         .unwrap();
     assert!(replay.idempotent_replay);
     assert_eq!(replay.id, original.id);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn rustfs_streaming_bulk_write_is_bounded_batched_and_ordered() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+    let (aws, bucket) = rustfs_client().await;
+    let client = Client::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(unique_name("streaming-bulk-write"))
+        .writer("rustfs-streaming-bulk-writer")
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimit::Finite(10_000))
+        .initialize()
+        .await
+        .unwrap();
+
+    let objects = stream::iter((0..257).map(|index| {
+        Ok(PutObjectInput {
+            key: format!("stream/{index:04}.txt"),
+            bytes: format!("value-{index}").into_bytes(),
+            headers: Default::default(),
+            user_metadata: Default::default(),
+        })
+    }));
+    let receipts = client
+        .put_object_stream(
+            objects,
+            BulkWriteOptions {
+                batch_size: 128,
+                concurrency: 16,
+                checkpoint_every: 32,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(receipts.len(), 3);
+    assert_eq!(
+        receipts
+            .iter()
+            .map(|receipt| receipt.changed_keys)
+            .collect::<Vec<_>>(),
+        vec![128, 128, 1]
+    );
+    let (_, first) = client
+        .head_object("stream/0000.txt")
+        .await
+        .unwrap()
+        .unwrap();
+    let (_, second) = client
+        .head_object("stream/0001.txt")
+        .await
+        .unwrap()
+        .unwrap();
+    let first_binding = first.version.binding.unwrap();
+    let second_binding = second.version.binding.unwrap();
+    assert!(first_binding.is_packed());
+    assert_eq!(first_binding.path, second_binding.path);
+    assert_ne!(first_binding.pack_range, second_binding.pack_range);
+    assert_eq!(
+        client
+            .get_object_range(receipts[0].id, "stream/0000.txt", 0..=u64::MAX)
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        b"value-0"
+    );
+    for index in [0, 31, 127, 128, 255, 256] {
+        assert_eq!(
+            client
+                .get_object(format!("stream/{index:04}.txt"))
+                .await
+                .unwrap()
+                .unwrap()
+                .bytes,
+            format!("value-{index}").as_bytes()
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn rustfs_streaming_bulk_failure_preserves_completed_checkpoint() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+    let (aws, bucket) = rustfs_client().await;
+    let client = Client::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(unique_name("streaming-bulk-resume"))
+        .writer("rustfs-streaming-resume-writer")
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimit::Finite(10_000))
+        .initialize()
+        .await
+        .unwrap();
+
+    let objects = stream::iter((0..40).map(|index| {
+        if index == 37 {
+            Err(Error::new(ErrorCode::Transport, "upstream source failed"))
+        } else {
+            Ok(PutObjectInput {
+                key: format!("resume/{index:04}.txt"),
+                bytes: vec![index as u8],
+                headers: Default::default(),
+                user_metadata: Default::default(),
+            })
+        }
+    }));
+    let error = client
+        .put_object_stream(
+            objects,
+            BulkWriteOptions {
+                batch_size: 128,
+                concurrency: 8,
+                checkpoint_every: 16,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, ErrorCode::Transport);
+    assert!(error.message.contains("after 32 staged objects"));
+    let batch: BatchId = error.operation_id.unwrap().parse().unwrap();
+    let resumed = client.resume_commit(batch).await.unwrap();
+    assert_eq!(resumed.staged_objects(), 32);
+    let receipt = resumed.publish().await.unwrap();
+    assert_eq!(receipt.changed_keys, 32);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+#[ignore = "10K tiny-file RustFS throughput release gate"]
+async fn rustfs_streaming_bulk_exceeds_500_files_per_second() {
+    assert!(rustfs_enabled(), "set PROLLY_S3_RUSTFS=1 to run");
+    const FILES: usize = 10_000;
+    let (aws, bucket) = rustfs_client().await;
+    let client = Client::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(unique_name("streaming-bulk-throughput"))
+        .writer("rustfs-streaming-throughput-writer")
+        .authority_lease_duration(Duration::from_secs(600))
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimit::Finite(10_000))
+        .initialize()
+        .await
+        .unwrap();
+    let objects = stream::iter((0..FILES).map(|index| {
+        Ok(PutObjectInput {
+            key: format!("tiny/{index:05}.txt"),
+            bytes: format!("{index:016x}").into_bytes(),
+            headers: Default::default(),
+            user_metadata: Default::default(),
+        })
+    }));
+    client.reset_s3_operation_metrics();
+    let started = std::time::Instant::now();
+    let receipts = client
+        .put_object_stream(objects, BulkWriteOptions::default())
+        .await
+        .unwrap();
+    let elapsed = started.elapsed();
+    let throughput = FILES as f64 / elapsed.as_secs_f64();
+    let metrics = client.reset_s3_operation_metrics();
+    eprintln!(
+        "RUSTFS_STREAMING_BULK files={FILES} wall_ms={} files_per_second={throughput:.2} s3_calls={} uploaded_bytes={}",
+        elapsed.as_millis(),
+        metrics.total_calls(),
+        metrics.uploaded_body_bytes,
+    );
+    assert_eq!(receipts.len(), 1);
+    assert!(
+        throughput >= 500.0,
+        "throughput was {throughput:.2} files/s"
+    );
+    assert!(
+        metrics.put_object < 100,
+        "packing should require fewer than 100 physical PUTs: {metrics:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+#[ignore = "10K warm-read and cursor-listing RustFS release gate"]
+async fn rustfs_warm_reads_and_cursor_listing_meet_scale_slos() {
+    assert!(rustfs_enabled(), "set PROLLY_S3_RUSTFS=1 to run");
+    const FILES: usize = 10_000;
+    const READS: usize = 100;
+    let (aws, bucket) = rustfs_client().await;
+    let client = Client::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(unique_name("read-list-performance"))
+        .writer("rustfs-read-list-writer")
+        .authority_lease_duration(Duration::from_secs(600))
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimit::Finite(10_000))
+        .background_index_maintenance(false)
+        .initialize()
+        .await
+        .unwrap();
+    client
+        .put_object_stream(
+            stream::iter((0..FILES).map(|index| {
+                Ok(PutObjectInput {
+                    key: format!("tiny/{index:05}.txt"),
+                    bytes: format!("{index:016x}").into_bytes(),
+                    headers: Default::default(),
+                    user_metadata: Default::default(),
+                })
+            })),
+            BulkWriteOptions::default(),
+        )
+        .await
+        .unwrap();
+    client.advance_branch_indexes().await.unwrap();
+
+    let sample = (0..READS)
+        .map(|index| index * (FILES / READS))
+        .collect::<Vec<_>>();
+    for index in &sample {
+        client
+            .get_object(format!("tiny/{index:05}.txt"))
+            .await
+            .unwrap()
+            .unwrap();
+    }
+    client.reset_s3_operation_metrics();
+    let mut latencies = stream::iter(sample)
+        .map(|index| {
+            let client = client.clone();
+            async move {
+                let started = std::time::Instant::now();
+                let object = client
+                    .get_object(format!("tiny/{index:05}.txt"))
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(object.bytes, format!("{index:016x}").as_bytes());
+                started.elapsed()
+            }
+        })
+        .buffer_unordered(32)
+        .collect::<Vec<_>>()
+        .await;
+    latencies.sort_unstable();
+    let p99 = latencies[(latencies.len() * 99).div_ceil(100) - 1];
+    let read_metrics = client.reset_s3_operation_metrics();
+    eprintln!(
+        "RUSTFS_WARM_READS reads={READS} p99_ms={:.2} downloaded_bytes={} bytes_per_read={:.2} s3_calls={}",
+        p99.as_secs_f64() * 1_000.0,
+        read_metrics.downloaded_body_bytes,
+        read_metrics.downloaded_body_bytes as f64 / READS as f64,
+        read_metrics.total_calls(),
+    );
+    assert!(p99 < Duration::from_millis(100), "warm p99 was {p99:?}");
+    assert!(
+        read_metrics.downloaded_body_bytes < 4 * 1024 * 1024,
+        "warm reads transferred too much metadata: {read_metrics:?}"
+    );
+
+    client.reset_s3_operation_metrics();
+    let started = std::time::Instant::now();
+    let listed = client
+        .stream_objects("tiny/", 1_000)
+        .collect::<Vec<_>>()
+        .await;
+    for object in &listed {
+        object.as_ref().unwrap();
+    }
+    let elapsed = started.elapsed();
+    let throughput = listed.len() as f64 / elapsed.as_secs_f64();
+    let list_metrics = client.reset_s3_operation_metrics();
+    eprintln!(
+        "RUSTFS_CURSOR_LIST files={} wall_ms={} files_per_second={throughput:.2} downloaded_bytes={} s3_calls={} put_calls={}",
+        listed.len(),
+        elapsed.as_millis(),
+        list_metrics.downloaded_body_bytes,
+        list_metrics.total_calls(),
+        list_metrics.put_object,
+    );
+    assert_eq!(listed.len(), FILES);
+    assert!(throughput > 10_000.0, "listing achieved {throughput:.2}/s");
+    assert_eq!(list_metrics.put_object, 0, "foreground listing wrote data");
 }
 
 /// Reproducible release gate for the same-branch publication lane.

--- a/extensions/s3/core/src/lib.rs
+++ b/extensions/s3/core/src/lib.rs
@@ -65,12 +65,12 @@ pub use repository::{
     validate_branch, BackupVerificationCursor, BackupVerificationPage, BackupVerificationReport,
     BranchCatalogPage, BranchHead, BranchIndexAdvanceReport, BranchIndexHealth,
     BranchIndexMaintenance, CommitClosureCursor, CommitClosurePage, CommitPage, CommitReceipt,
-    DelimitedObjectPage, FsckCursor, FsckPage, FsckPhase, FsckReport, HistoryCursor,
-    NodeCachePrewarmReport, ObjectData, ObjectDiff, ObjectDiffCursor, ObjectDiffPage,
-    ObjectRangeData, ObjectSummary, RefCatalogRepairPage, RefMoveReceipt, RepairCursor, RepairPage,
-    RepairPhase, RepairReport, Repository, RepositoryOptions, RestoreCursor, RestorePage,
-    RetentionPin, RetentionPinPage, ShardAuthorityMaintenance, Tag, TagCatalogPage,
-    TraversalBudget, VersionSummary,
+    CommitSessionPutInput, DelimitedObjectPage, FsckCursor, FsckPage, FsckPhase, FsckReport,
+    HistoryCursor, ListObjectsPage, NodeCachePrewarmReport, ObjectData, ObjectDiff,
+    ObjectDiffCursor, ObjectDiffPage, ObjectRangeData, ObjectSummary, RefCatalogRepairPage,
+    RefMoveReceipt, RepairCursor, RepairPage, RepairPhase, RepairReport, Repository,
+    RepositoryOptions, RestoreCursor, RestorePage, RetentionPin, RetentionPinPage,
+    ShardAuthorityMaintenance, Tag, TagCatalogPage, TraversalBudget, VersionSummary,
 };
 pub use runtime::*;
 pub use store::{NodeCacheSnapshot, ProllyObjectStore};

--- a/extensions/s3/core/src/model.rs
+++ b/extensions/s3/core/src/model.rs
@@ -1407,6 +1407,37 @@ pub struct CommitObject {
 }
 
 impl CommitObject {
+    pub(crate) fn commit_object_header_len() -> usize {
+        COMMIT_OBJECT_HEADER_LEN
+    }
+
+    pub(crate) fn commit_len_from_header(header: &[u8]) -> Result<usize> {
+        if header.len() != COMMIT_OBJECT_HEADER_LEN || &header[..8] != COMMIT_OBJECT_MAGIC {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "commit object has an invalid wire header",
+            ));
+        }
+        Ok(u32::from_be_bytes(header[8..12].try_into().expect("fixed range")) as usize)
+    }
+
+    pub(crate) fn decode_commit_metadata(encoded: &[u8]) -> Result<BucketCommit> {
+        if encoded.len() < COMMIT_OBJECT_HEADER_LEN {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "commit metadata is shorter than its header",
+            ));
+        }
+        let commit_len = Self::commit_len_from_header(&encoded[..COMMIT_OBJECT_HEADER_LEN])?;
+        let end = COMMIT_OBJECT_HEADER_LEN
+            .checked_add(commit_len)
+            .filter(|end| *end == encoded.len())
+            .ok_or_else(|| {
+                Error::new(ErrorCode::CorruptCommit, "commit metadata length mismatch")
+            })?;
+        decode_canonical(&encoded[COMMIT_OBJECT_HEADER_LEN..end])
+    }
+
     pub fn new(commit: BucketCommit, node_pack: Option<NodePack>) -> Result<Self> {
         let object = Self { commit, node_pack };
         object.validate()?;
@@ -1527,18 +1558,38 @@ pub struct PayloadBinding {
     pub path: ObjectPath,
     pub provider_version_id: Option<String>,
     pub provider_etag: String,
+    /// SHA-256 of this logical object's bytes.
     pub checksum_sha256: [u8; 32],
+    /// SHA-256 of the physical pack. Absent for legacy/direct payloads.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pack_checksum_sha256: Option<[u8; 32]>,
+    /// Inclusive logical extent inside the physical pack.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pack_range: Option<(u64, u64)>,
 }
 
 impl PayloadBinding {
     pub fn validate(&self) -> Result<()> {
-        if self.provider_etag.is_empty() {
+        let pack_shape_valid = match (self.pack_checksum_sha256, self.pack_range) {
+            (None, None) => true,
+            (Some(physical), Some((start, end))) => physical != [0; 32] && start <= end,
+            _ => false,
+        };
+        if self.provider_etag.is_empty() || self.checksum_sha256 == [0; 32] || !pack_shape_valid {
             return Err(Error::new(
                 ErrorCode::CorruptCommit,
                 "physical payload binding is malformed",
             ));
         }
         Ok(())
+    }
+
+    pub fn physical_checksum_sha256(&self) -> [u8; 32] {
+        self.pack_checksum_sha256.unwrap_or(self.checksum_sha256)
+    }
+
+    pub fn is_packed(&self) -> bool {
+        self.pack_range.is_some()
     }
 }
 

--- a/extensions/s3/core/src/payload.rs
+++ b/extensions/s3/core/src/payload.rs
@@ -41,6 +41,8 @@ impl<P: ObjectPlane> ImmutablePayloadStore<P> {
             provider_version_id: metadata.token.version_id,
             provider_etag: metadata.token.etag,
             checksum_sha256,
+            pack_checksum_sha256: None,
+            pack_range: None,
         };
         binding.validate()?;
         Ok(binding)
@@ -77,6 +79,8 @@ impl<P: ObjectPlane> ImmutablePayloadStore<P> {
             provider_version_id: metadata.token.version_id,
             provider_etag: metadata.token.etag,
             checksum_sha256,
+            pack_checksum_sha256: None,
+            pack_range: None,
         };
         binding.validate()?;
         Ok(binding)
@@ -84,7 +88,11 @@ impl<P: ObjectPlane> ImmutablePayloadStore<P> {
 
     pub async fn get(&self, binding: &PayloadBinding) -> Result<Vec<u8>> {
         binding.validate()?;
-        let expected_path = self.path(binding.checksum_sha256)?;
+        let expected_path = if binding.is_packed() {
+            self.pack_path(binding.physical_checksum_sha256())?
+        } else {
+            self.path(binding.checksum_sha256)?
+        };
         if binding.path != expected_path {
             return Err(crate::Error::new(
                 crate::ErrorCode::CorruptContent,
@@ -102,7 +110,7 @@ impl<P: ObjectPlane> ImmutablePayloadStore<P> {
             .plane
             .get(GetRequest {
                 path: binding.path.clone(),
-                range: None,
+                range: binding.pack_range.map(|(start, end)| start..=end),
                 physical_version,
             })
             .await?
@@ -118,6 +126,79 @@ impl<P: ObjectPlane> ImmutablePayloadStore<P> {
         Ok(stored.bytes)
     }
 
+    pub async fn put_pack(&self, objects: Vec<([u8; 32], Vec<u8>)>) -> Result<Vec<PayloadBinding>> {
+        if objects.is_empty() {
+            return Ok(Vec::new());
+        }
+        let total = objects.iter().try_fold(0_usize, |total, (_, bytes)| {
+            total.checked_add(bytes.len()).ok_or_else(|| {
+                crate::Error::new(
+                    crate::ErrorCode::EntityTooLarge,
+                    "payload pack size overflow",
+                )
+            })
+        })?;
+        let mut packed = Vec::with_capacity(total);
+        let mut ranges = Vec::with_capacity(objects.len());
+        let mut extents = std::collections::BTreeMap::new();
+        for (logical_checksum, bytes) in objects {
+            if sha256(&bytes) != logical_checksum {
+                return Err(crate::Error::new(
+                    crate::ErrorCode::ChecksumMismatch,
+                    "payload pack input does not match its logical checksum",
+                ));
+            }
+            if let Some((start, end)) = extents.get(&logical_checksum).copied() {
+                ranges.push((logical_checksum, start, end));
+                continue;
+            }
+            let start = u64::try_from(packed.len()).map_err(|_| {
+                crate::Error::new(
+                    crate::ErrorCode::EntityTooLarge,
+                    "payload pack offset overflow",
+                )
+            })?;
+            packed.extend_from_slice(&bytes);
+            let end = u64::try_from(packed.len() - 1).map_err(|_| {
+                crate::Error::new(
+                    crate::ErrorCode::EntityTooLarge,
+                    "payload pack extent overflow",
+                )
+            })?;
+            extents.insert(logical_checksum, (start, end));
+            ranges.push((logical_checksum, start, end));
+        }
+        let pack_checksum = sha256(&packed);
+        let path = self.pack_path(pack_checksum)?;
+        let outcome = self
+            .plane
+            .put_immutable(ImmutablePut {
+                path: path.clone(),
+                expected_sha256: pack_checksum,
+                bytes: packed,
+            })
+            .await?;
+        let metadata = match outcome {
+            crate::ImmutablePutOutcome::Created(metadata)
+            | crate::ImmutablePutOutcome::AlreadyPresent(metadata) => metadata,
+        };
+        ranges
+            .into_iter()
+            .map(|(logical_checksum, start, end)| {
+                let binding = PayloadBinding {
+                    path: path.clone(),
+                    provider_version_id: metadata.token.version_id.clone(),
+                    provider_etag: metadata.token.etag.clone(),
+                    checksum_sha256: logical_checksum,
+                    pack_checksum_sha256: Some(pack_checksum),
+                    pack_range: Some((start, end)),
+                };
+                binding.validate()?;
+                Ok(binding)
+            })
+            .collect()
+    }
+
     pub fn path(&self, checksum_sha256: [u8; 32]) -> Result<ObjectPath> {
         let encoded = hex::encode(checksum_sha256);
         ObjectPath::new(format!(
@@ -128,5 +209,25 @@ impl<P: ObjectPlane> ImmutablePayloadStore<P> {
             &encoded[2..4],
             encoded
         ))
+    }
+
+    pub fn pack_path(&self, checksum_sha256: [u8; 32]) -> Result<ObjectPath> {
+        let encoded = hex::encode(checksum_sha256);
+        ObjectPath::new(format!(
+            "{}/payload-packs/{}/sha256/{}/{}/{}",
+            self.prefix,
+            hex::encode(self.repository.as_bytes()),
+            &encoded[..2],
+            &encoded[2..4],
+            encoded
+        ))
+    }
+
+    pub fn expected_path(&self, binding: &PayloadBinding) -> Result<ObjectPath> {
+        if binding.is_packed() {
+            self.pack_path(binding.physical_checksum_sha256())
+        } else {
+            self.path(binding.checksum_sha256)
+        }
     }
 }

--- a/extensions/s3/core/src/publication.rs
+++ b/extensions/s3/core/src/publication.rs
@@ -796,7 +796,42 @@ impl<P: ObjectPlane> ShardedBranchPublisher<P> {
     }
 
     pub async fn load_commit(&self, id: CommitId) -> Result<BucketCommit> {
-        Ok(self.load_commit_object(id).await?.commit)
+        let path = self.commit_path(id)?;
+        let header_len = CommitObject::commit_object_header_len();
+        let header = self
+            .plane
+            .get(GetRequest {
+                path: path.clone(),
+                range: Some(0..=header_len as u64 - 1),
+                physical_version: None,
+            })
+            .await?
+            .ok_or_else(|| Error::new(ErrorCode::MissingClosure, "parent commit is missing"))?
+            .bytes;
+        let commit_len = CommitObject::commit_len_from_header(&header)?;
+        let end = header_len
+            .checked_add(commit_len)
+            .ok_or_else(|| Error::new(ErrorCode::CorruptCommit, "commit length overflow"))?;
+        let body = self
+            .plane
+            .get(GetRequest {
+                path,
+                range: Some(header_len as u64..=end as u64 - 1),
+                physical_version: None,
+            })
+            .await?
+            .ok_or_else(|| Error::new(ErrorCode::MissingClosure, "parent commit is missing"))?
+            .bytes;
+        let mut encoded = header;
+        encoded.extend_from_slice(&body);
+        let commit = CommitObject::decode_commit_metadata(&encoded)?;
+        if commit.id()? != id {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "parent commit ID does not match its path",
+            ));
+        }
+        Ok(commit)
     }
 
     async fn cas_ref(

--- a/extensions/s3/core/src/repository.rs
+++ b/extensions/s3/core/src/repository.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     path::PathBuf,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -129,6 +129,72 @@ pub struct ObjectRangeData {
 pub struct ObjectSummary {
     pub key: Vec<u8>,
     pub version: ObjectVersion,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct ListObjectsCursor {
+    repository: crate::RepositoryId,
+    branch: String,
+    snapshot: CommitId,
+    prefix: Vec<u8>,
+    traversal: prolly::RangeCursor,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ListObjectsPage {
+    pub snapshot: CommitId,
+    pub objects: Vec<ObjectSummary>,
+    /// Opaque, snapshot-bound continuation. `None` means traversal completed.
+    pub continuation: Option<String>,
+}
+
+/// One logical object accepted by a bounded commit-session staging window.
+pub type CommitSessionPutInput = (Vec<u8>, Vec<u8>, ObjectHeaders, BTreeMap<String, String>);
+
+struct CommitMetadataCache {
+    entries: BTreeMap<CommitId, (Arc<BucketCommit>, usize)>,
+    order: VecDeque<CommitId>,
+    bytes: usize,
+    max_bytes: usize,
+}
+
+impl CommitMetadataCache {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            entries: BTreeMap::new(),
+            order: VecDeque::new(),
+            bytes: 0,
+            max_bytes,
+        }
+    }
+
+    fn get(&mut self, id: CommitId) -> Option<Arc<BucketCommit>> {
+        let commit = self.entries.get(&id)?.0.clone();
+        self.order.retain(|candidate| *candidate != id);
+        self.order.push_back(id);
+        Some(commit)
+    }
+
+    fn insert(&mut self, id: CommitId, commit: Arc<BucketCommit>, bytes: usize) {
+        if bytes > self.max_bytes {
+            return;
+        }
+        if let Some((_, previous_bytes)) = self.entries.remove(&id) {
+            self.bytes = self.bytes.saturating_sub(previous_bytes);
+            self.order.retain(|candidate| *candidate != id);
+        }
+        while self.bytes.saturating_add(bytes) > self.max_bytes {
+            let Some(oldest) = self.order.pop_front() else {
+                break;
+            };
+            if let Some((_, evicted_bytes)) = self.entries.remove(&oldest) {
+                self.bytes = self.bytes.saturating_sub(evicted_bytes);
+            }
+        }
+        self.bytes = self.bytes.saturating_add(bytes);
+        self.entries.insert(id, (commit, bytes));
+        self.order.push_back(id);
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -638,6 +704,8 @@ pub struct Repository<P: ObjectPlane> {
     permits: RwLock<BTreeMap<AuthorityScope, AuthorityPermit>>,
     fenced_scopes: RwLock<BTreeSet<AuthorityScope>>,
     authority_renewal: tokio::sync::Mutex<()>,
+    commit_metadata_cache: std::sync::Mutex<CommitMetadataCache>,
+    commit_metadata_fetch: tokio::sync::Mutex<()>,
     publication_lanes: std::sync::Mutex<BTreeMap<String, Weak<tokio::sync::Mutex<()>>>>,
     index_lanes: std::sync::Mutex<BTreeMap<String, Weak<tokio::sync::Mutex<()>>>>,
     local_index_heads: RwLock<BTreeMap<String, CommitId>>,
@@ -916,6 +984,7 @@ impl<P: ObjectPlane> Repository<P> {
         });
         node_store.set_node_locator(locator.clone())?;
         let writable = !options.read_only;
+        let commit_metadata_cache_bytes = options.max_cached_node_bytes;
         Ok(Self {
             plane,
             options,
@@ -933,6 +1002,10 @@ impl<P: ObjectPlane> Repository<P> {
             permits: RwLock::new(BTreeMap::new()),
             fenced_scopes: RwLock::new(BTreeSet::new()),
             authority_renewal: tokio::sync::Mutex::new(()),
+            commit_metadata_cache: std::sync::Mutex::new(CommitMetadataCache::new(
+                commit_metadata_cache_bytes,
+            )),
+            commit_metadata_fetch: tokio::sync::Mutex::new(()),
             publication_lanes: std::sync::Mutex::new(BTreeMap::new()),
             index_lanes: std::sync::Mutex::new(BTreeMap::new()),
             local_index_heads: RwLock::new(BTreeMap::new()),
@@ -1519,6 +1592,87 @@ impl<P: ObjectPlane> Repository<P> {
         })
     }
 
+    /// Stage a bounded input window, packing non-empty payloads up to 4 KiB
+    /// into deterministic immutable segments no larger than 4 MiB. Larger and
+    /// empty payloads retain the direct content-addressed representation.
+    pub async fn stage_commit_session_put_batch(
+        &self,
+        session: &CommitSessionManifest,
+        mut objects: Vec<CommitSessionPutInput>,
+        concurrency: usize,
+    ) -> Result<Vec<StagedMutation>> {
+        self.validate_commit_session(session).await?;
+        if concurrency == 0 {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "payload staging concurrency is zero",
+            ));
+        }
+        objects.sort_by(|left, right| left.0.cmp(&right.0));
+        for pair in objects.windows(2) {
+            if pair[0].0 == pair[1].0 {
+                return Err(Error::new(
+                    ErrorCode::InvalidRequest,
+                    "payload staging window contains a duplicate key",
+                ));
+            }
+        }
+        for (key, bytes, _, _) in &objects {
+            self.validate_key(key)?;
+            if bytes.len() as u64 > self.format.canonical_limits.max_object_bytes {
+                return Err(Error::new(
+                    ErrorCode::EntityTooLarge,
+                    "object exceeds the repository object-size limit",
+                ));
+            }
+        }
+
+        const SMALL_OBJECT_MAX: usize = 4 * 1024;
+        const PACK_MAX: usize = 4 * 1024 * 1024;
+        let mut packed_groups = Vec::new();
+        let mut current = Vec::new();
+        let mut current_bytes = 0_usize;
+        let mut direct = Vec::new();
+        for object in objects {
+            if object.1.is_empty() || object.1.len() > SMALL_OBJECT_MAX {
+                direct.push(object);
+                continue;
+            }
+            if !current.is_empty() && current_bytes.saturating_add(object.1.len()) > PACK_MAX {
+                packed_groups.push(std::mem::take(&mut current));
+                current_bytes = 0;
+            }
+            current_bytes = current_bytes.saturating_add(object.1.len());
+            current.push(object);
+        }
+        if !current.is_empty() {
+            packed_groups.push(current);
+        }
+
+        let mut staged = Vec::new();
+        for group in packed_groups {
+            let pack_inputs = group
+                .iter()
+                .map(|(_, bytes, _, _)| (crate::codec::sha256(bytes), bytes.clone()))
+                .collect();
+            let bindings = self.payloads.put_pack(pack_inputs).await?;
+            for ((key, bytes, headers, user_metadata), binding) in group.into_iter().zip(bindings) {
+                staged.push(staged_put(key, bytes, headers, user_metadata, binding));
+            }
+        }
+        let direct = stream::iter(direct)
+            .map(|(key, bytes, headers, user_metadata)| async move {
+                self.stage_commit_session_put(session, key, bytes, headers, user_metadata)
+                    .await
+            })
+            .buffer_unordered(concurrency)
+            .collect::<Vec<_>>()
+            .await;
+        staged.extend(direct.into_iter().collect::<Result<Vec<_>>>()?);
+        staged.sort_by(|left, right| left.key().cmp(right.key()));
+        Ok(staged)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn stage_commit_session_file(
         &self,
@@ -1843,7 +1997,7 @@ impl<P: ObjectPlane> Repository<P> {
             .md5
             .map(|md5| format!("\"{}\"", hex::encode(md5)));
         if staged.size > self.format.canonical_limits.max_object_bytes
-            || staged.binding.path != self.payloads.path(staged.binding.checksum_sha256)?
+            || staged.binding.path != self.payloads.expected_path(&staged.binding)?
             || staged.checksums.sha256 != Some(staged.binding.checksum_sha256)
             || expected_etag.as_deref() != Some(staged.logical_etag.as_str())
         {
@@ -2027,10 +2181,7 @@ impl<P: ObjectPlane> Repository<P> {
         let reference = self.publisher.load(branch).await?;
         self.require_branch_indexes_ready_for(branch, &reference)
             .await?;
-        let commit = self
-            .load_commit_object(reference.value.target)
-            .await?
-            .commit;
+        let commit = self.load_commit_metadata(reference.value.target).await?;
         let objects = self.tree_from_root(&commit.state.objects)?;
         let Some(encoded) = self
             .engine(self.node_store.clone())
@@ -2065,7 +2216,7 @@ impl<P: ObjectPlane> Repository<P> {
         self.validate_key(key)?;
         self.locator.register(branch)?;
         self.require_branch_indexes_ready(branch).await?;
-        let commit = self.load_commit_object(snapshot).await?.commit;
+        let commit = self.load_commit_metadata(snapshot).await?;
         let objects = self.tree_from_root(&commit.state.objects)?;
         let Some(encoded) = self
             .engine(self.node_store.clone())
@@ -2113,7 +2264,7 @@ impl<P: ObjectPlane> Repository<P> {
         self.validate_key(key)?;
         self.locator.register(branch)?;
         self.require_branch_indexes_ready(branch).await?;
-        let commit = self.load_commit_object(snapshot).await?.commit;
+        let commit = self.load_commit_metadata(snapshot).await?;
         let objects = self.tree_from_root(&commit.state.objects)?;
         let Some(encoded) = self
             .engine(self.node_store.clone())
@@ -2167,7 +2318,7 @@ impl<P: ObjectPlane> Repository<P> {
                 "live object has no payload binding",
             )
         })?;
-        if binding.path != self.payloads.path(binding.checksum_sha256)? {
+        if binding.path != self.payloads.expected_path(binding)? {
             return Err(Error::new(
                 ErrorCode::CorruptContent,
                 "payload binding path does not match its checksum",
@@ -2180,16 +2331,34 @@ impl<P: ObjectPlane> Repository<P> {
                 .map(|version_id| PhysicalVersion::Versioned {
                     version_id: version_id.clone(),
                 });
+        let logical_range = *range.start()..=(*range.end()).min(size - 1);
+        let translated = if let Some((offset, pack_end)) = binding.pack_range {
+            let start = offset.checked_add(*logical_range.start()).ok_or_else(|| {
+                Error::new(ErrorCode::InvalidRange, "packed payload range overflow")
+            })?;
+            let end = offset
+                .checked_add(*logical_range.end())
+                .filter(|end| *end <= pack_end)
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::CorruptContent,
+                        "packed payload range exceeds its logical extent",
+                    )
+                })?;
+            start..=end
+        } else {
+            logical_range.clone()
+        };
         let stored = self
             .plane
             .get(GetRequest {
                 path: binding.path.clone(),
-                range: Some(range.clone()),
+                range: Some(translated),
                 physical_version,
             })
             .await?
             .ok_or_else(|| Error::new(ErrorCode::MissingClosure, "payload is missing"))?;
-        if stored.metadata.sha256 != binding.checksum_sha256
+        if stored.metadata.sha256 != binding.physical_checksum_sha256()
             || stored.metadata.token.etag != binding.provider_etag
             || stored.metadata.token.version_id != binding.provider_version_id
         {
@@ -2203,7 +2372,7 @@ impl<P: ObjectPlane> Repository<P> {
             version: summary.version,
             bytes: stored.bytes,
             snapshot,
-            range,
+            range: logical_range,
         }))
     }
 
@@ -2422,6 +2591,99 @@ impl<P: ObjectPlane> Repository<P> {
         Ok((snapshot, objects, truncated))
     }
 
+    /// List a stable snapshot using an opaque traversal cursor. Resumption
+    /// seeks directly to the saved key in O(log n), rather than replaying and
+    /// discarding every earlier prefix entry. Cursors remain valid while their
+    /// immutable snapshot is retained; callers spanning GC should hold a
+    /// retention pin for `snapshot`.
+    pub async fn list_objects_page(
+        &self,
+        branch: &str,
+        prefix: &[u8],
+        continuation: Option<&str>,
+        requested_limit: usize,
+    ) -> Result<ListObjectsPage> {
+        std::str::from_utf8(prefix)
+            .map_err(|_| Error::new(ErrorCode::InvalidKey, "list prefix is not UTF-8"))?;
+        let limit = requested_limit.min(self.format.canonical_limits.max_list_page as usize);
+        if limit == 0 {
+            return Err(Error::new(
+                ErrorCode::InvalidLimit,
+                "list cursor page size is zero",
+            ));
+        }
+        let cursor = match continuation {
+            Some(token) => {
+                let bytes = hex::decode(token).map_err(|_| {
+                    Error::new(
+                        ErrorCode::InvalidContinuationToken,
+                        "list continuation is not canonical hex",
+                    )
+                })?;
+                let cursor: ListObjectsCursor = decode_canonical(&bytes).map_err(|_| {
+                    Error::new(
+                        ErrorCode::InvalidContinuationToken,
+                        "list continuation is malformed",
+                    )
+                })?;
+                if cursor.repository != self.format.repository_id
+                    || cursor.branch != branch
+                    || cursor.prefix != prefix
+                {
+                    return Err(Error::new(
+                        ErrorCode::InvalidContinuationToken,
+                        "list continuation belongs to another repository, branch, or prefix",
+                    ));
+                }
+                cursor
+            }
+            None => ListObjectsCursor {
+                repository: self.format.repository_id,
+                branch: branch.to_string(),
+                snapshot: self.head(branch).await?,
+                prefix: prefix.to_vec(),
+                traversal: prolly::RangeCursor::start(),
+            },
+        };
+        self.locator.register(branch)?;
+        self.require_branch_indexes_ready(branch).await?;
+        let commit = self.load_commit_metadata(cursor.snapshot).await?;
+        let objects = self.tree_from_root(&commit.state.objects)?;
+        let engine = self.engine(self.node_store.clone());
+        let mut page = engine
+            .prefix_page(&objects, prefix, &cursor.traversal, limit.saturating_add(1))
+            .await?;
+        let truncated = page.entries.len() > limit;
+        page.entries.truncate(limit);
+        let next = if truncated {
+            page.entries.last().map(|(key, _)| ListObjectsCursor {
+                traversal: prolly::RangeCursor::after_key(key.clone()),
+                ..cursor.clone()
+            })
+        } else {
+            None
+        };
+        let objects = page
+            .entries
+            .into_iter()
+            .map(|(key, encoded)| {
+                let current: CurrentObject = decode_canonical(&encoded)?;
+                current.version.validate()?;
+                Ok(ObjectSummary {
+                    key,
+                    version: current.version,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(ListObjectsPage {
+            snapshot: cursor.snapshot,
+            objects,
+            continuation: next
+                .map(|cursor| encode_canonical(&cursor).map(hex::encode))
+                .transpose()?,
+        })
+    }
+
     /// S3-style delimiter projection over a stable ordered object page.
     pub async fn list_objects_delimited(
         &self,
@@ -2501,7 +2763,7 @@ impl<P: ObjectPlane> Repository<P> {
         }
         self.locator.register(branch)?;
         self.require_branch_indexes_ready(branch).await?;
-        let commit = self.load_commit_object(snapshot).await?.commit;
+        let commit = self.load_commit_metadata(snapshot).await?;
         let objects = self.tree_from_root(&commit.state.objects)?;
         let engine = self.engine(self.node_store.clone());
         let mut iter = engine.prefix(&objects, prefix).await?;
@@ -5239,6 +5501,18 @@ impl<P: ObjectPlane> Repository<P> {
                 "repository branch authority is fenced in this repository instance",
             ));
         }
+        // Renewal changes the mutable object's storage token before the
+        // renewed permit can be installed locally. Serialize the complete
+        // cached-permit read and remote validation with renewal so foreground
+        // operations can never observe that transient stale-token window and
+        // fence an otherwise healthy authority epoch.
+        let _renewal = self.authority_renewal.lock().await;
+        if self.is_scope_fenced(&scope)? {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "repository branch authority is fenced in this repository instance",
+            ));
+        }
         let cached = self
             .permits
             .read()
@@ -5249,13 +5523,6 @@ impl<P: ObjectPlane> Repository<P> {
         {
             permit
         } else {
-            let _renewal = self.authority_renewal.lock().await;
-            if self.is_scope_fenced(&scope)? {
-                return Err(Error::new(
-                    ErrorCode::PreconditionFailed,
-                    "repository branch authority is fenced in this repository instance",
-                ));
-            }
             let current = self
                 .permits
                 .read()
@@ -5413,6 +5680,43 @@ impl<P: ObjectPlane> Repository<P> {
         Ok(object)
     }
 
+    async fn load_commit_metadata(&self, id: CommitId) -> Result<Arc<BucketCommit>> {
+        if let Some(commit) = self
+            .commit_metadata_cache
+            .lock()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "commit cache lock poisoned"))?
+            .get(id)
+        {
+            return Ok(commit);
+        }
+
+        // A commit is immutable. Serializing misses prevents a cold burst for the
+        // same branch head from downloading and decoding the same large metadata
+        // envelope once per request; the second lookup lets waiters share it.
+        let _fetch = self.commit_metadata_fetch.lock().await;
+        if let Some(commit) = self
+            .commit_metadata_cache
+            .lock()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "commit cache lock poisoned"))?
+            .get(id)
+        {
+            return Ok(commit);
+        }
+        let commit = Arc::new(self.publisher.load_commit(id).await?);
+        let encoded_bytes = encode_canonical(commit.as_ref())?.len();
+        self.commit_metadata_cache
+            .lock()
+            .map_err(|_| Error::new(ErrorCode::InternalInvariant, "commit cache lock poisoned"))?
+            .insert(id, commit.clone(), encoded_bytes);
+        Ok(commit)
+    }
+
+    /// Administrative traversal fallback for commits that may not exist in a
+    /// live branch's journal-derived node index (notably GC history closure).
+    async fn load_commit_object_with_pack(&self, id: CommitId) -> Result<CommitObject> {
+        self.load_commit_object(id).await
+    }
+
     async fn finalize_pack(
         &self,
         id: CommitId,
@@ -5473,7 +5777,7 @@ impl<P: ObjectPlane> Repository<P> {
                 "live object version has no payload binding",
             )
         })?;
-        if binding.path != self.payloads.path(binding.checksum_sha256)? {
+        if binding.path != self.payloads.expected_path(binding)? {
             return Err(Error::new(
                 ErrorCode::CorruptContent,
                 "payload binding path does not match its content checksum",
@@ -5483,8 +5787,13 @@ impl<P: ObjectPlane> Repository<P> {
             self.plane.head(&binding.path).await?.ok_or_else(|| {
                 Error::new(ErrorCode::MissingClosure, "immutable payload is missing")
             })?;
-        if metadata.len != *size
-            || metadata.sha256 != binding.checksum_sha256
+        let expected_physical_len = binding
+            .pack_range
+            .map(|(_, end)| end.saturating_add(1))
+            .unwrap_or(*size);
+        if metadata.len < expected_physical_len
+            || (!binding.is_packed() && metadata.len != *size)
+            || metadata.sha256 != binding.physical_checksum_sha256()
             || metadata.token.etag != binding.provider_etag
             || metadata.token.version_id != binding.provider_version_id
         {
@@ -5621,7 +5930,7 @@ impl<P: ObjectPlane> Repository<P> {
             let mark_key = gc_commit_mark_key(id);
             let mut mutations = vec![Mutation::Delete { key: queue_key }];
             if engine.get(&tree, &mark_key).await?.is_none() {
-                let commit = self.load_commit_object(id).await?.commit;
+                let commit = self.load_commit_object_with_pack(id).await?.commit;
                 mutations.push(Mutation::Upsert {
                     key: mark_key,
                     val: Vec::new(),
@@ -7834,6 +8143,34 @@ fn decode_retention_pin_tag(tag: &str) -> Result<Option<String>> {
     })
 }
 
+fn staged_put(
+    key: Vec<u8>,
+    bytes: Vec<u8>,
+    headers: ObjectHeaders,
+    user_metadata: BTreeMap<String, String>,
+    binding: crate::PayloadBinding,
+) -> StagedMutation {
+    let size = bytes.len() as u64;
+    let checksum_md5: [u8; 16] = Md5::digest(&bytes).into();
+    let checksum_sha256: [u8; 32] = Sha256::digest(&bytes).into();
+    StagedMutation {
+        body: StagedMutationBody::Put(Box::new(StagedPut {
+            key,
+            size,
+            logical_etag: format!("\"{}\"", hex::encode(checksum_md5)),
+            checksums: Checksums {
+                md5: Some(checksum_md5),
+                sha256: Some(checksum_sha256),
+                algorithm_values: BTreeMap::new(),
+            },
+            headers,
+            user_metadata,
+            tags: BTreeMap::new(),
+            binding,
+        })),
+    }
+}
+
 fn validate_options(options: &RepositoryOptions) -> Result<()> {
     crate::repository::validate_branch(&options.default_branch)?;
     options.idempotency_retention.validate()?;
@@ -7966,7 +8303,7 @@ fn gc_managed_kind(prefix: &str, path: &ObjectPath) -> Option<&'static str> {
         Some("commits")
     } else if relative.starts_with("nodes/sha256/") {
         Some("nodes")
-    } else if relative.starts_with("payloads/") {
+    } else if relative.starts_with("payloads/") || relative.starts_with("payload-packs/") {
         Some("payloads")
     } else {
         None

--- a/extensions/s3/core/src/store.rs
+++ b/extensions/s3/core/src/store.rs
@@ -45,6 +45,9 @@ struct PackedNodeState {
     cache_corruptions: AtomicU64,
     coalesced_waits: AtomicU64,
     ranged_fetches: AtomicU64,
+    fetched_bytes: AtomicU64,
+    avoided_bytes: AtomicU64,
+    admission_rejections: AtomicU64,
     locator: RwLock<Option<Arc<dyn NodeLocator>>>,
 }
 
@@ -59,6 +62,9 @@ struct DirectNodeState {
     cache_corruptions: AtomicU64,
     coalesced_waits: AtomicU64,
     object_fetches: AtomicU64,
+    fetched_bytes: AtomicU64,
+    avoided_bytes: AtomicU64,
+    admission_rejections: AtomicU64,
 }
 
 struct BoundedNodeLocations {
@@ -135,6 +141,9 @@ pub struct NodeCacheSnapshot {
     pub corruptions: u64,
     pub coalesced_waits: u64,
     pub ranged_fetches: u64,
+    pub fetched_bytes: u64,
+    pub avoided_bytes: u64,
+    pub admission_rejections: u64,
 }
 
 impl NodeCacheSnapshot {
@@ -147,6 +156,11 @@ impl NodeCacheSnapshot {
             corruptions: self.corruptions.saturating_add(other.corruptions),
             coalesced_waits: self.coalesced_waits.saturating_add(other.coalesced_waits),
             ranged_fetches: self.ranged_fetches.saturating_add(other.ranged_fetches),
+            fetched_bytes: self.fetched_bytes.saturating_add(other.fetched_bytes),
+            avoided_bytes: self.avoided_bytes.saturating_add(other.avoided_bytes),
+            admission_rejections: self
+                .admission_rejections
+                .saturating_add(other.admission_rejections),
         }
     }
 }
@@ -274,6 +288,9 @@ impl<P> ProllyObjectStore<P> {
                 cache_corruptions: AtomicU64::new(0),
                 coalesced_waits: AtomicU64::new(0),
                 ranged_fetches: AtomicU64::new(0),
+                fetched_bytes: AtomicU64::new(0),
+                avoided_bytes: AtomicU64::new(0),
+                admission_rejections: AtomicU64::new(0),
                 locator: RwLock::new(None),
             })),
             packed_pending: Some(Arc::new(RwLock::new(BTreeMap::new()))),
@@ -308,6 +325,9 @@ impl<P> ProllyObjectStore<P> {
                 cache_corruptions: AtomicU64::new(0),
                 coalesced_waits: AtomicU64::new(0),
                 object_fetches: AtomicU64::new(0),
+                fetched_bytes: AtomicU64::new(0),
+                avoided_bytes: AtomicU64::new(0),
+                admission_rejections: AtomicU64::new(0),
             })),
             write_direct: true,
         }
@@ -403,6 +423,9 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
                 corruptions: state.cache_corruptions.load(Ordering::Relaxed),
                 coalesced_waits: state.coalesced_waits.load(Ordering::Relaxed),
                 ranged_fetches: state.ranged_fetches.load(Ordering::Relaxed),
+                fetched_bytes: state.fetched_bytes.load(Ordering::Relaxed),
+                avoided_bytes: state.avoided_bytes.load(Ordering::Relaxed),
+                admission_rejections: state.admission_rejections.load(Ordering::Relaxed),
             };
         }
         if let Some(state) = &self.direct {
@@ -414,6 +437,9 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
                 corruptions: state.cache_corruptions.load(Ordering::Relaxed),
                 coalesced_waits: state.coalesced_waits.load(Ordering::Relaxed),
                 ranged_fetches: state.object_fetches.load(Ordering::Relaxed),
+                fetched_bytes: state.fetched_bytes.load(Ordering::Relaxed),
+                avoided_bytes: state.avoided_bytes.load(Ordering::Relaxed),
+                admission_rejections: state.admission_rejections.load(Ordering::Relaxed),
             };
         }
         NodeCacheSnapshot::default()
@@ -566,6 +592,7 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
         Ok(())
     }
 
+    #[allow(dead_code)] // Retained for offline callers that already hold a complete object.
     pub(crate) fn register_commit_object(
         &self,
         container: CommitId,
@@ -580,6 +607,7 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
         )
     }
 
+    #[allow(dead_code)]
     fn register_node_pack(
         &self,
         container: PackedCommitId,
@@ -725,6 +753,9 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
         match cache.get(&key).await {
             Ok(Some(bytes)) if sha256(&bytes).as_slice() == cid.as_bytes() => {
                 state.cache_hits.fetch_add(1, Ordering::Relaxed);
+                state
+                    .avoided_bytes
+                    .fetch_add(bytes.len() as u64, Ordering::Relaxed);
                 Some(bytes)
             }
             Ok(Some(_)) => {
@@ -762,6 +793,7 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
             return;
         };
         if !cache.admits(&key, bytes.len()) {
+            state.admission_rejections.fetch_add(1, Ordering::Relaxed);
             return;
         }
         match cache.insert(key, bytes).await {
@@ -862,6 +894,9 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
             })
             .await?
             .ok_or_else(|| Error::new(ErrorCode::MissingClosure, "node pack is missing"))?;
+        state
+            .fetched_bytes
+            .fetch_add(object.bytes.len() as u64, Ordering::Relaxed);
         if object.bytes.len() != location.len as usize
             || sha256(&object.bytes) != location.sha256
             || cid.as_bytes() != location.sha256
@@ -889,6 +924,9 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
         match state.node_cache.get(&key).await {
             Ok(Some(bytes)) if sha256(&bytes).as_slice() == cid.as_bytes() => {
                 state.cache_hits.fetch_add(1, Ordering::Relaxed);
+                state
+                    .avoided_bytes
+                    .fetch_add(bytes.len() as u64, Ordering::Relaxed);
                 Some(bytes)
             }
             Ok(Some(_)) => {
@@ -923,6 +961,7 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
             return;
         };
         if !state.node_cache.admits(&key, bytes.len()) {
+            state.admission_rejections.fetch_add(1, Ordering::Relaxed);
             return;
         }
         match state.node_cache.insert(key, bytes).await {
@@ -971,6 +1010,9 @@ impl<P: ObjectPlane> ProllyObjectStore<P> {
         state.object_fetches.fetch_add(1, Ordering::Relaxed);
         let bytes = self.get_uncached_direct(key).await?;
         if let Some(bytes) = &bytes {
+            state
+                .fetched_bytes
+                .fetch_add(bytes.len() as u64, Ordering::Relaxed);
             self.admit_direct_node(cid, bytes.clone()).await;
         }
         Ok(bytes)

--- a/extensions/s3/core/tests/repository.rs
+++ b/extensions/s3/core/tests/repository.rs
@@ -289,6 +289,90 @@ async fn repository_history_listing_delete_markers_and_payload_dedup_are_stable(
 }
 
 #[tokio::test]
+async fn object_list_cursor_is_snapshot_bound_and_resumes_without_replay() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane.clone(),
+        RepositoryOptions {
+            repository_prefix: ".tests/list-cursor".to_string(),
+            writer: "list-writer".to_string(),
+            ids: Arc::new(SequenceIdSource::new(0x89, 1)),
+            provider_per_key_version_limit: ProviderPerKeyVersionLimit::Finite(10_000),
+            ..RepositoryOptions::default()
+        },
+    )
+    .await
+    .unwrap();
+    let session = repository
+        .begin_commit_session("main", "seed cursor listing", 60_000)
+        .await
+        .unwrap();
+    let mut mutations = Vec::new();
+    for index in 0..250 {
+        mutations.push(
+            repository
+                .stage_commit_session_put(
+                    &session,
+                    format!("cursor/{index:04}.txt").into_bytes(),
+                    vec![index as u8],
+                    ObjectHeaders::default(),
+                    BTreeMap::new(),
+                )
+                .await
+                .unwrap(),
+        );
+    }
+    repository
+        .publish_commit_session(session, mutations)
+        .await
+        .unwrap();
+
+    let first = repository
+        .list_objects_page("main", b"cursor/", None, 100)
+        .await
+        .unwrap();
+    assert_eq!(first.objects.len(), 100);
+    let snapshot = first.snapshot;
+    repository
+        .put_object(
+            "main",
+            b"cursor/9999.txt".to_vec(),
+            b"later".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+
+    plane.reset_request_counts();
+    let second = repository
+        .list_objects_page("main", b"cursor/", first.continuation.as_deref(), 100)
+        .await
+        .unwrap();
+    let third = repository
+        .list_objects_page("main", b"cursor/", second.continuation.as_deref(), 100)
+        .await
+        .unwrap();
+    assert_eq!(second.snapshot, snapshot);
+    assert_eq!(third.snapshot, snapshot);
+    assert_eq!(second.objects.len(), 100);
+    assert_eq!(third.objects.len(), 50);
+    assert!(third.continuation.is_none());
+    assert!(second.objects[0].key > first.objects[99].key);
+    assert!(third.objects[0].key > second.objects[99].key);
+    assert_eq!(plane.request_snapshot().immutable_put, 0);
+
+    let error = repository
+        .list_objects_page("main", b"other/", first.continuation.as_deref(), 100)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error.code,
+        prolly_s3_core::ErrorCode::InvalidContinuationToken
+    );
+}
+
+#[tokio::test]
 async fn repository_takeover_fences_old_writer_before_payload_put() {
     let plane = Arc::new(MemoryObjectPlane::new(true));
     let clock = Arc::new(FixedClock::new(20_000));
@@ -450,6 +534,197 @@ async fn repository_manual_authority_renewal_extends_the_write_window() {
 }
 
 #[tokio::test]
+async fn durable_commit_session_survives_repeated_authority_renewal_and_restart() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(55_000));
+    let options = RepositoryOptions {
+        repository_prefix: ".tests/session-multiple-renewals".to_string(),
+        writer: "stable-writer".to_string(),
+        clock: clock.clone(),
+        ids: Arc::new(SequenceIdSource::new(0xab, 1)),
+        authority_lease_millis: 10_000,
+        provider_per_key_version_limit: ProviderPerKeyVersionLimit::Finite(10_000),
+        ..RepositoryOptions::default()
+    };
+    let repository = Repository::initialize(plane.clone(), options.clone())
+        .await
+        .unwrap();
+    let checkpoint = repository
+        .begin_durable_commit_session("main", "long import", 4 * 60 * 60 * 1_000)
+        .await
+        .unwrap();
+    let original_stamp = checkpoint.session.identity.authority.clone();
+    let mut staged = Vec::new();
+
+    for renewal in 0..2_700 {
+        clock.advance(4_000).unwrap();
+        repository.renew_shard_authorities().await.unwrap();
+        if renewal % 900 != 899 {
+            continue;
+        }
+        let index = renewal / 900;
+        let mutation = repository
+            .stage_commit_session_put(
+                &checkpoint.session,
+                format!("renewed/{index}.txt").into_bytes(),
+                format!("value-{index}").into_bytes(),
+                ObjectHeaders::default(),
+                BTreeMap::new(),
+            )
+            .await
+            .unwrap();
+        staged.push(mutation);
+        repository
+            .checkpoint_commit_session(
+                &checkpoint.session,
+                staged.clone(),
+                u64::try_from(index + 1).unwrap(),
+            )
+            .await
+            .unwrap();
+    }
+    assert_eq!(checkpoint.session.identity.authority, original_stamp);
+    drop(repository);
+
+    clock.advance(1).unwrap();
+    let reopened = Repository::open(plane, options).await.unwrap();
+    let resumed = reopened
+        .resume_commit_session(checkpoint.session.id)
+        .await
+        .unwrap();
+    assert_eq!(resumed.mutations.len(), 3);
+    assert_eq!(resumed.session.identity.authority, original_stamp);
+    let receipt = reopened
+        .publish_commit_session(resumed.session, resumed.mutations)
+        .await
+        .unwrap();
+    assert_eq!(receipt.changed_keys, 3);
+}
+
+#[tokio::test]
+async fn concurrent_session_staging_and_authority_renewal_do_not_self_fence() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(58_000));
+    let repository = Arc::new(
+        Repository::initialize(
+            plane,
+            RepositoryOptions {
+                repository_prefix: ".tests/session-concurrent-renewal".to_string(),
+                writer: "concurrent-writer".to_string(),
+                clock: clock.clone(),
+                ids: Arc::new(SequenceIdSource::new(0xac, 1)),
+                authority_lease_millis: 10_000,
+                provider_per_key_version_limit: ProviderPerKeyVersionLimit::Finite(10_000),
+                ..RepositoryOptions::default()
+            },
+        )
+        .await
+        .unwrap(),
+    );
+    let session = repository
+        .begin_commit_session("main", "concurrent renewal import", 120_000)
+        .await
+        .unwrap();
+    let mut mutations = Vec::new();
+
+    for index in 0..64 {
+        clock.advance(100).unwrap();
+        let renewing = repository.clone();
+        let staging = repository.clone();
+        let session = session.clone();
+        let ((), mutation) = tokio::join!(
+            async move { renewing.renew_shard_authorities().await.unwrap() },
+            async move {
+                staging
+                    .stage_commit_session_put(
+                        &session,
+                        format!("concurrent/{index:03}.txt").into_bytes(),
+                        vec![index as u8],
+                        ObjectHeaders::default(),
+                        BTreeMap::new(),
+                    )
+                    .await
+                    .unwrap()
+            }
+        );
+        mutations.push(mutation);
+    }
+    assert!(repository.fenced_branches().unwrap().is_empty());
+    let receipt = repository
+        .publish_commit_session(session, mutations)
+        .await
+        .unwrap();
+    assert_eq!(receipt.changed_keys, 64);
+}
+
+#[tokio::test]
+async fn real_takeover_fences_an_open_commit_session() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let clock = Arc::new(FixedClock::new(59_000));
+    let prefix = ".tests/session-takeover";
+    let old_options = RepositoryOptions {
+        repository_prefix: prefix.to_string(),
+        writer: "writer-a".to_string(),
+        clock: clock.clone(),
+        ids: Arc::new(SequenceIdSource::new(0xad, 1)),
+        authority_lease_millis: 10_000,
+        provider_per_key_version_limit: ProviderPerKeyVersionLimit::Finite(10_000),
+        ..RepositoryOptions::default()
+    };
+    let old = Repository::initialize(plane.clone(), old_options.clone())
+        .await
+        .unwrap();
+    let checkpoint = old
+        .begin_durable_commit_session("main", "must be fenced", 120_000)
+        .await
+        .unwrap();
+    let staged = old
+        .stage_commit_session_put(
+            &checkpoint.session,
+            b"stale.txt".to_vec(),
+            b"stale".to_vec(),
+            ObjectHeaders::default(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+    old.checkpoint_commit_session(&checkpoint.session, vec![staged.clone()], 1)
+        .await
+        .unwrap();
+
+    let replacement = Repository::open(
+        plane,
+        RepositoryOptions {
+            writer: "writer-b".to_string(),
+            read_only: true,
+            ids: Arc::new(SequenceIdSource::new(0xae, 1)),
+            ..old_options
+        },
+    )
+    .await
+    .unwrap();
+    clock.advance(1).unwrap();
+    replacement
+        .takeover_branch_writer("main", "writer-a", 1, "writer-a credentials revoked")
+        .await
+        .unwrap();
+
+    let error = old
+        .publish_commit_session(checkpoint.session.clone(), vec![staged])
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, prolly_s3_core::ErrorCode::PreconditionFailed);
+    let resume_error = replacement
+        .resume_commit_session(checkpoint.session.id)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        resume_error.code,
+        prolly_s3_core::ErrorCode::PreconditionFailed
+    );
+}
+
+#[tokio::test]
 async fn repository_commit_session_batches_payloads_into_one_replayable_publication() {
     let plane = Arc::new(MemoryObjectPlane::new(true));
     let clock = Arc::new(FixedClock::new(60_000));
@@ -541,6 +816,82 @@ async fn repository_commit_session_batches_payloads_into_one_replayable_publicat
         .unwrap();
     assert_eq!(replay.id, receipt.id);
     assert!(replay.idempotent_replay);
+}
+
+#[tokio::test]
+async fn repository_small_object_pack_deduplicates_and_bounds_logical_ranges() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let repository = Repository::initialize(
+        plane,
+        RepositoryOptions {
+            repository_prefix: ".tests/repository-payload-pack".to_string(),
+            writer: "pack-writer".to_string(),
+            provider_per_key_version_limit: ProviderPerKeyVersionLimit::Finite(10_000),
+            ..RepositoryOptions::default()
+        },
+    )
+    .await
+    .unwrap();
+    let session = repository
+        .begin_commit_session("main", "packed import", 60_000)
+        .await
+        .unwrap();
+    let staged = repository
+        .stage_commit_session_put_batch(
+            &session,
+            vec![
+                (
+                    b"pack/a".to_vec(),
+                    b"same".to_vec(),
+                    ObjectHeaders::default(),
+                    BTreeMap::new(),
+                ),
+                (
+                    b"pack/b".to_vec(),
+                    b"same".to_vec(),
+                    ObjectHeaders::default(),
+                    BTreeMap::new(),
+                ),
+                (
+                    b"pack/c".to_vec(),
+                    b"next".to_vec(),
+                    ObjectHeaders::default(),
+                    BTreeMap::new(),
+                ),
+            ],
+            4,
+        )
+        .await
+        .unwrap();
+    let receipt = repository
+        .publish_commit_session(session, staged)
+        .await
+        .unwrap();
+    let mut bindings = Vec::new();
+    for key in [b"pack/a".as_slice(), b"pack/b", b"pack/c"] {
+        bindings.push(
+            repository
+                .head_object_at("main", receipt.id, key)
+                .await
+                .unwrap()
+                .unwrap()
+                .version
+                .binding
+                .unwrap(),
+        );
+    }
+    assert!(bindings.iter().all(|binding| binding.is_packed()));
+    assert_eq!(bindings[0].path, bindings[1].path);
+    assert_eq!(bindings[0].pack_range, bindings[1].pack_range);
+    assert_ne!(bindings[1].pack_range, bindings[2].pack_range);
+
+    let range = repository
+        .get_object_range("main", receipt.id, b"pack/a", 0..=u64::MAX)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(range.bytes, b"same");
+    assert_eq!(range.range, 0..=3);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- keep commit sessions valid across ordinary authority lease renewals while preserving takeover fencing
- add bounded, backpressured streaming bulk ingestion with durable checkpoints and resumable failures
- pack tiny logical payloads into immutable content-addressed segments with ranged reads, integrity checks, deduplication, GC, and history support
- range-fetch and cache commit metadata, coalesce cold misses, and expose cache byte-amplification telemetry
- replace key-replay pagination with snapshot-bound traversal cursors and a bounded-memory listing stream
- externalize large commit deltas so commit descriptors stay bounded
- build journal indexes from compact commit descriptors and node-pack TOCs
- initialize branches by inheriting safe immutable index roots
- batch sparse structural diff/merge traversal and share the node cache

## Root cause and impact

Long-running commit sessions retained an authority stamp while background renewal briefly replaced the underlying mutable-object token. Foreground validation could observe the stale cached permit during that transition and self-fence a healthy writer. Renewal and active-permit validation are now serialized across the remote check, while the stable authority epoch changes only during a real takeover.

The previous bulk and history paths also required a complete Vec, uploaded sequentially, stored one physical object per tiny file, fetched complete commit/node packs for point reads and sparse history operations, and rebuilt prefix traversal for every list page. The new paths keep memory and descriptors bounded, use range reads and shared caches, structurally prune unchanged data, and avoid snapshot-sized branch initialization.

## Validation

- cargo fmt --manifest-path extensions/s3/Cargo.toml --all -- --check
- cargo clippy --locked --manifest-path extensions/s3/Cargo.toml --workspace --all-targets -- -D warnings
- cargo test --locked --manifest-path extensions/s3/Cargo.toml --workspace
- four-hour simulated session with 2,700 renewals, checkpoints, restart/resume, publication, and real-takeover fencing
- RustFS 10K ingestion: 1,944.91 files/s, 67 S3 calls
- RustFS 20K warm reads: 22.74 ms p99, 1,196 downloaded bytes/read
- RustFS 20K full listing: 62,431 entries/s, 24,195 bytes downloaded, zero PUTs
- RustFS 20K branch creation: 61.78 ms, 8,034 bytes downloaded
- RustFS 20K sparse diffs (100 changes): 8.74/11.19 ms, 18,183/18,175 bytes downloaded
- RustFS 20K merge plan (100 changes): 299.70 ms, 23,833 bytes downloaded
- RustFS merge publication: 38.28 ms, merged content verified

Before this change, the same warm 20K workload downloaded 46.7 MB for branch creation, about 16 MB per sparse diff, and 22.4 MB for merge planning.

## Compatibility

Direct payload bindings remain wire-compatible through optional packed-payload fields. Empty and larger objects retain direct content-addressed storage. Large deltas use the existing changes-root representation, while small deltas remain inline. Existing history, recovery, restartable merge, transfer, fsck, GC, authority, and protocol suites pass for both representations.