### PR TITLE
Reduce S3 history operation amplification

### DIFF
--- a/extensions/s3/API.md
+++ b/extensions/s3/API.md
@@ -134,9 +134,16 @@ failure, call `resume_commit` with the batch ID; verified payload bindings are r
 Expired durable sessions are removed in bounded pages with
 `cleanup_expired_commit_sessions`.
 
+Commit descriptors remain bounded as batches grow. Deltas of up to 128 logical
+changes are embedded directly; larger deltas are stored in a content-addressed
+Prolly tree and referenced by root and count. Resume, reconciliation, diff, and
+publication preserve the same atomic semantics for both representations.
+
 ## Branches, tags, and retention
 
-- `create_branch` creates a branch at an explicit commit or current head.
+- `create_branch` creates a branch at an explicit commit or current head. It
+  inherits immutable node-location and commit-graph roots from the checked-out
+  source branch, so branch creation does not download or rebuild the snapshot.
 - `delete_branch` requires the expected head.
 - `create_tag`, `tag`, and `delete_tag` manage immutable-history names.
 - `create_retention_pin`, `retention_pin`, `delete_retention_pin`, and
@@ -150,7 +157,8 @@ Branch and tag catalogs are derived, bounded indexes. Enumerate them with
 - `commit` loads and validates one immutable commit.
 - `log` and `diff` are convenience APIs for small bounded results.
 - `log_bounded` accepts `TraversalBudget`; `diff_bounded` uses an opaque
-  structural cursor and prunes identical subtrees.
+  structural cursor and prunes identical subtrees. Diff resolves compact commit
+  descriptors and fetches only nodes on the structural frontier.
 - `open_reflog` captures a stable immutable journal snapshot;
   `read_reflog_page` reads newest-to-oldest pages from it.
 - `reset_branch` is a CAS-protected administrative ref move.
@@ -166,6 +174,10 @@ Call `start_merge`, persist the returned cursor, and repeatedly call
 `merge_changes_page` and `merge_conflicts_page`. Only `publish_merge` moves the
 target branch. `cleanup_merge` exact-deletes job-scoped plan data in bounded
 pages after publication or abandonment.
+
+Merge planning shares the immutable node cache with foreground reads and
+advances structural-diff frontiers in bounded batches. Unchanged subtrees are
+pruned without loading full commit node packs.
 
 ## Integrity and garbage collection
 
@@ -232,6 +244,10 @@ These methods are operational controls, not normal foreground request paths:
 
 Metrics are process-local. Export them before process termination and correlate
 them with provider request IDs and service-side metrics.
+
+Journal-derived node indexes are built from compact commit descriptors and
+node-pack tables of contents. Payload sections are range-fetched only when a
+referenced node is actually read.
 
 ## Error and consistency model
 

--- a/extensions/s3/QUALIFICATION.md
+++ b/extensions/s3/QUALIFICATION.md
@@ -72,6 +72,21 @@ PROLLY_S3_RUSTFS=1 PROLLY_S3_10K_CONCURRENCY=32 \
   rustfs_10k_concurrent_commit_regression_gate -- --ignored --nocapture
 ```
 
+Run the 20K point-read, full-list, branch, sparse-diff, and merge gate with:
+
+```bash
+PROLLY_S3_RUSTFS=1 \
+  cargo test --release --manifest-path extensions/s3/Cargo.toml \
+  -p prolly-s3-client --test rustfs_repository \
+  rustfs_20k_branch_diff_merge_meets_amplification_slos \
+  -- --ignored --exact --nocapture
+```
+
+The release gate requires warm read p99 below 100 ms, listing above 10K
+entries/s, branch creation below 500 ms and 512 KiB downloaded, each 100-key
+sparse diff below 500 ms and 1 MiB, and merge planning below one second and
+2 MiB. It also verifies merge publication and merged object content.
+
 ## AWS qualification
 
 Run the ignored AWS tests only against an isolated versioned bucket:

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -515,6 +515,11 @@ bytes, and admission rejections.
   the batch.
 - A current or historical read resolves a ref/commit/tree path and one payload.
 - Warm immutable-node caches remove most repeated metadata reads.
+- Branch creation inherits immutable derived-index roots from its source and is
+  independent of snapshot size. Sparse diff and merge fetch compact commit
+  descriptors and only the node ranges on their traversal frontier.
+- Large commit deltas are external Prolly trees, keeping commit descriptors and
+  restart metadata bounded independently of batch size.
 - Same-branch writers contend on one ref CAS; different branches publish
   independently.
 

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -78,8 +78,9 @@ cargo run --release --locked --manifest-path extensions/s3/Cargo.toml \
 ```
 
 Use `PROLLY_RUSTFS_PERF_STAGES=10000,20000` for a shorter run. RustFS defaults
-to the `prolly` bucket and `prolly/prolly` local credentials; all values remain
-overridable with the `PROLLY_RUSTFS_*` environment variables.
+to the `prolly` bucket and the repository's standard local credentials
+(`prollyadmin` / `prolly-local-secret-change-me`); all values remain overridable
+with the `PROLLY_RUSTFS_*` environment variables.
 
 | Example | Demonstrates |
 |---|---|

