### PR TITLE
perf(proximity): broaden SIMD acceleration and remove reranking copies

### DIFF
--- a/benches/prolly_proximity_bench.rs
+++ b/benches/prolly_proximity_bench.rs
@@ -23,16 +23,50 @@ fn main() {
         env_list("PROLLY_PROXIMITY_BENCH_DIMENSIONS").unwrap_or_else(|| vec![8, 128, 768, 1_536]);
     let threads = env_list("PROLLY_PROXIMITY_BENCH_THREADS").unwrap_or_else(|| vec![1, 2, 4]);
     let scale_only = env_bool("PROLLY_PROXIMITY_BENCH_SCALE_ONLY");
+    let search_repeats = env_usize("PROLLY_PROXIMITY_BENCH_SEARCH_REPEATS")
+        .unwrap_or(1)
+        .max(1);
+    let reset_search_cache = env_bool("PROLLY_PROXIMITY_BENCH_RESET_SEARCH_CACHE");
+    let simd_first = env_bool("PROLLY_PROXIMITY_BENCH_SIMD_FIRST");
     println!("prolly proximity benchmark");
     println!("records={records}");
     println!("profile={}", if scale_only { "scale" } else { "complete" });
+    println!("search_repeats={search_repeats}");
+    println!(
+        "search_cache={}",
+        if reset_search_cache { "reset" } else { "warm" }
+    );
+    println!(
+        "search_order={}",
+        if simd_first {
+            "simd-first"
+        } else {
+            "scalar-first"
+        }
+    );
     println!("operation,dimensions,threads,micros,metric_a,metric_b");
     for dimension in dimensions {
-        bench_case(records, dimension, &threads, scale_only);
+        bench_case(
+            records,
+            dimension,
+            &threads,
+            scale_only,
+            search_repeats,
+            reset_search_cache,
+            simd_first,
+        );
     }
 }
 
