### PR TITLE
Pin detached listings to selected commits

### DIFF
--- a/extensions/s3/API.md
+++ b/extensions/s3/API.md
@@ -98,7 +98,8 @@ the direct representation.
 - `list_objects_delimited` returns objects plus S3-style common prefixes.
 - `list_objects_page` returns a snapshot-bound opaque cursor and resumes with a
   direct tree seek; `stream_objects` lazily consumes those pages with bounded
-  memory.
+  memory. On detached tag or commit checkouts, page one is seeded from that
+  immutable target rather than the branch's current head.
 - `list_object_versions` lists versions for one logical key.
 - `list_versions_prefix` and `list_versions_at` scan version history across a
   logical key prefix.

--- a/extensions/s3/client/README.md
+++ b/extensions/s3/client/README.md
@@ -248,6 +248,23 @@ while let Some(object) = objects.next().await {
 }
 ```
 
+Paged and streamed listings honor the selected revision. For efficient
+historical traversal, detach from the branch handle that contains the commit;
+the clone retains that branch's derived node index as its lookup context:
+
+```rust
+let feature = client.checkout("feature").await?;
+let historical = feature.checkout(commit_id).await?;
+
+let first = historical.list_objects_page("incoming/", None, 1_000).await?;
+assert_eq!(first.snapshot, commit_id);
+
+let mut objects = historical.stream_objects("incoming/", 1_000);
+while let Some(object) = objects.next().await {
+    consume(object?);
+}
+```
+
 `list_objects_page` returns an opaque continuation that seeks directly into the
 same immutable snapshot. A continuation is bound to its repository, branch,
 and prefix and cannot be reused for another query. Hold a retention pin on the

--- a/extensions/s3/client/examples/branch_diff_merge.rs
+++ b/extensions/s3/client/examples/branch_diff_merge.rs
@@ -3,6 +3,7 @@
 mod common;
 
 use common::ExampleResult;
+use futures_util::StreamExt;
 use prolly_s3_client::core::{MergePhase, MergePolicy};
 
 #[tokio::main]
@@ -19,8 +20,16 @@ async fn main() -> ExampleResult {
 
     // Branches publish through independent ref lanes. Here each branch changes
     // a different key, so Fail policy can merge without resolving conflicts.
-    let feature_head = feature
+    feature
         .put_object("features/search.txt", b"enabled\n".to_vec())
+        .await?;
+    let selected_feature = feature
+        .put_object("features/filters.txt", b"enabled\n".to_vec())
+        .await?
+        .id;
+    let historical_feature = feature.checkout(selected_feature).await?;
+    let feature_head = feature
+        .put_object("features/post-snapshot.txt", b"not historical\n".to_vec())
         .await?
         .id;
     let main_head = main
@@ -28,8 +37,46 @@ async fn main() -> ExampleResult {
         .await?
         .id;
 
+    // Detached pagination and streaming remain pinned to the selected commit
+    // even after the source branch advances. The checkout retains `feature`
+    // as its branch-derived node-index context for efficient node resolution.
+    let first_historical_page = historical_feature
+        .list_objects_page("features/", None, 1)
+        .await?;
+    assert_eq!(first_historical_page.snapshot, selected_feature);
+    let second_historical_page = historical_feature
+        .list_objects_page(
+            "features/",
+            first_historical_page.continuation.as_deref(),
+            1,
+        )
+        .await?;
+    let paged_historical = first_historical_page
+        .objects
+        .into_iter()
+        .chain(second_historical_page.objects)
+        .map(|object| object.key)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        paged_historical,
+        vec![
+            b"features/filters.txt".to_vec(),
+            b"features/search.txt".to_vec(),
+        ]
+    );
+    assert!(second_historical_page.continuation.is_none());
+
+    let historical_stream = historical_feature.stream_objects("features/", 1);
+    futures_util::pin_mut!(historical_stream);
+    let mut streamed_historical = Vec::new();
+    while let Some(object) = historical_stream.next().await {
+        streamed_historical.push(object?.key);
+    }
+    assert_eq!(streamed_historical, paged_historical);
+
     let diff = feature.diff_bounded(base, feature_head, None, 100).await?;
     println!("feature_changed_keys={}", diff.changes.len());
+    println!("historical_listed_keys={}", paged_historical.len());
 
     // Merge construction is restartable. Persist the returned cursor after
     // every page for large repositories or long-running merge workers.

--- a/extensions/s3/client/src/client.rs
+++ b/extensions/s3/client/src/client.rs
@@ -1179,6 +1179,9 @@ impl Client {
         }
     }
 
+    /// List one cursor page from the selected revision. Attached checkouts pin
+    /// the current branch head on page one; detached commit and tag checkouts
+    /// pin their immutable target. Continuations cannot cross those revisions.
     pub async fn list_objects_page(
         &self,
         prefix: impl AsRef<str>,
@@ -1186,18 +1189,34 @@ impl Client {
         limit: usize,
     ) -> Result<ListObjectsPage> {
         self.ensure_provider_qualified()?;
-        self.repository
-            .list_objects_page(
-                &self.branch,
-                prefix.as_ref().as_bytes(),
-                continuation,
-                limit,
-            )
-            .await
+        match self.checked_out.target() {
+            Some(snapshot) => {
+                self.repository
+                    .list_objects_page_at(
+                        &self.branch,
+                        snapshot,
+                        prefix.as_ref().as_bytes(),
+                        continuation,
+                        limit,
+                    )
+                    .await
+            }
+            None => {
+                self.repository
+                    .list_objects_page(
+                        &self.branch,
+                        prefix.as_ref().as_bytes(),
+                        continuation,
+                        limit,
+                    )
+                    .await
+            }
+        }
     }
 
-    /// Lazily stream a snapshot-bound prefix listing. The first page captures
-    /// the branch snapshot; subsequent pages seek through its opaque cursor.
+    /// Lazily stream a snapshot-bound prefix listing. An attached checkout
+    /// captures the branch head on its first page; a detached checkout starts
+    /// from its immutable commit. Later pages seek through the opaque cursor.
     pub fn stream_objects(
         &self,
         prefix: impl Into<String>,

--- a/extensions/s3/client/tests/rustfs_repository.rs
+++ b/extensions/s3/client/tests/rustfs_repository.rs
@@ -381,6 +381,100 @@ async fn rustfs_ref_lifecycle_uses_catalog_shards_without_ref_scans() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rustfs_detached_paged_and_streamed_lists_stay_on_the_selected_commit() {
+    if !rustfs_enabled() {
+        eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");
+        return;
+    }
+
+    let (aws, bucket) = rustfs_client().await;
+    let client = Client::builder()
+        .aws_client(aws)
+        .bucket(&bucket)
+        .repository_prefix(unique_name("detached-listing"))
+        .writer("rustfs-detached-list-writer")
+        .provider_identity(provider_identity())
+        .attestation_signer(attestation_signer())
+        .provider_per_key_version_limit(ProviderPerKeyVersionLimit::Finite(10_000))
+        .background_index_maintenance(false)
+        .initialize()
+        .await
+        .unwrap();
+    let base = client.head().await.unwrap();
+    client.create_branch("feature", Some(base)).await.unwrap();
+    let feature = client.checkout("feature").await.unwrap();
+    feature
+        .put_object("docs/a.txt", b"a".to_vec())
+        .await
+        .unwrap();
+    feature
+        .put_object("docs/b.txt", b"b".to_vec())
+        .await
+        .unwrap();
+    let selected = feature
+        .put_object("docs/c.txt", b"c".to_vec())
+        .await
+        .unwrap()
+        .id;
+    feature.advance_branch_indexes().await.unwrap();
+
+    // Checkout clones retain `feature` as the node-index lookup context while
+    // exposing the selected immutable commit as their logical revision.
+    let detached = feature.checkout(selected).await.unwrap();
+    assert_eq!(detached.branch(), None);
+    feature.delete_object("docs/b.txt").await.unwrap();
+    feature
+        .put_object("docs/later.txt", b"later".to_vec())
+        .await
+        .unwrap();
+    feature.advance_branch_indexes().await.unwrap();
+
+    let branch_page = feature.list_objects_page("docs/", None, 10).await.unwrap();
+    assert_ne!(branch_page.snapshot, selected);
+    assert_eq!(
+        branch_page
+            .objects
+            .iter()
+            .map(|object| object.key.as_slice())
+            .collect::<Vec<_>>(),
+        vec![
+            b"docs/a.txt".as_slice(),
+            b"docs/c.txt".as_slice(),
+            b"docs/later.txt".as_slice(),
+        ]
+    );
+
+    let mut continuation = None;
+    let mut paged_keys = Vec::new();
+    loop {
+        let page = detached
+            .list_objects_page("docs/", continuation.as_deref(), 1)
+            .await
+            .unwrap();
+        assert_eq!(page.snapshot, selected);
+        paged_keys.extend(page.objects.into_iter().map(|object| object.key));
+        continuation = page.continuation;
+        if continuation.is_none() {
+            break;
+        }
+    }
+    let historical_keys = vec![
+        b"docs/a.txt".to_vec(),
+        b"docs/b.txt".to_vec(),
+        b"docs/c.txt".to_vec(),
+    ];
+    assert_eq!(paged_keys, historical_keys);
+
+    let streamed = detached.stream_objects("docs/", 1);
+    futures_util::pin_mut!(streamed);
+    let mut streamed_keys = Vec::new();
+    while let Some(object) = streamed.next().await {
+        streamed_keys.push(object.unwrap().key);
+    }
+    assert_eq!(streamed_keys, historical_keys);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn rustfs_commit_session_preserves_n_plus_three_puts() {
     if !rustfs_enabled() {
         eprintln!("set PROLLY_S3_RUSTFS=1 to run RustFS integration tests");

--- a/extensions/s3/core/src/repository.rs
+++ b/extensions/s3/core/src/repository.rs
@@ -2653,6 +2653,39 @@ impl<P: ObjectPlane> Repository<P> {
         continuation: Option<&str>,
         requested_limit: usize,
     ) -> Result<ListObjectsPage> {
+        self.list_objects_page_from_snapshot(branch, None, prefix, continuation, requested_limit)
+            .await
+    }
+
+    /// List an explicit immutable snapshot using the same opaque traversal
+    /// cursor as [`Self::list_objects_page`]. The first page is seeded from
+    /// `snapshot`; every continuation is validated against that commit.
+    pub async fn list_objects_page_at(
+        &self,
+        branch: &str,
+        snapshot: CommitId,
+        prefix: &[u8],
+        continuation: Option<&str>,
+        requested_limit: usize,
+    ) -> Result<ListObjectsPage> {
+        self.list_objects_page_from_snapshot(
+            branch,
+            Some(snapshot),
+            prefix,
+            continuation,
+            requested_limit,
+        )
+        .await
+    }
+
+    async fn list_objects_page_from_snapshot(
+        &self,
+        branch: &str,
+        requested_snapshot: Option<CommitId>,
+        prefix: &[u8],
+        continuation: Option<&str>,
+        requested_limit: usize,
+    ) -> Result<ListObjectsPage> {
         std::str::from_utf8(prefix)
             .map_err(|_| Error::new(ErrorCode::InvalidKey, "list prefix is not UTF-8"))?;
         let limit = requested_limit.min(self.format.canonical_limits.max_list_page as usize);
@@ -2679,10 +2712,11 @@ impl<P: ObjectPlane> Repository<P> {
                 if cursor.repository != self.format.repository_id
                     || cursor.branch != branch
                     || cursor.prefix != prefix
+                    || requested_snapshot.is_some_and(|snapshot| cursor.snapshot != snapshot)
                 {
                     return Err(Error::new(
                         ErrorCode::InvalidContinuationToken,
-                        "list continuation belongs to another repository, branch, or prefix",
+                        "list continuation belongs to another repository, branch, snapshot, or prefix",
                     ));
                 }
                 cursor
@@ -2690,7 +2724,10 @@ impl<P: ObjectPlane> Repository<P> {
             None => ListObjectsCursor {
                 repository: self.format.repository_id,
                 branch: branch.to_string(),
-                snapshot: self.head(branch).await?,
+                snapshot: match requested_snapshot {
+                    Some(snapshot) => snapshot,
+                    None => self.head(branch).await?,
+                },
                 prefix: prefix.to_vec(),
                 traversal: prolly::RangeCursor::start(),
             },

--- a/extensions/s3/core/tests/repository.rs
+++ b/extensions/s3/core/tests/repository.rs
@@ -344,6 +344,29 @@ async fn object_list_cursor_is_snapshot_bound_and_resumes_without_replay() {
         .await
         .unwrap();
 
+    let historical_first = repository
+        .list_objects_page_at("main", snapshot, b"cursor/", None, 100)
+        .await
+        .unwrap();
+    assert_eq!(historical_first.snapshot, snapshot);
+    assert_eq!(historical_first.objects, first.objects);
+
+    let current = repository.head("main").await.unwrap();
+    let error = repository
+        .list_objects_page_at(
+            "main",
+            current,
+            b"cursor/",
+            first.continuation.as_deref(),
+            100,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error.code,
+        prolly_s3_core::ErrorCode::InvalidContinuationToken
+    );
+
     plane.reset_request_counts();
     let second = repository
         .list_objects_page("main", b"cursor/", first.continuation.as_deref(), 100)


### PR DESCRIPTION
## Summary

- seed paged listings on detached tag/commit checkouts from the selected immutable commit
- validate explicit-commit continuations against their repository, branch context, snapshot, and prefix
- make `stream_objects` inherit the same detached snapshot behavior
- retain the checkout source branch as the branch-derived node-index lookup context
- demonstrate the behavior in the runnable branch/diff/merge RustFS example

## Why

`list_objects` already honored detached revisions, but `list_objects_page` always captured the current branch head. Because `stream_objects` consumes that cursor API, large historical listings could silently return newer branch state after checkout.

The core now exposes `list_objects_page_at`, and the client selects it whenever `CheckedOutRef` has an immutable target. Attached branch pagination retains its existing behavior: page one captures the head and subsequent pages remain bound to the cursor snapshot.

## Verification

- Rust 1.94.1 strict Clippy with all targets and features
- full S3 workspace test suite with all features
- required RustFS integration suite: 11 passed, 4 explicit scale gates ignored
- new RustFS regression creates a detached feature commit, advances the branch with a delete and add, and verifies paged and streamed historical keys
- runnable `branch_diff_merge` example passed against RustFS and reported `historical_listed_keys=2`

The regression also verifies the current branch listing sees the new state while the detached listing remains on the selected commit.