--- a/extensions/s3/client/examples/rustfs_small_files_benchmark.rs
+++ b/extensions/s3/client/examples/rustfs_small_files_benchmark.rs
@@ -140,8 +140,8 @@ async fn ensure_versioned_bucket(aws: &aws_sdk_s3::Client, bucket: &str) -> Benc
 #[tokio::main(flavor = "multi_thread", worker_threads = 12)]
 async fn main() -> BenchResult {
     let endpoint = env("PROLLY_RUSTFS_ENDPOINT", "http://127.0.0.1:9000");
-    let access_key = env("PROLLY_RUSTFS_ACCESS_KEY", "prolly");
-    let secret_key = env("PROLLY_RUSTFS_SECRET_KEY", "prolly");
+    let access_key = env("PROLLY_RUSTFS_ACCESS_KEY", "prollyadmin");
+    let secret_key = env("PROLLY_RUSTFS_SECRET_KEY", "prolly-local-secret-change-me");
     let bucket = env("PROLLY_RUSTFS_BUCKET", "prolly");
     let read_sample_size = env("PROLLY_RUSTFS_PERF_READ_SAMPLES", "1000").parse::<usize>()?;
     let read_concurrency = env("PROLLY_RUSTFS_PERF_READ_CONCURRENCY", "32").parse::<usize>()?;

--- a/extensions/s3/client/examples/rustfs_small_files_benchmark.rs
+++ b/extensions/s3/client/examples/rustfs_small_files_benchmark.rs
@@ -49,7 +49,7 @@ fn parse_stages() -> BenchResult<Vec<usize>> {
             .collect::<Result<Vec<_>, _>>()?,
         None => DEFAULT_STAGES.to_vec(),
     };
-    if stages.is_empty() || stages.iter().any(|stage| *stage == 0) {
+    if stages.is_empty() || stages.contains(&0) {
         return Err("benchmark stages must be non-empty positive integers".into());
     }
     stages.sort_unstable();

--- a/extensions/s3/client/src/client.rs
+++ b/extensions/s3/client/src/client.rs
@@ -288,7 +288,9 @@ impl Client {
             Some(from) => from,
             None => self.head().await?,
         };
-        self.repository.create_branch(name.as_ref(), from).await
+        self.repository
+            .create_branch_from(self.attached_branch()?, name.as_ref(), from)
+            .await
     }
 
     pub async fn delete_branch(&self, name: impl AsRef<str>, expected: CommitId) -> Result<()> {

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -1105,6 +1105,241 @@ async fn rustfs_warm_reads_and_cursor_listing_meet_scale_slos() {
     assert_eq!(list_metrics.put_object, 0, "foreground listing wrote data");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+#[ignore = "20K branch, structural-diff, and merge performance release gate"]
+async fn rustfs_20k_branch_diff_merge_meets_amplification_slos() {
+    assert!(rustfs_enabled(), "set PROLLY_S3_RUSTFS=1 to run");
+    const FILES: usize = 20_000;
+    const CHANGES: usize = 100;
+    let (aws, bucket) = rustfs_client().await;
+    let client = Client::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(unique_name("20k-branch-diff-merge"))
+        .writer("rustfs-20k-branch-diff-merge-writer")
+        .authority_lease_duration(Duration::from_secs(600))
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimit::Finite(10_000))
+        .background_index_maintenance(false)
+        .initialize()
+        .await
+        .unwrap();
+    let make_input = |index: usize, value: &'static str| PutObjectInput {
+        key: format!("scale/{index:05}.txt"),
+        bytes: format!("{index:016x}-{value}").into_bytes(),
+        headers: Default::default(),
+        user_metadata: Default::default(),
+    };
+    let receipts = client
+        .put_object_stream(
+            stream::iter((0..FILES).map(|index| Ok(make_input(index, "base")))),
+            BulkWriteOptions::default(),
+        )
+        .await
+        .unwrap();
+    client.advance_branch_indexes().await.unwrap();
+    let baseline = receipts.last().unwrap().id;
+
+    let sample = (0..100)
+        .map(|index| index * (FILES / 100))
+        .collect::<Vec<_>>();
+    for index in &sample {
+        client
+            .get_object(format!("scale/{index:05}.txt"))
+            .await
+            .unwrap()
+            .unwrap();
+    }
+    client.reset_s3_operation_metrics();
+    let read_started = std::time::Instant::now();
+    let mut read_latencies = stream::iter(sample)
+        .map(|index| {
+            let client = client.clone();
+            async move {
+                let started = std::time::Instant::now();
+                client
+                    .get_object(format!("scale/{index:05}.txt"))
+                    .await
+                    .unwrap()
+                    .unwrap();
+                started.elapsed()
+            }
+        })
+        .buffer_unordered(32)
+        .collect::<Vec<_>>()
+        .await;
+    read_latencies.sort_unstable();
+    let read_p99 = read_latencies[(read_latencies.len() * 99).div_ceil(100) - 1];
+    let read_metrics = client.reset_s3_operation_metrics();
+    eprintln!(
+        "RUSTFS_20K_READ wall_ms={:.2} p99_ms={:.2} downloaded_bytes={} bytes_per_read={:.2} s3_calls={}",
+        read_started.elapsed().as_secs_f64() * 1_000.0,
+        read_p99.as_secs_f64() * 1_000.0,
+        read_metrics.downloaded_body_bytes,
+        read_metrics.downloaded_body_bytes as f64 / 100.0,
+        read_metrics.total_calls(),
+    );
+    assert!(read_p99 < Duration::from_millis(100));
+    assert!(read_metrics.downloaded_body_bytes < 4 * 1024 * 1024);
+
+    client.reset_s3_operation_metrics();
+    let list_started = std::time::Instant::now();
+    let listed = client
+        .stream_objects("scale/", 1_000)
+        .collect::<Vec<_>>()
+        .await;
+    assert_eq!(listed.len(), FILES);
+    assert!(listed.iter().all(Result::is_ok));
+    let list_elapsed = list_started.elapsed();
+    let list_throughput = FILES as f64 / list_elapsed.as_secs_f64();
+    let list_metrics = client.reset_s3_operation_metrics();
+    eprintln!(
+        "RUSTFS_20K_LIST wall_ms={:.2} entries_per_second={list_throughput:.2} downloaded_bytes={} s3_calls={} put_calls={}",
+        list_elapsed.as_secs_f64() * 1_000.0,
+        list_metrics.downloaded_body_bytes,
+        list_metrics.total_calls(),
+        list_metrics.put_object,
+    );
+    assert!(list_throughput > 10_000.0);
+    assert_eq!(list_metrics.put_object, 0);
+
+    client.reset_s3_operation_metrics();
+    let branch_started = std::time::Instant::now();
+    client
+        .create_branch("feature", Some(baseline))
+        .await
+        .unwrap();
+    let branch_elapsed = branch_started.elapsed();
+    let branch_metrics = client.reset_s3_operation_metrics();
+    eprintln!(
+        "RUSTFS_20K_BRANCH wall_ms={:.2} downloaded_bytes={} s3_calls={}",
+        branch_elapsed.as_secs_f64() * 1_000.0,
+        branch_metrics.downloaded_body_bytes,
+        branch_metrics.total_calls(),
+    );
+    assert!(branch_elapsed < Duration::from_millis(500));
+    assert!(branch_metrics.downloaded_body_bytes < 512 * 1024);
+
+    let feature = client.checkout("feature").await.unwrap();
+    client
+        .put_object_stream(
+            stream::iter((0..CHANGES).map(|index| Ok(make_input(index, "main")))),
+            BulkWriteOptions::default(),
+        )
+        .await
+        .unwrap();
+    client.advance_branch_indexes().await.unwrap();
+    let main_head = client.head().await.unwrap();
+    feature
+        .put_object_stream(
+            stream::iter((CHANGES..CHANGES * 2).map(|index| Ok(make_input(index, "feature")))),
+            BulkWriteOptions::default(),
+        )
+        .await
+        .unwrap();
+    feature.advance_branch_indexes().await.unwrap();
+    let feature_head = feature.head().await.unwrap();
+
+    for (label, checkout, head) in [
+        ("main", &client, main_head),
+        ("feature", &feature, feature_head),
+    ] {
+        checkout.reset_s3_operation_metrics();
+        let started = std::time::Instant::now();
+        let page = checkout
+            .diff_bounded(baseline, head, None, 1_000)
+            .await
+            .unwrap();
+        let elapsed = started.elapsed();
+        let metrics = checkout.reset_s3_operation_metrics();
+        eprintln!(
+            "RUSTFS_20K_DIFF branch={label} wall_ms={:.2} changes={} compared_nodes={} reused_subtrees={} downloaded_bytes={} s3_calls={}",
+            elapsed.as_secs_f64() * 1_000.0,
+            page.changes.len(), page.compared_nodes, page.reused_subtrees,
+            metrics.downloaded_body_bytes, metrics.total_calls(),
+        );
+        assert_eq!(page.changes.len(), CHANGES);
+        assert!(page.continuation.is_none());
+        assert!(elapsed < Duration::from_millis(500));
+        assert!(metrics.downloaded_body_bytes < 1024 * 1024);
+    }
+
+    client.reset_s3_operation_metrics();
+    let plan_started = std::time::Instant::now();
+    let mut merge = client
+        .start_merge("feature", None, MergePolicy::Fail, "20K sparse merge")
+        .await
+        .unwrap();
+    let start_metrics = client.reset_s3_operation_metrics();
+    let mut plan_downloaded = start_metrics.downloaded_body_bytes;
+    let mut plan_calls = start_metrics.total_calls();
+    eprintln!(
+        "RUSTFS_20K_MERGE_STEP step=start phase={:?} downloaded_bytes={} s3_calls={}",
+        merge.phase,
+        start_metrics.downloaded_body_bytes,
+        start_metrics.total_calls(),
+    );
+    let mut processed = 0_usize;
+    let mut pages = 0_usize;
+    while merge.phase != MergePhase::ReadyToPublish {
+        let before = merge.phase;
+        let cache_before = client.node_cache_snapshot();
+        let page = client.advance_merge(&merge, 256).await.unwrap();
+        let cache_after = client.node_cache_snapshot();
+        let step_metrics = client.reset_s3_operation_metrics();
+        plan_downloaded = plan_downloaded.saturating_add(step_metrics.downloaded_body_bytes);
+        plan_calls = plan_calls.saturating_add(step_metrics.total_calls());
+        eprintln!(
+            "RUSTFS_20K_MERGE_STEP step=advance before={before:?} after={:?} processed={} downloaded_bytes={} node_fetched_bytes={} node_avoided_bytes={} ranged_fetches={} s3_calls={}",
+            page.cursor.phase, page.processed,
+            step_metrics.downloaded_body_bytes,
+            cache_after.fetched_bytes.saturating_sub(cache_before.fetched_bytes),
+            cache_after.avoided_bytes.saturating_sub(cache_before.avoided_bytes),
+            cache_after.ranged_fetches.saturating_sub(cache_before.ranged_fetches),
+            step_metrics.total_calls(),
+        );
+        processed += page.processed;
+        pages += 1;
+        merge = page.cursor;
+    }
+    let plan_elapsed = plan_started.elapsed();
+    eprintln!(
+        "RUSTFS_20K_MERGE_PLAN wall_ms={:.2} pages={pages} processed={processed} changes={} conflicts={} downloaded_bytes={} s3_calls={}",
+        plan_elapsed.as_secs_f64() * 1_000.0,
+        merge.planned_changes, merge.conflicts,
+        plan_downloaded, plan_calls,
+    );
+    assert_eq!(merge.planned_changes, CHANGES as u64);
+    assert_eq!(merge.conflicts, 0);
+    assert!(plan_elapsed < Duration::from_secs(1));
+    assert!(plan_downloaded < 2 * 1024 * 1024);
+
+    client.reset_s3_operation_metrics();
+    let publish_started = std::time::Instant::now();
+    let merged = client.publish_merge(&merge).await.unwrap();
+    let publish_elapsed = publish_started.elapsed();
+    let publish_metrics = client.reset_s3_operation_metrics();
+    eprintln!(
+        "RUSTFS_20K_MERGE_PUBLISH wall_ms={:.2} changes={} downloaded_bytes={} s3_calls={}",
+        publish_elapsed.as_secs_f64() * 1_000.0,
+        merged.changed_keys,
+        publish_metrics.downloaded_body_bytes,
+        publish_metrics.total_calls(),
+    );
+    assert_eq!(merged.changed_keys, CHANGES as u64);
+    assert!(publish_elapsed < Duration::from_millis(250));
+    assert_eq!(
+        client
+            .get_object(format!("scale/{CHANGES:05}.txt"))
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        make_input(CHANGES, "feature").bytes,
+    );
+}
+
 /// Reproducible release gate for the same-branch publication lane.
 ///
 /// This is intentionally ignored because it creates exactly 10,000 commits

--- a/extensions/s3/core/src/journal_indexes.rs
+++ b/extensions/s3/core/src/journal_indexes.rs
@@ -4,14 +4,14 @@ use prolly::{AsyncProlly, Config, Mutation, RuntimeConfig, Tree, TreeFormat};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    decode_canonical, encode_canonical, tree_format_digest, CommitId, CommitObject,
+    decode_canonical, encode_canonical, tree_format_digest, BucketCommit, CommitId,
     CompareExchange, CompareExchangeOutcome, DeleteOutcome, Error, ErrorCode, GetRequest,
     ImmutablePut, ImmutablePutOutcome, JournalCommitGraphEntry, JournalDerivedIndexHead,
     JournalIndexRebuildChunk, JournalIndexRebuildChunkId, JournalNodeIndexEntry, ListRequest,
-    MemoryNodeCache, MutableControlStore, NodeCache, ObjectPath, ObjectPlane, OperationId,
-    PhysicalVersion, ProllyObjectStore, PublicationEventId, PublicationJournalCursor,
-    RefGeneration, RepositoryId, Result, RetryAdvice, RootManifest, ShardedBranchPublisher,
-    StorageToken, DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,
+    LoadedRef, MemoryNodeCache, MutableControlStore, NodeCache, NodePackToc, ObjectPath,
+    ObjectPlane, OperationId, PhysicalVersion, ProllyObjectStore, PublicationEventId,
+    PublicationJournalCursor, RefGeneration, RepositoryId, Result, RetryAdvice, RootManifest,
+    ShardedBranchPublisher, StorageToken, DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,
 };
 
 pub const DEFAULT_JOURNAL_INDEX_MAX_UNINDEXED_EVENTS: usize = 4_096;