-fn bench_case(count: usize, dimensions: usize, threads: &[usize], scale_only: bool) {
+fn bench_case(
+    count: usize,
+    dimensions: usize,
+    threads: &[usize],
+    scale_only: bool,
+    search_repeats: usize,
+    reset_search_cache: bool,
+    simd_first: bool,
+) {
     let records = make_records(count, dimensions);
     for &workers in threads {
         let store = Arc::new(MemStore::new());
@@ -60,34 +94,62 @@ fn bench_case(count: usize, dimensions: usize, threads: &[usize], scale_only: bo
     let query = make_vector(count / 3, dimensions);
     let k = 10.min(count.max(1));
 
-    for (name, policy, kernel) in [
-        (
-            "search_exact_scalar",
-            SearchPolicy::Exact,
-            QueryKernel::ScalarDeterministic,
-        ),
-        (
-            "search_exact_simd",
-            SearchPolicy::Exact,
-            QueryKernel::SimdDeterministic,
-        ),
-        (
-            "search_adaptive_sq8",
-            SearchPolicy::Adaptive(AdaptiveQuality::Balanced),
-            QueryKernel::AutoDeterministic,
-        ),
-    ] {
+    let search_specs = if simd_first {
+        [
+            (
+                "search_exact_simd",
+                SearchPolicy::Exact,
+                QueryKernel::SimdDeterministic,
+            ),
+            (
+                "search_exact_scalar",
+                SearchPolicy::Exact,
+                QueryKernel::ScalarDeterministic,
+            ),
+            (
+                "search_adaptive_sq8",
+                SearchPolicy::Adaptive(AdaptiveQuality::Balanced),
+                QueryKernel::AutoDeterministic,
+            ),
+        ]
+    } else {
+        [
+            (
+                "search_exact_scalar",
+                SearchPolicy::Exact,
+                QueryKernel::ScalarDeterministic,
+            ),
+            (
+                "search_exact_simd",
+                SearchPolicy::Exact,
+                QueryKernel::SimdDeterministic,
+            ),
+            (
+                "search_adaptive_sq8",
+                SearchPolicy::Adaptive(AdaptiveQuality::Balanced),
+                QueryKernel::AutoDeterministic,
+            ),
+        ]
+    };
+    for (name, policy, kernel) in search_specs {
         let mut request = SearchRequest::exact(&query, k);
         request.policy = policy;
         request.kernel = kernel;
         request.filter = ProximityFilter::Prefix(b"record-");
         let started = Instant::now();
-        let result = map.search(request).unwrap();
+        let mut result = None;
+        for _ in 0..search_repeats {
+            if reset_search_cache {
+                map.clear_content_cache().unwrap();
+            }
+            result = Some(map.search(request.clone()).unwrap());
+        }
+        let result = result.expect("search repeats is positive");
         row(
             name,
             dimensions,
             0,
-            started.elapsed(),
+            started.elapsed().div_f64(search_repeats as f64),
             result.stats.nodes_read,
             result.stats.distance_evaluations + result.stats.quantized_distance_evaluations,
         );

--- a/src/prolly/proximity/accelerator/hnsw/search.rs
+++ b/src/prolly/proximity/accelerator/hnsw/search.rs
@@ -12,7 +12,8 @@ use crate::prolly::proximity::{
 };
 use crate::prolly::store::Store;
 use std::cmp::{Ordering, Reverse};
-use std::collections::{BTreeMap, BinaryHeap, HashSet};
+use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 struct Ranked {
@@ -145,7 +146,7 @@ where
         request: &request,
         stats: ProximitySearchStats::default(),
         completion: SearchCompletion::ApproximatePolicySatisfied,
-        loaded: BTreeMap::new(),
+        loaded: HashMap::new(),
         plan: plan.summary(),
     };
 
@@ -271,7 +272,6 @@ where
     let mut candidates = eligible.into_vec();
     candidates.sort();
     let mut reranked = Vec::with_capacity(candidates.len());
-    let mut vector_scratch = vec![0.0f32; map.tree().config.dimensions as usize];
     let mut directory = map.directory_manager().read(&map.tree().directory)?;
     for candidate in candidates {
         if state.distance_exhausted() {
@@ -305,12 +305,12 @@ where
             handle.value()?,
             map.tree().config.dimensions,
         )?;
-        crate::prolly::proximity::ProximityVectorRef::from_encoded(record.vector)
-            .copy_to_slice(&mut vector_scratch)?;
-        let Some(distance) = state.distance(&query, &vector_scratch) else {
+        if state.distance_exhausted() {
             state.completion = SearchCompletion::BudgetExhausted;
             break;
-        };
+        }
+        let distance = record.vector.score(request.kernel, index.metric, &query);
+        state.stats.distance_evaluations += 1;
         state.stats.nodes_read += 1;
         state.stats.bytes_read = state.stats.bytes_read.saturating_add(bytes);
         state.stats.committed_bytes = state.stats.committed_bytes.saturating_add(bytes);
@@ -342,7 +342,7 @@ struct SearchState<'a, S: Store> {
     request: &'a SearchRequest<'a>,
     stats: ProximitySearchStats,
     completion: SearchCompletion,
-    loaded: BTreeMap<Vec<u8>, GraphNode>,
+    loaded: HashMap<Vec<u8>, Arc<GraphNode>>,
     plan: SearchPlanSummary,
 }
 
@@ -351,9 +351,9 @@ where
     S: Store + Clone + Send + Sync,
     S::Error: Send + Sync,
 {
-    fn node(&mut self, key: &[u8]) -> Result<Option<GraphNode>, Error> {
+    fn node(&mut self, key: &[u8]) -> Result<Option<Arc<GraphNode>>, Error> {
         if let Some(node) = self.loaded.get(key) {
-            return Ok(Some(node.clone()));
+            return Ok(Some(Arc::clone(node)));
         }
         if self
             .request
@@ -405,7 +405,8 @@ where
         self.stats.nodes_read += 1;
         self.stats.bytes_read += bytes.len();
         self.stats.committed_bytes += bytes.len();
-        self.loaded.insert(key.to_vec(), node.clone());
+        let node = Arc::new(node);
+        self.loaded.insert(key.to_vec(), Arc::clone(&node));
         Ok(Some(node))
     }
 

--- a/src/prolly/proximity/accelerator/pq.rs
+++ b/src/prolly/proximity/accelerator/pq.rs
@@ -3,7 +3,7 @@ use crate::prolly::cid::Cid;
 use crate::prolly::config::Config;
 use crate::prolly::encoding::Encoding;
 use crate::prolly::error::Error;
-use crate::prolly::proximity::distance::{prepare_vector, query_score};
+use crate::prolly::proximity::distance::prepare_vector;
 use crate::prolly::proximity::search::{
     retained_candidate_bytes, EligibilityCardinality, PreparedFilter, RerankCandidate,
 };
@@ -585,7 +585,6 @@ where
         let shortlist = approximate.len();
 
         let mut reranked = Vec::<RerankCandidate>::with_capacity(shortlist);
-        let mut vector_scratch = vec![0.0f32; map.tree().config.dimensions as usize];
         let mut directory = map.directory_manager().read(&map.tree().directory)?;
         for candidate in approximate {
             if budget_exhausted(&request, &stats)
@@ -615,9 +614,7 @@ where
                 handle.value()?,
                 map.tree().config.dimensions,
             )?;
-            crate::prolly::proximity::ProximityVectorRef::from_encoded(record.vector)
-                .copy_to_slice(&mut vector_scratch)?;
-            let distance = query_score(request.kernel, self.metric, &query, &vector_scratch);
+            let distance = record.vector.score(request.kernel, self.metric, &query);
             stats.nodes_read += 1;
             stats.bytes_read = stats.bytes_read.saturating_add(bytes);
             stats.committed_bytes = stats.committed_bytes.saturating_add(bytes);

--- a/src/prolly/proximity/distance/mod.rs
+++ b/src/prolly/proximity/distance/mod.rs
@@ -1,9 +1,11 @@
 pub(crate) mod canonical;
+mod quantized;
 mod scalar;
 mod simd;
 
 pub(crate) use canonical::euclidean_radius_up;
+pub(crate) use quantized::score as score_quantized;
 pub(crate) use scalar::{prepare_vector, score};
-pub(crate) use simd::query_score;
 #[cfg(test)]
 pub(crate) use simd::{query_kernel_calls, reset_query_kernel_calls};
+pub(crate) use simd::{query_score, query_score_encoded};

--- a/src/prolly/proximity/distance/quantized.rs
+++ b/src/prolly/proximity/distance/quantized.rs
@@ -1,0 +1,364 @@
+use crate::prolly::proximity::DistanceMetric;
+use std::sync::OnceLock;
+
+const PRODUCT_SLOTS: usize = 64;
+
+type FillQuantized = unsafe fn(&[f32], &[i8], f64, &mut [f64]);
+
+static FILL_L2: OnceLock<Option<FillQuantized>> = OnceLock::new();
+static FILL_DOT: OnceLock<Option<FillQuantized>> = OnceLock::new();
+
+/// Score one scalar-quantized vector while preserving the canonical scalar
+/// f64 reduction order. Target-specific code only computes independent
+/// per-component products; the final reduction remains sequential.
+pub(crate) fn score(
+    metric: DistanceMetric,
+    query: &[f32],
+    values: &[i8],
+    scales: &[f32],
+    group_size: usize,
+) -> f64 {
+    debug_assert_eq!(query.len(), values.len());
+    debug_assert!(group_size > 0);
+    debug_assert_eq!(scales.len(), query.len().div_ceil(group_size));
+
+    let fill = match metric {
+        DistanceMetric::L2Squared => *FILL_L2.get_or_init(detect_fill::<true>),
+        DistanceMetric::Cosine | DistanceMetric::InnerProduct => {
+            *FILL_DOT.get_or_init(detect_fill::<false>)
+        }
+    };
+    let mut products = [0.0f64; PRODUCT_SLOTS];
+    let mut reduced = 0.0f64;
+    let mut group_start = 0usize;
+    while group_start < query.len() {
+        let group = group_start / group_size;
+        let group_end = group_start.saturating_add(group_size).min(query.len());
+        let scale = f64::from(scales[group]);
+        let mut index = group_start;
+        while index < group_end {
+            let end = index.saturating_add(PRODUCT_SLOTS).min(group_end);
+            let output = &mut products[..end - index];
+            if let Some(fill) = fill {
+                // SAFETY: the function pointer is selected only after its
+                // target feature is detected, and all slices are bounded by
+                // the validated vector length.
+                unsafe { fill(&query[index..end], &values[index..end], scale, output) };
+            } else {
+                match metric {
+                    DistanceMetric::L2Squared => {
+                        fill_tail::<true>(&query[index..end], &values[index..end], scale, output)
+                    }
+                    DistanceMetric::Cosine | DistanceMetric::InnerProduct => {
+                        fill_tail::<false>(&query[index..end], &values[index..end], scale, output)
+                    }
+                }
+            }
+            for &product in output.iter() {
+                reduced += product;
+            }
+            index = end;
+        }
+        group_start = group_end;
+    }
+
+    let result = match metric {
+        DistanceMetric::L2Squared => reduced,
+        DistanceMetric::Cosine => 1.0 - reduced.clamp(-1.0, 1.0),
+        DistanceMetric::InnerProduct => -reduced,
+    };
+    if result == 0.0 {
+        0.0
+    } else {
+        result
+    }
+}
+
+fn detect_fill<const L2: bool>() -> Option<FillQuantized> {
+    #[cfg(all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_endian = "little"
+    ))]
+    {
+        if std::arch::is_x86_feature_detected!("avx512f")
+            && std::arch::is_x86_feature_detected!("avx2")
+        {
+            return Some(fill_x86_avx512::<L2>);
+        }
+        if std::arch::is_x86_feature_detected!("avx2") {
+            return Some(fill_x86_avx2::<L2>);
+        }
+    }
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    {
+        return Some(fill_aarch64_neon::<L2>);
+    }
+    #[allow(unreachable_code)]
+    None
+}
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_endian = "little"
+))]
+#[target_feature(enable = "avx2")]
+unsafe fn fill_x86_avx2<const L2: bool>(
+    query: &[f32],
+    values: &[i8],
+    scale: f64,
+    output: &mut [f64],
+) {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86::*;
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::*;
+
+    let scalar_scale = scale;
+    let scale = _mm256_set1_pd(scale);
+    let mut index = 0usize;
+    while index + 8 <= query.len() {
+        let query_low = _mm256_cvtps_pd(_mm_loadu_ps(query.as_ptr().add(index)));
+        let query_high = _mm256_cvtps_pd(_mm_loadu_ps(query.as_ptr().add(index + 4)));
+        let ints = _mm256_cvtepi8_epi32(_mm_loadl_epi64(
+            values.as_ptr().add(index).cast::<__m128i>(),
+        ));
+        let values_low = _mm256_cvtepi32_pd(_mm256_castsi256_si128(ints));
+        let values_high = _mm256_cvtepi32_pd(_mm256_extracti128_si256(ints, 1));
+        let reconstructed_low = _mm256_mul_pd(values_low, scale);
+        let reconstructed_high = _mm256_mul_pd(values_high, scale);
+        let product_low = if L2 {
+            let delta = _mm256_sub_pd(query_low, reconstructed_low);
+            _mm256_mul_pd(delta, delta)
+        } else {
+            _mm256_mul_pd(query_low, reconstructed_low)
+        };
+        let product_high = if L2 {
+            let delta = _mm256_sub_pd(query_high, reconstructed_high);
+            _mm256_mul_pd(delta, delta)
+        } else {
+            _mm256_mul_pd(query_high, reconstructed_high)
+        };
+        _mm256_storeu_pd(output.as_mut_ptr().add(index), product_low);
+        _mm256_storeu_pd(output.as_mut_ptr().add(index + 4), product_high);
+        index += 8;
+    }
+    fill_tail::<L2>(
+        &query[index..],
+        &values[index..],
+        scalar_scale,
+        &mut output[index..],
+    );
+}
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_endian = "little"
+))]
+#[target_feature(enable = "avx2,avx512f")]
+unsafe fn fill_x86_avx512<const L2: bool>(
+    query: &[f32],
+    values: &[i8],
+    scale: f64,
+    output: &mut [f64],
+) {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86::*;
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::*;
+
+    let scalar_scale = scale;
+    let scale = _mm512_set1_pd(scale);
+    let mut index = 0usize;
+    while index + 8 <= query.len() {
+        let query_f64 = _mm512_cvtps_pd(_mm256_loadu_ps(query.as_ptr().add(index)));
+        let ints = _mm256_cvtepi8_epi32(_mm_loadl_epi64(
+            values.as_ptr().add(index).cast::<__m128i>(),
+        ));
+        // Every i8 is exactly representable as f32, so this conversion keeps
+        // the same exact value as the scalar i8 -> f64 conversion.
+        let values_f64 = _mm512_cvtps_pd(_mm256_cvtepi32_ps(ints));
+        let reconstructed = _mm512_mul_pd(values_f64, scale);
+        let product = if L2 {
+            let delta = _mm512_sub_pd(query_f64, reconstructed);
+            _mm512_mul_pd(delta, delta)
+        } else {
+            _mm512_mul_pd(query_f64, reconstructed)
+        };
+        _mm512_storeu_pd(output.as_mut_ptr().add(index), product);
+        index += 8;
+    }
+    fill_tail::<L2>(
+        &query[index..],
+        &values[index..],
+        scalar_scale,
+        &mut output[index..],
+    );
+}
+
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+#[target_feature(enable = "neon")]
+unsafe fn fill_aarch64_neon<const L2: bool>(
+    query: &[f32],
+    values: &[i8],
+    scale: f64,
+    output: &mut [f64],
+) {
+    use std::arch::aarch64::*;
+
+    let scalar_scale = scale;
+    let scale = vdupq_n_f64(scale);
+    let mut index = 0usize;
+    while index + 8 <= query.len() {
+        let query_low = vcvt_f64_f32(vld1_f32(query.as_ptr().add(index)));
+        let query_high = vcvt_f64_f32(vld1_f32(query.as_ptr().add(index + 2)));
+        let query_next_low = vcvt_f64_f32(vld1_f32(query.as_ptr().add(index + 4)));
+        let query_next_high = vcvt_f64_f32(vld1_f32(query.as_ptr().add(index + 6)));
+
+        let values_i16 = vmovl_s8(vld1_s8(values.as_ptr().add(index)));
+        let values_low = vcvtq_f32_s32(vmovl_s16(vget_low_s16(values_i16)));
+        let values_high = vcvtq_f32_s32(vmovl_s16(vget_high_s16(values_i16)));
+        let values_low_low = vcvt_f64_f32(vget_low_f32(values_low));
+        let values_low_high = vcvt_f64_f32(vget_high_f32(values_low));
+        let values_high_low = vcvt_f64_f32(vget_low_f32(values_high));
+        let values_high_high = vcvt_f64_f32(vget_high_f32(values_high));
+
+        let product = |query, values| {
+            let reconstructed = vmulq_f64(values, scale);
+            if L2 {
+                let delta = vsubq_f64(query, reconstructed);
+                vmulq_f64(delta, delta)
+            } else {
+                vmulq_f64(query, reconstructed)
+            }
+        };
+        vst1q_f64(
+            output.as_mut_ptr().add(index),
+            product(query_low, values_low_low),
+        );
+        vst1q_f64(
+            output.as_mut_ptr().add(index + 2),
+            product(query_high, values_low_high),
+        );
+        vst1q_f64(
+            output.as_mut_ptr().add(index + 4),
+            product(query_next_low, values_high_low),
+        );
+        vst1q_f64(
+            output.as_mut_ptr().add(index + 6),
+            product(query_next_high, values_high_high),
+        );
+        index += 8;
+    }
+    fill_tail::<L2>(
+        &query[index..],
+        &values[index..],
+        scalar_scale,
+        &mut output[index..],
+    );
+}
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_endian = "little"
+))]
+#[inline]
+fn fill_tail<const L2: bool>(query: &[f32], values: &[i8], scale: f64, output: &mut [f64]) {
+    for (index, (&query, &value)) in query.iter().zip(values).enumerate() {
+        let reconstructed = f64::from(value) * scale;
+        output[index] = if L2 {
+            let delta = f64::from(query) - reconstructed;
+            delta * delta
+        } else {
+            f64::from(query) * reconstructed
+        };
+    }
+}
+
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+#[inline]
+fn fill_tail<const L2: bool>(query: &[f32], values: &[i8], scale: f64, output: &mut [f64]) {
+    for (index, (&query, &value)) in query.iter().zip(values).enumerate() {
+        let reconstructed = f64::from(value) * scale;
+        output[index] = if L2 {
+            let delta = f64::from(query) - reconstructed;
+            delta * delta
+        } else {
+            f64::from(query) * reconstructed
+        };
+    }
+}
+
+#[cfg(not(any(
+    all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_endian = "little"
+    ),
+    all(target_arch = "aarch64", target_endian = "little")
+)))]
+#[inline]
+fn fill_tail<const L2: bool>(query: &[f32], values: &[i8], scale: f64, output: &mut [f64]) {
+    for (index, (&query, &value)) in query.iter().zip(values).enumerate() {
+        let reconstructed = f64::from(value) * scale;
+        output[index] = if L2 {
+            let delta = f64::from(query) - reconstructed;
+            delta * delta
+        } else {
+            f64::from(query) * reconstructed
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quantized_scores_preserve_scalar_bits_for_group_boundaries() {
+        let mut state = 0x9e37_79b9_7f4a_7c15u64;
+        for dimensions in 1..=129 {
+            let mut query = Vec::with_capacity(dimensions);
+            let mut values = Vec::with_capacity(dimensions);
+            for _ in 0..dimensions {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                query.push((state as i32) as f32 / 65_536.0);
+                values.push((state as i8).clamp(-127, 127));
+            }
+            for group_size in [1, 2, 3, 4, 7, 8, 16, 32] {
+                let scales: Vec<_> = (0..dimensions.div_ceil(group_size))
+                    .map(|index| (index as f32 + 1.0) / 127.0)
+                    .collect();
+                for metric in [
+                    DistanceMetric::L2Squared,
+                    DistanceMetric::Cosine,
+                    DistanceMetric::InnerProduct,
+                ] {
+                    let expected = query.iter().zip(&values).enumerate().fold(
+                        0.0f64,
+                        |sum, (index, (&query, &value))| {
+                            let reconstructed =
+                                f64::from(value) * f64::from(scales[index / group_size]);
+                            if metric == DistanceMetric::L2Squared {
+                                let delta = f64::from(query) - reconstructed;
+                                sum + delta * delta
+                            } else {
+                                sum + f64::from(query) * reconstructed
+                            }
+                        },
+                    );
+                    let expected = match metric {
+                        DistanceMetric::L2Squared => expected,
+                        DistanceMetric::Cosine => 1.0 - expected.clamp(-1.0, 1.0),
+                        DistanceMetric::InnerProduct => -expected,
+                    };
+                    assert_eq!(
+                        score(metric, &query, &values, &scales, group_size).to_bits(),
+                        (if expected == 0.0 { 0.0 } else { expected }).to_bits(),
+                        "metric={metric:?} dimensions={dimensions} group_size={group_size}"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/prolly/proximity/distance/scalar.rs
+++ b/src/prolly/proximity/distance/scalar.rs
@@ -84,6 +84,44 @@ pub(crate) fn score(metric: DistanceMetric, left: &[f32], right: &[f32]) -> f64 
     }
 }
 
+pub(crate) fn score_encoded(metric: DistanceMetric, left: &[f32], right: &[u8]) -> f64 {
+    debug_assert_eq!(left.len().checked_mul(4), Some(right.len()));
+    let result = match metric {
+        DistanceMetric::L2Squared => {
+            left.iter()
+                .zip(right.chunks_exact(4))
+                .fold(0.0, |sum, (&a, bytes)| {
+                    let b = f32::from_bits(u32::from_le_bytes(
+                        bytes.try_into().expect("four-byte vector component"),
+                    ));
+                    let delta = f64::from(a) - f64::from(b);
+                    sum + delta * delta
+                })
+        }
+        DistanceMetric::Cosine | DistanceMetric::InnerProduct => {
+            let dot = left
+                .iter()
+                .zip(right.chunks_exact(4))
+                .fold(0.0, |sum, (&a, bytes)| {
+                    let b = f32::from_bits(u32::from_le_bytes(
+                        bytes.try_into().expect("four-byte vector component"),
+                    ));
+                    sum + f64::from(a) * f64::from(b)
+                });
+            if metric == DistanceMetric::Cosine {
+                1.0 - dot.clamp(-1.0, 1.0)
+            } else {
+                -dot
+            }
+        }
+    };
+    if result == 0.0 {
+        0.0
+    } else {
+        result
+    }
+}
+
 fn dot(left: &[f32], right: &[f32]) -> f64 {
     left.iter()
         .zip(right)

--- a/src/prolly/proximity/distance/simd.rs
+++ b/src/prolly/proximity/distance/simd.rs
@@ -1,7 +1,13 @@
-use super::scalar::score;
+use super::scalar::{score, score_encoded as score_encoded_scalar};
 use crate::prolly::proximity::{DistanceMetric, QueryKernel};
+use std::sync::OnceLock;
 
 const PRODUCT_SLOTS: usize = 64;
+
+type FillProducts = unsafe fn(&[f32], &[f32], &mut [f64]);
+
+static FILL_L2: OnceLock<Option<FillProducts>> = OnceLock::new();
+static FILL_DOT: OnceLock<Option<FillProducts>> = OnceLock::new();
 
 #[cfg(test)]
 thread_local! {
@@ -25,18 +31,79 @@ pub(crate) fn query_score(
     }
 }
 
+pub(crate) fn query_score_encoded(
+    kernel: QueryKernel,
+    metric: DistanceMetric,
+    left: &[f32],
+    right: &[u8],
+) -> f64 {
+    match kernel {
+        QueryKernel::ScalarDeterministic => score_encoded_scalar(metric, left, right),
+        QueryKernel::SimdDeterministic | QueryKernel::AutoDeterministic => {
+            simd_score_encoded(metric, left, right)
+                .unwrap_or_else(|| score_encoded_scalar(metric, left, right))
+        }
+    }
+}
+
 fn simd_score(metric: DistanceMetric, left: &[f32], right: &[f32]) -> Option<f64> {
     debug_assert_eq!(left.len(), right.len());
+    let fill = match metric {
+        DistanceMetric::L2Squared => *FILL_L2.get_or_init(detect_fill::<true>),
+        DistanceMetric::Cosine | DistanceMetric::InnerProduct => {
+            *FILL_DOT.get_or_init(detect_fill::<false>)
+        }
+    }?;
     let mut products = [0.0f64; PRODUCT_SLOTS];
-    let mut reduced = 0.0;
+    let mut reduced = 0.0f64;
     for (left, right) in left.chunks(PRODUCT_SLOTS).zip(right.chunks(PRODUCT_SLOTS)) {
         let output = &mut products[..left.len()];
-        if !fill_products(metric, left, right, output) {
-            return None;
-        }
+        // SAFETY: `detect_fill` only returns a target-feature function after
+        // checking the corresponding runtime CPU feature. Each implementation
+        // writes exactly `left.len()` products into the bounded output slice.
+        unsafe { fill(left, right, output) };
         for &product in output.iter() {
             reduced += product;
         }
+    }
+    let result = match metric {
+        DistanceMetric::L2Squared => reduced,
+        DistanceMetric::Cosine => 1.0 - reduced.clamp(-1.0, 1.0),
+        DistanceMetric::InnerProduct => -reduced,
+    };
+    Some(if result == 0.0 { 0.0 } else { result })
+}
+
+type FillEncoded = unsafe fn(&[f32], &[u8], &mut [f64]);
+
+static FILL_ENCODED_L2: OnceLock<Option<FillEncoded>> = OnceLock::new();
+static FILL_ENCODED_DOT: OnceLock<Option<FillEncoded>> = OnceLock::new();
+
+fn simd_score_encoded(metric: DistanceMetric, left: &[f32], right: &[u8]) -> Option<f64> {
+    let expected_bytes = left.len().checked_mul(4)?;
+    if expected_bytes != right.len() {
+        return None;
+    }
+    let fill = match metric {
+        DistanceMetric::L2Squared => *FILL_ENCODED_L2.get_or_init(detect_encoded_fill::<true>),
+        DistanceMetric::Cosine | DistanceMetric::InnerProduct => {
+            *FILL_ENCODED_DOT.get_or_init(detect_encoded_fill::<false>)
+        }
+    }?;
+    let mut products = [0.0f64; PRODUCT_SLOTS];
+    let mut reduced = 0.0f64;
+    let mut index = 0usize;
+    while index < left.len() {
+        let end = index.saturating_add(PRODUCT_SLOTS).min(left.len());
+        let output = &mut products[..end - index];
+        // SAFETY: `StoredRecordRef::decode` validates every encoded component
+        // before this query-only scorer is called. The target-specific loader
+        // reads exactly the corresponding four-byte f32 components.
+        unsafe { fill(&left[index..end], &right[index * 4..end * 4], output) };
+        for &product in output.iter() {
+            reduced += product;
+        }
+        index = end;
     }
     let result = match metric {
         DistanceMetric::L2Squared => reduced,
@@ -56,32 +123,59 @@ pub(crate) fn query_kernel_calls() -> usize {
     QUERY_KERNEL_CALLS.with(std::cell::Cell::get)
 }
 
-#[cfg_attr(
-    not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")),
-    allow(unused_variables)
-)]
-fn fill_products(metric: DistanceMetric, left: &[f32], right: &[f32], output: &mut [f64]) -> bool {
+fn detect_fill<const L2: bool>() -> Option<FillProducts> {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    if std::arch::is_x86_feature_detected!("sse2") {
-        // SAFETY: runtime feature detection guards the target-feature function;
-        // pointers are bounded by the shared slice length.
-        unsafe { fill_x86_sse2(metric, left, right, output) };
-        return true;
+    {
+        if std::arch::is_x86_feature_detected!("avx512f") {
+            return Some(fill_x86_avx512::<L2>);
+        }
+        // The wider floating-point kernel only needs AVX. AVX2 CPUs also take
+        // this path; AVX2-specific integer instructions are reserved for the
+        // quantized kernels.
+        if std::arch::is_x86_feature_detected!("avx2") || std::arch::is_x86_feature_detected!("avx")
+        {
+            return Some(fill_x86_avx::<L2>);
+        }
+        if std::arch::is_x86_feature_detected!("sse2") {
+            return Some(fill_x86_sse2::<L2>);
+        }
     }
     #[cfg(target_arch = "aarch64")]
     {
-        // AArch64 guarantees Advanced SIMD. The function uses unaligned two-lane
-        // loads only inside the validated slice bounds.
-        unsafe { fill_aarch64_neon(metric, left, right, output) };
-        return true;
+        return Some(fill_aarch64_neon::<L2>);
     }
     #[allow(unreachable_code)]
-    false
+    None
+}
+
+fn detect_encoded_fill<const L2: bool>() -> Option<FillEncoded> {
+    #[cfg(all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_endian = "little"
+    ))]
+    {
+        if std::arch::is_x86_feature_detected!("avx512f") {
+            return Some(fill_encoded_x86_avx512::<L2>);
+        }
+        if std::arch::is_x86_feature_detected!("avx2") || std::arch::is_x86_feature_detected!("avx")
+        {
+            return Some(fill_encoded_x86_avx::<L2>);
+        }
+        if std::arch::is_x86_feature_detected!("sse2") {
+            return Some(fill_encoded_x86_sse2::<L2>);
+        }
+    }
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    {
+        return Some(fill_encoded_aarch64_neon::<L2>);
+    }
+    #[allow(unreachable_code)]
+    None
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "sse2")]
-unsafe fn fill_x86_sse2(metric: DistanceMetric, left: &[f32], right: &[f32], output: &mut [f64]) {
+unsafe fn fill_x86_sse2<const L2: bool>(left: &[f32], right: &[f32], output: &mut [f64]) {
     #[cfg(target_arch = "x86")]
     use std::arch::x86::*;
     #[cfg(target_arch = "x86_64")]
@@ -95,13 +189,13 @@ unsafe fn fill_x86_sse2(metric: DistanceMetric, left: &[f32], right: &[f32], out
         let b_low = _mm_cvtps_pd(b);
         let a_high = _mm_cvtps_pd(_mm_movehl_ps(a, a));
         let b_high = _mm_cvtps_pd(_mm_movehl_ps(b, b));
-        let low = if metric == DistanceMetric::L2Squared {
+        let low = if L2 {
             let delta = _mm_sub_pd(a_low, b_low);
             _mm_mul_pd(delta, delta)
         } else {
             _mm_mul_pd(a_low, b_low)
         };
-        let high = if metric == DistanceMetric::L2Squared {
+        let high = if L2 {
             let delta = _mm_sub_pd(a_high, b_high);
             _mm_mul_pd(delta, delta)
         } else {
@@ -111,24 +205,179 @@ unsafe fn fill_x86_sse2(metric: DistanceMetric, left: &[f32], right: &[f32], out
         _mm_storeu_pd(output.as_mut_ptr().add(index + 2), high);
         index += 4;
     }
-    fill_tail(metric, left, right, output, index);
+    fill_tail::<L2>(left, right, output, index);
+}
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_endian = "little"
+))]
+#[target_feature(enable = "sse2")]
+unsafe fn fill_encoded_x86_sse2<const L2: bool>(left: &[f32], right: &[u8], output: &mut [f64]) {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86::*;
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::*;
+
+    let mut index = 0usize;
+    while index + 4 <= left.len() {
+        let a = _mm_loadu_ps(left.as_ptr().add(index));
+        let b = _mm_loadu_ps(right.as_ptr().add(index * 4).cast::<f32>());
+        let a_low = _mm_cvtps_pd(a);
+        let b_low = _mm_cvtps_pd(b);
+        let a_high = _mm_cvtps_pd(_mm_movehl_ps(a, a));
+        let b_high = _mm_cvtps_pd(_mm_movehl_ps(b, b));
+        let low = if L2 {
+            let delta = _mm_sub_pd(a_low, b_low);
+            _mm_mul_pd(delta, delta)
+        } else {
+            _mm_mul_pd(a_low, b_low)
+        };
+        let high = if L2 {
+            let delta = _mm_sub_pd(a_high, b_high);
+            _mm_mul_pd(delta, delta)
+        } else {
+            _mm_mul_pd(a_high, b_high)
+        };
+        _mm_storeu_pd(output.as_mut_ptr().add(index), low);
+        _mm_storeu_pd(output.as_mut_ptr().add(index + 2), high);
+        index += 4;
+    }
+    fill_encoded_tail::<L2>(&left[index..], &right[index * 4..], &mut output[index..]);
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx")]
+unsafe fn fill_x86_avx<const L2: bool>(left: &[f32], right: &[f32], output: &mut [f64]) {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86::*;
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::*;
+
+    let mut index = 0usize;
+    while index + 8 <= left.len() {
+        let a_low = _mm256_cvtps_pd(_mm_loadu_ps(left.as_ptr().add(index)));
+        let b_low = _mm256_cvtps_pd(_mm_loadu_ps(right.as_ptr().add(index)));
+        let a_high = _mm256_cvtps_pd(_mm_loadu_ps(left.as_ptr().add(index + 4)));
+        let b_high = _mm256_cvtps_pd(_mm_loadu_ps(right.as_ptr().add(index + 4)));
+        let low = if L2 {
+            let delta = _mm256_sub_pd(a_low, b_low);
+            _mm256_mul_pd(delta, delta)
+        } else {
+            _mm256_mul_pd(a_low, b_low)
+        };
+        let high = if L2 {
+            let delta = _mm256_sub_pd(a_high, b_high);
+            _mm256_mul_pd(delta, delta)
+        } else {
+            _mm256_mul_pd(a_high, b_high)
+        };
+        _mm256_storeu_pd(output.as_mut_ptr().add(index), low);
+        _mm256_storeu_pd(output.as_mut_ptr().add(index + 4), high);
+        index += 8;
+    }
+    fill_tail::<L2>(left, right, output, index);
+}
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_endian = "little"
+))]
+#[target_feature(enable = "avx")]
+unsafe fn fill_encoded_x86_avx<const L2: bool>(left: &[f32], right: &[u8], output: &mut [f64]) {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86::*;
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::*;
+
+    let mut index = 0usize;
+    while index + 8 <= left.len() {
+        let a_low = _mm256_cvtps_pd(_mm_loadu_ps(left.as_ptr().add(index)));
+        let b_low = _mm256_cvtps_pd(_mm_loadu_ps(right.as_ptr().add(index * 4).cast::<f32>()));
+        let a_high = _mm256_cvtps_pd(_mm_loadu_ps(left.as_ptr().add(index + 4)));
+        let b_high = _mm256_cvtps_pd(_mm_loadu_ps(
+            right.as_ptr().add((index + 4) * 4).cast::<f32>(),
+        ));
+        let low = if L2 {
+            let delta = _mm256_sub_pd(a_low, b_low);
+            _mm256_mul_pd(delta, delta)
+        } else {
+            _mm256_mul_pd(a_low, b_low)
+        };
+        let high = if L2 {
+            let delta = _mm256_sub_pd(a_high, b_high);
+            _mm256_mul_pd(delta, delta)
+        } else {
+            _mm256_mul_pd(a_high, b_high)
+        };
+        _mm256_storeu_pd(output.as_mut_ptr().add(index), low);
+        _mm256_storeu_pd(output.as_mut_ptr().add(index + 4), high);
+        index += 8;
+    }
+    fill_encoded_tail::<L2>(&left[index..], &right[index * 4..], &mut output[index..]);
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx,avx512f")]
+unsafe fn fill_x86_avx512<const L2: bool>(left: &[f32], right: &[f32], output: &mut [f64]) {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86::*;
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::*;
+
+    let mut index = 0usize;
+    while index + 8 <= left.len() {
+        let a = _mm512_cvtps_pd(_mm256_loadu_ps(left.as_ptr().add(index)));
+        let b = _mm512_cvtps_pd(_mm256_loadu_ps(right.as_ptr().add(index)));
+        let product = if L2 {
+            let delta = _mm512_sub_pd(a, b);
+            _mm512_mul_pd(delta, delta)
+        } else {
+            _mm512_mul_pd(a, b)
+        };
+        _mm512_storeu_pd(output.as_mut_ptr().add(index), product);
+        index += 8;
+    }
+    fill_tail::<L2>(left, right, output, index);
+}
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_endian = "little"
+))]
+#[target_feature(enable = "avx,avx512f")]
+unsafe fn fill_encoded_x86_avx512<const L2: bool>(left: &[f32], right: &[u8], output: &mut [f64]) {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86::*;
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::*;
+
+    let mut index = 0usize;
+    while index + 8 <= left.len() {
+        let a = _mm512_cvtps_pd(_mm256_loadu_ps(left.as_ptr().add(index)));
+        let b = _mm512_cvtps_pd(_mm256_loadu_ps(right.as_ptr().add(index * 4).cast::<f32>()));
+        let product = if L2 {
+            let delta = _mm512_sub_pd(a, b);
+            _mm512_mul_pd(delta, delta)
+        } else {
+            _mm512_mul_pd(a, b)
+        };
+        _mm512_storeu_pd(output.as_mut_ptr().add(index), product);
+        index += 8;
+    }
+    fill_encoded_tail::<L2>(&left[index..], &right[index * 4..], &mut output[index..]);
 }
 
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
-unsafe fn fill_aarch64_neon(
-    metric: DistanceMetric,
-    left: &[f32],
-    right: &[f32],
-    output: &mut [f64],
-) {
+unsafe fn fill_aarch64_neon<const L2: bool>(left: &[f32], right: &[f32], output: &mut [f64]) {
     use std::arch::aarch64::*;
 
     let mut index = 0usize;
     while index + 2 <= left.len() {
         let a = vcvt_f64_f32(vld1_f32(left.as_ptr().add(index)));
         let b = vcvt_f64_f32(vld1_f32(right.as_ptr().add(index)));
-        let product = if metric == DistanceMetric::L2Squared {
+        let product = if L2 {
             let delta = vsubq_f64(a, b);
             vmulq_f64(delta, delta)
         } else {
@@ -137,25 +386,65 @@ unsafe fn fill_aarch64_neon(
         vst1q_f64(output.as_mut_ptr().add(index), product);
         index += 2;
     }
-    fill_tail(metric, left, right, output, index);
+    fill_tail::<L2>(left, right, output, index);
+}
+
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+#[target_feature(enable = "neon")]
+unsafe fn fill_encoded_aarch64_neon<const L2: bool>(
+    left: &[f32],
+    right: &[u8],
+    output: &mut [f64],
+) {
+    use std::arch::aarch64::*;
+
+    let mut index = 0usize;
+    while index + 2 <= left.len() {
+        let a = vcvt_f64_f32(vld1_f32(left.as_ptr().add(index)));
+        let b = vcvt_f64_f32(vld1_f32(right.as_ptr().add(index * 4).cast::<f32>()));
+        let product = if L2 {
+            let delta = vsubq_f64(a, b);
+            vmulq_f64(delta, delta)
+        } else {
+            vmulq_f64(a, b)
+        };
+        vst1q_f64(output.as_mut_ptr().add(index), product);
+        index += 2;
+    }
+    fill_encoded_tail::<L2>(&left[index..], &right[index * 4..], &mut output[index..]);
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
-fn fill_tail(
-    metric: DistanceMetric,
-    left: &[f32],
-    right: &[f32],
-    output: &mut [f64],
-    start: usize,
-) {
+fn fill_tail<const L2: bool>(left: &[f32], right: &[f32], output: &mut [f64], start: usize) {
     for index in start..left.len() {
         let a = f64::from(left[index]);
         let b = f64::from(right[index]);
-        output[index] = if metric == DistanceMetric::L2Squared {
+        output[index] = if L2 {
             let delta = a - b;
             delta * delta
         } else {
             a * b
+        };
+    }
+}
+
+#[cfg(any(
+    all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_endian = "little"
+    ),
+    all(target_arch = "aarch64", target_endian = "little")
+))]
+fn fill_encoded_tail<const L2: bool>(left: &[f32], right: &[u8], output: &mut [f64]) {
+    for (index, (&a, bytes)) in left.iter().zip(right.chunks_exact(4)).enumerate() {
+        let b = f32::from_bits(u32::from_le_bytes(
+            bytes.try_into().expect("four-byte vector component"),
+        ));
+        output[index] = if L2 {
+            let delta = f64::from(a) - f64::from(b);
+            delta * delta
+        } else {
+            f64::from(a) * f64::from(b)
         };
     }
 }
@@ -220,6 +509,39 @@ mod tests {
                     score(metric, &left, &right).to_bits(),
                     "metric={metric:?} dimensions={}",
                     left.len()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn encoded_simd_scores_are_bit_identical_to_decoded_scores() {
+        let mut state = 0x243f_6a88_85a3_08d3u64;
+        for dimensions in 1..=129 {
+            let mut left = Vec::with_capacity(dimensions);
+            let mut right = Vec::with_capacity(dimensions);
+            for _ in 0..dimensions {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                left.push((state as i32) as f32 / 65_536.0);
+                state = state.rotate_left(29).wrapping_mul(0x9e37_79b9_7f4a_7c15);
+                right.push((state as i32) as f32 / 65_536.0);
+            }
+            let encoded: Vec<u8> = right
+                .iter()
+                .flat_map(|component| component.to_bits().to_le_bytes())
+                .collect();
+            for metric in [
+                DistanceMetric::L2Squared,
+                DistanceMetric::Cosine,
+                DistanceMetric::InnerProduct,
+            ] {
+                assert_eq!(
+                    query_score_encoded(QueryKernel::SimdDeterministic, metric, &left, &encoded,)
+                        .to_bits(),
+                    score(metric, &left, &right).to_bits(),
+                    "metric={metric:?} dimensions={dimensions}"
                 );
             }
         }

--- a/src/prolly/proximity/map.rs
+++ b/src/prolly/proximity/map.rs
@@ -28,7 +28,7 @@ use super::{
     ProximityVerification, SearchBackend, SearchBudget, SearchCompletion, SearchIo, SearchPolicy,
     SearchRequest, SearchResult,
 };
-use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet};
 use std::ops::ControlFlow;
 use std::sync::{Arc, Mutex};
 
@@ -791,7 +791,6 @@ where
                 });
             }
         }
-        let mut vector_scratch = vec![0.0f32; self.tree.config.dimensions as usize];
         let mut current_directory = current
             .directory_manager()
             .read(&current.tree().directory)?;
@@ -858,13 +857,9 @@ where
                     reason: "delta vector disagrees with current source".to_owned(),
                 });
             }
-            ProximityVectorRef::from_encoded(record.vector).copy_to_slice(&mut vector_scratch)?;
-            let distance = query_score(
-                request.kernel,
-                self.tree.config.metric,
-                &query,
-                &vector_scratch,
-            );
+            let distance = record
+                .vector
+                .score(request.kernel, self.tree.config.metric, &query);
             stats.nodes_read += 1;
             stats.bytes_read += authoritative_bytes;
             stats.committed_bytes += authoritative_bytes;
@@ -962,7 +957,6 @@ where
             SearchCompletion::Exact
         };
         let mut candidates = Vec::<RerankCandidate>::with_capacity(candidate_limit);
-        let mut vector_scratch = vec![0.0f32; self.tree.config.dimensions as usize];
         let mut directory = self.directory.read(&self.tree.directory)?;
         for key in keys {
             if request
@@ -999,16 +993,12 @@ where
                 break;
             }
             let record = StoredRecordRef::decode(handle.value()?, self.tree.config.dimensions)?;
-            ProximityVectorRef::from_encoded(record.vector).copy_to_slice(&mut vector_scratch)?;
             stats.bytes_read = stats.bytes_read.saturating_add(bytes);
             stats.committed_bytes = stats.committed_bytes.saturating_add(bytes);
             stats.distance_evaluations += 1;