@@ -285,15 +285,17 @@ impl<P: ObjectPlane> JournalDerivedIndexes<P> {
             {
                 continue;
             }
-            let object = publisher.load_commit_object(event.new_target).await?;
+            let object = publisher.load_commit_index(event.new_target).await?;
             self.index_node_pack(
                 &mut node_tree,
                 event.new_target,
-                &object,
+                object.commit.node_pack.as_ref().map(|pack| pack.id),
+                object.toc.as_ref(),
+                object.payload_offset,
                 &mut indexed_nodes,
             )
             .await?;
-            self.index_commit_graph(&mut graph_tree, event.new_target, object)
+            self.index_commit_graph(&mut graph_tree, event.new_target, object.commit)
                 .await?;
             indexed_commits += 1;
         }
@@ -394,6 +396,86 @@ impl<P: ObjectPlane> JournalDerivedIndexes<P> {
             indexed_nodes,
             initialized,
         })
+    }
+
+    /// Initialize a newly created branch by reusing immutable repository-wide
+    /// node-location and commit-graph roots from the source branch. The roots
+    /// are safe supersets: entries are content-addressed and never encode
+    /// branch-local authority.
+    pub async fn initialize_branch_from(
+        &self,
+        source_branch: &str,
+        branch: &str,
+        reference: &LoadedRef,
+        now_millis: u64,
+    ) -> Result<()> {
+        crate::repository::validate_branch(source_branch)?;
+        crate::repository::validate_branch(branch)?;
+        let source = self
+            .require_branch_covers(source_branch, reference.value.target)
+            .await?;
+        let digest = tree_format_digest(&self.format)?;
+        let next = JournalDerivedIndexHead {
+            repository: self.repository,
+            branch: branch.to_string(),
+            checkpoint: reference.value.publication,
+            checkpoint_generation: reference.value.generation,
+            target: reference.value.target,
+            node_root: source.node_root,
+            commit_graph_root: source.commit_graph_root,
+            generation: 0,
+            indexed_publications: 1,
+            indexed_commits: source.indexed_commits,
+            updated_at_millis: now_millis,
+        };
+        next.validate(self.repository, branch, digest)?;
+        let bytes = encode_canonical(&next)?;
+        let path = self.head_path(branch)?;
+        match self
+            .controls
+            .compare_exchange(CompareExchange {
+                path,
+                expected: None,
+                bytes: bytes.clone(),
+            })
+            .await?
+        {
+            CompareExchangeOutcome::Applied(_) => Ok(()),
+            CompareExchangeOutcome::Conflict(Some(current)) if current.bytes == bytes => Ok(()),
+            CompareExchangeOutcome::Conflict(_) => Err(Error::new(
+                ErrorCode::RefConflict,
+                "new branch derived indexes were initialized concurrently",
+            )),
+        }
+    }
+
+    /// Return the source branch's immutable derived roots only when they cover
+    /// `target`. Callers use this preflight before publishing a new branch ref.
+    pub async fn require_branch_covers(
+        &self,
+        source_branch: &str,
+        target: CommitId,
+    ) -> Result<JournalDerivedIndexHead> {
+        crate::repository::validate_branch(source_branch)?;
+        let source = self.load_head(source_branch).await?.ok_or_else(|| {
+            Error::new(
+                ErrorCode::PreconditionFailed,
+                "source branch derived indexes are not initialized",
+            )
+        })?;
+        let graph = self.tree_from_root(&source.value.commit_graph_root);
+        if self
+            .graph_engine
+            .get(&graph, target.as_bytes())
+            .await?
+            .is_none()
+        {
+            return Err(Error::new(
+                ErrorCode::PreconditionFailed,
+                "source branch indexes do not cover the requested branch point",
+            ));
+        }
+        Ok(source.value)
     }
 
     pub async fn start_rebuild(
@@ -561,15 +643,17 @@ impl<P: ObjectPlane> JournalDerivedIndexes<P> {
             {
                 continue;
             }
-            let object = publisher.load_commit_object(event.new_target).await?;
+            let object = publisher.load_commit_index(event.new_target).await?;
             self.index_node_pack(
                 &mut node_tree,
                 event.new_target,
-                &object,
+                object.commit.node_pack.as_ref().map(|pack| pack.id),
+                object.toc.as_ref(),
+                object.payload_offset,
                 &mut indexed_nodes,
             )
             .await?;
-            self.index_commit_graph(&mut graph_tree, event.new_target, object)
+            self.index_commit_graph(&mut graph_tree, event.new_target, object.commit)
                 .await?;
             indexed_commits += 1;
         }
@@ -959,22 +1043,28 @@ impl<P: ObjectPlane> JournalDerivedIndexes<P> {
         &self,
         tree: &mut Tree,
         commit: CommitId,
-        object: &CommitObject,
+        pack_id: Option<crate::NodePackId>,
+        toc: Option<&NodePackToc>,
+        payload_offset: Option<u64>,
         indexed_nodes: &mut usize,
     ) -> Result<()> {
-        let Some(pack) = object.node_pack.as_ref() else {
+        let Some(toc) = toc else {
             return Ok(());
         };
-        let encoded = object.encode_object()?;
-        let payload_offset = CommitObject::node_payload_offset(&encoded)?.ok_or_else(|| {
+        let pack_id = pack_id.ok_or_else(|| {
+            Error::new(
+                ErrorCode::CorruptCommit,
+                "journal-indexed node pack has no logical reference",
+            )
+        })?;
+        let payload_offset = payload_offset.ok_or_else(|| {
             Error::new(
                 ErrorCode::CorruptCommit,
                 "journal-indexed node pack has no payload offset",
             )
         })?;
-        let pack_id = pack.reference()?.id;
-        let mut mutations = Vec::with_capacity(pack.entries.len());
-        for entry in &pack.entries {
+        let mut mutations = Vec::with_capacity(toc.entries.len());
+        for entry in &toc.entries {
             let absolute_offset = payload_offset.checked_add(entry.offset).ok_or_else(|| {
                 Error::new(ErrorCode::CorruptNode, "journal node offset overflow")
             })?;
@@ -1003,10 +1093,10 @@ impl<P: ObjectPlane> JournalDerivedIndexes<P> {
         &self,
         tree: &mut Tree,
         id: CommitId,
-        object: CommitObject,
+        commit: BucketCommit,
     ) -> Result<()> {
         let mut jumps = Vec::new();
-        if let Some(first_parent) = object.commit.parents.first().copied() {
+        if let Some(first_parent) = commit.parents.first().copied() {
             jumps.push(first_parent);
             for level in 1..64usize {
                 let ancestor = jumps[level - 1];
@@ -1022,8 +1112,8 @@ impl<P: ObjectPlane> JournalDerivedIndexes<P> {
         }
         let entry = JournalCommitGraphEntry {
             commit: id,
-            generation: object.commit.generation,
-            parents: object.commit.parents,
+            generation: commit.generation,
+            parents: commit.parents,
             first_parent_jumps: jumps,
         };
         *tree = self

--- a/extensions/s3/core/src/model.rs
+++ b/extensions/s3/core/src/model.rs
@@ -721,6 +721,20 @@ impl CommitGraphHead {
 }
 
 impl NodePack {
+    pub(crate) const fn object_header_len() -> usize {
+        12
+    }
+
+    pub(crate) fn toc_len_from_header(header: &[u8]) -> Result<usize> {
+        if header.len() != Self::object_header_len() || &header[..8] != NODE_PACK_MAGIC {
+            return Err(Error::new(
+                ErrorCode::CorruptNode,
+                "node pack has an invalid wire header",
+            ));
+        }
+        Ok(u32::from_be_bytes(header[8..12].try_into().expect("fixed range")) as usize)
+    }
+
     /// Encode a range-readable pack: fixed magic and header length, canonical
     /// CBOR table of contents, then the raw concatenated payload.
     pub fn encode_object(&self) -> Result<Vec<u8>> {
@@ -1419,6 +1433,13 @@ impl CommitObject {
             ));
         }
         Ok(u32::from_be_bytes(header[8..12].try_into().expect("fixed range")) as usize)
+    }
+
+    pub(crate) fn pack_len_from_header(header: &[u8]) -> Result<u64> {
+        Self::commit_len_from_header(header)?;
+        Ok(u64::from_be_bytes(
+            header[12..20].try_into().expect("fixed range"),
+        ))
     }
 
     pub(crate) fn decode_commit_metadata(encoded: &[u8]) -> Result<BucketCommit> {

--- a/extensions/s3/core/src/publication.rs
+++ b/extensions/s3/core/src/publication.rs
@@ -5,16 +5,24 @@ use serde::{Deserialize, Serialize};
 use crate::{
     encode_canonical, AuthorityPermit, AuthorityScope, BranchRefBarrier, BucketCommit, CommitId,
     CommitObject, CompareExchange, CompareExchangeOutcome, Error, ErrorCode, GetRequest,
-    ImmutablePut, MutableControlObserver, MutableControlStore, NodePack, ObjectPath, ObjectPlane,
-    OperationId, PendingAuthority, PublicationEvent, PublicationEventId, RefGeneration, RefValue,
-    ReflogEntry, RepositoryId, Result, RetryAdvice, ShardWriterAuthority, StorageToken,
-    DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,
+    ImmutablePut, MutableControlObserver, MutableControlStore, NodePack, NodePackToc, ObjectPath,
+    ObjectPlane, OperationId, PendingAuthority, PublicationEvent, PublicationEventId,
+    RefGeneration, RefValue, ReflogEntry, RepositoryId, Result, RetryAdvice, ShardWriterAuthority,
+    StorageToken, DEFAULT_MUTABLE_CONTROL_VERSIONS_TO_RETAIN,
 };
 
 #[derive(Clone, Debug)]
 pub struct LoadedRef {
     pub value: RefValue,
     pub token: StorageToken,
+}
+
+/// Commit data needed by derived indexes without downloading the immutable
+/// node-pack payload. Every node remains independently CID-verified when read.
+pub(crate) struct CommitIndexView {
+    pub(crate) commit: BucketCommit,
+    pub(crate) toc: Option<NodePackToc>,
+    pub(crate) payload_offset: Option<u64>,
 }
 
 #[derive(Clone, Debug)]
@@ -198,7 +206,7 @@ impl<P: ObjectPlane> ShardedBranchPublisher<P> {
                 name: branch.to_string(),
             },
         )?;
-        self.load_commit_object(target).await?;
+        self.load_commit(target).await?;
         let existing = match self.load_including_tombstone(branch).await {
             Ok(existing) if !existing.value.tombstone => {
                 return Err(Error::new(ErrorCode::RefConflict, "branch already exists"));
@@ -832,6 +840,121 @@ impl<P: ObjectPlane> ShardedBranchPublisher<P> {
             ));
         }
         Ok(commit)
+    }
+
+    pub(crate) async fn load_commit_index(&self, id: CommitId) -> Result<CommitIndexView> {
+        let path = self.commit_path(id)?;
+        let header_len = CommitObject::commit_object_header_len();
+        let header = self
+            .plane
+            .get(GetRequest {
+                path: path.clone(),
+                range: Some(0..=header_len as u64 - 1),
+                physical_version: None,
+            })
+            .await?
+            .ok_or_else(|| Error::new(ErrorCode::MissingClosure, "parent commit is missing"))?
+            .bytes;
+        let commit_len = CommitObject::commit_len_from_header(&header)?;
+        let pack_len = CommitObject::pack_len_from_header(&header)?;
+        let commit_end = header_len
+            .checked_add(commit_len)
+            .ok_or_else(|| Error::new(ErrorCode::CorruptCommit, "commit length overflow"))?;
+        let body = self
+            .plane
+            .get(GetRequest {
+                path: path.clone(),
+                range: Some(header_len as u64..=commit_end as u64 - 1),
+                physical_version: None,
+            })
+            .await?
+            .ok_or_else(|| Error::new(ErrorCode::MissingClosure, "parent commit is missing"))?
+            .bytes;
+        let mut encoded = header;
+        encoded.extend_from_slice(&body);
+        let commit = CommitObject::decode_commit_metadata(&encoded)?;
+        if commit.id()? != id {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "parent commit ID does not match its path",
+            ));
+        }
+        let Some(expected) = commit.node_pack.as_ref() else {
+            if pack_len != 0 {
+                return Err(Error::new(
+                    ErrorCode::CorruptCommit,
+                    "commit has an unreferenced node pack",
+                ));
+            }
+            return Ok(CommitIndexView {
+                commit,
+                toc: None,
+                payload_offset: None,
+            });
+        };
+        if pack_len != expected.object_len {
+            return Err(Error::new(
+                ErrorCode::CorruptCommit,
+                "commit node-pack length disagrees with its reference",
+            ));
+        }
+        let pack_start = u64::try_from(commit_end)
+            .map_err(|_| Error::new(ErrorCode::CorruptCommit, "commit offset overflow"))?;
+        let pack_header_len = NodePack::object_header_len();
+        let pack_header_end = pack_start
+            .checked_add(pack_header_len as u64)
+            .ok_or_else(|| Error::new(ErrorCode::CorruptNode, "node-pack header overflow"))?;
+        let pack_header = self
+            .plane
+            .get(GetRequest {
+                path: path.clone(),
+                range: Some(pack_start..=pack_header_end - 1),
+                physical_version: None,
+            })
+            .await?
+            .ok_or_else(|| Error::new(ErrorCode::MissingClosure, "commit node pack is missing"))?
+            .bytes;
+        let toc_len = NodePack::toc_len_from_header(&pack_header)?;
+        if toc_len == 0 {
+            return Err(Error::new(
+                ErrorCode::CorruptNode,
+                "node-pack TOC cannot be empty",
+            ));
+        }
+        let toc_start = pack_header_end;
+        let toc_end = toc_start
+            .checked_add(toc_len as u64)
+            .ok_or_else(|| Error::new(ErrorCode::CorruptNode, "node-pack TOC overflow"))?;
+        let toc_bytes = self
+            .plane
+            .get(GetRequest {
+                path,
+                range: Some(toc_start..=toc_end - 1),
+                physical_version: None,
+            })
+            .await?
+            .ok_or_else(|| {
+                Error::new(ErrorCode::MissingClosure, "commit node-pack TOC is missing")
+            })?
+            .bytes;
+        let toc = NodePack::decode_toc(&toc_bytes)?;
+        let encoded_pack_len = (pack_header_len as u64)
+            .checked_add(toc_len as u64)
+            .and_then(|value| value.checked_add(toc.payload_len))
+            .ok_or_else(|| Error::new(ErrorCode::CorruptNode, "node-pack length overflow"))?;
+        if encoded_pack_len != expected.object_len
+            || toc.entries.len() != expected.node_count as usize
+        {
+            return Err(Error::new(
+                ErrorCode::CorruptNode,
+                "node-pack TOC disagrees with its commit reference",
+            ));
+        }
+        Ok(CommitIndexView {
+            commit,
+            toc: Some(toc),
+            payload_offset: Some(toc_end),
+        })
     }
 
     async fn cas_ref(

--- a/extensions/s3/core/src/repository.rs
+++ b/extensions/s3/core/src/repository.rs
@@ -45,6 +45,11 @@ use crate::{
     TakeoverRequest,
 };
 
+/// Keep ordinary commit descriptors small enough for one bounded metadata
+/// range read. Larger transition sets live in the same immutable Prolly node
+/// pack as the state roots and remain content-addressed by the commit.
+const INLINE_COMMIT_DELTA_LIMIT: usize = 128;
+
 #[derive(Clone)]
 pub struct RepositoryOptions {
     pub repository_prefix: String,
@@ -692,6 +697,7 @@ pub struct Repository<P: ObjectPlane> {
     options: RepositoryOptions,
     format: RepositoryFormat,
     node_store: ProllyObjectStore<P>,
+    node_cache: Arc<dyn NodeCache>,
     authority: Arc<ShardWriterAuthority<P>>,
     publisher: ShardedBranchPublisher<P>,
     payloads: ImmutablePayloadStore<P>,
@@ -974,7 +980,7 @@ impl<P: ObjectPlane> Repository<P> {
             options.repository_prefix.clone(),
             format.repository_id,
             format.state_tree_format.clone(),
-            node_cache,
+            node_cache.clone(),
             options.journal_index_max_unindexed_events,
             options.mutable_control_versions_to_retain,
         )?);
@@ -990,6 +996,7 @@ impl<P: ObjectPlane> Repository<P> {
             options,
             format,
             node_store,
+            node_cache,
             authority,
             publisher,
             payloads,
@@ -1075,9 +1082,24 @@ impl<P: ObjectPlane> Repository<P> {
     }
 
     pub async fn create_branch(&self, name: &str, from: CommitId) -> Result<BranchHead> {
+        self.create_branch_from(&self.options.default_branch, name, from)
+            .await
+    }
+
+    pub async fn create_branch_from(
+        &self,
+        source_branch: &str,
+        name: &str,
+        from: CommitId,
+    ) -> Result<BranchHead> {
         crate::repository::validate_branch(name)?;
+        crate::repository::validate_branch(source_branch)?;
+        self.locator.register(source_branch)?;
+        self.advance_branch_indexes(source_branch).await?;
+        self.journal_indexes
+            .require_branch_covers(source_branch, from)
+            .await?;
         let _lane = self.lock_branch(name).await;
-        self.load_commit_object(from).await?;
         let now = self.options.clock.now_millis()?;
         let permit = self.active_permit(name, now).await?;
         let reference = self
@@ -1092,6 +1114,9 @@ impl<P: ObjectPlane> Repository<P> {
             )
             .await?;
         self.locator.register(name)?;
+        self.journal_indexes
+            .initialize_branch_from(source_branch, name, &reference, now)
+            .await?;
         self.advance_branch_indexes(name).await?;
         Ok(BranchHead {
             name: name.to_string(),
@@ -1137,7 +1162,7 @@ impl<P: ObjectPlane> Repository<P> {
     pub async fn create_tag(&self, name: &str, target: CommitId) -> Result<Tag> {
         crate::repository::validate_branch(name)?;
         let _lane = self.lock_branch(&format!("tag:{name}")).await;
-        self.load_commit_object(target).await?;
+        self.load_commit_metadata(target).await?;
         let now = self.options.clock.now_millis()?;
         let permit = self.active_system_permit("tags", now).await?;
         let tag = self
@@ -1856,6 +1881,31 @@ impl<P: ObjectPlane> Repository<P> {
         }
         let objects = engine.batch(&objects, object_mutations).await?;
         let versions = engine.batch(&versions, version_mutations).await?;
+        let (inline_transitions, changes_root, change_count) =
+            if transitions.len() > INLINE_COMMIT_DELTA_LIMIT {
+                let delta = engine.create();
+                let delta = engine
+                    .batch(
+                        &delta,
+                        transitions
+                            .iter()
+                            .map(|transition| {
+                                Ok(Mutation::Upsert {
+                                    key: transition.key.clone(),
+                                    val: encode_canonical(transition)?,
+                                })
+                            })
+                            .collect::<Result<Vec<_>>>()?,
+                    )
+                    .await?;
+                (
+                    Vec::new(),
+                    Some(RootManifest::from_tree(&delta)?),
+                    transitions.len() as u64,
+                )
+            } else {
+                (transitions, None, 0)
+            };
         let prepared = write_store.prepare_node_pack(
             tree_format_digest(&self.format.state_tree_format)?,
             Vec::new(),
@@ -1869,9 +1919,9 @@ impl<P: ObjectPlane> Repository<P> {
             generation,
             delta: BucketDelta {
                 input_digest,
-                changes: transitions,
-                changes_root: None,
-                change_count: 0,
+                changes: inline_transitions,
+                changes_root,
+                change_count,
             },
             node_pack: prepared.as_ref().map(PreparedNodePack::reference),
             authority: permit.stamp(),
@@ -4256,8 +4306,8 @@ impl<P: ObjectPlane> Repository<P> {
         validate_branch(branch)?;
         self.locator.register(branch)?;
         self.require_branch_indexes_ready(branch).await?;
-        let from_commit = self.load_commit_object(from).await?.commit;
-        let to_commit = self.load_commit_object(to).await?.commit;
+        let from_commit = self.load_commit_metadata(from).await?;
+        let to_commit = self.load_commit_metadata(to).await?;
         let from_tree = self.tree_from_root(&from_commit.state.objects)?;
         let to_tree = self.tree_from_root(&to_commit.state.objects)?;
         self.engine(self.node_store.clone())
@@ -4299,8 +4349,8 @@ impl<P: ObjectPlane> Repository<P> {
         }
         self.locator.register(branch)?;
         self.require_branch_indexes_ready(branch).await?;
-        let from_commit = self.load_commit_object(from).await?.commit;
-        let to_commit = self.load_commit_object(to).await?.commit;
+        let from_commit = self.load_commit_metadata(from).await?;
+        let to_commit = self.load_commit_metadata(to).await?;
         let from_tree = self.tree_from_root(&from_commit.state.objects)?;
         let to_tree = self.tree_from_root(&to_commit.state.objects)?;
         let page = self
@@ -4945,8 +4995,8 @@ impl<P: ObjectPlane> Repository<P> {
             ));
         }
         let permit = self.active_permit(&cursor.target_branch, now).await?;
-        let ours = self.load_commit_object(cursor.ours).await?.commit;
-        let theirs = self.load_commit_object(cursor.theirs).await?.commit;
+        let ours = self.load_commit_metadata(cursor.ours).await?;
+        let theirs = self.load_commit_metadata(cursor.theirs).await?;
         let generation = CommitGeneration(
             ours.generation
                 .0
@@ -5453,7 +5503,7 @@ impl<P: ObjectPlane> Repository<P> {
             operation,
             branch: branch.to_string(),
             parents: commit.parents,
-            changed_keys: commit.delta.changes.len() as u64,
+            changed_keys: commit.delta.logical_change_count(),
             object_versions: commit
                 .delta
                 .changes
@@ -6889,12 +6939,15 @@ impl<P: ObjectPlane> Repository<P> {
                 "merge job ID is nil",
             ));
         }
-        Ok(self.engine(ProllyObjectStore::new(
+        Ok(self.engine(ProllyObjectStore::new_cached_direct(
             self.plane.clone(),
             format!(
                 "{}/administration/merge/{job}/plan",
                 self.options.repository_prefix
             ),
+            self.format.repository_id,
+            tree_format_digest(&self.format.state_tree_format)?,
+            self.node_cache.clone(),
         )))
     }
 
@@ -6914,6 +6967,12 @@ impl<P: ObjectPlane> Repository<P> {
     async fn validate_merge_cursor(&self, cursor: &MergeCursor) -> Result<()> {
         crate::repository::validate_branch(&cursor.target_branch)?;
         crate::repository::validate_branch(&cursor.source_branch)?;
+        self.locator.register(&cursor.target_branch)?;
+        self.locator.register(&cursor.source_branch)?;
+        self.require_branch_indexes_ready(&cursor.target_branch)
+            .await?;
+        self.require_branch_indexes_ready(&cursor.source_branch)
+            .await?;
         self.tree_from_merge_root(&cursor.plan_root)?;
         if cursor.repository != self.format.repository_id
             || cursor.job.is_nil()
@@ -7015,11 +7074,11 @@ impl<P: ObjectPlane> Repository<P> {
         {
             return Ok(entry);
         }
-        let commit_object = self.load_commit_object(commit).await?.commit;
+        let commit_object = self.load_commit_metadata(commit).await?;
         Ok(JournalCommitGraphEntry {
             commit,
             generation: commit_object.generation,
-            parents: commit_object.parents,
+            parents: commit_object.parents.clone(),
             first_parent_jumps: Vec::new(),
         })
     }
@@ -7274,9 +7333,9 @@ impl<P: ObjectPlane> Repository<P> {
                 "merge plan has no selected base",
             )
         })?;
-        let base_commit = self.load_commit_object(base).await?.commit;
-        let ours_commit = self.load_commit_object(cursor.ours).await?.commit;
-        let theirs_commit = self.load_commit_object(cursor.theirs).await?.commit;
+        let base_commit = self.load_commit_metadata(base).await?;
+        let ours_commit = self.load_commit_metadata(cursor.ours).await?;
+        let theirs_commit = self.load_commit_metadata(cursor.theirs).await?;
         let base_tree = self.tree_from_root(&base_commit.state.objects)?;
         let ours_tree = self.tree_from_root(&ours_commit.state.objects)?;
         let theirs_tree = self.tree_from_root(&theirs_commit.state.objects)?;
@@ -7285,28 +7344,35 @@ impl<P: ObjectPlane> Repository<P> {
         let mut plan_tree = self.tree_from_merge_root(&cursor.plan_root)?;
         let mut processed = 0usize;
         let mut page_mutations = Vec::new();
+        let mut ours_buffer = VecDeque::new();
+        let mut theirs_buffer = VecDeque::new();
+        if let Some(pending) = cursor.ours_pending.take() {
+            ours_buffer.push_back(pending);
+        }
+        if let Some(pending) = cursor.theirs_pending.take() {
+            theirs_buffer.push_back(pending);
+        }
+        if !cursor.ours_finished {
+            let page = state_engine
+                .structural_diff_page(&base_tree, &ours_tree, cursor.ours_diff.as_ref(), max_steps)
+                .await?;
+            ours_buffer.extend(page.diffs);
+            cursor.ours_diff = page.next_cursor;
+        }
+        if !cursor.theirs_finished {
+            let page = state_engine
+                .structural_diff_page(
+                    &base_tree,
+                    &theirs_tree,
+                    cursor.theirs_diff.as_ref(),
+                    max_steps,
+                )
+                .await?;
+            theirs_buffer.extend(page.diffs);
+            cursor.theirs_diff = page.next_cursor;
+        }
         while processed < max_steps {
-            if cursor.ours_pending.is_none() && !cursor.ours_finished {
-                let page = state_engine
-                    .structural_diff_page(&base_tree, &ours_tree, cursor.ours_diff.as_ref(), 1)
-                    .await?;
-                cursor.ours_pending = page.diffs.into_iter().next();
-                cursor.ours_diff = page.next_cursor;
-                if cursor.ours_diff.is_none() {
-                    cursor.ours_finished = true;
-                }
-            }
-            if cursor.theirs_pending.is_none() && !cursor.theirs_finished {
-                let page = state_engine
-                    .structural_diff_page(&base_tree, &theirs_tree, cursor.theirs_diff.as_ref(), 1)
-                    .await?;
-                cursor.theirs_pending = page.diffs.into_iter().next();
-                cursor.theirs_diff = page.next_cursor;
-                if cursor.theirs_diff.is_none() {
-                    cursor.theirs_finished = true;
-                }
-            }
-            let key_order = match (&cursor.ours_pending, &cursor.theirs_pending) {
+            let key_order = match (ours_buffer.front(), theirs_buffer.front()) {
                 (None, None) => break,
                 (Some(_), None) => std::cmp::Ordering::Less,
                 (None, Some(_)) => std::cmp::Ordering::Greater,
@@ -7314,24 +7380,18 @@ impl<P: ObjectPlane> Repository<P> {
             };
             let (key, base_value, ours_value, theirs_value) = match key_order {
                 std::cmp::Ordering::Less => {
-                    let ours = cursor.ours_pending.take().expect("matched pending ours");
+                    let ours = ours_buffer.pop_front().expect("matched pending ours");
                     let (key, base, ours) = merge_diff_values(ours);
                     (key, base.clone(), ours, base)
                 }
                 std::cmp::Ordering::Greater => {
-                    let theirs = cursor
-                        .theirs_pending
-                        .take()
-                        .expect("matched pending theirs");
+                    let theirs = theirs_buffer.pop_front().expect("matched pending theirs");
                     let (key, base, theirs) = merge_diff_values(theirs);
                     (key, base.clone(), base, theirs)
                 }
                 std::cmp::Ordering::Equal => {
-                    let ours = cursor.ours_pending.take().expect("matched pending ours");
-                    let theirs = cursor
-                        .theirs_pending
-                        .take()
-                        .expect("matched pending theirs");
+                    let ours = ours_buffer.pop_front().expect("matched pending ours");
+                    let theirs = theirs_buffer.pop_front().expect("matched pending theirs");
                     let (key, ours_base, ours_value) = merge_diff_values(ours);
                     let (theirs_key, theirs_base, theirs_value) = merge_diff_values(theirs);
                     if key != theirs_key || ours_base != theirs_base {
@@ -7394,6 +7454,20 @@ impl<P: ObjectPlane> Repository<P> {
             }
             processed += 1;
         }
+        cursor.ours_diff = structural_cursor_with_pending(
+            cursor.ours_diff.take(),
+            &base_tree,
+            &ours_tree,
+            ours_buffer.into(),
+        );
+        cursor.theirs_diff = structural_cursor_with_pending(
+            cursor.theirs_diff.take(),
+            &base_tree,
+            &theirs_tree,
+            theirs_buffer.into(),
+        );
+        cursor.ours_finished = cursor.ours_diff.is_none();
+        cursor.theirs_finished = cursor.theirs_diff.is_none();
         if !page_mutations.is_empty() {
             plan_tree = plan_engine.batch(&plan_tree, page_mutations).await?;
             cursor.plan_root = RootManifest::from_tree(&plan_tree)?;
@@ -7406,8 +7480,8 @@ impl<P: ObjectPlane> Repository<P> {
             if cursor.policy == MergePolicy::Fail && cursor.conflicts != 0 {
                 cursor.phase = MergePhase::Conflicted;
             } else {
-                cursor.final_objects = Some(ours_commit.state.objects);
-                cursor.final_versions = Some(ours_commit.state.versions);
+                cursor.final_objects = Some(ours_commit.state.objects.clone());
+                cursor.final_versions = Some(ours_commit.state.versions.clone());
                 let empty_delta = self.merge_state_engine().create();
                 cursor.delta_root = Some(RootManifest::from_tree(&empty_delta)?);
                 cursor.phase = MergePhase::BuildingVersions;
@@ -7421,8 +7495,8 @@ impl<P: ObjectPlane> Repository<P> {
         cursor: &mut MergeCursor,
         max_steps: usize,
     ) -> Result<usize> {
-        let ours_commit = self.load_commit_object(cursor.ours).await?.commit;
-        let theirs_commit = self.load_commit_object(cursor.theirs).await?.commit;
+        let ours_commit = self.load_commit_metadata(cursor.ours).await?;
+        let theirs_commit = self.load_commit_metadata(cursor.theirs).await?;
         let ours_versions = self.tree_from_root(&ours_commit.state.versions)?;
         let theirs_versions = self.tree_from_root(&theirs_commit.state.versions)?;
         let read_engine = self.engine(self.node_store.clone());
@@ -7513,8 +7587,8 @@ impl<P: ObjectPlane> Repository<P> {
             cursor.phase = MergePhase::ReadyToPublish;
             return Ok(0);
         }
-        let ours = self.load_commit_object(cursor.ours).await?.commit;
-        let theirs = self.load_commit_object(cursor.theirs).await?.commit;
+        let ours = self.load_commit_metadata(cursor.ours).await?;
+        let theirs = self.load_commit_metadata(cursor.theirs).await?;
         let generation = CommitGeneration(
             ours.generation
                 .0
@@ -8041,6 +8115,27 @@ fn merge_diff_values(diff: Diff) -> (Vec<u8>, Option<Vec<u8>>, Option<Vec<u8>>) 
         Diff::Removed { key, val } => (key, Some(val), None),
         Diff::Changed { key, old, new } => (key, Some(old), Some(new)),
     }
+}
+
+fn structural_cursor_with_pending(
+    cursor: Option<prolly::StructuralDiffCursor>,
+    base: &Tree,
+    other: &Tree,
+    pending: Vec<Diff>,
+) -> Option<prolly::StructuralDiffCursor> {
+    if pending.is_empty() {
+        return cursor;
+    }
+    let mut cursor = cursor.unwrap_or_else(|| prolly::StructuralDiffCursor {
+        base_root: base.root.clone(),
+        other_root: other.root.clone(),
+        markers: Vec::new(),
+        pending: Vec::new(),
+    });
+    let mut combined = pending;
+    combined.append(&mut cursor.pending);
+    cursor.pending = combined;
+    Some(cursor)
 }
 
 fn object_diff_from_prolly(diff: Diff) -> Result<ObjectDiff> {

--- a/extensions/s3/core/tests/repository.rs
+++ b/extensions/s3/core/tests/repository.rs
@@ -895,6 +895,78 @@ async fn repository_small_object_pack_deduplicates_and_bounds_logical_ranges() {
 }
 
 #[tokio::test]
+async fn large_commit_delta_is_external_and_survives_toc_only_reopen() {
+    let plane = Arc::new(MemoryObjectPlane::new(true));
+    let options = RepositoryOptions {
+        repository_prefix: ".tests/repository-external-delta".to_string(),
+        writer: "external-delta-writer".to_string(),
+        provider_per_key_version_limit: ProviderPerKeyVersionLimit::Finite(10_000),
+        ..RepositoryOptions::default()
+    };
+    let repository = Repository::initialize(plane.clone(), options.clone())
+        .await
+        .unwrap();
+    let base = repository.head("main").await.unwrap();
+    let session = repository
+        .begin_commit_session("main", "external delta", 60_000)
+        .await
+        .unwrap();
+    let staged = repository
+        .stage_commit_session_put_batch(
+            &session,
+            (0..129)
+                .map(|index| {
+                    (
+                        format!("external/{index:03}").into_bytes(),
+                        vec![index as u8],
+                        ObjectHeaders::default(),
+                        BTreeMap::new(),
+                    )
+                })
+                .collect(),
+            8,
+        )
+        .await
+        .unwrap();
+    let receipt = repository
+        .publish_commit_session(session, staged)
+        .await
+        .unwrap();
+    assert_eq!(receipt.changed_keys, 129);
+    let commit = repository.commit(receipt.id).await.unwrap();
+    assert!(commit.delta.changes.is_empty());
+    assert!(commit.delta.changes_root.is_some());
+    assert_eq!(commit.delta.change_count, 129);
+    repository.advance_branch_indexes("main").await.unwrap();
+    drop(repository);
+
+    let reopened = Repository::open(
+        plane,
+        RepositoryOptions {
+            read_only: true,
+            ..options
+        },
+    )
+    .await
+    .unwrap();
+    let page = reopened
+        .diff_page_bounded("main", base, receipt.id, None, 1_000)
+        .await
+        .unwrap();
+    assert_eq!(page.changes.len(), 129);
+    assert!(page.continuation.is_none());
+    assert_eq!(
+        reopened
+            .get_object("main", b"external/128")
+            .await
+            .unwrap()
+            .unwrap()
+            .bytes,
+        vec![128]
+    );
+}
+
+#[tokio::test]
 async fn repository_durable_session_resumes_after_process_authority_reacquisition() {
     let plane = Arc::new(MemoryObjectPlane::new(true));
     let clock = Arc::new(FixedClock::new(70_000));

--- a/extensions/s3/docker-compose.rustfs.yml
+++ b/extensions/s3/docker-compose.rustfs.yml
@@ -15,8 +15,8 @@ services:
       RUSTFS_ADDRESS: 0.0.0.0:9000
       RUSTFS_CONSOLE_ADDRESS: 0.0.0.0:9001
       RUSTFS_CONSOLE_ENABLE: "true"
-      RUSTFS_ACCESS_KEY: ${PROLLY_RUSTFS_ACCESS_KEY:-prolly}
-      RUSTFS_SECRET_KEY: ${PROLLY_RUSTFS_SECRET_KEY:-prolly}
+      RUSTFS_ACCESS_KEY: ${PROLLY_RUSTFS_ACCESS_KEY:-prollyadmin}
+      RUSTFS_SECRET_KEY: ${PROLLY_RUSTFS_SECRET_KEY:-prolly-local-secret-change-me}
       RUSTFS_RPC_SECRET: ${PROLLY_RUSTFS_RPC_SECRET:-prolly-local-rpc-secret-change-me}
       RUSTFS_OBS_LOGGER_LEVEL: ${PROLLY_RUSTFS_LOG_LEVEL:-info}
     volumes:


### PR DESCRIPTION
## Summary

- externalize large commit deltas so commit descriptors stay bounded
- range-fetch compact commit metadata and node-pack tables of contents for index maintenance
- initialize branches by inheriting safe immutable node and commit-graph index roots
- batch sparse structural diff and merge traversal while sharing the foreground node cache
- add an exact 20K RustFS release gate for reads, listing, branch, diff, and merge latency and byte amplification

## Why

Branch creation, sparse diff, and merge already pruned unchanged Prolly subtrees, but still loaded complete commit envelopes and node packs. On the 20K workload that downloaded 46.7 MB to create a branch, about 16 MB for each 100-key sparse diff, and 22.4 MB to plan a merge.

This change keeps descriptors bounded, indexes node locations from TOCs without reading payload sections, reuses immutable derived roots during branch creation, and advances structural frontiers in cached bounded batches. Branch preflight verifies that the source graph covers the requested target before publishing the new ref.

## Results

Final 20K RustFS release run:

- warm point reads: 22.74 ms p99, 1,196 downloaded bytes/read
- full listing: 62,431 entries/s, 24,195 bytes downloaded, zero PUTs
- branch creation: 61.78 ms, 8,034 bytes downloaded
- main sparse diff (100 changes): 8.74 ms, 18,183 bytes downloaded
- feature sparse diff (100 changes): 11.19 ms, 18,175 bytes downloaded
- merge plan (100 changes): 299.70 ms, 23,833 bytes downloaded
- merge publication: 38.28 ms, merged content verified

## Validation

- `cargo fmt --manifest-path extensions/s3/Cargo.toml --all -- --check`
- `cargo clippy --locked --manifest-path extensions/s3/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo test --locked --manifest-path extensions/s3/Cargo.toml --workspace`
- `PROLLY_S3_RUSTFS=1 cargo test --release --locked --manifest-path extensions/s3/Cargo.toml -p prolly-s3-client --test rustfs_repository rustfs_20k_branch_diff_merge_meets_amplification_slos -- --ignored --exact --nocapture`

Existing history, recovery, restartable merge, history transfer, fsck, GC, authority, and protocol suites pass.