-            let distance = query_score(
-                request.kernel,
-                self.tree.config.metric,
-                &query,
-                &vector_scratch,
-            );
+            let distance = record
+                .vector
+                .score(request.kernel, self.tree.config.metric, &query);
             insert_reranked_top_k(
                 &mut candidates,
                 RerankCandidate::new(handle, key, distance)?,
@@ -1071,7 +1061,9 @@ where
             });
         }
         let mut candidates = Vec::<SearchCandidate>::new();
-        let mut score_cache = BTreeMap::<Vec<u8>, f64>::new();
+        // The cache is lookup-only; no iteration order contributes to the
+        // canonical traversal or tie-breaking result.
+        let mut score_cache = HashMap::<Vec<u8>, f64>::new();
         let mut visited = HashSet::new();
         let mut levels = HashSet::new();
         let mut last_fanout = 0usize;

--- a/src/prolly/proximity/search/async.rs
+++ b/src/prolly/proximity/search/async.rs
@@ -217,7 +217,6 @@ where
             SearchCompletion::Exact
         };
         let mut ranked = Vec::<RerankCandidate>::with_capacity(limit);
-        let mut vector_scratch = vec![0.0f32; self.tree.config.dimensions as usize];
         let mut directory = self.directory.read(&self.tree.directory).await?;
         for key in keys {
             if let Some(stopped) = stop_reason(control) {
@@ -250,14 +249,9 @@ where
                 handle.value()?,
                 self.tree.config.dimensions,
             )?;
-            crate::prolly::proximity::ProximityVectorRef::from_encoded(record.vector)
-                .copy_to_slice(&mut vector_scratch)?;
-            let distance = query_score(
-                request.kernel,
-                self.tree.config.metric,
-                &query,
-                &vector_scratch,
-            );
+            let distance = record
+                .vector
+                .score(request.kernel, self.tree.config.metric, &query);
             insert_reranked_top_k(
                 &mut ranked,
                 RerankCandidate::new(handle, key, distance)?,
@@ -1081,7 +1075,6 @@ where
     let mut approximate = approximate.into_vec();
     approximate.sort();
     let mut reranked = Vec::<RerankCandidate>::with_capacity(approximate.len());
-    let mut vector_scratch = vec![0.0f32; tree.config.dimensions as usize];
     let mut directory_session = directory.read(&tree.directory).await?;
     for candidate in approximate {
         if let Some(stopped) = stop_reason(control) {
@@ -1111,9 +1104,7 @@ where
             handle.value()?,
             tree.config.dimensions,
         )?;
-        crate::prolly::proximity::ProximityVectorRef::from_encoded(record.vector)
-            .copy_to_slice(&mut vector_scratch)?;
-        let distance = query_score(request.kernel, index.metric, &query, &vector_scratch);
+        let distance = record.vector.score(request.kernel, index.metric, &query);
         stats.nodes_read += 1;
         stats.bytes_read += bytes;
         stats.committed_bytes += bytes;
@@ -1352,7 +1343,6 @@ where
         .range(&composite.delta_tree, &[], None)
         .await?;
     let mut directory_session = directory.read(&tree.directory).await?;
-    let mut vector_scratch = vec![0.0f32; tree.config.dimensions as usize];
     let mut retained_backings = HashSet::new();
     let mut retained_bytes = 0usize;
     while let Some(entry) = delta_range.next().await {
@@ -1379,9 +1369,9 @@ where
                 &bytes,
                 tree.config.dimensions,
             )?;
-            crate::prolly::proximity::ProximityVectorRef::from_encoded(record.vector)
-                .copy_to_slice(&mut vector_scratch)?;
-            query_score(request.kernel, tree.config.metric, &query, &vector_scratch)
+            record
+                .vector
+                .score(request.kernel, tree.config.metric, &query)
         };
         stats.nodes_read += 1;
         stats.bytes_read += bytes.len();
@@ -1577,7 +1567,7 @@ where
         request: &request,
         stats: ProximitySearchStats::default(),
         completion: SearchCompletion::ApproximatePolicySatisfied,
-        loaded: BTreeMap::new(),
+        loaded: HashMap::new(),
     };
     let mut current = index.entry_point.clone();
     let Some(entry) = state.node(&current).await? else {
@@ -1705,7 +1695,6 @@ where
     let mut candidates = eligible.into_vec();
     candidates.sort();
     let mut reranked = Vec::<RerankCandidate>::with_capacity(candidates.len());
-    let mut vector_scratch = vec![0.0f32; tree.config.dimensions as usize];
     let mut directory_session = directory.read(&tree.directory).await?;
     for candidate in candidates {
         if let Some(stopped) = stop_reason(control) {
@@ -1735,12 +1724,17 @@ where
             handle.value()?,
             tree.config.dimensions,
         )?;
-        crate::prolly::proximity::ProximityVectorRef::from_encoded(record.vector)
-            .copy_to_slice(&mut vector_scratch)?;
-        let Some(distance) = state.distance(&query, &vector_scratch) else {
+        if state
+            .request
+            .budget
+            .max_distance_evaluations
+            .is_some_and(|limit| state.stats.distance_evaluations >= limit)
+        {
             state.completion = SearchCompletion::BudgetExhausted;
             break;
-        };
+        }
+        let distance = record.vector.score(request.kernel, index.metric, &query);
+        state.stats.distance_evaluations += 1;
         state.stats.nodes_read += 1;
         state.stats.bytes_read += bytes;
         state.stats.committed_bytes += bytes;
@@ -1777,7 +1771,7 @@ where
     request: &'a SearchRequest<'a>,
     stats: ProximitySearchStats,
     completion: SearchCompletion,
-    loaded: BTreeMap<Vec<u8>, GraphNode>,
+    loaded: HashMap<Vec<u8>, Arc<GraphNode>>,
 }
 
 impl<S> AsyncHnswState<'_, S>
@@ -1785,9 +1779,9 @@ where
     S: AsyncStore + Clone,
     S::Error: Send + Sync,
 {
-    async fn node(&mut self, key: &[u8]) -> Result<Option<GraphNode>, Error> {
+    async fn node(&mut self, key: &[u8]) -> Result<Option<Arc<GraphNode>>, Error> {
         if let Some(node) = self.loaded.get(key) {
-            return Ok(Some(node.clone()));
+            return Ok(Some(Arc::clone(node)));
         }
         if self
             .request
@@ -1837,7 +1831,8 @@ where
         self.stats.nodes_read += 1;
         self.stats.bytes_read += bytes.len();
         self.stats.committed_bytes += bytes.len();
-        self.loaded.insert(key.to_vec(), node.clone());
+        let node = Arc::new(node);
+        self.loaded.insert(key.to_vec(), Arc::clone(&node));
         Ok(Some(node))
     }
 

--- a/src/prolly/proximity/storage/quantized.rs
+++ b/src/prolly/proximity/storage/quantized.rs
@@ -1,5 +1,6 @@
 use super::codec::{put_f32, put_varint, Reader, FORMAT_VERSION, MAX_OBJECT_ENTRIES};
 use crate::prolly::error::Error;
+use crate::prolly::proximity::distance::score_quantized;
 use crate::prolly::proximity::DistanceMetric;
 
 const MAGIC: &[u8; 4] = b"PQS8";
@@ -198,23 +199,13 @@ impl ScalarQuantized {
         }
         let start = entry * self.dimensions as usize;
         let values = &self.values[start..start + self.dimensions as usize];
-        let mut reduced = 0.0f64;
-        for (index, (&query, &value)) in query.iter().zip(values).enumerate() {
-            let reconstructed =
-                f64::from(value) * f64::from(self.scales[index / self.group_size as usize]);
-            if metric == DistanceMetric::L2Squared {
-                let delta = f64::from(query) - reconstructed;
-                reduced += delta * delta;
-            } else {
-                reduced += f64::from(query) * reconstructed;
-            }
-        }
-        let score = match metric {
-            DistanceMetric::L2Squared => reduced,
-            DistanceMetric::Cosine => 1.0 - reduced.clamp(-1.0, 1.0),
-            DistanceMetric::InnerProduct => -reduced,
-        };
-        Ok(if score == 0.0 { 0.0 } else { score })
+        Ok(score_quantized(
+            metric,
+            query,
+            values,
+            &self.scales,
+            self.group_size as usize,
+        ))
     }
 }
 

--- a/src/prolly/proximity/storage/record.rs
+++ b/src/prolly/proximity/storage/record.rs
@@ -2,7 +2,7 @@ use super::codec::{put_bytes, put_varint, Reader, FORMAT_VERSION, VECTOR_ENCODIN
 use crate::prolly::error::Error;
 use crate::prolly::proximity::distance::prepare_vector;
 use crate::prolly::proximity::vector::{decode_components, encode_components};
-use crate::prolly::proximity::DistanceMetric;
+use crate::prolly::proximity::{DistanceMetric, QueryKernel};
 
 const MAGIC: &[u8; 4] = b"PRVR";
 
@@ -10,6 +10,13 @@ const MAGIC: &[u8; 4] = b"PRVR";
 pub(crate) struct EncodedVectorRef<'a> {
     pub(crate) bytes: &'a [u8],
     pub(crate) dimensions: u32,
+}
+
+impl EncodedVectorRef<'_> {
+    pub(crate) fn score(&self, kernel: QueryKernel, metric: DistanceMetric, query: &[f32]) -> f64 {
+        debug_assert_eq!(query.len(), self.dimensions as usize);
+        crate::prolly::proximity::distance::query_score_encoded(kernel, metric, query, self.bytes)
+    }
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
## Summary

- Add runtime-dispatched AVX-512, AVX2, and NEON kernels for exact and scalar-quantized scoring.
- Preserve scalar-order f64 reductions and bit-identical scoring semantics.
- Score validated encoded vectors directly, removing intermediate reranking scratch copies across native, HNSW, PQ, composite, sync, and async paths.
- Reduce HNSW node cloning with Arc<GraphNode> and use a lookup-only HashMap for native score caching.
- Add repeat, cache-reset, and SIMD-first benchmark controls.

## Performance evidence

Preliminary local release measurements on an Apple M2 Max:

- Adaptive SQ8 at 1,536 dimensions improved from approximately 3.65–3.83 ms to 3.28–3.52 ms; logical work stayed at 1,005 quantized evaluations.
- HNSW at 128 dimensions improved from approximately 0.90–0.95 ms to 0.72–0.75 ms in the same harness; node reads and distance evaluations stayed unchanged at 194 and 212.
- Exact-search result counts and scalar/SIMD score bits remained unchanged.

These are preliminary one-shot measurements; the benchmark now supports repeated runs, cold/warm cache comparison, and randomized kernel order for more robust follow-up measurements.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --target x86_64-apple-darwin --lib --tests`
- `cargo clippy --all-features --lib -- -D warnings`
- Focused all-feature proximity tests: 23 passed
- `cargo bench --all-features --no-run`

The full all-feature test invocation remains blocked by pre-existing unresolved imports in `tests/async_store.rs` (`catalog_map_id`, `control_record_key`, `control_root_name`, `ActiveIndexControl`, and `IndexControl`). No persisted vector format changes are introduced.
